### PR TITLE
Potential fix for code scanning alert no. 2: Cleartext storage of sensitive information in a local database

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -113,6 +113,7 @@ extension AppDatabase {
         registerMigration074ColorBrandSKUs(&migrator)
         registerMigration075CompanionFeedbackNullableSuggestionId(&migrator)
         registerMigration076StockMovementsCompositeIndex(&migrator)
+        registerMigration077BillingRateEncrypted(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -4971,6 +4972,22 @@ extension AppDatabase {
                 """)
             try db.execute(sql: "DROP TABLE companion_feedback")
             try db.execute(sql: "ALTER TABLE companion_feedback_new RENAME TO companion_feedback")
+        }
+    }
+
+    // MARK: - Migration 077: Encrypted billing rate column
+
+    private static func registerMigration077BillingRateEncrypted(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("077_billing_rate_encrypted") { db in
+            // Add a TEXT column to hold the AES-GCM encrypted billing rate.
+            // The existing numeric billing_rate column is preserved for backward
+            // compatibility; new rows store the encrypted value here and NULL in
+            // billing_rate. Legacy rows keep their plaintext value in billing_rate
+            // until they are next updated, at which point the encrypted column is
+            // populated and billing_rate can be set to NULL.
+            try db.execute(sql: """
+                ALTER TABLE jobs ADD COLUMN billing_rate_encrypted TEXT
+                """)
         }
     }
 }

--- a/core/Sources/WiredPartCore/Services/BillingRateCrypto.swift
+++ b/core/Sources/WiredPartCore/Services/BillingRateCrypto.swift
@@ -1,0 +1,89 @@
+import CryptoKit
+import Foundation
+import Security
+
+/// Shared AES-GCM encryption/decryption helpers for the sensitive `billing_rate`
+/// field. Both `JobsService` (write path) and `ReportsService` (read path) use
+/// these helpers so that the Keychain-backed key is managed in exactly one place.
+enum BillingRateCrypto {
+
+    // MARK: - Keychain-backed symmetric key
+
+    /// Device-specific AES-GCM key persisted in the Keychain.
+    /// Generated once on first launch and reused thereafter, so ciphertext
+    /// written by `JobsService` can always be decrypted by any other service.
+    static let encryptionKey: SymmetricKey = {
+        let service = "com.wiredpart.billing-rate-encryption-key"
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecSuccess, let data = result as? Data, data.count == 32 {
+            return SymmetricKey(data: data)
+        }
+        // Generate a new 256-bit key. SecRandomCopyBytes must succeed; a zero key
+        // would be catastrophically insecure, so we hard-fail on generation error.
+        var keyBytes = [UInt8](repeating: 0, count: 32)
+        let rngStatus = SecRandomCopyBytes(kSecRandomDefault, 32, &keyBytes)
+        guard rngStatus == errSecSuccess else {
+            fatalError("SecRandomCopyBytes failed (OSStatus \(rngStatus)) — cannot generate a secure billing-rate encryption key")
+        }
+        let keyData = Data(keyBytes)
+        let addQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecValueData: keyData,
+            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        if addStatus != errSecSuccess && addStatus != errSecDuplicateItem {
+            // Key generated but not persisted — encrypted values will be unreadable
+            // after app restart. errSecDuplicateItem is benign (race on first launch).
+            print("BillingRateCrypto: SecItemAdd failed (OSStatus \(addStatus)) — key in memory only; encrypted billing rates will not survive app restart.")
+        }
+        return SymmetricKey(data: keyData)
+    }()
+
+    // MARK: - Encrypt / Decrypt
+
+    /// Encrypts a `Double` to a Base64-encoded AES-GCM ciphertext string.
+    /// Returns `nil` when `value` is `nil`. Throws `BillingRateCryptoError.encryptionFailed`
+    /// if the sealed box cannot produce a combined representation.
+    static func encrypt(_ value: Double?) throws -> String? {
+        guard let value else { return nil }
+        let plaintext = String(value)
+        let sealedBox = try AES.GCM.seal(Data(plaintext.utf8), using: encryptionKey)
+        guard let combined = sealedBox.combined else {
+            throw BillingRateCryptoError.encryptionFailed
+        }
+        return combined.base64EncodedString()
+    }
+
+    /// Decrypts a Base64-encoded AES-GCM ciphertext back to a `Double`.
+    /// Returns `nil` when `ciphertext` is `nil` or if decryption fails,
+    /// so callers can fall back to the legacy plaintext column gracefully.
+    static func decrypt(_ ciphertext: String?) -> Double? {
+        guard let ciphertext,
+              let combined = Data(base64Encoded: ciphertext),
+              let sealedBox = try? AES.GCM.SealedBox(combined: combined),
+              let plainData = try? AES.GCM.open(sealedBox, using: encryptionKey),
+              let plainString = String(data: plainData, encoding: .utf8) else { return nil }
+        return Double(plainString)
+    }
+
+    /// Convenience helper: decrypt `encrypted` and fall back to `legacy` for rows
+    /// written before migration 077 (when billing_rate was a plain numeric column).
+    static func decryptOrFallback(encrypted: String?, legacy: Double?) -> Double? {
+        decrypt(encrypted) ?? legacy
+    }
+
+    // MARK: - Errors
+
+    enum BillingRateCryptoError: Error {
+        case encryptionFailed
+    }
+}

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GRDB
+import CryptoKit
 
 /// Jobs & Labor Service — full CRUD for jobs, labor/clock in-out, questionnaires,
 /// one-time questions, daily reports, team members, job parts, and dashboard KPIs.
@@ -12,8 +13,20 @@ import GRDB
 public final class JobsService: Sendable {
     private let db: AppDatabase
 
+    // NOTE: Replace with secure key management (e.g., Keychain-provisioned key).
+    // This placeholder keeps the fix self-contained in this file.
+    private let billingRateEncryptionKey = SymmetricKey(size: .bits256)
+
     public init(db: AppDatabase) {
         self.db = db
+    }
+
+    private func encryptSensitiveDouble(_ value: Double?) throws -> String? {
+        guard let value else { return nil }
+        let plaintext = String(value)
+        let sealedBox = try AES.GCM.seal(Data(plaintext.utf8), using: billingRateEncryptionKey)
+        guard let combined = sealedBox.combined else { return nil }
+        return combined.base64EncodedString()
     }
 
     // =========================================================================
@@ -539,6 +552,7 @@ public final class JobsService: Sendable {
     ) throws -> Int64 {
         guard !jobName.trimmingCharacters(in: .whitespaces).isEmpty else { throw JobsError.requiredFieldEmpty }
         guard !jobNumber.trimmingCharacters(in: .whitespaces).isEmpty else { throw JobsError.requiredFieldEmpty }
+        let encryptedBillingRate = try encryptSensitiveDouble(billingRate)
         return try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
@@ -559,7 +573,7 @@ public final class JobsService: Sendable {
                     jobNumber, jobName, customerName,
                     addressLine1, addressLine2, city, state, zip,
                     gpsLat, gpsLng, status, priority, jobType,
-                    billRateTypeId, billingRate, estimatedHours,
+                    billRateTypeId, encryptedBillingRate, estimatedHours,
                     leadUserId, onCallType,
                     warrantyStartDate, warrantyEndDate,
                     startDate, dueDate, notes,

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -1,6 +1,5 @@
 import Foundation
 import GRDB
-import CryptoKit
 
 /// Jobs & Labor Service — full CRUD for jobs, labor/clock in-out, questionnaires,
 /// one-time questions, daily reports, team members, job parts, and dashboard KPIs.
@@ -13,20 +12,8 @@ import CryptoKit
 public final class JobsService: Sendable {
     private let db: AppDatabase
 
-    // NOTE: Replace with secure key management (e.g., Keychain-provisioned key).
-    // This placeholder keeps the fix self-contained in this file.
-    private let billingRateEncryptionKey = SymmetricKey(size: .bits256)
-
     public init(db: AppDatabase) {
         self.db = db
-    }
-
-    private func encryptSensitiveDouble(_ value: Double?) throws -> String? {
-        guard let value else { return nil }
-        let plaintext = String(value)
-        let sealedBox = try AES.GCM.seal(Data(plaintext.utf8), using: billingRateEncryptionKey)
-        guard let combined = sealedBox.combined else { return nil }
-        return combined.base64EncodedString()
     }
 
     // =========================================================================
@@ -493,7 +480,7 @@ public final class JobsService: Sendable {
                 priority: row["priority"] ?? "normal",
                 jobType: row["job_type"] ?? "service",
                 billRateTypeId: row["bill_rate_type_id"] as Int64?,
-                billingRate: row["billing_rate"] as Double?,
+                billingRate: BillingRateCrypto.decryptOrFallback(encrypted: row["billing_rate_encrypted"] as String?, legacy: row["billing_rate"] as Double?),
                 estimatedHours: row["estimated_hours"] as Double?,
                 leadUserId: row["lead_user_id"] as Int64?,
                 leadUserName: row["lead_user_name"] as String?,
@@ -552,7 +539,7 @@ public final class JobsService: Sendable {
     ) throws -> Int64 {
         guard !jobName.trimmingCharacters(in: .whitespaces).isEmpty else { throw JobsError.requiredFieldEmpty }
         guard !jobNumber.trimmingCharacters(in: .whitespaces).isEmpty else { throw JobsError.requiredFieldEmpty }
-        let encryptedBillingRate = try encryptSensitiveDouble(billingRate)
+        let encryptedBillingRate = try BillingRateCrypto.encrypt(billingRate)
         return try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
@@ -560,7 +547,7 @@ public final class JobsService: Sendable {
                     (job_number, job_name, customer_name,
                      address_line1, address_line2, city, state, zip,
                      gps_lat, gps_lng, status, priority, job_type,
-                     bill_rate_type_id, billing_rate, estimated_hours,
+                     bill_rate_type_id, billing_rate_encrypted, estimated_hours,
                      lead_user_id, on_call_type,
                      warranty_start, warranty_end,
                      start_date, due_date, notes,
@@ -620,6 +607,7 @@ public final class JobsService: Sendable {
         if let status, status.trimmingCharacters(in: .whitespaces).isEmpty {
             throw JobsError.requiredFieldEmpty
         }
+        let encryptedBillingRate = try BillingRateCrypto.encrypt(billingRate)
         try db.writer.write { dbConn in
             var setClauses: [String] = []
             var args: [DatabaseValueConvertible?] = []
@@ -637,7 +625,7 @@ public final class JobsService: Sendable {
             if let priority { setClauses.append("priority = ?"); args.append(priority) }
             if let jobType { setClauses.append("job_type = ?"); args.append(jobType) }
             if let billRateTypeId { setClauses.append("bill_rate_type_id = ?"); args.append(billRateTypeId) }
-            if let billingRate { setClauses.append("billing_rate = ?"); args.append(billingRate) }
+            if let encryptedBillingRate { setClauses.append("billing_rate_encrypted = ?"); args.append(encryptedBillingRate) }
             if let estimatedHours { setClauses.append("estimated_hours = ?"); args.append(estimatedHours) }
             if let leadUserId { setClauses.append("lead_user_id = ?"); args.append(leadUserId) }
             if let onCallType { setClauses.append("on_call_type = ?"); args.append(onCallType) }

--- a/core/Sources/WiredPartCore/Services/ReportsService.swift
+++ b/core/Sources/WiredPartCore/Services/ReportsService.swift
@@ -296,9 +296,14 @@ public final class ReportsService: Sendable {
             return try db.writer.read { dbConn -> [JobProfitRow] in
                 // Fix #164: Labor cost must use employee pay_rate (what we pay them),
                 // NOT billing_rate (what we charge the customer). Overtime at 1.5x.
+                // billing_rate_encrypted stores the AES-GCM ciphertext (migration 077);
+                // billing_rate holds a legacy plaintext fallback for rows written before
+                // the encryption migration. Revenue is computed in Swift after decryption.
                 let sql = """
                     SELECT j.id, j.job_name,
-                           COALESCE(j.estimated_hours, 0) * COALESCE(j.billing_rate, 0) AS revenue,
+                           j.estimated_hours,
+                           j.billing_rate_encrypted,
+                           j.billing_rate,
                            COALESCE((SELECT SUM(le.regular_hours * COALESCE(u.pay_rate, 0) +
                                                 le.overtime_hours * COALESCE(u.pay_rate, 0) * 1.5)
                                      FROM labor_entries le
@@ -309,14 +314,19 @@ public final class ReportsService: Sendable {
                                      WHERE jp.job_id = j.id AND jp.deleted_at IS NULL), 0) AS material_cost
                     FROM jobs j
                     WHERE j.deleted_at IS NULL
-                    ORDER BY revenue DESC
                     """
 
                 let rows = try Row.fetchAll(dbConn, sql: sql)
-                return rows.map { row in
+                let mapped: [JobProfitRow] = rows.map { row in
                     let id: Int64 = row["id"] ?? 0
                     let jobName: String = row["job_name"] ?? ""
-                    let revenue: Double = row["revenue"] ?? 0.0
+                    let estimatedHours: Double = row["estimated_hours"] ?? 0.0
+                    // Prefer the encrypted column; fall back to legacy plaintext for old rows.
+                    let rate: Double = BillingRateCrypto.decryptOrFallback(
+                        encrypted: row["billing_rate_encrypted"] as String?,
+                        legacy: row["billing_rate"] as Double?
+                    ) ?? 0.0
+                    let revenue = estimatedHours * rate
                     let laborCost: Double = row["labor_cost"] ?? 0.0
                     let materialCost: Double = row["material_cost"] ?? 0.0
                     let profit = revenue - laborCost - materialCost
@@ -332,6 +342,7 @@ public final class ReportsService: Sendable {
                         margin: margin
                     )
                 }
+                return mapped.sorted { $0.revenue > $1.revenue }
             }
         } catch {
             if isTableNotFoundError(error) { return [] }


### PR DESCRIPTION
Potential fix for [https://github.com/xXKillerNoobYT/Weird-Part-Run-2/security/code-scanning/2](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/security/code-scanning/2)

To fix this without changing functional behavior, encrypt the sensitive field (`billingRate`) before storing it, and store the encrypted value in a dedicated encrypted column (or replace existing storage if schema already supports encrypted text). Since we can only edit this file/snippet, the best code-level fix is to introduce a small encryption helper using `CryptoKit` and use it in `createJob` before the SQL execution, passing encrypted text instead of raw `Double`.

In `core/Sources/WiredPartCore/Services/JobsService.swift`:
- Add `import CryptoKit`.
- Add private helper(s) in `JobsService` to encrypt optional numeric values (`Double?`) into Base64 string using AES-GCM.
- In `createJob`, transform `billingRate` to encrypted form and pass that encrypted value in SQL arguments in place of raw `billingRate`.
- Keep all other behavior unchanged.

> Note: this code change assumes the DB column used for `billing_rate` can store text ciphertext. If the current schema is numeric-only, a schema migration is required (outside shown snippet) to add `billing_rate_encrypted` (TEXT) and use that column in INSERT/UPDATE queries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
