### PR TITLE
Potential fix for code scanning alert no. 9: Cleartext storage of sensitive information in a local database

### DIFF
--- a/core/Sources/WiredPartCore/Services/AuthService.swift
+++ b/core/Sources/WiredPartCore/Services/AuthService.swift
@@ -184,7 +184,11 @@ public final class AuthService: Sendable {
 
         Self.clearFailedAttempts(userId: userId)
         let token = Self.generateLocalToken(userId: userId)
-        return AuthResult(success: true, user: user, token: token, message: "Authenticated")
+        // Decrypt email/phone before returning to callers so they receive plaintext.
+        var decryptedUser = user
+        decryptedUser.email = FieldEncryption.decrypt(user.email)
+        decryptedUser.phone = FieldEncryption.decrypt(user.phone)
+        return AuthResult(success: true, user: decryptedUser, token: token, message: "Authenticated")
     }
 
     /// Get list of active users for the login screen.
@@ -478,8 +482,8 @@ public final class AuthService: Sendable {
         return UserProfile(
             id: profileId,
             displayName: user.displayName,
-            email: user.email,
-            phone: user.phone,
+            email: FieldEncryption.decrypt(user.email),
+            phone: FieldEncryption.decrypt(user.phone),
             avatarURL: user.avatarUrl,
             certification: user.certification,
             hireDate: user.hireDate,
@@ -670,13 +674,16 @@ public final class AuthService: Sendable {
         let salt = Self.generateSalt()
         let pinHash = Self.hashPin(pin, salt: salt)
         let now = Self.currentTimestamp()
+        // Encrypt sensitive fields before persisting.
+        let encryptedEmail = try? FieldEncryption.encrypt(email)
+        let encryptedPhone = try? FieldEncryption.encrypt(phone)
         return try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
                     INSERT INTO users (display_name, pin_hash, pin_salt, email, phone, is_active, created_at, updated_at)
                     VALUES (?, ?, ?, ?, ?, 1, ?, ?)
                     """,
-                arguments: [displayName, pinHash, salt, email, phone, now, now]
+                arguments: [displayName, pinHash, salt, encryptedEmail ?? email, encryptedPhone ?? phone, now, now]
             )
             return dbConn.lastInsertedRowID
         }

--- a/core/Sources/WiredPartCore/Services/AuthService.swift
+++ b/core/Sources/WiredPartCore/Services/AuthService.swift
@@ -674,16 +674,17 @@ public final class AuthService: Sendable {
         let salt = Self.generateSalt()
         let pinHash = Self.hashPin(pin, salt: salt)
         let now = Self.currentTimestamp()
-        // Encrypt sensitive fields before persisting.
-        let encryptedEmail = try? FieldEncryption.encrypt(email)
-        let encryptedPhone = try? FieldEncryption.encrypt(phone)
+        // Encrypt sensitive fields before persisting. Propagate errors — callers should
+        // know when encryption is unavailable rather than silently falling back to plaintext.
+        let encryptedEmail = try FieldEncryption.encrypt(email)
+        let encryptedPhone = try FieldEncryption.encrypt(phone)
         return try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
                     INSERT INTO users (display_name, pin_hash, pin_salt, email, phone, is_active, created_at, updated_at)
                     VALUES (?, ?, ?, ?, ?, 1, ?, ?)
                     """,
-                arguments: [displayName, pinHash, salt, encryptedEmail ?? email, encryptedPhone ?? phone, now, now]
+                arguments: [displayName, pinHash, salt, encryptedEmail, encryptedPhone, now, now]
             )
             return dbConn.lastInsertedRowID
         }

--- a/core/Sources/WiredPartCore/Services/FieldEncryption.swift
+++ b/core/Sources/WiredPartCore/Services/FieldEncryption.swift
@@ -1,0 +1,89 @@
+import Foundation
+import CryptoKit
+import Security
+
+/// Device-local AES-GCM encryption for sensitive database fields (email, phone, etc.).
+///
+/// The symmetric key is generated once per device and persisted in the Keychain under
+/// `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`. On first launch a cryptographically
+/// random 256-bit key is created and stored; subsequent launches reuse the same key so
+/// ciphertext survives app restarts.
+///
+/// This follows the same Keychain-persistence pattern as `AuthService.signingKey`.
+enum FieldEncryption {
+
+    // MARK: - Keychain-backed symmetric key
+
+    /// Device-specific 256-bit key, persisted in the Keychain so encrypted field values
+    /// survive app restarts. Never falls back to a constant — if the key cannot be
+    /// persisted it is still used for the lifetime of the process (same graceful-degradation
+    /// pattern used by `AuthService.signingKey`).
+    static let key: SymmetricKey = {
+        let service = "com.wiredpart.field-encryption-key"
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecSuccess, let data = result as? Data, data.count == 32 {
+            return SymmetricKey(data: data)
+        }
+        // Generate a new cryptographically random 256-bit key.
+        var keyBytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, 32, &keyBytes)
+        let keyData = Data(keyBytes)
+        let addQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecValueData: keyData,
+            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        if addStatus != errSecSuccess && addStatus != errSecDuplicateItem {
+            // Key generated but not persisted — ciphertext will not survive app restart.
+            // errSecDuplicateItem is benign (item was added between our read and write).
+        }
+        return SymmetricKey(data: keyData)
+    }()
+
+    // MARK: - Encrypt / Decrypt
+
+    /// Encrypt an optional plaintext string using AES-GCM with the device-specific Keychain key.
+    ///
+    /// - Returns the input unchanged when `value` is `nil` or empty (preserves `nil` semantics
+    ///   for optional columns).
+    /// - Returns a base64-encoded AES-GCM sealed box (nonce + ciphertext + tag) otherwise.
+    /// - Throws `SyncCrypto.CryptoError.encryptionFailed` if the sealed box cannot produce
+    ///   combined bytes (should never happen in practice with CryptoKit AES.GCM).
+    static func encrypt(_ value: String?) throws -> String? {
+        guard let value, !value.isEmpty else { return value }
+        let sealed = try AES.GCM.seal(Data(value.utf8), using: key)
+        guard let combined = sealed.combined else {
+            throw SyncCrypto.CryptoError.encryptionFailed
+        }
+        return combined.base64EncodedString()
+    }
+
+    /// Decrypt a base64-encoded AES-GCM ciphertext produced by `encrypt(_:)`.
+    ///
+    /// - Returns the input unchanged when `value` is `nil` or empty.
+    /// - Returns the original plaintext on success.
+    /// - Returns the original value as-is on any decryption failure (invalid base64, wrong key,
+    ///   or a row that was stored as plaintext before encryption was enabled). This ensures a
+    ///   seamless transition from existing plaintext rows.
+    static func decrypt(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return value }
+        guard let data = Data(base64Encoded: value),
+              let sealedBox = try? AES.GCM.SealedBox(combined: data),
+              let plainData = try? AES.GCM.open(sealedBox, using: key),
+              let plainText = String(data: plainData, encoding: .utf8) else {
+            // Not valid ciphertext — return as-is for backward compatibility with
+            // rows written before this encryption was introduced.
+            return value
+        }
+        return plainText
+    }
+}

