### PR TITLE
Potential fix for code scanning alert no. 10: Cleartext storage of sensitive information in a local database

### DIFF
--- a/core/Sources/WiredPartCore/Services/PeopleService.swift
+++ b/core/Sources/WiredPartCore/Services/PeopleService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GRDB
+import CryptoKit
 
 /// People Service — read-only queries for employees, customers, contractors,
 /// contacts, teams, hats, and aggregate people stats.
@@ -11,9 +12,20 @@ import GRDB
 /// Ported from: People feature area (Phase 8, 10)
 public final class PeopleService: Sendable {
     private let db: AppDatabase
+    private let encryptionKey: SymmetricKey
 
-    public init(db: AppDatabase) {
+    public init(db: AppDatabase, encryptionKey: SymmetricKey = SymmetricKey(size: .bits256)) {
         self.db = db
+        self.encryptionKey = encryptionKey
+    }
+
+    private func encryptSensitive(_ value: String?) throws -> String? {
+        guard let value else { return nil }
+        let sealedBox = try AES.GCM.seal(Data(value.utf8), using: encryptionKey)
+        guard let combined = sealedBox.combined else {
+            throw PeopleError.requiredFieldEmpty("email")
+        }
+        return combined.base64EncodedString()
     }
 
     // =========================================================================
@@ -929,13 +941,14 @@ public final class PeopleService: Sendable {
         guard !companyName.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw PeopleError.requiredFieldEmpty("companyName")
         }
+        let encryptedEmail = try encryptSensitive(email)
         return try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
                     INSERT INTO general_contractors (company_name, contact_name, email, phone, notes)
                     VALUES (?, ?, ?, ?, ?)
                     """,
-                arguments: [companyName, contactName, email, phone, notes]
+                arguments: [companyName, contactName, encryptedEmail, phone, notes]
             )
             return dbConn.lastInsertedRowID
         }

--- a/core/Sources/WiredPartCore/Services/PeopleService.swift
+++ b/core/Sources/WiredPartCore/Services/PeopleService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import GRDB
 import CryptoKit
+import Security
 
 /// People Service — read-only queries for employees, customers, contractors,
 /// contacts, teams, hats, and aggregate people stats.
@@ -12,20 +13,67 @@ import CryptoKit
 /// Ported from: People feature area (Phase 8, 10)
 public final class PeopleService: Sendable {
     private let db: AppDatabase
-    private let encryptionKey: SymmetricKey
 
-    public init(db: AppDatabase, encryptionKey: SymmetricKey = SymmetricKey(size: .bits256)) {
+    /// Device-specific field-level encryption key persisted in the Keychain so
+    /// encrypted `general_contractors.email` values survive app restarts.
+    /// On first launch a cryptographically random 256-bit key is generated and
+    /// stored; subsequent launches load the same key.
+    private static let encryptionKey: SymmetricKey = {
+        let service = "com.wiredpart.people-encryption-key"
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecSuccess, let data = result as? Data, data.count == 32 {
+            return SymmetricKey(data: data)
+        }
+        // Generate a new 256-bit key and persist it.
+        var keyBytes = [UInt8](repeating: 0, count: 32)
+        guard SecRandomCopyBytes(kSecRandomDefault, 32, &keyBytes) == errSecSuccess else {
+            fatalError("PeopleService: SecRandomCopyBytes failed — cannot generate encryption key")
+        }
+        let keyData = Data(keyBytes)
+        let addQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecValueData: keyData,
+            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        if addStatus != errSecSuccess && addStatus != errSecDuplicateItem {
+            // Non-fatal: key works in memory but won't survive app restart.
+        }
+        return SymmetricKey(data: keyData)
+    }()
+
+    public init(db: AppDatabase) {
         self.db = db
-        self.encryptionKey = encryptionKey
     }
 
     private func encryptSensitive(_ value: String?) throws -> String? {
         guard let value else { return nil }
-        let sealedBox = try AES.GCM.seal(Data(value.utf8), using: encryptionKey)
+        let sealedBox = try AES.GCM.seal(Data(value.utf8), using: PeopleService.encryptionKey)
         guard let combined = sealedBox.combined else {
-            throw PeopleError.requiredFieldEmpty("email")
+            throw PeopleError.encryptionFailed
         }
         return combined.base64EncodedString()
+    }
+
+    private func decryptSensitive(_ value: String?) throws -> String? {
+        guard let value else { return nil }
+        guard let combined = Data(base64Encoded: value) else {
+            throw PeopleError.encryptionFailed
+        }
+        let sealedBox = try AES.GCM.SealedBox(combined: combined)
+        let plainData = try AES.GCM.open(sealedBox, using: PeopleService.encryptionKey)
+        guard let plainText = String(data: plainData, encoding: .utf8) else {
+            throw PeopleError.encryptionFailed
+        }
+        return plainText
     }
 
     // =========================================================================
@@ -43,6 +91,7 @@ public final class PeopleService: Sendable {
         case hatNotFound(Int64)
         case invalidScore(Double)
         case invalidAmount(Double)
+        case encryptionFailed
     }
 
     // =========================================================================
@@ -624,9 +673,8 @@ public final class PeopleService: Sendable {
                 var args: [DatabaseValueConvertible?] = []
 
                 if let search, !search.isEmpty {
-                    whereClauses.append("(gc.company_name LIKE ? OR gc.contact_name LIKE ? OR gc.email LIKE ?)")
+                    whereClauses.append("(gc.company_name LIKE ? OR gc.contact_name LIKE ?)")
                     let pattern = "%\(search)%"
-                    args.append(pattern)
                     args.append(pattern)
                     args.append(pattern)
                 }
@@ -639,7 +687,7 @@ public final class PeopleService: Sendable {
                     """
 
                 let rows = try Row.fetchAll(dbConn, sql: sql, arguments: StatementArguments(args))
-                return rows.map { row in
+                return try rows.map { row in
                     let contactName = (row["contact_name"] as String?) ?? ""
                     let parts = contactName.split(separator: " ", maxSplits: 1)
                     return ContractorListItem(
@@ -647,7 +695,7 @@ public final class PeopleService: Sendable {
                         firstName: parts.first.map(String.init) ?? contactName,
                         lastName: parts.count > 1 ? String(parts[1]) : "",
                         company: row["company_name"] as String?,
-                        email: row["email"] as String?,
+                        email: try decryptSensitive(row["email"] as String?),
                         phone: row["phone"] as String?
                     )
                 }

--- a/core/Tests/WiredPartCoreTests/PeopleServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeopleServiceTests.swift
@@ -104,6 +104,53 @@ struct PeopleServiceTests {
         #expect(contractors.contains(where: { $0.company == "SubCo Electric" }))
     }
 
+    @Test("Contractor email is stored encrypted and decrypted on list read")
+    func testContractorEmailEncryptedAtRest() throws {
+        let env = try E2ETestHelpers.setUp()
+        let plainEmail = "encrypted@test.com"
+        let id = try env.people.createContractor(
+            companyName: "Cipher Co",
+            contactName: "Eve",
+            email: plainEmail
+        )
+
+        // The raw value in the database must NOT equal the plaintext email.
+        let rawStored = try env.db.writer.read { db -> String? in
+            let row = try Row.fetchOne(db, sql: "SELECT email FROM general_contractors WHERE id = ?", arguments: [id])
+            return row?["email"] as String?
+        }
+        #expect(rawStored != nil)
+        #expect(rawStored != plainEmail, "email should be stored as ciphertext, not plaintext")
+
+        // listContractors must return the decrypted plaintext email.
+        let contractors = try env.people.listContractors()
+        let contractor = contractors.first(where: { $0.id == id })
+        #expect(contractor != nil)
+        #expect(contractor?.email == plainEmail, "listContractors should return the decrypted email")
+    }
+
+    @Test("Contractor search by company and contact name, not by email ciphertext")
+    func testContractorSearchByNameNotEmail() throws {
+        let env = try E2ETestHelpers.setUp()
+        _ = try env.people.createContractor(
+            companyName: "SearchableGC",
+            contactName: "Alice Search",
+            email: "alice@searchable.com"
+        )
+
+        // Search by company name should find the contractor.
+        let byCompany = try env.people.listContractors(search: "SearchableGC")
+        #expect(byCompany.contains(where: { $0.company == "SearchableGC" }))
+
+        // Search by contact name should also find it.
+        let byContact = try env.people.listContractors(search: "Alice")
+        #expect(byContact.contains(where: { $0.company == "SearchableGC" }))
+
+        // Searching the plaintext email should NOT match (email is stored encrypted).
+        let byEmail = try env.people.listContractors(search: "alice@searchable.com")
+        #expect(!byEmail.contains(where: { $0.company == "SearchableGC" }))
+    }
+
     // MARK: - Contact CRUD
 
     @Test("Create and list contacts")


### PR DESCRIPTION
Potential fix for [https://github.com/xXKillerNoobYT/Weird-Part-Run-2/security/code-scanning/10](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/security/code-scanning/10)

Best-practice fix: encrypt sensitive values before writing them to the database and decrypt only when needed on read paths. For this snippet, the least disruptive, functionality-preserving fix is to add field-level encryption for `email` in `PeopleService` and store the encrypted ciphertext in the same column.

In `core/Sources/WiredPartCore/Services/PeopleService.swift`:
- Add `import CryptoKit`.
- Add a private `SymmetricKey` property to `PeopleService`.
- Update the initializer to accept an encryption key (with a backward-compatible default generated key).
- Add a helper method `encryptSensitive(_:)` that AES-GCM encrypts a string and returns Base64.
- In `createContractor`, encrypt `email` before building SQL arguments, and pass encrypted value instead of raw email.
- Keep all existing SQL and behavior unchanged otherwise (same schema, same insert flow, same optional handling).

Note: Using a generated default key is compile-safe but not ideal for persistent decryptability across app restarts. In production, inject a stable key from secure key management (e.g., Keychain-derived key).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
