### PR TITLE
Potential fix for code scanning alert no. 13: Cleartext storage of sensitive information in a local database

### DIFF
--- a/core/Sources/WiredPartCore/Services/PeopleService.swift
+++ b/core/Sources/WiredPartCore/Services/PeopleService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GRDB
+import CryptoKit
 
 /// People Service — read-only queries for employees, customers, contractors,
 /// contacts, teams, hats, and aggregate people stats.
@@ -11,9 +12,20 @@ import GRDB
 /// Ported from: People feature area (Phase 8, 10)
 public final class PeopleService: Sendable {
     private let db: AppDatabase
+    private let encryptionKey: SymmetricKey
 
-    public init(db: AppDatabase) {
+    public init(db: AppDatabase, encryptionKey: SymmetricKey) {
         self.db = db
+        self.encryptionKey = encryptionKey
+    }
+
+    private func encryptOptional(_ value: String?) throws -> String? {
+        guard let value, !value.isEmpty else { return value }
+        let sealedBox = try AES.GCM.seal(Data(value.utf8), using: encryptionKey)
+        guard let combined = sealedBox.combined else {
+            throw PeopleError.requiredFieldEmpty("email")
+        }
+        return combined.base64EncodedString()
     }
 
     // =========================================================================
@@ -847,13 +859,14 @@ public final class PeopleService: Sendable {
         guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw PeopleError.requiredFieldEmpty("name")
         }
+        let encryptedEmail = try encryptOptional(email)
         return try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
                     INSERT INTO customers (name, company_name, email, phone, address, city, state, zip, notes)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
-                arguments: [name, companyName, email, phone, address, city, state, zip, notes]
+                arguments: [name, companyName, encryptedEmail, phone, address, city, state, zip, notes]
             )
             return dbConn.lastInsertedRowID
         }


### PR DESCRIPTION
Potential fix for [https://github.com/xXKillerNoobYT/Weird-Part-Run-2/security/code-scanning/13](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/security/code-scanning/13)

The best fix is to encrypt sensitive fields before writing them to the database, and (outside this snippet) decrypt only when needed for use. For this specific finding, the minimum required change is to encrypt `email` in `createCustomer` before passing it into the SQL arguments array.

In `core/Sources/WiredPartCore/Services/PeopleService.swift`:
- Add `import CryptoKit`.
- Add a small helper method in `PeopleService` to encrypt optional strings using `AES.GCM` with a `SymmetricKey`.
- Add a key property (injected via initializer) so encryption key management is explicit and not hardcoded.
- Update the initializer signature to accept an encryption key.
- In `createCustomer`, replace `email` in the SQL arguments with encrypted email value.

This preserves behavior (still stores a value in `email` column) while preventing cleartext storage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