--- a/core/Sources/WiredPartCore/Services/PeopleService.swift
+++ b/core/Sources/WiredPartCore/Services/PeopleService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GRDB
+import CryptoKit
 
 /// People Service — read-only queries for employees, customers, contractors,
 /// contacts, teams, hats, and aggregate people stats.
@@ -14,6 +15,22 @@ public final class PeopleService: Sendable {
 
     public init(db: AppDatabase) {
         self.db = db
+    }
+
+    private static func peopleEncryptionKey() -> SymmetricKey {
+        let secret = ProcessInfo.processInfo.environment["WIREDPART_DB_FIELD_KEY"] ?? "wiredpart-default-field-key"
+        let digest = SHA256.hash(data: Data(secret.utf8))
+        return SymmetricKey(data: Data(digest))
+    }
+
+    private static func encryptOptionalField(_ value: String?) throws -> String? {
+        guard let value, !value.isEmpty else { return value }
+        let key = peopleEncryptionKey()
+        let sealed = try AES.GCM.seal(Data(value.utf8), using: key)
+        guard let combined = sealed.combined else {
+            throw PeopleError.requiredFieldEmpty("encryptedField")
+        }
+        return combined.base64EncodedString()
     }
 
     // =========================================================================
@@ -1226,13 +1243,15 @@ public final class PeopleService: Sendable {
         phone: String?,
         email: String?
     ) throws {
+        let encryptedEmail = try Self.encryptOptionalField(email)
+        let encryptedPhone = try Self.encryptOptionalField(phone)
         try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
                     UPDATE users SET display_name = ?, email = ?, phone = ?, updated_at = datetime('now')
                     WHERE id = ? AND deleted_at IS NULL
                     """,
-                arguments: [displayName, email, phone, employeeId]
+                arguments: [displayName, encryptedEmail, encryptedPhone, employeeId]
             )
         }
     }

--- a/core/Sources/WiredPartCore/Services/PeopleService.swift
+++ b/core/Sources/WiredPartCore/Services/PeopleService.swift
@@ -16,11 +16,6 @@ public final class PeopleService: Sendable {
         self.db = db
     }
 
-    private static func peopleEncryptionKey() -> SymmetricKey {
-        // Replaced by FieldEncryption.key — kept for migration awareness only.
-        fatalError("peopleEncryptionKey should never be called; use FieldEncryption helpers instead")
-    }
-
     // =========================================================================
     // MARK: - Error Types
     // =========================================================================

--- a/core/Sources/WiredPartCore/Services/PeopleService.swift
+++ b/core/Sources/WiredPartCore/Services/PeopleService.swift
@@ -1,6 +1,5 @@
 import Foundation
 import GRDB
-import CryptoKit
 
 /// People Service — read-only queries for employees, customers, contractors,
 /// contacts, teams, hats, and aggregate people stats.
@@ -18,19 +17,8 @@ public final class PeopleService: Sendable {
     }
 
     private static func peopleEncryptionKey() -> SymmetricKey {
-        let secret = ProcessInfo.processInfo.environment["WIREDPART_DB_FIELD_KEY"] ?? "wiredpart-default-field-key"
-        let digest = SHA256.hash(data: Data(secret.utf8))
-        return SymmetricKey(data: Data(digest))
-    }
-
-    private static func encryptOptionalField(_ value: String?) throws -> String? {
-        guard let value, !value.isEmpty else { return value }
-        let key = peopleEncryptionKey()
-        let sealed = try AES.GCM.seal(Data(value.utf8), using: key)
-        guard let combined = sealed.combined else {
-            throw PeopleError.requiredFieldEmpty("encryptedField")
-        }
-        return combined.base64EncodedString()
+        // Replaced by FieldEncryption.key — kept for migration awareness only.
+        fatalError("peopleEncryptionKey should never be called; use FieldEncryption helpers instead")
     }
 
     // =========================================================================
@@ -48,6 +36,25 @@ public final class PeopleService: Sendable {
         case hatNotFound(Int64)
         case invalidScore(Double)
         case invalidAmount(Double)
+        case encryptionFailed
+    }
+
+    // MARK: - Field encryption helpers
+
+    /// Encrypt a sensitive field using the device-specific Keychain-backed AES-GCM key.
+    /// Throws `PeopleError.encryptionFailed` if encryption fails (distinct from input-validation errors).
+    private static func encryptField(_ value: String?) throws -> String? {
+        do {
+            return try FieldEncryption.encrypt(value)
+        } catch {
+            throw PeopleError.encryptionFailed
+        }
+    }
+
+    /// Decrypt a sensitive field. Returns the original value as-is on decryption failure to
+    /// preserve backward compatibility with rows written before encryption was introduced.
+    private static func decryptField(_ value: String?) -> String? {
+        FieldEncryption.decrypt(value)
     }
 
     // =========================================================================
@@ -284,16 +291,12 @@ public final class PeopleService: Sendable {
     ) throws -> [EmployeeListItem] {
         do {
             return try db.writer.read { dbConn -> [EmployeeListItem] in
+                // email/phone are stored encrypted; SQL LIKE won't match ciphertext.
+                // Only display_name uses a SQL filter; email/phone are filtered in-memory
+                // after decryption so that searches like "user@example.com" still work.
                 var whereClauses = ["u.deleted_at IS NULL"]
                 var args: [DatabaseValueConvertible?] = []
 
-                if let search, !search.isEmpty {
-                    whereClauses.append("(u.display_name LIKE ? OR u.email LIKE ? OR u.phone LIKE ?)")
-                    let pattern = "%\(search)%"
-                    args.append(pattern)
-                    args.append(pattern)
-                    args.append(pattern)
-                }
                 if let status, !status.isEmpty {
                     if status == "active" {
                         whereClauses.append("u.is_active = 1")
@@ -312,21 +315,33 @@ public final class PeopleService: Sendable {
                     LEFT JOIN hats h ON h.id = uh.hat_id
                     WHERE \(whereClauses.joined(separator: " AND "))
                     GROUP BY u.id
-                    ORDER BY u.display_name ASC, u.email ASC
+                    ORDER BY u.display_name ASC
                     """
 
                 let rows = try Row.fetchAll(dbConn, sql: sql, arguments: StatementArguments(args))
-                return rows.map { row in
-                    EmployeeListItem(
+                var items = rows.map { row -> EmployeeListItem in
+                    let decryptedEmail = Self.decryptField(row["email"] as String?)
+                    let decryptedPhone = Self.decryptField(row["phone"] as String?)
+                    return EmployeeListItem(
                         id: row["id"] ?? 0,
-                        displayName: row["display_name"] ?? row["email"] ?? "Unknown",
-                        email: row["email"] ?? "",
-                        phone: row["phone"] as String?,
+                        displayName: row["display_name"] ?? decryptedEmail ?? "Unknown",
+                        email: decryptedEmail ?? "",
+                        phone: decryptedPhone,
                         status: row["status"] ?? "active",
                         role: row["role"] ?? "user",
                         hatNames: row["hat_names"] as String?
                     )
                 }
+                // In-memory filter runs after decryption so email/phone searches work.
+                if let search, !search.isEmpty {
+                    let term = search.lowercased()
+                    items = items.filter { item in
+                        item.displayName.lowercased().contains(term) ||
+                        item.email.lowercased().contains(term) ||
+                        (item.phone?.lowercased().contains(term) ?? false)
+                    }
+                }
+                return items
             }
         } catch {
             if isTableNotFoundError(error) { return [] }
@@ -430,11 +445,13 @@ public final class PeopleService: Sendable {
                 if !isTableNotFoundError(error) { throw error }
             }
 
+            let decryptedEmail = Self.decryptField(userRow["email"] as String?)
+            let decryptedPhone = Self.decryptField(userRow["phone"] as String?)
             return EmployeeDetail(
                 id: userRow["id"] ?? 0,
-                displayName: userRow["display_name"] ?? userRow["email"] ?? "Unknown",
-                email: userRow["email"] ?? "",
-                phone: userRow["phone"] as String?,
+                displayName: userRow["display_name"] ?? decryptedEmail ?? "Unknown",
+                email: decryptedEmail ?? "",
+                phone: decryptedPhone,
                 status: userRow["status"] ?? "active",
                 role: hats.first?.name ?? "user",
                 createdAt: userRow["created_at"] as String?,
@@ -580,13 +597,13 @@ public final class PeopleService: Sendable {
     public func listCustomers(search: String? = nil) throws -> [CustomerListItem] {
         do {
             return try db.writer.read { dbConn -> [CustomerListItem] in
+                // email/phone are stored encrypted; only name/company_name use SQL LIKE.
                 var whereClauses = ["c.deleted_at IS NULL", "c.is_active = 1"]
                 var args: [DatabaseValueConvertible?] = []
 
                 if let search, !search.isEmpty {
-                    whereClauses.append("(c.company_name LIKE ? OR c.name LIKE ? OR c.email LIKE ?)")
+                    whereClauses.append("(c.company_name LIKE ? OR c.name LIKE ?)")
                     let pattern = "%\(search)%"
-                    args.append(pattern)
                     args.append(pattern)
                     args.append(pattern)
                 }
@@ -601,15 +618,26 @@ public final class PeopleService: Sendable {
                     """
 
                 let rows = try Row.fetchAll(dbConn, sql: sql, arguments: StatementArguments(args))
-                return rows.map { row in
+                var items = rows.map { row -> CustomerListItem in
                     CustomerListItem(
                         id: row["id"] ?? 0,
                         companyName: row["company_name"] as String?,
                         contactName: row["contact_name"] as String?,
-                        email: row["email"] as String?,
-                        phone: row["phone"] as String?
+                        email: Self.decryptField(row["email"] as String?),
+                        phone: Self.decryptField(row["phone"] as String?)
                     )
                 }
+                // In-memory filter for encrypted email/phone fields.
+                if let search, !search.isEmpty {
+                    let term = search.lowercased()
+                    items = items.filter { item in
+                        (item.companyName?.lowercased().contains(term) ?? false) ||
+                        (item.contactName?.lowercased().contains(term) ?? false) ||
+                        (item.email?.lowercased().contains(term) ?? false) ||
+                        (item.phone?.lowercased().contains(term) ?? false)
+                    }
+                }
+                return items
             }
         } catch {
             if isTableNotFoundError(error) { return [] }
@@ -625,13 +653,13 @@ public final class PeopleService: Sendable {
     public func listContractors(search: String? = nil) throws -> [ContractorListItem] {
         do {
             return try db.writer.read { dbConn -> [ContractorListItem] in
+                // email/phone are stored encrypted; only company_name/contact_name use SQL LIKE.
                 var whereClauses = ["gc.deleted_at IS NULL", "gc.is_active = 1"]
                 var args: [DatabaseValueConvertible?] = []
 
                 if let search, !search.isEmpty {
-                    whereClauses.append("(gc.company_name LIKE ? OR gc.contact_name LIKE ? OR gc.email LIKE ?)")
+                    whereClauses.append("(gc.company_name LIKE ? OR gc.contact_name LIKE ?)")
                     let pattern = "%\(search)%"
-                    args.append(pattern)
                     args.append(pattern)
                     args.append(pattern)
                 }
@@ -644,7 +672,7 @@ public final class PeopleService: Sendable {
                     """
 
                 let rows = try Row.fetchAll(dbConn, sql: sql, arguments: StatementArguments(args))
-                return rows.map { row in
+                var items = rows.map { row -> ContractorListItem in
                     let contactName = (row["contact_name"] as String?) ?? ""
                     let parts = contactName.split(separator: " ", maxSplits: 1)
                     return ContractorListItem(
@@ -652,10 +680,22 @@ public final class PeopleService: Sendable {
                         firstName: parts.first.map(String.init) ?? contactName,
                         lastName: parts.count > 1 ? String(parts[1]) : "",
                         company: row["company_name"] as String?,
-                        email: row["email"] as String?,
-                        phone: row["phone"] as String?
+                        email: Self.decryptField(row["email"] as String?),
+                        phone: Self.decryptField(row["phone"] as String?)
                     )
                 }
+                // In-memory filter for encrypted email/phone fields.
+                if let search, !search.isEmpty {
+                    let term = search.lowercased()
+                    items = items.filter { item in
+                        item.firstName.lowercased().contains(term) ||
+                        item.lastName.lowercased().contains(term) ||
+                        (item.company?.lowercased().contains(term) ?? false) ||
+                        (item.email?.lowercased().contains(term) ?? false) ||
+                        (item.phone?.lowercased().contains(term) ?? false)
+                    }
+                }
+                return items
             }
         } catch {
             if isTableNotFoundError(error) { return [] }
@@ -674,13 +714,13 @@ public final class PeopleService: Sendable {
     ) throws -> [ContactListItem] {
         do {
             return try db.writer.read { dbConn -> [ContactListItem] in
+                // email/phone are stored encrypted; only name/role fields use SQL LIKE.
                 var whereClauses = ["co.deleted_at IS NULL", "co.is_active = 1"]
                 var args: [DatabaseValueConvertible?] = []
 
                 if let search, !search.isEmpty {
-                    whereClauses.append("(co.first_name LIKE ? OR co.last_name LIKE ? OR co.role LIKE ? OR co.email LIKE ?)")
+                    whereClauses.append("(co.first_name LIKE ? OR co.last_name LIKE ? OR co.role LIKE ?)")
                     let pattern = "%\(search)%"
-                    args.append(pattern)
                     args.append(pattern)
                     args.append(pattern)
                     args.append(pattern)
@@ -699,17 +739,29 @@ public final class PeopleService: Sendable {
                     """
 
                 let rows = try Row.fetchAll(dbConn, sql: sql, arguments: StatementArguments(args))
-                return rows.map { row in
+                var items = rows.map { row -> ContactListItem in
                     ContactListItem(
                         id: row["id"] ?? 0,
                         firstName: row["first_name"] ?? "",
                         lastName: row["last_name"] ?? "",
                         company: row["role"] as String?,
-                        email: row["email"] as String?,
-                        phone: row["phone"] as String?,
+                        email: Self.decryptField(row["email"] as String?),
+                        phone: Self.decryptField(row["phone"] as String?),
                         contactType: row["entity_type"] as String?
                     )
                 }
+                // In-memory filter for encrypted email/phone fields.
+                if let search, !search.isEmpty {
+                    let term = search.lowercased()
+                    items = items.filter { item in
+                        item.firstName.lowercased().contains(term) ||
+                        item.lastName.lowercased().contains(term) ||
+                        (item.company?.lowercased().contains(term) ?? false) ||
+                        (item.email?.lowercased().contains(term) ?? false) ||
+                        (item.phone?.lowercased().contains(term) ?? false)
+                    }
+                }
+                return items
             }
         } catch {
             if isTableNotFoundError(error) { return [] }
@@ -806,8 +858,8 @@ public final class PeopleService: Sendable {
                     HatMember(
                         id: row["id"] ?? 0,
                         displayName: row["display_name"] ?? "",
-                        phone: row["phone"] as String?,
-                        email: row["email"] as String?,
+                        phone: Self.decryptField(row["phone"] as String?),
+                        email: Self.decryptField(row["email"] as String?),
                         assignedAt: row["assigned_at"] as String?
                     )
                 }
@@ -864,13 +916,15 @@ public final class PeopleService: Sendable {
         guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw PeopleError.requiredFieldEmpty("name")
         }
+        let encryptedEmail = try Self.encryptField(email)
+        let encryptedPhone = try Self.encryptField(phone)
         return try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
                     INSERT INTO customers (name, company_name, email, phone, address, city, state, zip, notes)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
-                arguments: [name, companyName, email, phone, address, city, state, zip, notes]
+                arguments: [name, companyName, encryptedEmail, encryptedPhone, address, city, state, zip, notes]
             )
             return dbConn.lastInsertedRowID
         }
@@ -896,13 +950,15 @@ public final class PeopleService: Sendable {
         guard !firstName.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw PeopleError.requiredFieldEmpty("firstName")
         }
+        let encryptedPhone = try Self.encryptField(phone)
+        let encryptedEmail = try Self.encryptField(email)
         return try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
                     INSERT INTO entity_contacts (entity_type, entity_id, first_name, last_name, role, phone, email, is_primary, notes)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
-                arguments: [entityType, entityId, firstName, lastName, role, phone, email, isPrimary ? 1 : 0, notes]
+                arguments: [entityType, entityId, firstName, lastName, role, encryptedPhone, encryptedEmail, isPrimary ? 1 : 0, notes]
             )
             return dbConn.lastInsertedRowID
         }
@@ -920,6 +976,8 @@ public final class PeopleService: Sendable {
         guard !firstName.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw PeopleError.requiredFieldEmpty("firstName")
         }
+        let encryptedPhone = try Self.encryptField(phone)
+        let encryptedEmail = try Self.encryptField(email)
         try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
@@ -928,7 +986,7 @@ public final class PeopleService: Sendable {
                         updated_at = datetime('now')
                     WHERE id = ? AND deleted_at IS NULL
                     """,
-                arguments: [firstName, lastName, phone, email, role, id]
+                arguments: [firstName, lastName, encryptedPhone, encryptedEmail, role, id]
             )
         }
     }
@@ -946,13 +1004,15 @@ public final class PeopleService: Sendable {
         guard !companyName.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw PeopleError.requiredFieldEmpty("companyName")
         }
+        let encryptedEmail = try Self.encryptField(email)
+        let encryptedPhone = try Self.encryptField(phone)
         return try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
                     INSERT INTO general_contractors (company_name, contact_name, email, phone, notes)
                     VALUES (?, ?, ?, ?, ?)
                     """,
-                arguments: [companyName, contactName, email, phone, notes]
+                arguments: [companyName, contactName, encryptedEmail, encryptedPhone, notes]
             )
             return dbConn.lastInsertedRowID
         }
@@ -1182,8 +1242,8 @@ public final class PeopleService: Sendable {
                     EmployeeListItem(
                         id: row["id"] ?? 0,
                         displayName: row["display_name"] ?? "",
-                        email: row["email"] ?? "",
-                        phone: row["phone"] as String?,
+                        email: Self.decryptField(row["email"] as String?) ?? "",
+                        phone: Self.decryptField(row["phone"] as String?),
                         status: row["status"] ?? "active",
                         role: "user",
                         hatNames: nil
@@ -1243,8 +1303,8 @@ public final class PeopleService: Sendable {
         phone: String?,
         email: String?
     ) throws {
-        let encryptedEmail = try Self.encryptOptionalField(email)
-        let encryptedPhone = try Self.encryptOptionalField(phone)
+        let encryptedEmail = try Self.encryptField(email)
+        let encryptedPhone = try Self.encryptField(phone)
         try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
@@ -1599,8 +1659,8 @@ public final class PeopleService: Sendable {
                     id: r["id"] as Int64? ?? 0,
                     name: r["name"] as String? ?? "",
                     role: r["role"] as String?,
-                    phone: r["phone"] as String?,
-                    email: r["email"] as String?
+                    phone: Self.decryptField(r["phone"] as String?),
+                    email: Self.decryptField(r["email"] as String?)
                 )
             }
 
@@ -1677,8 +1737,8 @@ public final class PeopleService: Sendable {
                 customerId: customerId,
                 companyName: row["company_name"] as String?,
                 contactName: row["contact_name"] as String?,
-                email: row["email"] as String?,
-                phone: row["phone"] as String?,
+                email: Self.decryptField(row["email"] as String?),
+                phone: Self.decryptField(row["phone"] as String?),
                 address: row["address"] as String?,
                 customerType: row["customer_type"] as String?,
                 contacts: contacts, jobHistory: jobHistory,
@@ -1913,8 +1973,8 @@ public final class PeopleService: Sendable {
                     firstName: r["first_name"] as String? ?? "",
                     lastName: r["last_name"] as String? ?? "",
                     company: r["company"] as String?,
-                    email: r["email"] as String?,
-                    phone: r["phone"] as String?,
+                    email: Self.decryptField(r["email"] as String?),
+                    phone: Self.decryptField(r["phone"] as String?),
                     contactType: r["contact_type"] as String?
                 )
                 let isActive = (r["is_active"] as Int?) ?? 1
@@ -1949,8 +2009,8 @@ public final class PeopleService: Sendable {
                 firstName: r["first_name"] as String? ?? "",
                 lastName: r["last_name"] as String? ?? "",
                 company: r["company"] as String?,
-                email: r["email"] as String?,
-                phone: r["phone"] as String?,
+                email: Self.decryptField(r["email"] as String?),
+                phone: Self.decryptField(r["phone"] as String?),
                 contactType: r["contact_type"] as String?
             )
         }

--- a/core/Tests/WiredPartCoreTests/PeopleServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeopleServiceTests.swift
@@ -45,6 +45,44 @@ struct PeopleServiceTests {
         #expect(detail.displayName == "Updated Admin")
     }
 
+    @Test("email and phone round-trip through AES-GCM encryption via updateEmployeeContact + getEmployeeDetail")
+    func testUpdateEmployeeContact_emailPhoneRoundTrip() throws {
+        let env = try E2ETestHelpers.setUp()
+        try env.people.updateEmployeeContact(
+            employeeId: env.adminUserId,
+            displayName: "Enc Admin",
+            phone: "555-9999",
+            email: "enc@example.com"
+        )
+        // getEmployeeDetail must return plaintext, not base64 ciphertext.
+        let detail = try env.people.getEmployeeDetail(id: env.adminUserId)
+        #expect(detail.email == "enc@example.com")
+        #expect(detail.phone == "555-9999")
+        // The raw DB value must NOT be the plaintext (it is encrypted).
+        let rawEmail = try env.db.writer.read { db in
+            try String?.fetchOne(db, sql: "SELECT email FROM users WHERE id = ?", arguments: [env.adminUserId])
+        }
+        #expect(rawEmail != "enc@example.com", "email should be encrypted at rest, not stored as plaintext")
+    }
+
+    @Test("listEmployees search by email works after encryption (in-memory filter on decrypted values)")
+    func testListEmployees_searchByEmailAfterEncryption() throws {
+        let env = try E2ETestHelpers.setUp()
+        try env.people.updateEmployeeContact(
+            employeeId: env.adminUserId,
+            displayName: "SearchableAdmin",
+            phone: "555-1234",
+            email: "searchable@domain.com"
+        )
+        // In-memory search must match on decrypted email.
+        let results = try env.people.listEmployees(search: "searchable@domain.com")
+        #expect(results.count >= 1)
+        #expect(results.contains(where: { $0.email == "searchable@domain.com" }))
+        // An unrelated search term must return zero.
+        let none = try env.people.listEmployees(search: "nobody@nowhere.invalid")
+        #expect(none.isEmpty)
+    }
+
     // MARK: - Customer CRUD
 
     @Test("Create and list customers")


### PR DESCRIPTION
Potential fix for [https://github.com/xXKillerNoobYT/Weird-Part-Run-2/security/code-scanning/9](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/security/code-scanning/9)

Best fix: encrypt sensitive contact fields (`email`, `phone`) before storing them, while preserving existing behavior for nullable values and not changing schema/query shape.

In `core/Sources/WiredPartCore/Services/PeopleService.swift`, add a small CryptoKit-based helper inside `PeopleService` that:
- accepts optional `String`,
- returns optional encrypted base64 payload for non-empty inputs,
- leaves `nil`/empty as-is to preserve semantics.

Then update `updateEmployeeContact(...)` to pass encrypted values for `email` and `phone` in SQL arguments. `displayName` can remain plaintext unless your policy considers it sensitive too. To avoid broad architectural changes outside shown code, derive a deterministic symmetric key locally from an app-provided secret in `ProcessInfo.processInfo.environment` (fallback included), and use AES.GCM for authenticated encryption. This addresses both alert variants at the same sink.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
