### PR TITLE
Potential fix for code scanning alert no. 11: Cleartext storage of sensitive information in a local database

### DIFF
--- a/core/Sources/WiredPartCore/Services/PeopleService.swift
+++ b/core/Sources/WiredPartCore/Services/PeopleService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GRDB
+import CryptoKit
 
 /// People Service — read-only queries for employees, customers, contractors,
 /// contacts, teams, hats, and aggregate people stats.
@@ -11,9 +12,20 @@ import GRDB
 /// Ported from: People feature area (Phase 8, 10)
 public final class PeopleService: Sendable {
     private let db: AppDatabase
+    private let contactFieldEncryptionKey: SymmetricKey
 
-    public init(db: AppDatabase) {
+    public init(db: AppDatabase, contactFieldEncryptionKey: SymmetricKey) {
         self.db = db
+        self.contactFieldEncryptionKey = contactFieldEncryptionKey
+    }
+
+    private func encryptSensitiveField(_ value: String?) throws -> String? {
+        guard let value, !value.isEmpty else { return value }
+        let sealedBox = try AES.GCM.seal(Data(value.utf8), using: contactFieldEncryptionKey)
+        guard let combined = sealedBox.combined else {
+            throw NSError(domain: "PeopleService.Encryption", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to combine sealed box"])
+        }
+        return combined.base64EncodedString()
     }
 
     // =========================================================================
@@ -903,6 +915,7 @@ public final class PeopleService: Sendable {
         guard !firstName.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw PeopleError.requiredFieldEmpty("firstName")
         }
+        let encryptedEmail = try encryptSensitiveField(email)
         try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
@@ -911,7 +924,7 @@ public final class PeopleService: Sendable {
                         updated_at = datetime('now')
                     WHERE id = ? AND deleted_at IS NULL
                     """,
-                arguments: [firstName, lastName, phone, email, role, id]
+                arguments: [firstName, lastName, phone, encryptedEmail, role, id]
             )
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/xXKillerNoobYT/Weird-Part-Run-2/security/code-scanning/11](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/security/code-scanning/11)

To fix this without changing external behavior more than necessary, encrypt sensitive fields before writing them to SQLite, and decrypt only when reading (read-side not shown here). In this snippet, the concrete sink is `updateContact`, so the best targeted fix is to encrypt `email` before binding it into SQL arguments.

In `core/Sources/WiredPartCore/Services/PeopleService.swift`:
1. Add `import CryptoKit`.
2. Add a small internal encryption helper in `PeopleService` (AES-GCM with a `SymmetricKey`), plus a stored key reference.
3. In `updateContact`, transform `email` to encrypted ciphertext (if non-nil) and store that encrypted value instead of cleartext.
4. Keep all other fields and SQL structure unchanged to preserve functionality and minimize migration scope in this patch.

This addresses the flagged sink directly and keeps DB writes functional. (A complete rollout should also apply the same handling to other sensitive writes like `createContact`/`createContractor` and implement read-side decryption.)


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
