### PR TITLE
Add Paperclip tracker sync automation

### DIFF
--- a/.github/workflows/paperclip-tracker-sync.yml
+++ b/.github/workflows/paperclip-tracker-sync.yml
@@ -20,6 +20,7 @@ jobs:
       PAPERCLIP_WEB_URL: ${{ vars.PAPERCLIP_WEB_URL }}
       GITHUB_REPO: ${{ github.repository }}
       GITHUB_TRACKER_ISSUE: "372"
+      GH_TOKEN: ${{ github.token }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/paperclip-tracker-sync.yml
+++ b/.github/workflows/paperclip-tracker-sync.yml
@@ -20,7 +20,6 @@ jobs:
       PAPERCLIP_WEB_URL: ${{ vars.PAPERCLIP_WEB_URL }}
       GITHUB_REPO: ${{ github.repository }}
       GITHUB_TRACKER_ISSUE: "372"
-      GH_TOKEN: ${{ github.token }}
 
     steps:
       - name: Checkout

--- a/docs/github-issue-sync/2026-05-12T05-06-08Z/issues.json
+++ b/docs/github-issue-sync/2026-05-12T05-06-08Z/issues.json
@@ -1,0 +1,5697 @@
+[
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-08T23:10:06Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 372,
+    "state": "OPEN",
+    "title": "Paperclip/GitHub sync tracker for active WEI execution",
+    "updatedAt": "2026-05-12T05:04:14Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/372"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T21:24:22Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 371,
+    "state": "OPEN",
+    "title": "[Orders][T2][Bug] generatePOFromJPO doesn't update jpo_line_items.line_status — two PO-generation paths produce inconsistent per-line state",
+    "updatedAt": "2026-05-09T05:21:13Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/371"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T20:56:08Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 370,
+    "state": "OPEN",
+    "title": "[Scheduling][T2][Bug] checkTimeOffConflict returns PENDING requests as conflicts (missing is_approved=1 filter)",
+    "updatedAt": "2026-05-09T05:21:18Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/370"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T20:27:53Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 369,
+    "state": "OPEN",
+    "title": "[Warehouse][T2][Bug] movement_type values are stringly-typed across UI + service + queries — no canonical constants, forecasting depends on 'consume' string only",
+    "updatedAt": "2026-05-06T20:28:49Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/369"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T19:31:42Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 368,
+    "state": "OPEN",
+    "title": "[Cross-Cutting][T2][Bug-Umbrella] 35 service mutation methods lack permission gates (service-permission-gate-scanner output)",
+    "updatedAt": "2026-05-09T05:21:13Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/368"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T19:29:19Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 367,
+    "state": "OPEN",
+    "title": "[Parts][T2][Bug] approveRecommendation + dismissRecommendation lack permission gates (sister to #355/#363/#364)",
+    "updatedAt": "2026-05-06T19:29:58Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/367"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T19:24:57Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcTw",
+        "name": "priority:P1",
+        "description": "High — next sprint",
+        "color": "e11d48"
+      }
+    ],
+    "number": 366,
+    "state": "OPEN",
+    "title": "[Cross-Cutting][T1][Security] hasPermission doesn't check user.deleted_at — soft-deleted users retain all hat permissions",
+    "updatedAt": "2026-05-06T19:26:00Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/366"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T18:56:14Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 365,
+    "state": "OPEN",
+    "title": "[Settings][T2][Bug] upsertSettingsMap is non-atomic — partial save on mid-loop failure leaves inconsistent state",
+    "updatedAt": "2026-05-06T18:57:07Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/365"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T18:27:15Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 364,
+    "state": "OPEN",
+    "title": "[Chat][T2][Bug] sendMessage doesn't check channel membership — read-side filters, write-side wide open (read-write asymmetry)",
+    "updatedAt": "2026-05-06T18:28:14Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/364"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T18:24:14Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 363,
+    "state": "OPEN",
+    "title": "[Notebooks][T2][Bug] Classification methods lack permission gates + can leak orphan history rows for soft-deleted entries",
+    "updatedAt": "2026-05-06T18:25:11Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/363"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T17:56:05Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 362,
+    "state": "OPEN",
+    "title": "[Reports][T2][Bug] getPreBillingData ignores billing_periods.locked_at — returns labor from locked periods",
+    "updatedAt": "2026-05-06T17:56:53Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/362"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T17:27:35Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 361,
+    "state": "OPEN",
+    "title": "[Inventory][T2][Bug] Wishlist sendToProcurement is a dead-end status — no consumer reads sent_to_procurement items",
+    "updatedAt": "2026-05-06T17:28:32Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/361"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T17:24:15Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 360,
+    "state": "OPEN",
+    "title": "[Fleet][T2][Bug] assignDriver doesn't deactivate existing active assignments — vehicle/user can have multiple active rows",
+    "updatedAt": "2026-05-06T17:25:06Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/360"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T16:55:24Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 359,
+    "state": "OPEN",
+    "title": "[Tools][T2][Bug] expireOldTrades + updateConfidenceScores not auto-scheduled — only run when iOS detail page opened",
+    "updatedAt": "2026-05-06T20:00:48Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/359"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T16:27:13Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 358,
+    "state": "OPEN",
+    "title": "[People][T2][Bug] getExpiringCertifications excludes already-expired certs (regulatory compliance risk)",
+    "updatedAt": "2026-05-06T16:27:51Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/358"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T16:05:05Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 357,
+    "state": "OPEN",
+    "title": "[Orders][T2][Plan-Drift] PO state machine has 5 statuses in code but plan says 7; 'cancelled' + 'submitted' referenced by queries but absent from validPOTransitions",
+    "updatedAt": "2026-05-06T16:05:49Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/357"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T15:34:43Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 355,
+    "state": "CLOSED",
+    "title": "[Scheduling][T2][Bug] createDispatch doesn't check time-off conflicts at service layer (UI-only enforcement)",
+    "updatedAt": "2026-05-11T02:32:19Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/355"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T14:58:34Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 354,
+    "state": "OPEN",
+    "title": "[Warehouse][T2][Bug] adjustAuditCount writes newQty (absolute) instead of delta to stock_movements.qty",
+    "updatedAt": "2026-05-06T14:58:34Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/354"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T14:29:09Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 353,
+    "state": "OPEN",
+    "title": "[Jobs][T2][Bug] Overtime threshold applied per-labor-entry not per-day — under-counts OT when worker switches jobs",
+    "updatedAt": "2026-05-06T14:29:09Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/353"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-06T14:01:09Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 351,
+    "state": "CLOSED",
+    "title": "[Inventory][T2][Tests] 5 critical PartsService recommendation-pipeline methods have zero tests",
+    "updatedAt": "2026-05-11T02:07:45Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/351"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-05-01T22:38:56Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 347,
+    "state": "OPEN",
+    "title": "[Cross-Cutting][T2][Bug] IOSMainView root chain has 2 .sheet(isPresented:) modifiers — SwiftUI silent-dismissal pattern",
+    "updatedAt": "2026-05-01T22:38:56Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/347"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-30T14:45:37Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcTw",
+        "name": "priority:P1",
+        "description": "High — next sprint",
+        "color": "e11d48"
+      }
+    ],
+    "number": 345,
+    "state": "CLOSED",
+    "title": "[Cross-Cutting][T1][Bug] LEFT JOIN NULL propagation candidates in 5 services — 10 SQL queries need owner triage",
+    "updatedAt": "2026-05-12T04:57:28Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/345"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-30T14:44:51Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcTw",
+        "name": "priority:P1",
+        "description": "High — next sprint",
+        "color": "e11d48"
+      }
+    ],
+    "number": 344,
+    "state": "CLOSED",
+    "title": "[Parts][T1][Bug] GRDB Int? boolean fields inserted as NULL bypassing SQL DEFAULT (3 instances)",
+    "updatedAt": "2026-04-30T18:41:08Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/344"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-30T10:43:49Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbTw",
+        "name": "security",
+        "description": "Security vulnerability",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcTw",
+        "name": "priority:P1",
+        "description": "High — next sprint",
+        "color": "e11d48"
+      }
+    ],
+    "number": 342,
+    "state": "CLOSED",
+    "title": "[Inventory][T1][Security] WishlistService.processAutoApprovals accepts free-form approver, no permission check",
+    "updatedAt": "2026-04-30T14:41:15Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/342"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-30T06:45:08Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcgw",
+        "name": "priority:P3",
+        "description": "Low / backburner",
+        "color": "6b7280"
+      }
+    ],
+    "number": 340,
+    "state": "CLOSED",
+    "title": "[Cross-Cutting][T3][Perf] Render-perf scanner discoveries: first(where:) + filter().count in 4 view-builder contexts",
+    "updatedAt": "2026-04-30T10:41:08Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/340"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-30T02:43:48Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcgw",
+        "name": "priority:P3",
+        "description": "Low / backburner",
+        "color": "6b7280"
+      }
+    ],
+    "number": 338,
+    "state": "CLOSED",
+    "title": "[Reports][T3][Perf] Render-perf bundle: filter().count + uncached DateFormatter creations across 3 report pages",
+    "updatedAt": "2026-04-30T06:41:20Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/338"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-27T14:18:47Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcgw",
+        "name": "priority:P3",
+        "description": "Low / backburner",
+        "color": "6b7280"
+      }
+    ],
+    "number": 330,
+    "state": "OPEN",
+    "title": "[Inventory][T3][Perf] OrdersService.getProcurementDemand groups in Swift instead of SQL",
+    "updatedAt": "2026-04-27T14:18:47Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/330"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-27T14:18:30Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 329,
+    "state": "CLOSED",
+    "title": "[Inventory][T2][Perf] Wishlist full re-fetch + re-section on every user interaction",
+    "updatedAt": "2026-04-29T22:44:10Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/329"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-27T14:18:09Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 328,
+    "state": "CLOSED",
+    "title": "[Inventory][T2][Perf] Repeated in-Swift filter/count scans on every render across 4 inventory pages",
+    "updatedAt": "2026-04-29T18:52:52Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/328"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-27T12:44:16Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbTw",
+        "name": "security",
+        "description": "Security vulnerability",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcTw",
+        "name": "priority:P1",
+        "description": "High — next sprint",
+        "color": "e11d48"
+      }
+    ],
+    "number": 327,
+    "state": "CLOSED",
+    "title": "[Inventory][T1][Security] Wishlist state-mutation methods accept arbitrary identifiers, no permission check",
+    "updatedAt": "2026-04-29T17:32:31Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/327"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-27T12:15:02Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcgw",
+        "name": "priority:P3",
+        "description": "Low / backburner",
+        "color": "6b7280"
+      }
+    ],
+    "number": 326,
+    "state": "CLOSED",
+    "title": "[Inventory][T3] Haptic feedback missing on inventory state-changing actions",
+    "updatedAt": "2026-04-30T02:41:04Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/326"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-27T12:14:45Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 325,
+    "state": "CLOSED",
+    "title": "[Inventory][T2] Missing pre-action confirmations on bulk-irreversible procurement ops",
+    "updatedAt": "2026-04-29T18:45:28Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/325"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-27T10:16:43Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 324,
+    "state": "CLOSED",
+    "title": "[Inventory][T2] Dismiss-Safety: 3 inventory sheets missing isDirty + confirmation",
+    "updatedAt": "2026-04-29T18:41:35Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/324"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-27T04:51:36Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 323,
+    "state": "OPEN",
+    "title": "[Orders][T2][Plan-Drift] Supplier-lock-per-job for generic parts not implemented (Part F CONFIRMED)",
+    "updatedAt": "2026-04-27T04:51:36Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/323"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-27T04:40:16Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 322,
+    "state": "CLOSED",
+    "title": "[Infra][T2] Add .github/copilot-instructions.md so Copilot Coding Agent reads project conventions without per-issue restatement",
+    "updatedAt": "2026-04-29T17:27:06Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/322"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-26T00:59:28Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbTw",
+        "name": "security",
+        "description": "Security vulnerability",
+        "color": "B60205"
+      }
+    ],
+    "number": 319,
+    "state": "CLOSED",
+    "title": "[Security][DB] Implement SQLCipher whole-DB encryption (closes CodeQL #1-#15)",
+    "updatedAt": "2026-05-11T12:36:37Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/319"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-26T00:50:53Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 317,
+    "state": "OPEN",
+    "title": "[Fleet][Perf] IOSMyTruckPage loadData fires 6 sequential DB calls — could be 2 with batching",
+    "updatedAt": "2026-04-26T01:24:25Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/317"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-26T00:50:35Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 316,
+    "state": "OPEN",
+    "title": "[Fleet][Perf] IOSVehiclesPage countForStatus() iterates allVehicles 5× per render; status filter done in Swift not SQL",
+    "updatedAt": "2026-04-26T01:24:24Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/316"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-26T00:50:18Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 315,
+    "state": "OPEN",
+    "title": "[Fleet][Perf] DateFormatter created per-render in IOSFleetDashboardPage.todayString and per-load in 3 Fleet list pages",
+    "updatedAt": "2026-04-26T01:24:23Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/315"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-26T00:49:58Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 314,
+    "state": "OPEN",
+    "title": "[Fleet][Perf] vehicle_location_logs table has no index — listTelematicsData GROUP BY subquery is a full table scan",
+    "updatedAt": "2026-04-26T01:24:22Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/314"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-26T00:49:45Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 313,
+    "state": "OPEN",
+    "title": "[Fleet][Perf] Missing compound index on inspection_records(vehicle_id, performed_at) hurts dashboard correlated subquery",
+    "updatedAt": "2026-04-26T01:24:20Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/313"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-26T00:49:32Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 312,
+    "state": "OPEN",
+    "title": "[Fleet][Perf] getFleetDashboardStats fires 8 separate DB round-trips — consolidate to 1-2 queries",
+    "updatedAt": "2026-04-26T01:24:19Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/312"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-26T00:42:45Z",
+    "labels": [],
+    "number": 311,
+    "state": "CLOSED",
+    "title": "[Security][Refactor] Unify sensitive-field encryption across services (consolidates CodeQL #1-#15)",
+    "updatedAt": "2026-04-26T00:58:48Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/311"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:57:17Z",
+    "labels": [],
+    "number": 310,
+    "state": "OPEN",
+    "title": "#21",
+    "updatedAt": "2026-04-25T23:57:17Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/310"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:56:50Z",
+    "labels": [],
+    "number": 309,
+    "state": "OPEN",
+    "title": "#20",
+    "updatedAt": "2026-04-25T23:56:50Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/309"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:56:24Z",
+    "labels": [],
+    "number": 308,
+    "state": "OPEN",
+    "title": "#19",
+    "updatedAt": "2026-04-25T23:56:24Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/308"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:56:00Z",
+    "labels": [],
+    "number": 307,
+    "state": "OPEN",
+    "title": "#18",
+    "updatedAt": "2026-04-25T23:56:00Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/307"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:53:28Z",
+    "labels": [],
+    "number": 305,
+    "state": "CLOSED",
+    "title": "#17",
+    "updatedAt": "2026-04-25T23:59:12Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/305"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:53:00Z",
+    "labels": [],
+    "number": 304,
+    "state": "CLOSED",
+    "title": "#16",
+    "updatedAt": "2026-04-25T23:59:10Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/304"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:52:26Z",
+    "labels": [],
+    "number": 303,
+    "state": "OPEN",
+    "title": "#15",
+    "updatedAt": "2026-04-26T00:52:26Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/303"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:51:52Z",
+    "labels": [],
+    "number": 302,
+    "state": "CLOSED",
+    "title": "#14",
+    "updatedAt": "2026-04-25T23:59:08Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/302"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:51:11Z",
+    "labels": [],
+    "number": 300,
+    "state": "CLOSED",
+    "title": "#13",
+    "updatedAt": "2026-04-25T23:59:14Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/300"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:48:27Z",
+    "labels": [],
+    "number": 298,
+    "state": "OPEN",
+    "title": "#9",
+    "updatedAt": "2026-04-26T00:52:25Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/298"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:47:39Z",
+    "labels": [],
+    "number": 296,
+    "state": "OPEN",
+    "title": "#7",
+    "updatedAt": "2026-04-26T00:52:24Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/296"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:46:49Z",
+    "labels": [],
+    "number": 294,
+    "state": "OPEN",
+    "title": "#6",
+    "updatedAt": "2026-04-26T00:52:23Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/294"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:46:04Z",
+    "labels": [],
+    "number": 292,
+    "state": "OPEN",
+    "title": "#5",
+    "updatedAt": "2026-04-26T00:52:22Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/292"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:45:20Z",
+    "labels": [],
+    "number": 291,
+    "state": "CLOSED",
+    "title": "#4",
+    "updatedAt": "2026-04-25T23:59:06Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/291"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:43:59Z",
+    "labels": [],
+    "number": 289,
+    "state": "CLOSED",
+    "title": "#3",
+    "updatedAt": "2026-04-25T23:59:04Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/289"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:43:34Z",
+    "labels": [],
+    "number": 288,
+    "state": "CLOSED",
+    "title": "#2",
+    "updatedAt": "2026-04-25T23:59:02Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/288"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T23:42:31Z",
+    "labels": [],
+    "number": 287,
+    "state": "CLOSED",
+    "title": "#1",
+    "updatedAt": "2026-04-25T23:59:00Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/287"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T18:46:18Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbTw",
+        "name": "security",
+        "description": "Security vulnerability",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcgw",
+        "name": "priority:P3",
+        "description": "Low / backburner",
+        "color": "6b7280"
+      }
+    ],
+    "number": 282,
+    "state": "CLOSED",
+    "title": "[Fleet][T3] Defense-in-depth hygiene batch — recordedBy FK, free-text caps, userFriendlyError audit",
+    "updatedAt": "2026-04-27T05:56:55Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/282"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T17:54:07Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 281,
+    "state": "OPEN",
+    "title": "[Fleet][HIG] Inspection-status uses literal .red/.green instead of semantic asset colors",
+    "updatedAt": "2026-04-26T01:24:17Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/281"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T17:53:53Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 280,
+    "state": "CLOSED",
+    "title": "[Fleet][Security] Vehicle write paths lack permission/hat checks at UI layer",
+    "updatedAt": "2026-05-11T05:11:34Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/280"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T17:53:53Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 279,
+    "state": "OPEN",
+    "title": "[Fleet][UX] isLoading double-duty antipattern repeated across 6 list pages",
+    "updatedAt": "2026-04-26T01:24:15Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/279"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T17:21:04Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 278,
+    "state": "OPEN",
+    "title": "[Fleet][UX] Polish batch — presentationDetents, trailer-from-truck nav, search empty states",
+    "updatedAt": "2026-04-26T01:24:14Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/278"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T17:20:51Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 277,
+    "state": "CLOSED",
+    "title": "[Fleet][Bug] ReportVehicleIssueSheet Submit button is a no-op (no service call)",
+    "updatedAt": "2026-04-25T23:17:51Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/277"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T17:20:42Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 276,
+    "state": "CLOSED",
+    "title": "[Fleet][Bug] Date-range filter ignored on Fuel/Mileage/Maintenance pages",
+    "updatedAt": "2026-04-25T23:45:26Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/276"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T15:27:11Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 275,
+    "state": "CLOSED",
+    "title": "[Fleet][T3] FleetService isActive default in VehicleDetail hydration silently treats NULL as active",
+    "updatedAt": "2026-04-25T23:39:52Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/275"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T05:54:39Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJAg",
+        "name": "performance",
+        "description": "N+1 queries, memory, rendering",
+        "color": "FEF2C0"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcgw",
+        "name": "priority:P3",
+        "description": "Low / backburner",
+        "color": "6b7280"
+      }
+    ],
+    "number": 274,
+    "state": "OPEN",
+    "title": "[Tools][Perf] IOSToolsDashboardPage loads all checkouts unbounded — listCheckouts has no LIMIT",
+    "updatedAt": "2026-04-25T12:09:31Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/274"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T05:54:26Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJAg",
+        "name": "performance",
+        "description": "N+1 queries, memory, rendering",
+        "color": "FEF2C0"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 273,
+    "state": "CLOSED",
+    "title": "[Tools][Perf] getToolsStats checkedOut uses O(n²) correlated NOT EXISTS on unindexed tool_movements",
+    "updatedAt": "2026-05-11T09:31:47Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/273"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T05:47:12Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbTw",
+        "name": "security",
+        "description": "Security vulnerability",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcgw",
+        "name": "priority:P3",
+        "description": "Low / backburner",
+        "color": "6b7280"
+      }
+    ],
+    "number": 272,
+    "state": "CLOSED",
+    "title": "[Tools][Security] markToolMaintenance has no caller identity parameter — untraceable in audit log",
+    "updatedAt": "2026-04-25T23:53:35Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/272"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T05:47:06Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbTw",
+        "name": "security",
+        "description": "Security vulnerability",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACgkAcZw",
+        "name": "priority:P2",
+        "description": "Medium — planned",
+        "color": "f97316"
+      }
+    ],
+    "number": 271,
+    "state": "CLOSED",
+    "title": "[Tools][Security] respondToTrade has no service-level recipient check — UI-only gate",
+    "updatedAt": "2026-04-25T23:49:40Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/271"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T05:38:52Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 270,
+    "state": "CLOSED",
+    "title": "[Tools][P2] Duplicate formatDate() in Tools pages — Formatters.formatDateString already exists",
+    "updatedAt": "2026-04-25T23:54:39Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/270"
+  },
+  {
+    "assignees": [
+      {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "login": "xXKillerNoobYT",
+        "name": "",
+        "databaseId": 37959956
+      },
+      {
+        "id": "BOT_kgDOC9w8XQ",
+        "login": "Copilot",
+        "name": "",
+        "databaseId": 198982749
+      }
+    ],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T05:38:43Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 269,
+    "state": "CLOSED",
+    "title": "[Tools][P1] loadData() blocks main thread in 6 pages",
+    "updatedAt": "2026-05-06T11:30:50Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/269"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-25T05:31:03Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+        "name": "usability-hunter",
+        "description": "Behavioral usability bug found by usability-hunter scanner",
+        "color": "FF6B6B"
+      }
+    ],
+    "number": 268,
+    "state": "OPEN",
+    "title": "[Tools][UX] Tools sheets missing .presentationDetents (7 pages)",
+    "updatedAt": "2026-04-25T12:09:26Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/268"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-20T00:56:52Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbvw",
+        "name": "ui",
+        "description": "Needs iOS UI work (Xcode prompt)",
+        "color": "1D76DB"
+      }
+    ],
+    "number": 267,
+    "state": "CLOSED",
+    "title": "[Orders][UX] Missing .accessibilityHidden on decorative icons (~29 remaining locations)",
+    "updatedAt": "2026-04-20T03:14:55Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/267"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-20T00:35:45Z",
+    "labels": [],
+    "number": 266,
+    "state": "CLOSED",
+    "title": "[Warehouse][UX] Missing .accessibilityHidden on decorative icons (~68 locations)",
+    "updatedAt": "2026-04-20T01:46:42Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/266"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-19T23:02:52Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 265,
+    "state": "CLOSED",
+    "title": "[Chat][Performance] Debounce search in IOSQuestionsPage to avoid per-keystroke DB calls",
+    "updatedAt": "2026-04-19T23:03:01Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/265"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-19T23:02:47Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 264,
+    "state": "CLOSED",
+    "title": "[Chat][UX] Add confirmation dialog before escalating a Q&A thread",
+    "updatedAt": "2026-04-20T03:15:57Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/264"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-19T22:07:53Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 263,
+    "state": "CLOSED",
+    "title": "[Inventory][Performance] Add composite index on stock_movements(part_id, created_at, movement_type)",
+    "updatedAt": "2026-04-20T01:35:20Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/263"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-19T22:03:06Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 262,
+    "state": "CLOSED",
+    "title": "[Parts][Enhancement] Extract duplicated urgency filter logic in PartsForecastingPage",
+    "updatedAt": "2026-04-20T03:06:43Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/262"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-19T19:49:55Z",
+    "labels": [],
+    "number": 261,
+    "state": "CLOSED",
+    "title": "[Scheduling][Performance] getLongTermTimeline N+1: 72 queries per call (36 months × 2)",
+    "updatedAt": "2026-04-19T21:06:08Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/261"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-19T19:20:04Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 260,
+    "state": "CLOSED",
+    "title": "[Warehouse][Enhancement] IOSAuditPage confidence data loaded via 11 separate queries",
+    "updatedAt": "2026-04-19T21:34:17Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/260"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-19T19:19:53Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 259,
+    "state": "CLOSED",
+    "title": "[Warehouse][Bug] Movement Wizard batch execution lacks transaction atomicity",
+    "updatedAt": "2026-04-19T19:38:12Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/259"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-19T14:02:56Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 258,
+    "state": "OPEN",
+    "title": "[Settings][Sync] SettingsService needs SyncScope filtering when sync is implemented",
+    "updatedAt": "2026-05-01T14:38:13Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/258"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-18T23:17:31Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 257,
+    "state": "CLOSED",
+    "title": "[Docs][Hygiene] CLAUDE.md architecture section describes dual-platform Tauri/React that no longer exists",
+    "updatedAt": "2026-04-19T08:51:39Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/257"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-18T20:19:14Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 256,
+    "state": "OPEN",
+    "title": "[Automation][Subagent] parts-drift-detector — plan-vs-code drift report for C1b check",
+    "updatedAt": "2026-04-18T20:19:14Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/256"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-18T20:19:03Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 255,
+    "state": "CLOSED",
+    "title": "[Automation][Hook] PartsService SQL column validator — PostToolUse grep for known-bad column patterns",
+    "updatedAt": "2026-04-18T20:56:15Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/255"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-18T20:18:55Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 254,
+    "state": "CLOSED",
+    "title": "[Automation][Skill] parts-sql-schema-checker — cross-ref PartsService SQL against migration schema",
+    "updatedAt": "2026-04-18T20:22:43Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/254"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-18T20:17:25Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 253,
+    "state": "CLOSED",
+    "title": "[Parts][UI] Complete C7 usability audit — all 8 scanners on all 24 parts iOS files",
+    "updatedAt": "2026-04-20T00:02:30Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/253"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-18T20:09:50Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 252,
+    "state": "CLOSED",
+    "title": "[Tools][Bug] Compile warning: redundant #require (ToolsServiceTests.swift:1217)",
+    "updatedAt": "2026-04-19T04:00:32Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/252"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-18T20:09:44Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 251,
+    "state": "CLOSED",
+    "title": "[Scheduling][Bug] Compile warnings: 'is' test always true (SchedulingServiceTests.swift:2489-2491)",
+    "updatedAt": "2026-04-19T02:57:26Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/251"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-18T19:50:39Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 250,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] recordCompanionFeedback: companion_feedback log entry silently skipped — suggestion_id FK prevents logging",
+    "updatedAt": "2026-04-19T04:12:23Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/250"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-18T05:47:36Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbvw",
+        "name": "ui",
+        "description": "Needs iOS UI work (Xcode prompt)",
+        "color": "1D76DB"
+      }
+    ],
+    "number": 249,
+    "state": "OPEN",
+    "title": "[UX] Missing .refreshable on IOSFlexPoolPage, ReceivingRoutingFlow, CreateChannelSheet",
+    "updatedAt": "2026-05-06T07:27:50Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/249"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-18T05:47:31Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbvw",
+        "name": "ui",
+        "description": "Needs iOS UI work (Xcode prompt)",
+        "color": "1D76DB"
+      }
+    ],
+    "number": 248,
+    "state": "OPEN",
+    "title": "[HIG][UX] Missing .presentationDetents on ~160 sheet call sites app-wide",
+    "updatedAt": "2026-04-18T21:53:28Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/248"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-18T05:47:19Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbTw",
+        "name": "security",
+        "description": "Security vulnerability",
+        "color": "B60205"
+      }
+    ],
+    "number": 247,
+    "state": "CLOSED",
+    "title": "[Security][Sync] LAN sync HTTP missing NSAllowsLocalNetworking ATS exemption + MITM exposure",
+    "updatedAt": "2026-04-18T16:21:12Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/247"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-18T05:47:07Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbZQ",
+        "name": "accessibility",
+        "description": "Apple HIG / accessibility issue",
+        "color": "0E8A16"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbvw",
+        "name": "ui",
+        "description": "Needs iOS UI work (Xcode prompt)",
+        "color": "1D76DB"
+      }
+    ],
+    "number": 246,
+    "state": "CLOSED",
+    "title": "[HIG][Accessibility] Sub-44pt tap targets in color pickers and schedule config",
+    "updatedAt": "2026-04-20T00:39:54Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/246"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-18T05:41:59Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 245,
+    "state": "CLOSED",
+    "title": "[Usability][#143] EditEmployeeContactSheet uses wrong dismiss predicate — isSaving not isDirty",
+    "updatedAt": "2026-04-18T06:23:34Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/245"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-16T04:20:05Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+        "name": "usability-hunter",
+        "description": "Behavioral usability bug found by usability-hunter scanner",
+        "color": "FF6B6B"
+      }
+    ],
+    "number": 244,
+    "state": "CLOSED",
+    "title": "[Usability] Scanner 3: IOSDailyReportTemplatesPage saveSettings() has no success feedback",
+    "updatedAt": "2026-04-16T14:27:00Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/244"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T04:57:12Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbvw",
+        "name": "ui",
+        "description": "Needs iOS UI work (Xcode prompt)",
+        "color": "1D76DB"
+      }
+    ],
+    "number": 243,
+    "state": "OPEN",
+    "title": "[Orders][#98-10] Phase 3 UI — IOSPOCreationPage resolved-brand pill + wiring",
+    "updatedAt": "2026-04-15T04:57:12Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/243"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T04:56:57Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbvw",
+        "name": "ui",
+        "description": "Needs iOS UI work (Xcode prompt)",
+        "color": "1D76DB"
+      }
+    ],
+    "number": 242,
+    "state": "OPEN",
+    "title": "[Orders][#98-9] Phase 3 UI — IOSJPOCreationPage General/Specific toggle",
+    "updatedAt": "2026-04-15T04:56:57Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/242"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T04:56:42Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 241,
+    "state": "CLOSED",
+    "title": "[Orders][#98-8] Phase 3 service — OrdersService.resolveGeneralLineItem",
+    "updatedAt": "2026-04-18T06:20:12Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/241"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T04:56:27Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbvw",
+        "name": "ui",
+        "description": "Needs iOS UI work (Xcode prompt)",
+        "color": "1D76DB"
+      }
+    ],
+    "number": 240,
+    "state": "OPEN",
+    "title": "[Parts][#98-7] Phase 2 UI — New Supplier sheet linked-brand picker (#105 reverse direction)",
+    "updatedAt": "2026-04-18T17:31:32Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/240"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T04:56:10Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbvw",
+        "name": "ui",
+        "description": "Needs iOS UI work (Xcode prompt)",
+        "color": "1D76DB"
+      }
+    ],
+    "number": 239,
+    "state": "OPEN",
+    "title": "[Parts][#98-6] Phase 2 UI — TypeBrandColorSection rewrite (drop nested mental model)",
+    "updatedAt": "2026-04-18T17:31:32Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/239"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T04:55:56Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbvw",
+        "name": "ui",
+        "description": "Needs iOS UI work (Xcode prompt)",
+        "color": "1D76DB"
+      }
+    ],
+    "number": 238,
+    "state": "OPEN",
+    "title": "[Parts][#98-5] Phase 2 UI — CategoriesColorPicker hex=NULL named-only variants",
+    "updatedAt": "2026-04-18T17:31:32Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/238"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T04:55:37Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbvw",
+        "name": "ui",
+        "description": "Needs iOS UI work (Xcode prompt)",
+        "color": "1D76DB"
+      }
+    ],
+    "number": 237,
+    "state": "OPEN",
+    "title": "[Parts][#98-4] Phase 2 UI — CategoriesTreeView SKU rows + editor panel",
+    "updatedAt": "2026-04-19T13:04:38Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/237"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T04:55:17Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 236,
+    "state": "CLOSED",
+    "title": "[Parts][#98-3] Phase 1 search — searchParts UNION over part_colors + color_brand_skus",
+    "updatedAt": "2026-04-18T06:17:34Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/236"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T04:55:00Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 235,
+    "state": "CLOSED",
+    "title": "[Parts][#98-2] Phase 1 service — ColorBrandSKU CRUD methods",
+    "updatedAt": "2026-04-18T06:22:25Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/235"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T04:54:42Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 234,
+    "state": "CLOSED",
+    "title": "[Parts][#98-1] Phase 1 schema — color_brand_skus table + brand_selection_mode columns",
+    "updatedAt": "2026-04-18T06:22:28Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/234"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T04:37:00Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 233,
+    "state": "OPEN",
+    "title": "[Infra][Scanner] github-issues-sync auto-closes issues with active docs/dev-qa.md Pending entries",
+    "updatedAt": "2026-04-16T03:23:16Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/233"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T03:05:56Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 232,
+    "state": "CLOSED",
+    "title": "[Jobs][Bug] IOSJobDetailTabView progress bar crashes when job has only 1 stage (division by zero)",
+    "updatedAt": "2026-04-15T03:09:02Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/232"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T03:05:46Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbTw",
+        "name": "security",
+        "description": "Security vulnerability",
+        "color": "B60205"
+      }
+    ],
+    "number": 231,
+    "state": "CLOSED",
+    "title": "[Security][Medium] Keychain signing key uses AfterFirstUnlockThisDeviceOnly — should be WhenUnlockedThisDeviceOnly",
+    "updatedAt": "2026-04-15T04:41:37Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/231"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T03:05:36Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbTw",
+        "name": "security",
+        "description": "Security vulnerability",
+        "color": "B60205"
+      }
+    ],
+    "number": 230,
+    "state": "CLOSED",
+    "title": "[Security][Bug] encryptIfNeeded silently falls back to plaintext on encryption failure",
+    "updatedAt": "2026-04-15T03:35:02Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/230"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-15T03:02:42Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 229,
+    "state": "CLOSED",
+    "title": "[Plan Drift] CategoriesTreeView pricingOverride wired before resolveConflicts tests",
+    "updatedAt": "2026-04-16T14:24:48Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/229"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-14T04:31:30Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 228,
+    "state": "CLOSED",
+    "title": "[Auth][Security] SecItemAdd result unchecked — signing key may not persist to Keychain",
+    "updatedAt": "2026-04-15T03:35:05Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/228"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-14T04:31:24Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 227,
+    "state": "CLOSED",
+    "title": "[Parts][Performance] Service-layer pagination missing — Parts catalog fetches all rows into memory",
+    "updatedAt": "2026-04-15T04:41:37Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/227"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:06:14Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 226,
+    "state": "CLOSED",
+    "title": "[Code Quality] Debug print() statements in production code",
+    "updatedAt": "2026-04-15T04:11:11Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/226"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:06:13Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI4A",
+        "name": "concurrency",
+        "description": "Race conditions, thread safety",
+        "color": "D4C5F9"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 225,
+    "state": "CLOSED",
+    "title": "[Sync][Info] DeviceIdentity.current should be let instead of var",
+    "updatedAt": "2026-04-15T04:11:11Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/225"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:06:12Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 224,
+    "state": "CLOSED",
+    "title": "[Parts][Info] Forecasting ADU includes transfer movements — inflates demand",
+    "updatedAt": "2026-04-15T04:11:11Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/224"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:06:04Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJAg",
+        "name": "performance",
+        "description": "N+1 queries, memory, rendering",
+        "color": "FEF2C0"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 223,
+    "state": "CLOSED",
+    "title": "[Performance] BaseRepository.findAll() has no default limit",
+    "updatedAt": "2026-04-15T04:11:11Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/223"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:06:02Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI4A",
+        "name": "concurrency",
+        "description": "Race conditions, thread safety",
+        "color": "D4C5F9"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 222,
+    "state": "CLOSED",
+    "title": "[Concurrency] @unchecked Sendable on BaseRepository and PeerDiscovery",
+    "updatedAt": "2026-04-15T04:14:47Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/222"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:06:01Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 221,
+    "state": "OPEN",
+    "title": "[Sync][Info] LWW uses row-level timestamps for field-level conflicts",
+    "updatedAt": "2026-04-16T03:23:05Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/221"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:05:59Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 220,
+    "state": "CLOSED",
+    "title": "[Sync][Bug] Sync silently drops UPDATE when record doesn't exist locally",
+    "updatedAt": "2026-04-15T03:38:20Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/220"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:05:34Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 219,
+    "state": "CLOSED",
+    "title": "[UI][Bug] IOSLaborOverviewPage missing proper empty state",
+    "updatedAt": "2026-04-15T04:20:53Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/219"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:05:33Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbZQ",
+        "name": "accessibility",
+        "description": "Apple HIG / accessibility issue",
+        "color": "0E8A16"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 218,
+    "state": "CLOSED",
+    "title": "[Accessibility][Bug] Color-only status indicators in schedule calendar",
+    "updatedAt": "2026-04-15T04:20:53Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/218"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:05:32Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 217,
+    "state": "CLOSED",
+    "title": "[UI][Bug] IOSPublicReportView always shows error — dead-end route",
+    "updatedAt": "2026-04-15T04:20:53Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/217"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:05:31Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 216,
+    "state": "CLOSED",
+    "title": "[UI][Bug] @State holding Timer references in IOSClockPage",
+    "updatedAt": "2026-04-15T04:20:53Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/216"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:05:29Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 215,
+    "state": "CLOSED",
+    "title": "[UI][Bug] IOSSyncManager missing deinit — observer and timer leak on logout",
+    "updatedAt": "2026-04-15T04:20:54Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/215"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:05:28Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJAg",
+        "name": "performance",
+        "description": "N+1 queries, memory, rendering",
+        "color": "FEF2C0"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 214,
+    "state": "CLOSED",
+    "title": "[UI][Bug] DashboardView Timer.publish fires continuously when not visible",
+    "updatedAt": "2026-04-13T07:09:10Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/214"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:04:51Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 213,
+    "state": "CLOSED",
+    "title": "[Data][Bug] No string length or negative value validation on create/update methods",
+    "updatedAt": "2026-04-15T04:11:11Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/213"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:04:50Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 212,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] Model structs missing schema columns (PartCategory, PartStyle, PartType, Brand)",
+    "updatedAt": "2026-04-15T03:48:53Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/212"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:04:43Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 211,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] CompanionRule delete inconsistency — is_active vs deleted_at",
+    "updatedAt": "2026-04-13T07:06:27Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/211"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:04:41Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 210,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] Soft-delete doesn't cascade to children — orphaned records",
+    "updatedAt": "2026-04-13T07:06:27Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/210"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:04:40Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 209,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] Export sell price uses company_cost_price instead of weighted_avg_cost",
+    "updatedAt": "2026-04-15T03:48:56Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/209"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:04:38Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 208,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] addCostLayer is not atomic — 3 separate write transactions",
+    "updatedAt": "2026-04-13T07:06:27Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/208"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:04:30Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 207,
+    "state": "CLOSED",
+    "title": "[Scheduling][Bug] Time-off approval ignores existing dispatch conflicts",
+    "updatedAt": "2026-04-15T04:11:11Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/207"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:04:29Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 206,
+    "state": "CLOSED",
+    "title": "[Jobs][Bug] Clock-out doesn't subtract break time or calculate overtime",
+    "updatedAt": "2026-04-13T07:09:10Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/206"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:04:27Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 205,
+    "state": "CLOSED",
+    "title": "[Orders][Bug] JPO and PO status transitions are not validated",
+    "updatedAt": "2026-04-13T07:09:10Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/205"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:04:26Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 204,
+    "state": "CLOSED",
+    "title": "[Orders][Bug] PO status history hardcodes changed_by = 1",
+    "updatedAt": "2026-04-13T06:38:39Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/204"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:03:48Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 203,
+    "state": "CLOSED",
+    "title": "[Orders][Bug] try? on PO-JPO link INSERTs — procurement traceability silently breaks",
+    "updatedAt": "2026-04-13T06:38:39Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/203"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:03:41Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI4A",
+        "name": "concurrency",
+        "description": "Race conditions, thread safety",
+        "color": "D4C5F9"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 202,
+    "state": "CLOSED",
+    "title": "[Concurrency][Bug] @unchecked Sendable on MultipeerManager with mutable state",
+    "updatedAt": "2026-04-13T06:44:24Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/202"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:03:35Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 201,
+    "state": "CLOSED",
+    "title": "[Data][Bug] 18 try? in migrations silently swallow ALTER TABLE failures",
+    "updatedAt": "2026-04-13T06:50:45Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/201"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:03:25Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 200,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] No Stock model for primary stock table — all stock ops use raw SQL",
+    "updatedAt": "2026-04-13T06:42:50Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/200"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:03:18Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 199,
+    "state": "CLOSED",
+    "title": "[People][Bug] Hat hard-delete cascades to all user roles — no built-in protection",
+    "updatedAt": "2026-04-13T06:40:01Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/199"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:03:03Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 198,
+    "state": "CLOSED",
+    "title": "[Scheduling][Bug] Dispatch creation has no double-booking detection",
+    "updatedAt": "2026-04-13T06:40:01Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/198"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:02:58Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbTw",
+        "name": "security",
+        "description": "Security vulnerability",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 197,
+    "state": "CLOSED",
+    "title": "[Security][Bug] Sync encryption falls back to plaintext silently",
+    "updatedAt": "2026-04-13T06:44:24Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/197"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:02:51Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 196,
+    "state": "CLOSED",
+    "title": "[Sync][Bug] LWW merge converts NULL values to empty strings — corrupts nullable columns",
+    "updatedAt": "2026-04-13T06:42:50Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/196"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:02:36Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 195,
+    "state": "CLOSED",
+    "title": "[Orders][Bug] PO status history records wrong old_status — reads AFTER update",
+    "updatedAt": "2026-04-13T06:38:39Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/195"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:02:30Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJAg",
+        "name": "performance",
+        "description": "N+1 queries, memory, rendering",
+        "color": "FEF2C0"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 194,
+    "state": "CLOSED",
+    "title": "[Performance][P0] N+1 query in recalculateLocationTargets() — per-combo queries",
+    "updatedAt": "2026-04-13T06:35:58Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/194"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:02:25Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJAg",
+        "name": "performance",
+        "description": "N+1 queries, memory, rendering",
+        "color": "FEF2C0"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 193,
+    "state": "CLOSED",
+    "title": "[Performance][P0] N+1 query in recalculateTargets() — per-part queries inside loop",
+    "updatedAt": "2026-04-13T06:35:58Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/193"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:01:25Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbvw",
+        "name": "ui",
+        "description": "Needs iOS UI work (Xcode prompt)",
+        "color": "1D76DB"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 192,
+    "state": "CLOSED",
+    "title": "[Settings][Bug] 5 Settings pages flash defaults before data loads — no loading indicator",
+    "updatedAt": "2026-04-15T04:23:33Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/192"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:01:18Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbTw",
+        "name": "security",
+        "description": "Security vulnerability",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 191,
+    "state": "CLOSED",
+    "title": "[Security][Bug] Sync key exchange endpoint returns X25519 public key without auth",
+    "updatedAt": "2026-04-15T03:47:35Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/191"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:01:05Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI4A",
+        "name": "concurrency",
+        "description": "Race conditions, thread safety",
+        "color": "D4C5F9"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 190,
+    "state": "CLOSED",
+    "title": "[Sync][Bug] LanSyncServer continuation resume guard is not atomic",
+    "updatedAt": "2026-04-15T04:14:47Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/190"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:01:00Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI4A",
+        "name": "concurrency",
+        "description": "Race conditions, thread safety",
+        "color": "D4C5F9"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 189,
+    "state": "CLOSED",
+    "title": "[Sync][Bug] DeviceIdentity.current should be let, not var — unnecessary mutability",
+    "updatedAt": "2026-04-13T06:33:18Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/189"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:00:56Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 188,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] Forecasting ignores user-configured MIN/TARGET/MAX in reorder calculations",
+    "updatedAt": "2026-04-15T03:47:35Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/188"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:00:42Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI4A",
+        "name": "concurrency",
+        "description": "Race conditions, thread safety",
+        "color": "D4C5F9"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 187,
+    "state": "CLOSED",
+    "title": "[Sync][Bug] PeerDiscovery @unchecked Sendable with racy callback setter",
+    "updatedAt": "2026-04-15T04:14:48Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/187"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:00:36Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbZQ",
+        "name": "accessibility",
+        "description": "Apple HIG / accessibility issue",
+        "color": "0E8A16"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 186,
+    "state": "CLOSED",
+    "title": "[Accessibility][Bug] Hardcoded 7px font in warehouse placement grid — unreadable",
+    "updatedAt": "2026-04-15T04:20:53Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/186"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:00:30Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI4A",
+        "name": "concurrency",
+        "description": "Race conditions, thread safety",
+        "color": "D4C5F9"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 185,
+    "state": "CLOSED",
+    "title": "[Warehouse][Bug] CartManager missing @MainActor — only ObservableObject without it",
+    "updatedAt": "2026-04-15T03:35:08Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/185"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:00:17Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbTw",
+        "name": "security",
+        "description": "Security vulnerability",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 184,
+    "state": "CLOSED",
+    "title": "[Sync][Bug] JSON injection in certificate rejection error response",
+    "updatedAt": "2026-04-15T03:47:35Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/184"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:00:11Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJAg",
+        "name": "performance",
+        "description": "N+1 queries, memory, rendering",
+        "color": "FEF2C0"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 183,
+    "state": "CLOSED",
+    "title": "[Sync][Bug] Change log queries have no LIMIT — potential OOM on large backlogs",
+    "updatedAt": "2026-04-15T03:35:13Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/183"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T06:00:05Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 182,
+    "state": "CLOSED",
+    "title": "[Orders][Bug] PO-JPO link insertion uses try? — silently breaks traceability",
+    "updatedAt": "2026-04-13T06:33:18Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/182"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:59:53Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 181,
+    "state": "CLOSED",
+    "title": "[Sync][Bug] DeviceResetService writes text UUID to integer record_id column",
+    "updatedAt": "2026-04-15T02:53:53Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/181"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:59:47Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 180,
+    "state": "CLOSED",
+    "title": "[Notebooks][Bug] addEntry() does not set notebook_id — breaks direct lookups and badges",
+    "updatedAt": "2026-04-15T02:52:12Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/180"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:59:40Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbvw",
+        "name": "ui",
+        "description": "Needs iOS UI work (Xcode prompt)",
+        "color": "1D76DB"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 179,
+    "state": "CLOSED",
+    "title": "[Scheduling][Bug] Silently swallowed errors in dispatch/schedule creation sheets",
+    "updatedAt": "2026-04-15T04:20:53Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/179"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:59:27Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJAg",
+        "name": "performance",
+        "description": "N+1 queries, memory, rendering",
+        "color": "FEF2C0"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 178,
+    "state": "CLOSED",
+    "title": "[Performance][Bug] 15 inline NumberFormatter instances — same pattern as DateFormatter #146",
+    "updatedAt": "2026-04-15T03:47:35Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/178"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:59:18Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJAg",
+        "name": "performance",
+        "description": "N+1 queries, memory, rendering",
+        "color": "FEF2C0"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 177,
+    "state": "CLOSED",
+    "title": "[Performance][Bug] N+1 query pattern in procurement — 3 SQL queries per part in loop",
+    "updatedAt": "2026-04-15T02:54:55Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/177"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:59:10Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbTw",
+        "name": "security",
+        "description": "Security vulnerability",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 176,
+    "state": "CLOSED",
+    "title": "[Security][Bug] Sync status endpoint exposes device metadata without authentication",
+    "updatedAt": "2026-04-15T03:35:36Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/176"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:58:59Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI4A",
+        "name": "concurrency",
+        "description": "Race conditions, thread safety",
+        "color": "D4C5F9"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 175,
+    "state": "CLOSED",
+    "title": "[Sync][Bug] MultipeerManager onDataReceived can deadlock on syncQueue",
+    "updatedAt": "2026-04-15T02:53:54Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/175"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:58:52Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 174,
+    "state": "CLOSED",
+    "title": "[Sync][Bug] Delete-vs-update conflict: delete always wins silently, no conflict log",
+    "updatedAt": "2026-04-15T04:24:57Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/174"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:58:46Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACdTTbvw",
+        "name": "ui",
+        "description": "Needs iOS UI work (Xcode prompt)",
+        "color": "1D76DB"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 173,
+    "state": "CLOSED",
+    "title": "[UI][Bug] 3 nested sheet-from-sheet patterns — will glitch or fail to present on iOS",
+    "updatedAt": "2026-04-15T04:23:33Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/173"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:58:33Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 172,
+    "state": "CLOSED",
+    "title": "[Jobs][Bug] Clock-out does not deduct breaks or calculate overtime",
+    "updatedAt": "2026-04-15T02:52:12Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/172"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:58:26Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 171,
+    "state": "CLOSED",
+    "title": "[Orders][Bug] JPO/PO status transitions have no validation — any status can be set",
+    "updatedAt": "2026-04-13T06:33:18Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/171"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:58:20Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 170,
+    "state": "CLOSED",
+    "title": "[Scheduling][Bug] No double-booking detection — same employee dispatched to overlapping jobs",
+    "updatedAt": "2026-04-13T06:33:18Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/170"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:58:09Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 169,
+    "state": "CLOSED",
+    "title": "[Orders][Bug] PO status history records NEW status as old_status — audit trail broken",
+    "updatedAt": "2026-04-13T06:33:18Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/169"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:58:01Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 168,
+    "state": "CLOSED",
+    "title": "[Sync][Bug] ConflictResolver maps NULL to empty string — breaks soft-delete semantics",
+    "updatedAt": "2026-04-13T06:33:18Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/168"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:57:52Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 167,
+    "state": "CLOSED",
+    "title": "[Scheduling][Bug] Flex pool ignores team-level filter — all teams see restricted jobs",
+    "updatedAt": "2026-04-15T03:47:35Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/167"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:57:41Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 166,
+    "state": "CLOSED",
+    "title": "[Notebooks][Bug] Badge count unread query uses unreliable notebook_id JOIN — undercounts",
+    "updatedAt": "2026-04-15T04:11:11Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/166"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:57:33Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 165,
+    "state": "CLOSED",
+    "title": "[Tools][Bug] Badge count queries non-existent table tool_edit_log (should be tool_change_log)",
+    "updatedAt": "2026-04-15T02:52:12Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/165"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:57:26Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwI1A",
+        "name": "data-integrity",
+        "description": "SQL/schema/migration issues",
+        "color": "E99695"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACfHwJBg",
+        "name": "audit-2026-04",
+        "description": "Found during April 2026 full program audit",
+        "color": "C2E0C6"
+      }
+    ],
+    "number": 164,
+    "state": "CLOSED",
+    "title": "[Reports][Bug] Profitability report uses billing_rate for labor COST instead of pay_rate",
+    "updatedAt": "2026-04-15T02:52:12Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/164"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:40:04Z",
+    "labels": [],
+    "number": 163,
+    "state": "CLOSED",
+    "title": "[Parts][Feature] Free space rating UI — per-location 1-10 scale editor",
+    "updatedAt": "2026-04-18T16:17:48Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/163"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:40:00Z",
+    "labels": [],
+    "number": 162,
+    "state": "CLOSED",
+    "title": "[Parts][Feature] Forecast settings UI — per-location-type multiplier editor",
+    "updatedAt": "2026-04-18T16:17:47Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/162"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:20:44Z",
+    "labels": [],
+    "number": 161,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] LocationStockTarget model missing part_category and do_not_restock properties",
+    "updatedAt": "2026-04-13T05:27:50Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/161"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:20:38Z",
+    "labels": [],
+    "number": 160,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] CSV import duplicate detection silently fails on DB errors — creates duplicates",
+    "updatedAt": "2026-04-13T05:28:48Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/160"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:20:31Z",
+    "labels": [],
+    "number": 159,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] listCatalogParts missing type_name — catalog search results show no type",
+    "updatedAt": "2026-04-13T05:28:27Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/159"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:20:20Z",
+    "labels": [],
+    "number": 158,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] Stock queries use only legacy 'stock' table — miss stock_entries inventory",
+    "updatedAt": "2026-04-13T05:27:16Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/158"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:20:10Z",
+    "labels": [],
+    "number": 157,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] getHierarchy() ignores type_color_links — colors only show after parts exist",
+    "updatedAt": "2026-04-13T05:20:53Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/157"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T05:20:04Z",
+    "labels": [],
+    "number": 156,
+    "state": "CLOSED",
+    "title": "[Parts][Bug] BrandSupplierLink model missing carryStatus — carry status updates silently fail",
+    "updatedAt": "2026-04-13T05:20:51Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/156"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T03:23:30Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+        "name": "usability-hunter",
+        "description": "Behavioral usability bug found by usability-hunter scanner",
+        "color": "FF6B6B"
+      }
+    ],
+    "number": 155,
+    "state": "CLOSED",
+    "title": "[Usability] Scanner 1: DashboardDailyReportPage — ReportProblem/SubmitReport sheets missing interactiveDismissDisabled",
+    "updatedAt": "2026-04-13T05:11:07Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/155"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T03:23:23Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+        "name": "usability-hunter",
+        "description": "Behavioral usability bug found by usability-hunter scanner",
+        "color": "FF6B6B"
+      }
+    ],
+    "number": 154,
+    "state": "CLOSED",
+    "title": "[Usability] Scanner 1: IOSToolDetailPage — 7 action sheets missing interactiveDismissDisabled",
+    "updatedAt": "2026-04-13T05:11:07Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/154"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T03:23:18Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+        "name": "usability-hunter",
+        "description": "Behavioral usability bug found by usability-hunter scanner",
+        "color": "FF6B6B"
+      }
+    ],
+    "number": 153,
+    "state": "CLOSED",
+    "title": "[Usability] Scanner 1: IOSEstimationSettingsPage — Add/Edit sheets missing isSaving guard (duplicate question risk)",
+    "updatedAt": "2026-04-13T05:11:07Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/153"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T02:47:02Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 152,
+    "state": "CLOSED",
+    "title": "[Chat] IOSMessageThreadView: photo + reference picker buttons are dead (no sheets wired)",
+    "updatedAt": "2026-04-16T02:09:46Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/152"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-13T02:45:54Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      }
+    ],
+    "number": 151,
+    "state": "CLOSED",
+    "title": "[Bug] IOSMessageThreadView.handleAction(.markResolved) resolves wrong thread",
+    "updatedAt": "2026-04-13T03:05:11Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/151"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-12T17:14:44Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+        "name": "usability-hunter",
+        "description": "Behavioral usability bug found by usability-hunter scanner",
+        "color": "FF6B6B"
+      }
+    ],
+    "number": 150,
+    "state": "OPEN",
+    "title": "[Usability] Scanner 5a: Settings save buttons lack .disabled() validation guard",
+    "updatedAt": "2026-05-01T14:38:14Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/150"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-12T17:14:33Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+        "name": "usability-hunter",
+        "description": "Behavioral usability bug found by usability-hunter scanner",
+        "color": "FF6B6B"
+      }
+    ],
+    "number": 149,
+    "state": "CLOSED",
+    "title": "[Usability] Scanner 5b: ~30 pages missing keyboard dismiss (scrollDismissesKeyboard)",
+    "updatedAt": "2026-04-16T14:16:34Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/149"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-12T17:14:25Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+        "name": "usability-hunter",
+        "description": "Behavioral usability bug found by usability-hunter scanner",
+        "color": "FF6B6B"
+      }
+    ],
+    "number": 148,
+    "state": "CLOSED",
+    "title": "[Usability] Scanner 1: IOSMovementWizard missing Save & Exit button",
+    "updatedAt": "2026-04-18T05:40:34Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/148"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-12T06:33:14Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 147,
+    "state": "CLOSED",
+    "title": "[UX] Missing empty states: OfficeRouter, PricingBulkEditSheet, IOSDailyReportTemplatesPage",
+    "updatedAt": "2026-04-15T04:41:37Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/147"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-12T06:33:07Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 146,
+    "state": "CLOSED",
+    "title": "[Performance] Formatters.swift is dead code — 99 inline DateFormatter() instantiations",
+    "updatedAt": "2026-04-16T14:24:12Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/146"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-12T06:32:53Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 145,
+    "state": "CLOSED",
+    "title": "[UX] Chat thread view missing pull-to-refresh",
+    "updatedAt": "2026-04-13T03:05:13Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/145"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-12T06:29:33Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUQA",
+        "name": "enhancement",
+        "description": "New feature or request",
+        "color": "a2eeef"
+      }
+    ],
+    "number": 144,
+    "state": "CLOSED",
+    "title": "[Parts] Color-level part numbers needed — manufacturer/brand part number, not supplier-locked",
+    "updatedAt": "2026-04-18T17:30:23Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/144"
+  },
+  {
+    "assignees": [],
+    "author": {
+      "id": "MDQ6VXNlcjM3OTU5OTU2",
+      "is_bot": false,
+      "login": "xXKillerNoobYT",
+      "name": ""
+    },
+    "createdAt": "2026-04-11T04:49:14Z",
+    "labels": [
+      {
+        "id": "LA_kwDORWW5g88AAAACY_kUMg",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "d73a4a"
+      },
+      {
+        "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+        "name": "usability-hunter",
+        "description": "Behavioral usability bug found by usability-hunter scanner",
+        "color": "FF6B6B"
+      }
+    ],
+    "number": 143,
+    "state": "CLOSED",
+    "title": "[Usability] Scanner 1: 30+ sheets missing interactiveDismissDisabled (Settings, People, Chat)",
+    "updatedAt": "2026-04-20T03:21:08Z",
+    "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/143"
+  }
+]

--- a/docs/github-issue-sync/2026-05-12T05-06-08Z/summary.md
+++ b/docs/github-issue-sync/2026-05-12T05-06-08Z/summary.md
@@ -1,0 +1,33 @@
+# GitHub Issue Sync Snapshot
+
+- Repository: `xXKillerNoobYT/Weird-Part-Run-2`
+- Run timestamp (UTC): `2026-05-12T05:06:08Z`
+- Source issue: `WEI-44`
+- Requested state: `all`
+- Issues (non-PR): `200`
+- Open issues: `54`
+- Closed issues: `146`
+- Raw data: `issues.json`
+
+## Top 20 Recently Updated
+
+- #372 [OPEN]: Paperclip/GitHub sync tracker for active WEI execution (updated 2026-05-12T05:04:14Z)
+- #345 [CLOSED]: [Cross-Cutting][T1][Bug] LEFT JOIN NULL propagation candidates in 5 services — 10 SQL queries need owner triage (updated 2026-05-12T04:57:28Z)
+- #319 [CLOSED]: [Security][DB] Implement SQLCipher whole-DB encryption (closes CodeQL #1-#15) (updated 2026-05-11T12:36:37Z)
+- #273 [CLOSED]: [Tools][Perf] getToolsStats checkedOut uses O(n²) correlated NOT EXISTS on unindexed tool_movements (updated 2026-05-11T09:31:47Z)
+- #280 [CLOSED]: [Fleet][Security] Vehicle write paths lack permission/hat checks at UI layer (updated 2026-05-11T05:11:34Z)
+- #355 [CLOSED]: [Scheduling][T2][Bug] createDispatch doesn't check time-off conflicts at service layer (UI-only enforcement) (updated 2026-05-11T02:32:19Z)
+- #351 [CLOSED]: [Inventory][T2][Tests] 5 critical PartsService recommendation-pipeline methods have zero tests (updated 2026-05-11T02:07:45Z)
+- #370 [OPEN]: [Scheduling][T2][Bug] checkTimeOffConflict returns PENDING requests as conflicts (missing is_approved=1 filter) (updated 2026-05-09T05:21:18Z)
+- #368 [OPEN]: [Cross-Cutting][T2][Bug-Umbrella] 35 service mutation methods lack permission gates (service-permission-gate-scanner output) (updated 2026-05-09T05:21:13Z)
+- #371 [OPEN]: [Orders][T2][Bug] generatePOFromJPO doesn't update jpo_line_items.line_status — two PO-generation paths produce inconsistent per-line state (updated 2026-05-09T05:21:13Z)
+- #369 [OPEN]: [Warehouse][T2][Bug] movement_type values are stringly-typed across UI + service + queries — no canonical constants, forecasting depends on 'consume' string only (updated 2026-05-06T20:28:49Z)
+- #359 [OPEN]: [Tools][T2][Bug] expireOldTrades + updateConfidenceScores not auto-scheduled — only run when iOS detail page opened (updated 2026-05-06T20:00:48Z)
+- #367 [OPEN]: [Parts][T2][Bug] approveRecommendation + dismissRecommendation lack permission gates (sister to #355/#363/#364) (updated 2026-05-06T19:29:58Z)
+- #366 [OPEN]: [Cross-Cutting][T1][Security] hasPermission doesn't check user.deleted_at — soft-deleted users retain all hat permissions (updated 2026-05-06T19:26:00Z)
+- #365 [OPEN]: [Settings][T2][Bug] upsertSettingsMap is non-atomic — partial save on mid-loop failure leaves inconsistent state (updated 2026-05-06T18:57:07Z)
+- #364 [OPEN]: [Chat][T2][Bug] sendMessage doesn't check channel membership — read-side filters, write-side wide open (read-write asymmetry) (updated 2026-05-06T18:28:14Z)
+- #363 [OPEN]: [Notebooks][T2][Bug] Classification methods lack permission gates + can leak orphan history rows for soft-deleted entries (updated 2026-05-06T18:25:11Z)
+- #362 [OPEN]: [Reports][T2][Bug] getPreBillingData ignores billing_periods.locked_at — returns labor from locked periods (updated 2026-05-06T17:56:53Z)
+- #361 [OPEN]: [Inventory][T2][Bug] Wishlist sendToProcurement is a dead-end status — no consumer reads sent_to_procurement items (updated 2026-05-06T17:28:32Z)
+- #360 [OPEN]: [Fleet][T2][Bug] assignDriver doesn't deactivate existing active assignments — vehicle/user can have multiple active rows (updated 2026-05-06T17:25:06Z)

--- a/docs/github-issue-sync/README.md
+++ b/docs/github-issue-sync/README.md
@@ -1,0 +1,30 @@
+# GitHub Issue Sync Contract
+
+Owner: `CTO`  
+Backup owner: `CodexEngineer1`
+
+## Cadence
+- Standard cadence: Monday/Wednesday/Friday at 09:00 America/Denver.
+- Manual fallback: run before triage sessions and before WEI status rollups.
+
+## Command
+```bash
+scripts/github-issue-sync.sh --state all
+```
+
+The default state is `all`, so the snapshot validates both open and closed GitHub issue paths. Use `--state open` or `--state closed` only for targeted diagnostics.
+
+## Canonical Consumer Artifacts
+- `docs/github-issue-sync/latest-sync.md`
+- `docs/github-issue-sync/latest-sync.json`
+
+## Per-run Archive
+- `docs/github-issue-sync/<UTC timestamp>/summary.md`
+- `docs/github-issue-sync/<UTC timestamp>/issues.json`
+
+## Verification
+```bash
+test -s docs/github-issue-sync/latest-sync.md && test -s docs/github-issue-sync/latest-sync.json
+```
+
+If either canonical artifact is missing/empty, the run is considered failed.

--- a/docs/github-issue-sync/README.md
+++ b/docs/github-issue-sync/README.md
@@ -1,6 +1,6 @@
 # GitHub Issue Sync Contract
 
-Owner: `CTO`  
+Owner: `CTO`
 Backup owner: `CodexEngineer1`
 
 ## Cadence

--- a/docs/github-issue-sync/latest-sync.json
+++ b/docs/github-issue-sync/latest-sync.json
@@ -1,0 +1,5708 @@
+{
+  "repository": "xXKillerNoobYT/Weird-Part-Run-2",
+  "runTimestampUtc": "2026-05-12T05:06:08Z",
+  "sourceIssue": "WEI-44",
+  "requestedState": "all",
+  "openIssueCount": 54,
+  "issueCount": 200,
+  "openCount": 54,
+  "closedCount": 146,
+  "runDir": "docs/github-issue-sync/2026-05-12T05-06-08Z",
+  "issues": [
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-08T23:10:06Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 372,
+      "state": "OPEN",
+      "title": "Paperclip/GitHub sync tracker for active WEI execution",
+      "updatedAt": "2026-05-12T05:04:14Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/372"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T21:24:22Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 371,
+      "state": "OPEN",
+      "title": "[Orders][T2][Bug] generatePOFromJPO doesn't update jpo_line_items.line_status — two PO-generation paths produce inconsistent per-line state",
+      "updatedAt": "2026-05-09T05:21:13Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/371"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T20:56:08Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 370,
+      "state": "OPEN",
+      "title": "[Scheduling][T2][Bug] checkTimeOffConflict returns PENDING requests as conflicts (missing is_approved=1 filter)",
+      "updatedAt": "2026-05-09T05:21:18Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/370"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T20:27:53Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 369,
+      "state": "OPEN",
+      "title": "[Warehouse][T2][Bug] movement_type values are stringly-typed across UI + service + queries — no canonical constants, forecasting depends on 'consume' string only",
+      "updatedAt": "2026-05-06T20:28:49Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/369"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T19:31:42Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 368,
+      "state": "OPEN",
+      "title": "[Cross-Cutting][T2][Bug-Umbrella] 35 service mutation methods lack permission gates (service-permission-gate-scanner output)",
+      "updatedAt": "2026-05-09T05:21:13Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/368"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T19:29:19Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 367,
+      "state": "OPEN",
+      "title": "[Parts][T2][Bug] approveRecommendation + dismissRecommendation lack permission gates (sister to #355/#363/#364)",
+      "updatedAt": "2026-05-06T19:29:58Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/367"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T19:24:57Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcTw",
+          "name": "priority:P1",
+          "description": "High — next sprint",
+          "color": "e11d48"
+        }
+      ],
+      "number": 366,
+      "state": "OPEN",
+      "title": "[Cross-Cutting][T1][Security] hasPermission doesn't check user.deleted_at — soft-deleted users retain all hat permissions",
+      "updatedAt": "2026-05-06T19:26:00Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/366"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T18:56:14Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 365,
+      "state": "OPEN",
+      "title": "[Settings][T2][Bug] upsertSettingsMap is non-atomic — partial save on mid-loop failure leaves inconsistent state",
+      "updatedAt": "2026-05-06T18:57:07Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/365"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T18:27:15Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 364,
+      "state": "OPEN",
+      "title": "[Chat][T2][Bug] sendMessage doesn't check channel membership — read-side filters, write-side wide open (read-write asymmetry)",
+      "updatedAt": "2026-05-06T18:28:14Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/364"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T18:24:14Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 363,
+      "state": "OPEN",
+      "title": "[Notebooks][T2][Bug] Classification methods lack permission gates + can leak orphan history rows for soft-deleted entries",
+      "updatedAt": "2026-05-06T18:25:11Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/363"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T17:56:05Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 362,
+      "state": "OPEN",
+      "title": "[Reports][T2][Bug] getPreBillingData ignores billing_periods.locked_at — returns labor from locked periods",
+      "updatedAt": "2026-05-06T17:56:53Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/362"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T17:27:35Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 361,
+      "state": "OPEN",
+      "title": "[Inventory][T2][Bug] Wishlist sendToProcurement is a dead-end status — no consumer reads sent_to_procurement items",
+      "updatedAt": "2026-05-06T17:28:32Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/361"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T17:24:15Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 360,
+      "state": "OPEN",
+      "title": "[Fleet][T2][Bug] assignDriver doesn't deactivate existing active assignments — vehicle/user can have multiple active rows",
+      "updatedAt": "2026-05-06T17:25:06Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/360"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T16:55:24Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 359,
+      "state": "OPEN",
+      "title": "[Tools][T2][Bug] expireOldTrades + updateConfidenceScores not auto-scheduled — only run when iOS detail page opened",
+      "updatedAt": "2026-05-06T20:00:48Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/359"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T16:27:13Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 358,
+      "state": "OPEN",
+      "title": "[People][T2][Bug] getExpiringCertifications excludes already-expired certs (regulatory compliance risk)",
+      "updatedAt": "2026-05-06T16:27:51Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/358"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T16:05:05Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 357,
+      "state": "OPEN",
+      "title": "[Orders][T2][Plan-Drift] PO state machine has 5 statuses in code but plan says 7; 'cancelled' + 'submitted' referenced by queries but absent from validPOTransitions",
+      "updatedAt": "2026-05-06T16:05:49Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/357"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T15:34:43Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 355,
+      "state": "CLOSED",
+      "title": "[Scheduling][T2][Bug] createDispatch doesn't check time-off conflicts at service layer (UI-only enforcement)",
+      "updatedAt": "2026-05-11T02:32:19Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/355"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T14:58:34Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 354,
+      "state": "OPEN",
+      "title": "[Warehouse][T2][Bug] adjustAuditCount writes newQty (absolute) instead of delta to stock_movements.qty",
+      "updatedAt": "2026-05-06T14:58:34Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/354"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T14:29:09Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 353,
+      "state": "OPEN",
+      "title": "[Jobs][T2][Bug] Overtime threshold applied per-labor-entry not per-day — under-counts OT when worker switches jobs",
+      "updatedAt": "2026-05-06T14:29:09Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/353"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-06T14:01:09Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 351,
+      "state": "CLOSED",
+      "title": "[Inventory][T2][Tests] 5 critical PartsService recommendation-pipeline methods have zero tests",
+      "updatedAt": "2026-05-11T02:07:45Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/351"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-05-01T22:38:56Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 347,
+      "state": "OPEN",
+      "title": "[Cross-Cutting][T2][Bug] IOSMainView root chain has 2 .sheet(isPresented:) modifiers — SwiftUI silent-dismissal pattern",
+      "updatedAt": "2026-05-01T22:38:56Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/347"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-30T14:45:37Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcTw",
+          "name": "priority:P1",
+          "description": "High — next sprint",
+          "color": "e11d48"
+        }
+      ],
+      "number": 345,
+      "state": "CLOSED",
+      "title": "[Cross-Cutting][T1][Bug] LEFT JOIN NULL propagation candidates in 5 services — 10 SQL queries need owner triage",
+      "updatedAt": "2026-05-12T04:57:28Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/345"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-30T14:44:51Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcTw",
+          "name": "priority:P1",
+          "description": "High — next sprint",
+          "color": "e11d48"
+        }
+      ],
+      "number": 344,
+      "state": "CLOSED",
+      "title": "[Parts][T1][Bug] GRDB Int? boolean fields inserted as NULL bypassing SQL DEFAULT (3 instances)",
+      "updatedAt": "2026-04-30T18:41:08Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/344"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-30T10:43:49Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbTw",
+          "name": "security",
+          "description": "Security vulnerability",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcTw",
+          "name": "priority:P1",
+          "description": "High — next sprint",
+          "color": "e11d48"
+        }
+      ],
+      "number": 342,
+      "state": "CLOSED",
+      "title": "[Inventory][T1][Security] WishlistService.processAutoApprovals accepts free-form approver, no permission check",
+      "updatedAt": "2026-04-30T14:41:15Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/342"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-30T06:45:08Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcgw",
+          "name": "priority:P3",
+          "description": "Low / backburner",
+          "color": "6b7280"
+        }
+      ],
+      "number": 340,
+      "state": "CLOSED",
+      "title": "[Cross-Cutting][T3][Perf] Render-perf scanner discoveries: first(where:) + filter().count in 4 view-builder contexts",
+      "updatedAt": "2026-04-30T10:41:08Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/340"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-30T02:43:48Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcgw",
+          "name": "priority:P3",
+          "description": "Low / backburner",
+          "color": "6b7280"
+        }
+      ],
+      "number": 338,
+      "state": "CLOSED",
+      "title": "[Reports][T3][Perf] Render-perf bundle: filter().count + uncached DateFormatter creations across 3 report pages",
+      "updatedAt": "2026-04-30T06:41:20Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/338"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-27T14:18:47Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcgw",
+          "name": "priority:P3",
+          "description": "Low / backburner",
+          "color": "6b7280"
+        }
+      ],
+      "number": 330,
+      "state": "OPEN",
+      "title": "[Inventory][T3][Perf] OrdersService.getProcurementDemand groups in Swift instead of SQL",
+      "updatedAt": "2026-04-27T14:18:47Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/330"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-27T14:18:30Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 329,
+      "state": "CLOSED",
+      "title": "[Inventory][T2][Perf] Wishlist full re-fetch + re-section on every user interaction",
+      "updatedAt": "2026-04-29T22:44:10Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/329"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-27T14:18:09Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 328,
+      "state": "CLOSED",
+      "title": "[Inventory][T2][Perf] Repeated in-Swift filter/count scans on every render across 4 inventory pages",
+      "updatedAt": "2026-04-29T18:52:52Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/328"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-27T12:44:16Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbTw",
+          "name": "security",
+          "description": "Security vulnerability",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcTw",
+          "name": "priority:P1",
+          "description": "High — next sprint",
+          "color": "e11d48"
+        }
+      ],
+      "number": 327,
+      "state": "CLOSED",
+      "title": "[Inventory][T1][Security] Wishlist state-mutation methods accept arbitrary identifiers, no permission check",
+      "updatedAt": "2026-04-29T17:32:31Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/327"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-27T12:15:02Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcgw",
+          "name": "priority:P3",
+          "description": "Low / backburner",
+          "color": "6b7280"
+        }
+      ],
+      "number": 326,
+      "state": "CLOSED",
+      "title": "[Inventory][T3] Haptic feedback missing on inventory state-changing actions",
+      "updatedAt": "2026-04-30T02:41:04Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/326"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-27T12:14:45Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 325,
+      "state": "CLOSED",
+      "title": "[Inventory][T2] Missing pre-action confirmations on bulk-irreversible procurement ops",
+      "updatedAt": "2026-04-29T18:45:28Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/325"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-27T10:16:43Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 324,
+      "state": "CLOSED",
+      "title": "[Inventory][T2] Dismiss-Safety: 3 inventory sheets missing isDirty + confirmation",
+      "updatedAt": "2026-04-29T18:41:35Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/324"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-27T04:51:36Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 323,
+      "state": "OPEN",
+      "title": "[Orders][T2][Plan-Drift] Supplier-lock-per-job for generic parts not implemented (Part F CONFIRMED)",
+      "updatedAt": "2026-04-27T04:51:36Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/323"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-27T04:40:16Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 322,
+      "state": "CLOSED",
+      "title": "[Infra][T2] Add .github/copilot-instructions.md so Copilot Coding Agent reads project conventions without per-issue restatement",
+      "updatedAt": "2026-04-29T17:27:06Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/322"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-26T00:59:28Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbTw",
+          "name": "security",
+          "description": "Security vulnerability",
+          "color": "B60205"
+        }
+      ],
+      "number": 319,
+      "state": "CLOSED",
+      "title": "[Security][DB] Implement SQLCipher whole-DB encryption (closes CodeQL #1-#15)",
+      "updatedAt": "2026-05-11T12:36:37Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/319"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-26T00:50:53Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 317,
+      "state": "OPEN",
+      "title": "[Fleet][Perf] IOSMyTruckPage loadData fires 6 sequential DB calls — could be 2 with batching",
+      "updatedAt": "2026-04-26T01:24:25Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/317"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-26T00:50:35Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 316,
+      "state": "OPEN",
+      "title": "[Fleet][Perf] IOSVehiclesPage countForStatus() iterates allVehicles 5× per render; status filter done in Swift not SQL",
+      "updatedAt": "2026-04-26T01:24:24Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/316"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-26T00:50:18Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 315,
+      "state": "OPEN",
+      "title": "[Fleet][Perf] DateFormatter created per-render in IOSFleetDashboardPage.todayString and per-load in 3 Fleet list pages",
+      "updatedAt": "2026-04-26T01:24:23Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/315"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-26T00:49:58Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 314,
+      "state": "OPEN",
+      "title": "[Fleet][Perf] vehicle_location_logs table has no index — listTelematicsData GROUP BY subquery is a full table scan",
+      "updatedAt": "2026-04-26T01:24:22Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/314"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-26T00:49:45Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 313,
+      "state": "OPEN",
+      "title": "[Fleet][Perf] Missing compound index on inspection_records(vehicle_id, performed_at) hurts dashboard correlated subquery",
+      "updatedAt": "2026-04-26T01:24:20Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/313"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-26T00:49:32Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 312,
+      "state": "OPEN",
+      "title": "[Fleet][Perf] getFleetDashboardStats fires 8 separate DB round-trips — consolidate to 1-2 queries",
+      "updatedAt": "2026-04-26T01:24:19Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/312"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-26T00:42:45Z",
+      "labels": [],
+      "number": 311,
+      "state": "CLOSED",
+      "title": "[Security][Refactor] Unify sensitive-field encryption across services (consolidates CodeQL #1-#15)",
+      "updatedAt": "2026-04-26T00:58:48Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/311"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:57:17Z",
+      "labels": [],
+      "number": 310,
+      "state": "OPEN",
+      "title": "#21",
+      "updatedAt": "2026-04-25T23:57:17Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/310"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:56:50Z",
+      "labels": [],
+      "number": 309,
+      "state": "OPEN",
+      "title": "#20",
+      "updatedAt": "2026-04-25T23:56:50Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/309"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:56:24Z",
+      "labels": [],
+      "number": 308,
+      "state": "OPEN",
+      "title": "#19",
+      "updatedAt": "2026-04-25T23:56:24Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/308"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:56:00Z",
+      "labels": [],
+      "number": 307,
+      "state": "OPEN",
+      "title": "#18",
+      "updatedAt": "2026-04-25T23:56:00Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/307"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:53:28Z",
+      "labels": [],
+      "number": 305,
+      "state": "CLOSED",
+      "title": "#17",
+      "updatedAt": "2026-04-25T23:59:12Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/305"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:53:00Z",
+      "labels": [],
+      "number": 304,
+      "state": "CLOSED",
+      "title": "#16",
+      "updatedAt": "2026-04-25T23:59:10Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/304"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:52:26Z",
+      "labels": [],
+      "number": 303,
+      "state": "OPEN",
+      "title": "#15",
+      "updatedAt": "2026-04-26T00:52:26Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/303"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:51:52Z",
+      "labels": [],
+      "number": 302,
+      "state": "CLOSED",
+      "title": "#14",
+      "updatedAt": "2026-04-25T23:59:08Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/302"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:51:11Z",
+      "labels": [],
+      "number": 300,
+      "state": "CLOSED",
+      "title": "#13",
+      "updatedAt": "2026-04-25T23:59:14Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/300"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:48:27Z",
+      "labels": [],
+      "number": 298,
+      "state": "OPEN",
+      "title": "#9",
+      "updatedAt": "2026-04-26T00:52:25Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/298"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:47:39Z",
+      "labels": [],
+      "number": 296,
+      "state": "OPEN",
+      "title": "#7",
+      "updatedAt": "2026-04-26T00:52:24Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/296"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:46:49Z",
+      "labels": [],
+      "number": 294,
+      "state": "OPEN",
+      "title": "#6",
+      "updatedAt": "2026-04-26T00:52:23Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/294"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:46:04Z",
+      "labels": [],
+      "number": 292,
+      "state": "OPEN",
+      "title": "#5",
+      "updatedAt": "2026-04-26T00:52:22Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/292"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:45:20Z",
+      "labels": [],
+      "number": 291,
+      "state": "CLOSED",
+      "title": "#4",
+      "updatedAt": "2026-04-25T23:59:06Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/291"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:43:59Z",
+      "labels": [],
+      "number": 289,
+      "state": "CLOSED",
+      "title": "#3",
+      "updatedAt": "2026-04-25T23:59:04Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/289"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:43:34Z",
+      "labels": [],
+      "number": 288,
+      "state": "CLOSED",
+      "title": "#2",
+      "updatedAt": "2026-04-25T23:59:02Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/288"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T23:42:31Z",
+      "labels": [],
+      "number": 287,
+      "state": "CLOSED",
+      "title": "#1",
+      "updatedAt": "2026-04-25T23:59:00Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/287"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T18:46:18Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbTw",
+          "name": "security",
+          "description": "Security vulnerability",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcgw",
+          "name": "priority:P3",
+          "description": "Low / backburner",
+          "color": "6b7280"
+        }
+      ],
+      "number": 282,
+      "state": "CLOSED",
+      "title": "[Fleet][T3] Defense-in-depth hygiene batch — recordedBy FK, free-text caps, userFriendlyError audit",
+      "updatedAt": "2026-04-27T05:56:55Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/282"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T17:54:07Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 281,
+      "state": "OPEN",
+      "title": "[Fleet][HIG] Inspection-status uses literal .red/.green instead of semantic asset colors",
+      "updatedAt": "2026-04-26T01:24:17Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/281"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T17:53:53Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 280,
+      "state": "CLOSED",
+      "title": "[Fleet][Security] Vehicle write paths lack permission/hat checks at UI layer",
+      "updatedAt": "2026-05-11T05:11:34Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/280"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T17:53:53Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 279,
+      "state": "OPEN",
+      "title": "[Fleet][UX] isLoading double-duty antipattern repeated across 6 list pages",
+      "updatedAt": "2026-04-26T01:24:15Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/279"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T17:21:04Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 278,
+      "state": "OPEN",
+      "title": "[Fleet][UX] Polish batch — presentationDetents, trailer-from-truck nav, search empty states",
+      "updatedAt": "2026-04-26T01:24:14Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/278"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T17:20:51Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 277,
+      "state": "CLOSED",
+      "title": "[Fleet][Bug] ReportVehicleIssueSheet Submit button is a no-op (no service call)",
+      "updatedAt": "2026-04-25T23:17:51Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/277"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T17:20:42Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 276,
+      "state": "CLOSED",
+      "title": "[Fleet][Bug] Date-range filter ignored on Fuel/Mileage/Maintenance pages",
+      "updatedAt": "2026-04-25T23:45:26Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/276"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T15:27:11Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 275,
+      "state": "CLOSED",
+      "title": "[Fleet][T3] FleetService isActive default in VehicleDetail hydration silently treats NULL as active",
+      "updatedAt": "2026-04-25T23:39:52Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/275"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T05:54:39Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJAg",
+          "name": "performance",
+          "description": "N+1 queries, memory, rendering",
+          "color": "FEF2C0"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcgw",
+          "name": "priority:P3",
+          "description": "Low / backburner",
+          "color": "6b7280"
+        }
+      ],
+      "number": 274,
+      "state": "OPEN",
+      "title": "[Tools][Perf] IOSToolsDashboardPage loads all checkouts unbounded — listCheckouts has no LIMIT",
+      "updatedAt": "2026-04-25T12:09:31Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/274"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T05:54:26Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJAg",
+          "name": "performance",
+          "description": "N+1 queries, memory, rendering",
+          "color": "FEF2C0"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 273,
+      "state": "CLOSED",
+      "title": "[Tools][Perf] getToolsStats checkedOut uses O(n²) correlated NOT EXISTS on unindexed tool_movements",
+      "updatedAt": "2026-05-11T09:31:47Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/273"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T05:47:12Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbTw",
+          "name": "security",
+          "description": "Security vulnerability",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcgw",
+          "name": "priority:P3",
+          "description": "Low / backburner",
+          "color": "6b7280"
+        }
+      ],
+      "number": 272,
+      "state": "CLOSED",
+      "title": "[Tools][Security] markToolMaintenance has no caller identity parameter — untraceable in audit log",
+      "updatedAt": "2026-04-25T23:53:35Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/272"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T05:47:06Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbTw",
+          "name": "security",
+          "description": "Security vulnerability",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACgkAcZw",
+          "name": "priority:P2",
+          "description": "Medium — planned",
+          "color": "f97316"
+        }
+      ],
+      "number": 271,
+      "state": "CLOSED",
+      "title": "[Tools][Security] respondToTrade has no service-level recipient check — UI-only gate",
+      "updatedAt": "2026-04-25T23:49:40Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/271"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T05:38:52Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 270,
+      "state": "CLOSED",
+      "title": "[Tools][P2] Duplicate formatDate() in Tools pages — Formatters.formatDateString already exists",
+      "updatedAt": "2026-04-25T23:54:39Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/270"
+    },
+    {
+      "assignees": [
+        {
+          "id": "MDQ6VXNlcjM3OTU5OTU2",
+          "login": "xXKillerNoobYT",
+          "name": "",
+          "databaseId": 37959956
+        },
+        {
+          "id": "BOT_kgDOC9w8XQ",
+          "login": "Copilot",
+          "name": "",
+          "databaseId": 198982749
+        }
+      ],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T05:38:43Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 269,
+      "state": "CLOSED",
+      "title": "[Tools][P1] loadData() blocks main thread in 6 pages",
+      "updatedAt": "2026-05-06T11:30:50Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/269"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-25T05:31:03Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+          "name": "usability-hunter",
+          "description": "Behavioral usability bug found by usability-hunter scanner",
+          "color": "FF6B6B"
+        }
+      ],
+      "number": 268,
+      "state": "OPEN",
+      "title": "[Tools][UX] Tools sheets missing .presentationDetents (7 pages)",
+      "updatedAt": "2026-04-25T12:09:26Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/268"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-20T00:56:52Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbvw",
+          "name": "ui",
+          "description": "Needs iOS UI work (Xcode prompt)",
+          "color": "1D76DB"
+        }
+      ],
+      "number": 267,
+      "state": "CLOSED",
+      "title": "[Orders][UX] Missing .accessibilityHidden on decorative icons (~29 remaining locations)",
+      "updatedAt": "2026-04-20T03:14:55Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/267"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-20T00:35:45Z",
+      "labels": [],
+      "number": 266,
+      "state": "CLOSED",
+      "title": "[Warehouse][UX] Missing .accessibilityHidden on decorative icons (~68 locations)",
+      "updatedAt": "2026-04-20T01:46:42Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/266"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-19T23:02:52Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 265,
+      "state": "CLOSED",
+      "title": "[Chat][Performance] Debounce search in IOSQuestionsPage to avoid per-keystroke DB calls",
+      "updatedAt": "2026-04-19T23:03:01Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/265"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-19T23:02:47Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 264,
+      "state": "CLOSED",
+      "title": "[Chat][UX] Add confirmation dialog before escalating a Q&A thread",
+      "updatedAt": "2026-04-20T03:15:57Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/264"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-19T22:07:53Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 263,
+      "state": "CLOSED",
+      "title": "[Inventory][Performance] Add composite index on stock_movements(part_id, created_at, movement_type)",
+      "updatedAt": "2026-04-20T01:35:20Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/263"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-19T22:03:06Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 262,
+      "state": "CLOSED",
+      "title": "[Parts][Enhancement] Extract duplicated urgency filter logic in PartsForecastingPage",
+      "updatedAt": "2026-04-20T03:06:43Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/262"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-19T19:49:55Z",
+      "labels": [],
+      "number": 261,
+      "state": "CLOSED",
+      "title": "[Scheduling][Performance] getLongTermTimeline N+1: 72 queries per call (36 months × 2)",
+      "updatedAt": "2026-04-19T21:06:08Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/261"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-19T19:20:04Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 260,
+      "state": "CLOSED",
+      "title": "[Warehouse][Enhancement] IOSAuditPage confidence data loaded via 11 separate queries",
+      "updatedAt": "2026-04-19T21:34:17Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/260"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-19T19:19:53Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 259,
+      "state": "CLOSED",
+      "title": "[Warehouse][Bug] Movement Wizard batch execution lacks transaction atomicity",
+      "updatedAt": "2026-04-19T19:38:12Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/259"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-19T14:02:56Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 258,
+      "state": "OPEN",
+      "title": "[Settings][Sync] SettingsService needs SyncScope filtering when sync is implemented",
+      "updatedAt": "2026-05-01T14:38:13Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/258"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-18T23:17:31Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 257,
+      "state": "CLOSED",
+      "title": "[Docs][Hygiene] CLAUDE.md architecture section describes dual-platform Tauri/React that no longer exists",
+      "updatedAt": "2026-04-19T08:51:39Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/257"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-18T20:19:14Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 256,
+      "state": "OPEN",
+      "title": "[Automation][Subagent] parts-drift-detector — plan-vs-code drift report for C1b check",
+      "updatedAt": "2026-04-18T20:19:14Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/256"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-18T20:19:03Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 255,
+      "state": "CLOSED",
+      "title": "[Automation][Hook] PartsService SQL column validator — PostToolUse grep for known-bad column patterns",
+      "updatedAt": "2026-04-18T20:56:15Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/255"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-18T20:18:55Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 254,
+      "state": "CLOSED",
+      "title": "[Automation][Skill] parts-sql-schema-checker — cross-ref PartsService SQL against migration schema",
+      "updatedAt": "2026-04-18T20:22:43Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/254"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-18T20:17:25Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 253,
+      "state": "CLOSED",
+      "title": "[Parts][UI] Complete C7 usability audit — all 8 scanners on all 24 parts iOS files",
+      "updatedAt": "2026-04-20T00:02:30Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/253"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-18T20:09:50Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 252,
+      "state": "CLOSED",
+      "title": "[Tools][Bug] Compile warning: redundant #require (ToolsServiceTests.swift:1217)",
+      "updatedAt": "2026-04-19T04:00:32Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/252"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-18T20:09:44Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 251,
+      "state": "CLOSED",
+      "title": "[Scheduling][Bug] Compile warnings: 'is' test always true (SchedulingServiceTests.swift:2489-2491)",
+      "updatedAt": "2026-04-19T02:57:26Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/251"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-18T19:50:39Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 250,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] recordCompanionFeedback: companion_feedback log entry silently skipped — suggestion_id FK prevents logging",
+      "updatedAt": "2026-04-19T04:12:23Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/250"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-18T05:47:36Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbvw",
+          "name": "ui",
+          "description": "Needs iOS UI work (Xcode prompt)",
+          "color": "1D76DB"
+        }
+      ],
+      "number": 249,
+      "state": "OPEN",
+      "title": "[UX] Missing .refreshable on IOSFlexPoolPage, ReceivingRoutingFlow, CreateChannelSheet",
+      "updatedAt": "2026-05-06T07:27:50Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/249"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-18T05:47:31Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbvw",
+          "name": "ui",
+          "description": "Needs iOS UI work (Xcode prompt)",
+          "color": "1D76DB"
+        }
+      ],
+      "number": 248,
+      "state": "OPEN",
+      "title": "[HIG][UX] Missing .presentationDetents on ~160 sheet call sites app-wide",
+      "updatedAt": "2026-04-18T21:53:28Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/248"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-18T05:47:19Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbTw",
+          "name": "security",
+          "description": "Security vulnerability",
+          "color": "B60205"
+        }
+      ],
+      "number": 247,
+      "state": "CLOSED",
+      "title": "[Security][Sync] LAN sync HTTP missing NSAllowsLocalNetworking ATS exemption + MITM exposure",
+      "updatedAt": "2026-04-18T16:21:12Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/247"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-18T05:47:07Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbZQ",
+          "name": "accessibility",
+          "description": "Apple HIG / accessibility issue",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbvw",
+          "name": "ui",
+          "description": "Needs iOS UI work (Xcode prompt)",
+          "color": "1D76DB"
+        }
+      ],
+      "number": 246,
+      "state": "CLOSED",
+      "title": "[HIG][Accessibility] Sub-44pt tap targets in color pickers and schedule config",
+      "updatedAt": "2026-04-20T00:39:54Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/246"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-18T05:41:59Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 245,
+      "state": "CLOSED",
+      "title": "[Usability][#143] EditEmployeeContactSheet uses wrong dismiss predicate — isSaving not isDirty",
+      "updatedAt": "2026-04-18T06:23:34Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/245"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-16T04:20:05Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+          "name": "usability-hunter",
+          "description": "Behavioral usability bug found by usability-hunter scanner",
+          "color": "FF6B6B"
+        }
+      ],
+      "number": 244,
+      "state": "CLOSED",
+      "title": "[Usability] Scanner 3: IOSDailyReportTemplatesPage saveSettings() has no success feedback",
+      "updatedAt": "2026-04-16T14:27:00Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/244"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T04:57:12Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbvw",
+          "name": "ui",
+          "description": "Needs iOS UI work (Xcode prompt)",
+          "color": "1D76DB"
+        }
+      ],
+      "number": 243,
+      "state": "OPEN",
+      "title": "[Orders][#98-10] Phase 3 UI — IOSPOCreationPage resolved-brand pill + wiring",
+      "updatedAt": "2026-04-15T04:57:12Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/243"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T04:56:57Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbvw",
+          "name": "ui",
+          "description": "Needs iOS UI work (Xcode prompt)",
+          "color": "1D76DB"
+        }
+      ],
+      "number": 242,
+      "state": "OPEN",
+      "title": "[Orders][#98-9] Phase 3 UI — IOSJPOCreationPage General/Specific toggle",
+      "updatedAt": "2026-04-15T04:56:57Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/242"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T04:56:42Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 241,
+      "state": "CLOSED",
+      "title": "[Orders][#98-8] Phase 3 service — OrdersService.resolveGeneralLineItem",
+      "updatedAt": "2026-04-18T06:20:12Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/241"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T04:56:27Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbvw",
+          "name": "ui",
+          "description": "Needs iOS UI work (Xcode prompt)",
+          "color": "1D76DB"
+        }
+      ],
+      "number": 240,
+      "state": "OPEN",
+      "title": "[Parts][#98-7] Phase 2 UI — New Supplier sheet linked-brand picker (#105 reverse direction)",
+      "updatedAt": "2026-04-18T17:31:32Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/240"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T04:56:10Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbvw",
+          "name": "ui",
+          "description": "Needs iOS UI work (Xcode prompt)",
+          "color": "1D76DB"
+        }
+      ],
+      "number": 239,
+      "state": "OPEN",
+      "title": "[Parts][#98-6] Phase 2 UI — TypeBrandColorSection rewrite (drop nested mental model)",
+      "updatedAt": "2026-04-18T17:31:32Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/239"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T04:55:56Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbvw",
+          "name": "ui",
+          "description": "Needs iOS UI work (Xcode prompt)",
+          "color": "1D76DB"
+        }
+      ],
+      "number": 238,
+      "state": "OPEN",
+      "title": "[Parts][#98-5] Phase 2 UI — CategoriesColorPicker hex=NULL named-only variants",
+      "updatedAt": "2026-04-18T17:31:32Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/238"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T04:55:37Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbvw",
+          "name": "ui",
+          "description": "Needs iOS UI work (Xcode prompt)",
+          "color": "1D76DB"
+        }
+      ],
+      "number": 237,
+      "state": "OPEN",
+      "title": "[Parts][#98-4] Phase 2 UI — CategoriesTreeView SKU rows + editor panel",
+      "updatedAt": "2026-04-19T13:04:38Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/237"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T04:55:17Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 236,
+      "state": "CLOSED",
+      "title": "[Parts][#98-3] Phase 1 search — searchParts UNION over part_colors + color_brand_skus",
+      "updatedAt": "2026-04-18T06:17:34Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/236"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T04:55:00Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 235,
+      "state": "CLOSED",
+      "title": "[Parts][#98-2] Phase 1 service — ColorBrandSKU CRUD methods",
+      "updatedAt": "2026-04-18T06:22:25Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/235"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T04:54:42Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 234,
+      "state": "CLOSED",
+      "title": "[Parts][#98-1] Phase 1 schema — color_brand_skus table + brand_selection_mode columns",
+      "updatedAt": "2026-04-18T06:22:28Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/234"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T04:37:00Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 233,
+      "state": "OPEN",
+      "title": "[Infra][Scanner] github-issues-sync auto-closes issues with active docs/dev-qa.md Pending entries",
+      "updatedAt": "2026-04-16T03:23:16Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/233"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T03:05:56Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 232,
+      "state": "CLOSED",
+      "title": "[Jobs][Bug] IOSJobDetailTabView progress bar crashes when job has only 1 stage (division by zero)",
+      "updatedAt": "2026-04-15T03:09:02Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/232"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T03:05:46Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbTw",
+          "name": "security",
+          "description": "Security vulnerability",
+          "color": "B60205"
+        }
+      ],
+      "number": 231,
+      "state": "CLOSED",
+      "title": "[Security][Medium] Keychain signing key uses AfterFirstUnlockThisDeviceOnly — should be WhenUnlockedThisDeviceOnly",
+      "updatedAt": "2026-04-15T04:41:37Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/231"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T03:05:36Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbTw",
+          "name": "security",
+          "description": "Security vulnerability",
+          "color": "B60205"
+        }
+      ],
+      "number": 230,
+      "state": "CLOSED",
+      "title": "[Security][Bug] encryptIfNeeded silently falls back to plaintext on encryption failure",
+      "updatedAt": "2026-04-15T03:35:02Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/230"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-15T03:02:42Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 229,
+      "state": "CLOSED",
+      "title": "[Plan Drift] CategoriesTreeView pricingOverride wired before resolveConflicts tests",
+      "updatedAt": "2026-04-16T14:24:48Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/229"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-14T04:31:30Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 228,
+      "state": "CLOSED",
+      "title": "[Auth][Security] SecItemAdd result unchecked — signing key may not persist to Keychain",
+      "updatedAt": "2026-04-15T03:35:05Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/228"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-14T04:31:24Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 227,
+      "state": "CLOSED",
+      "title": "[Parts][Performance] Service-layer pagination missing — Parts catalog fetches all rows into memory",
+      "updatedAt": "2026-04-15T04:41:37Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/227"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:06:14Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 226,
+      "state": "CLOSED",
+      "title": "[Code Quality] Debug print() statements in production code",
+      "updatedAt": "2026-04-15T04:11:11Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/226"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:06:13Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI4A",
+          "name": "concurrency",
+          "description": "Race conditions, thread safety",
+          "color": "D4C5F9"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 225,
+      "state": "CLOSED",
+      "title": "[Sync][Info] DeviceIdentity.current should be let instead of var",
+      "updatedAt": "2026-04-15T04:11:11Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/225"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:06:12Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 224,
+      "state": "CLOSED",
+      "title": "[Parts][Info] Forecasting ADU includes transfer movements — inflates demand",
+      "updatedAt": "2026-04-15T04:11:11Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/224"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:06:04Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJAg",
+          "name": "performance",
+          "description": "N+1 queries, memory, rendering",
+          "color": "FEF2C0"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 223,
+      "state": "CLOSED",
+      "title": "[Performance] BaseRepository.findAll() has no default limit",
+      "updatedAt": "2026-04-15T04:11:11Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/223"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:06:02Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI4A",
+          "name": "concurrency",
+          "description": "Race conditions, thread safety",
+          "color": "D4C5F9"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 222,
+      "state": "CLOSED",
+      "title": "[Concurrency] @unchecked Sendable on BaseRepository and PeerDiscovery",
+      "updatedAt": "2026-04-15T04:14:47Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/222"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:06:01Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 221,
+      "state": "OPEN",
+      "title": "[Sync][Info] LWW uses row-level timestamps for field-level conflicts",
+      "updatedAt": "2026-04-16T03:23:05Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/221"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:05:59Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 220,
+      "state": "CLOSED",
+      "title": "[Sync][Bug] Sync silently drops UPDATE when record doesn't exist locally",
+      "updatedAt": "2026-04-15T03:38:20Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/220"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:05:34Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 219,
+      "state": "CLOSED",
+      "title": "[UI][Bug] IOSLaborOverviewPage missing proper empty state",
+      "updatedAt": "2026-04-15T04:20:53Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/219"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:05:33Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbZQ",
+          "name": "accessibility",
+          "description": "Apple HIG / accessibility issue",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 218,
+      "state": "CLOSED",
+      "title": "[Accessibility][Bug] Color-only status indicators in schedule calendar",
+      "updatedAt": "2026-04-15T04:20:53Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/218"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:05:32Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 217,
+      "state": "CLOSED",
+      "title": "[UI][Bug] IOSPublicReportView always shows error — dead-end route",
+      "updatedAt": "2026-04-15T04:20:53Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/217"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:05:31Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 216,
+      "state": "CLOSED",
+      "title": "[UI][Bug] @State holding Timer references in IOSClockPage",
+      "updatedAt": "2026-04-15T04:20:53Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/216"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:05:29Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 215,
+      "state": "CLOSED",
+      "title": "[UI][Bug] IOSSyncManager missing deinit — observer and timer leak on logout",
+      "updatedAt": "2026-04-15T04:20:54Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/215"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:05:28Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJAg",
+          "name": "performance",
+          "description": "N+1 queries, memory, rendering",
+          "color": "FEF2C0"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 214,
+      "state": "CLOSED",
+      "title": "[UI][Bug] DashboardView Timer.publish fires continuously when not visible",
+      "updatedAt": "2026-04-13T07:09:10Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/214"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:04:51Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 213,
+      "state": "CLOSED",
+      "title": "[Data][Bug] No string length or negative value validation on create/update methods",
+      "updatedAt": "2026-04-15T04:11:11Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/213"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:04:50Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 212,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] Model structs missing schema columns (PartCategory, PartStyle, PartType, Brand)",
+      "updatedAt": "2026-04-15T03:48:53Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/212"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:04:43Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 211,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] CompanionRule delete inconsistency — is_active vs deleted_at",
+      "updatedAt": "2026-04-13T07:06:27Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/211"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:04:41Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 210,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] Soft-delete doesn't cascade to children — orphaned records",
+      "updatedAt": "2026-04-13T07:06:27Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/210"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:04:40Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 209,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] Export sell price uses company_cost_price instead of weighted_avg_cost",
+      "updatedAt": "2026-04-15T03:48:56Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/209"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:04:38Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 208,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] addCostLayer is not atomic — 3 separate write transactions",
+      "updatedAt": "2026-04-13T07:06:27Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/208"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:04:30Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 207,
+      "state": "CLOSED",
+      "title": "[Scheduling][Bug] Time-off approval ignores existing dispatch conflicts",
+      "updatedAt": "2026-04-15T04:11:11Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/207"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:04:29Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 206,
+      "state": "CLOSED",
+      "title": "[Jobs][Bug] Clock-out doesn't subtract break time or calculate overtime",
+      "updatedAt": "2026-04-13T07:09:10Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/206"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:04:27Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 205,
+      "state": "CLOSED",
+      "title": "[Orders][Bug] JPO and PO status transitions are not validated",
+      "updatedAt": "2026-04-13T07:09:10Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/205"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:04:26Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 204,
+      "state": "CLOSED",
+      "title": "[Orders][Bug] PO status history hardcodes changed_by = 1",
+      "updatedAt": "2026-04-13T06:38:39Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/204"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:03:48Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 203,
+      "state": "CLOSED",
+      "title": "[Orders][Bug] try? on PO-JPO link INSERTs — procurement traceability silently breaks",
+      "updatedAt": "2026-04-13T06:38:39Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/203"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:03:41Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI4A",
+          "name": "concurrency",
+          "description": "Race conditions, thread safety",
+          "color": "D4C5F9"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 202,
+      "state": "CLOSED",
+      "title": "[Concurrency][Bug] @unchecked Sendable on MultipeerManager with mutable state",
+      "updatedAt": "2026-04-13T06:44:24Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/202"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:03:35Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 201,
+      "state": "CLOSED",
+      "title": "[Data][Bug] 18 try? in migrations silently swallow ALTER TABLE failures",
+      "updatedAt": "2026-04-13T06:50:45Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/201"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:03:25Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 200,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] No Stock model for primary stock table — all stock ops use raw SQL",
+      "updatedAt": "2026-04-13T06:42:50Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/200"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:03:18Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 199,
+      "state": "CLOSED",
+      "title": "[People][Bug] Hat hard-delete cascades to all user roles — no built-in protection",
+      "updatedAt": "2026-04-13T06:40:01Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/199"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:03:03Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 198,
+      "state": "CLOSED",
+      "title": "[Scheduling][Bug] Dispatch creation has no double-booking detection",
+      "updatedAt": "2026-04-13T06:40:01Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/198"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:02:58Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbTw",
+          "name": "security",
+          "description": "Security vulnerability",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 197,
+      "state": "CLOSED",
+      "title": "[Security][Bug] Sync encryption falls back to plaintext silently",
+      "updatedAt": "2026-04-13T06:44:24Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/197"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:02:51Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 196,
+      "state": "CLOSED",
+      "title": "[Sync][Bug] LWW merge converts NULL values to empty strings — corrupts nullable columns",
+      "updatedAt": "2026-04-13T06:42:50Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/196"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:02:36Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 195,
+      "state": "CLOSED",
+      "title": "[Orders][Bug] PO status history records wrong old_status — reads AFTER update",
+      "updatedAt": "2026-04-13T06:38:39Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/195"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:02:30Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJAg",
+          "name": "performance",
+          "description": "N+1 queries, memory, rendering",
+          "color": "FEF2C0"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 194,
+      "state": "CLOSED",
+      "title": "[Performance][P0] N+1 query in recalculateLocationTargets() — per-combo queries",
+      "updatedAt": "2026-04-13T06:35:58Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/194"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:02:25Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJAg",
+          "name": "performance",
+          "description": "N+1 queries, memory, rendering",
+          "color": "FEF2C0"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 193,
+      "state": "CLOSED",
+      "title": "[Performance][P0] N+1 query in recalculateTargets() — per-part queries inside loop",
+      "updatedAt": "2026-04-13T06:35:58Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/193"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:01:25Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbvw",
+          "name": "ui",
+          "description": "Needs iOS UI work (Xcode prompt)",
+          "color": "1D76DB"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 192,
+      "state": "CLOSED",
+      "title": "[Settings][Bug] 5 Settings pages flash defaults before data loads — no loading indicator",
+      "updatedAt": "2026-04-15T04:23:33Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/192"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:01:18Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbTw",
+          "name": "security",
+          "description": "Security vulnerability",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 191,
+      "state": "CLOSED",
+      "title": "[Security][Bug] Sync key exchange endpoint returns X25519 public key without auth",
+      "updatedAt": "2026-04-15T03:47:35Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/191"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:01:05Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI4A",
+          "name": "concurrency",
+          "description": "Race conditions, thread safety",
+          "color": "D4C5F9"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 190,
+      "state": "CLOSED",
+      "title": "[Sync][Bug] LanSyncServer continuation resume guard is not atomic",
+      "updatedAt": "2026-04-15T04:14:47Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/190"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:01:00Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI4A",
+          "name": "concurrency",
+          "description": "Race conditions, thread safety",
+          "color": "D4C5F9"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 189,
+      "state": "CLOSED",
+      "title": "[Sync][Bug] DeviceIdentity.current should be let, not var — unnecessary mutability",
+      "updatedAt": "2026-04-13T06:33:18Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/189"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:00:56Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 188,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] Forecasting ignores user-configured MIN/TARGET/MAX in reorder calculations",
+      "updatedAt": "2026-04-15T03:47:35Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/188"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:00:42Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI4A",
+          "name": "concurrency",
+          "description": "Race conditions, thread safety",
+          "color": "D4C5F9"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 187,
+      "state": "CLOSED",
+      "title": "[Sync][Bug] PeerDiscovery @unchecked Sendable with racy callback setter",
+      "updatedAt": "2026-04-15T04:14:48Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/187"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:00:36Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbZQ",
+          "name": "accessibility",
+          "description": "Apple HIG / accessibility issue",
+          "color": "0E8A16"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 186,
+      "state": "CLOSED",
+      "title": "[Accessibility][Bug] Hardcoded 7px font in warehouse placement grid — unreadable",
+      "updatedAt": "2026-04-15T04:20:53Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/186"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:00:30Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI4A",
+          "name": "concurrency",
+          "description": "Race conditions, thread safety",
+          "color": "D4C5F9"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 185,
+      "state": "CLOSED",
+      "title": "[Warehouse][Bug] CartManager missing @MainActor — only ObservableObject without it",
+      "updatedAt": "2026-04-15T03:35:08Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/185"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:00:17Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbTw",
+          "name": "security",
+          "description": "Security vulnerability",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 184,
+      "state": "CLOSED",
+      "title": "[Sync][Bug] JSON injection in certificate rejection error response",
+      "updatedAt": "2026-04-15T03:47:35Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/184"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:00:11Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJAg",
+          "name": "performance",
+          "description": "N+1 queries, memory, rendering",
+          "color": "FEF2C0"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 183,
+      "state": "CLOSED",
+      "title": "[Sync][Bug] Change log queries have no LIMIT — potential OOM on large backlogs",
+      "updatedAt": "2026-04-15T03:35:13Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/183"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T06:00:05Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 182,
+      "state": "CLOSED",
+      "title": "[Orders][Bug] PO-JPO link insertion uses try? — silently breaks traceability",
+      "updatedAt": "2026-04-13T06:33:18Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/182"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:59:53Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 181,
+      "state": "CLOSED",
+      "title": "[Sync][Bug] DeviceResetService writes text UUID to integer record_id column",
+      "updatedAt": "2026-04-15T02:53:53Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/181"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:59:47Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 180,
+      "state": "CLOSED",
+      "title": "[Notebooks][Bug] addEntry() does not set notebook_id — breaks direct lookups and badges",
+      "updatedAt": "2026-04-15T02:52:12Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/180"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:59:40Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbvw",
+          "name": "ui",
+          "description": "Needs iOS UI work (Xcode prompt)",
+          "color": "1D76DB"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 179,
+      "state": "CLOSED",
+      "title": "[Scheduling][Bug] Silently swallowed errors in dispatch/schedule creation sheets",
+      "updatedAt": "2026-04-15T04:20:53Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/179"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:59:27Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJAg",
+          "name": "performance",
+          "description": "N+1 queries, memory, rendering",
+          "color": "FEF2C0"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 178,
+      "state": "CLOSED",
+      "title": "[Performance][Bug] 15 inline NumberFormatter instances — same pattern as DateFormatter #146",
+      "updatedAt": "2026-04-15T03:47:35Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/178"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:59:18Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJAg",
+          "name": "performance",
+          "description": "N+1 queries, memory, rendering",
+          "color": "FEF2C0"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 177,
+      "state": "CLOSED",
+      "title": "[Performance][Bug] N+1 query pattern in procurement — 3 SQL queries per part in loop",
+      "updatedAt": "2026-04-15T02:54:55Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/177"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:59:10Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbTw",
+          "name": "security",
+          "description": "Security vulnerability",
+          "color": "B60205"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 176,
+      "state": "CLOSED",
+      "title": "[Security][Bug] Sync status endpoint exposes device metadata without authentication",
+      "updatedAt": "2026-04-15T03:35:36Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/176"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:58:59Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI4A",
+          "name": "concurrency",
+          "description": "Race conditions, thread safety",
+          "color": "D4C5F9"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 175,
+      "state": "CLOSED",
+      "title": "[Sync][Bug] MultipeerManager onDataReceived can deadlock on syncQueue",
+      "updatedAt": "2026-04-15T02:53:54Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/175"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:58:52Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 174,
+      "state": "CLOSED",
+      "title": "[Sync][Bug] Delete-vs-update conflict: delete always wins silently, no conflict log",
+      "updatedAt": "2026-04-15T04:24:57Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/174"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:58:46Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACdTTbvw",
+          "name": "ui",
+          "description": "Needs iOS UI work (Xcode prompt)",
+          "color": "1D76DB"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 173,
+      "state": "CLOSED",
+      "title": "[UI][Bug] 3 nested sheet-from-sheet patterns — will glitch or fail to present on iOS",
+      "updatedAt": "2026-04-15T04:23:33Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/173"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:58:33Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 172,
+      "state": "CLOSED",
+      "title": "[Jobs][Bug] Clock-out does not deduct breaks or calculate overtime",
+      "updatedAt": "2026-04-15T02:52:12Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/172"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:58:26Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 171,
+      "state": "CLOSED",
+      "title": "[Orders][Bug] JPO/PO status transitions have no validation — any status can be set",
+      "updatedAt": "2026-04-13T06:33:18Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/171"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:58:20Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 170,
+      "state": "CLOSED",
+      "title": "[Scheduling][Bug] No double-booking detection — same employee dispatched to overlapping jobs",
+      "updatedAt": "2026-04-13T06:33:18Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/170"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:58:09Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 169,
+      "state": "CLOSED",
+      "title": "[Orders][Bug] PO status history records NEW status as old_status — audit trail broken",
+      "updatedAt": "2026-04-13T06:33:18Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/169"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:58:01Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 168,
+      "state": "CLOSED",
+      "title": "[Sync][Bug] ConflictResolver maps NULL to empty string — breaks soft-delete semantics",
+      "updatedAt": "2026-04-13T06:33:18Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/168"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:57:52Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 167,
+      "state": "CLOSED",
+      "title": "[Scheduling][Bug] Flex pool ignores team-level filter — all teams see restricted jobs",
+      "updatedAt": "2026-04-15T03:47:35Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/167"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:57:41Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 166,
+      "state": "CLOSED",
+      "title": "[Notebooks][Bug] Badge count unread query uses unreliable notebook_id JOIN — undercounts",
+      "updatedAt": "2026-04-15T04:11:11Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/166"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:57:33Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 165,
+      "state": "CLOSED",
+      "title": "[Tools][Bug] Badge count queries non-existent table tool_edit_log (should be tool_change_log)",
+      "updatedAt": "2026-04-15T02:52:12Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/165"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:57:26Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwI1A",
+          "name": "data-integrity",
+          "description": "SQL/schema/migration issues",
+          "color": "E99695"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACfHwJBg",
+          "name": "audit-2026-04",
+          "description": "Found during April 2026 full program audit",
+          "color": "C2E0C6"
+        }
+      ],
+      "number": 164,
+      "state": "CLOSED",
+      "title": "[Reports][Bug] Profitability report uses billing_rate for labor COST instead of pay_rate",
+      "updatedAt": "2026-04-15T02:52:12Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/164"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:40:04Z",
+      "labels": [],
+      "number": 163,
+      "state": "CLOSED",
+      "title": "[Parts][Feature] Free space rating UI — per-location 1-10 scale editor",
+      "updatedAt": "2026-04-18T16:17:48Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/163"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:40:00Z",
+      "labels": [],
+      "number": 162,
+      "state": "CLOSED",
+      "title": "[Parts][Feature] Forecast settings UI — per-location-type multiplier editor",
+      "updatedAt": "2026-04-18T16:17:47Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/162"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:20:44Z",
+      "labels": [],
+      "number": 161,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] LocationStockTarget model missing part_category and do_not_restock properties",
+      "updatedAt": "2026-04-13T05:27:50Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/161"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:20:38Z",
+      "labels": [],
+      "number": 160,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] CSV import duplicate detection silently fails on DB errors — creates duplicates",
+      "updatedAt": "2026-04-13T05:28:48Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/160"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:20:31Z",
+      "labels": [],
+      "number": 159,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] listCatalogParts missing type_name — catalog search results show no type",
+      "updatedAt": "2026-04-13T05:28:27Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/159"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:20:20Z",
+      "labels": [],
+      "number": 158,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] Stock queries use only legacy 'stock' table — miss stock_entries inventory",
+      "updatedAt": "2026-04-13T05:27:16Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/158"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:20:10Z",
+      "labels": [],
+      "number": 157,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] getHierarchy() ignores type_color_links — colors only show after parts exist",
+      "updatedAt": "2026-04-13T05:20:53Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/157"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T05:20:04Z",
+      "labels": [],
+      "number": 156,
+      "state": "CLOSED",
+      "title": "[Parts][Bug] BrandSupplierLink model missing carryStatus — carry status updates silently fail",
+      "updatedAt": "2026-04-13T05:20:51Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/156"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T03:23:30Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+          "name": "usability-hunter",
+          "description": "Behavioral usability bug found by usability-hunter scanner",
+          "color": "FF6B6B"
+        }
+      ],
+      "number": 155,
+      "state": "CLOSED",
+      "title": "[Usability] Scanner 1: DashboardDailyReportPage — ReportProblem/SubmitReport sheets missing interactiveDismissDisabled",
+      "updatedAt": "2026-04-13T05:11:07Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/155"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T03:23:23Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+          "name": "usability-hunter",
+          "description": "Behavioral usability bug found by usability-hunter scanner",
+          "color": "FF6B6B"
+        }
+      ],
+      "number": 154,
+      "state": "CLOSED",
+      "title": "[Usability] Scanner 1: IOSToolDetailPage — 7 action sheets missing interactiveDismissDisabled",
+      "updatedAt": "2026-04-13T05:11:07Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/154"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T03:23:18Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+          "name": "usability-hunter",
+          "description": "Behavioral usability bug found by usability-hunter scanner",
+          "color": "FF6B6B"
+        }
+      ],
+      "number": 153,
+      "state": "CLOSED",
+      "title": "[Usability] Scanner 1: IOSEstimationSettingsPage — Add/Edit sheets missing isSaving guard (duplicate question risk)",
+      "updatedAt": "2026-04-13T05:11:07Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/153"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T02:47:02Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 152,
+      "state": "CLOSED",
+      "title": "[Chat] IOSMessageThreadView: photo + reference picker buttons are dead (no sheets wired)",
+      "updatedAt": "2026-04-16T02:09:46Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/152"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-13T02:45:54Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        }
+      ],
+      "number": 151,
+      "state": "CLOSED",
+      "title": "[Bug] IOSMessageThreadView.handleAction(.markResolved) resolves wrong thread",
+      "updatedAt": "2026-04-13T03:05:11Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/151"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-12T17:14:44Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+          "name": "usability-hunter",
+          "description": "Behavioral usability bug found by usability-hunter scanner",
+          "color": "FF6B6B"
+        }
+      ],
+      "number": 150,
+      "state": "OPEN",
+      "title": "[Usability] Scanner 5a: Settings save buttons lack .disabled() validation guard",
+      "updatedAt": "2026-05-01T14:38:14Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/150"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-12T17:14:33Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+          "name": "usability-hunter",
+          "description": "Behavioral usability bug found by usability-hunter scanner",
+          "color": "FF6B6B"
+        }
+      ],
+      "number": 149,
+      "state": "CLOSED",
+      "title": "[Usability] Scanner 5b: ~30 pages missing keyboard dismiss (scrollDismissesKeyboard)",
+      "updatedAt": "2026-04-16T14:16:34Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/149"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-12T17:14:25Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+          "name": "usability-hunter",
+          "description": "Behavioral usability bug found by usability-hunter scanner",
+          "color": "FF6B6B"
+        }
+      ],
+      "number": 148,
+      "state": "CLOSED",
+      "title": "[Usability] Scanner 1: IOSMovementWizard missing Save & Exit button",
+      "updatedAt": "2026-04-18T05:40:34Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/148"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-12T06:33:14Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 147,
+      "state": "CLOSED",
+      "title": "[UX] Missing empty states: OfficeRouter, PricingBulkEditSheet, IOSDailyReportTemplatesPage",
+      "updatedAt": "2026-04-15T04:41:37Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/147"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-12T06:33:07Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 146,
+      "state": "CLOSED",
+      "title": "[Performance] Formatters.swift is dead code — 99 inline DateFormatter() instantiations",
+      "updatedAt": "2026-04-16T14:24:12Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/146"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-12T06:32:53Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 145,
+      "state": "CLOSED",
+      "title": "[UX] Chat thread view missing pull-to-refresh",
+      "updatedAt": "2026-04-13T03:05:13Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/145"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-12T06:29:33Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUQA",
+          "name": "enhancement",
+          "description": "New feature or request",
+          "color": "a2eeef"
+        }
+      ],
+      "number": 144,
+      "state": "CLOSED",
+      "title": "[Parts] Color-level part numbers needed — manufacturer/brand part number, not supplier-locked",
+      "updatedAt": "2026-04-18T17:30:23Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/144"
+    },
+    {
+      "assignees": [],
+      "author": {
+        "id": "MDQ6VXNlcjM3OTU5OTU2",
+        "is_bot": false,
+        "login": "xXKillerNoobYT",
+        "name": ""
+      },
+      "createdAt": "2026-04-11T04:49:14Z",
+      "labels": [
+        {
+          "id": "LA_kwDORWW5g88AAAACY_kUMg",
+          "name": "bug",
+          "description": "Something isn't working",
+          "color": "d73a4a"
+        },
+        {
+          "id": "LA_kwDORWW5g88AAAACeHaG5Q",
+          "name": "usability-hunter",
+          "description": "Behavioral usability bug found by usability-hunter scanner",
+          "color": "FF6B6B"
+        }
+      ],
+      "number": 143,
+      "state": "CLOSED",
+      "title": "[Usability] Scanner 1: 30+ sheets missing interactiveDismissDisabled (Settings, People, Chat)",
+      "updatedAt": "2026-04-20T03:21:08Z",
+      "url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/143"
+    }
+  ]
+}

--- a/docs/github-issue-sync/latest-sync.md
+++ b/docs/github-issue-sync/latest-sync.md
@@ -1,0 +1,33 @@
+# GitHub Issue Sync Snapshot
+
+- Repository: `xXKillerNoobYT/Weird-Part-Run-2`
+- Run timestamp (UTC): `2026-05-12T05:06:08Z`
+- Source issue: `WEI-44`
+- Requested state: `all`
+- Issues (non-PR): `200`
+- Open issues: `54`
+- Closed issues: `146`
+- Raw data: `issues.json`
+
+## Top 20 Recently Updated
+
+- #372 [OPEN]: Paperclip/GitHub sync tracker for active WEI execution (updated 2026-05-12T05:04:14Z)
+- #345 [CLOSED]: [Cross-Cutting][T1][Bug] LEFT JOIN NULL propagation candidates in 5 services — 10 SQL queries need owner triage (updated 2026-05-12T04:57:28Z)
+- #319 [CLOSED]: [Security][DB] Implement SQLCipher whole-DB encryption (closes CodeQL #1-#15) (updated 2026-05-11T12:36:37Z)
+- #273 [CLOSED]: [Tools][Perf] getToolsStats checkedOut uses O(n²) correlated NOT EXISTS on unindexed tool_movements (updated 2026-05-11T09:31:47Z)
+- #280 [CLOSED]: [Fleet][Security] Vehicle write paths lack permission/hat checks at UI layer (updated 2026-05-11T05:11:34Z)
+- #355 [CLOSED]: [Scheduling][T2][Bug] createDispatch doesn't check time-off conflicts at service layer (UI-only enforcement) (updated 2026-05-11T02:32:19Z)
+- #351 [CLOSED]: [Inventory][T2][Tests] 5 critical PartsService recommendation-pipeline methods have zero tests (updated 2026-05-11T02:07:45Z)
+- #370 [OPEN]: [Scheduling][T2][Bug] checkTimeOffConflict returns PENDING requests as conflicts (missing is_approved=1 filter) (updated 2026-05-09T05:21:18Z)
+- #368 [OPEN]: [Cross-Cutting][T2][Bug-Umbrella] 35 service mutation methods lack permission gates (service-permission-gate-scanner output) (updated 2026-05-09T05:21:13Z)
+- #371 [OPEN]: [Orders][T2][Bug] generatePOFromJPO doesn't update jpo_line_items.line_status — two PO-generation paths produce inconsistent per-line state (updated 2026-05-09T05:21:13Z)
+- #369 [OPEN]: [Warehouse][T2][Bug] movement_type values are stringly-typed across UI + service + queries — no canonical constants, forecasting depends on 'consume' string only (updated 2026-05-06T20:28:49Z)
+- #359 [OPEN]: [Tools][T2][Bug] expireOldTrades + updateConfidenceScores not auto-scheduled — only run when iOS detail page opened (updated 2026-05-06T20:00:48Z)
+- #367 [OPEN]: [Parts][T2][Bug] approveRecommendation + dismissRecommendation lack permission gates (sister to #355/#363/#364) (updated 2026-05-06T19:29:58Z)
+- #366 [OPEN]: [Cross-Cutting][T1][Security] hasPermission doesn't check user.deleted_at — soft-deleted users retain all hat permissions (updated 2026-05-06T19:26:00Z)
+- #365 [OPEN]: [Settings][T2][Bug] upsertSettingsMap is non-atomic — partial save on mid-loop failure leaves inconsistent state (updated 2026-05-06T18:57:07Z)
+- #364 [OPEN]: [Chat][T2][Bug] sendMessage doesn't check channel membership — read-side filters, write-side wide open (read-write asymmetry) (updated 2026-05-06T18:28:14Z)
+- #363 [OPEN]: [Notebooks][T2][Bug] Classification methods lack permission gates + can leak orphan history rows for soft-deleted entries (updated 2026-05-06T18:25:11Z)
+- #362 [OPEN]: [Reports][T2][Bug] getPreBillingData ignores billing_periods.locked_at — returns labor from locked periods (updated 2026-05-06T17:56:53Z)
+- #361 [OPEN]: [Inventory][T2][Bug] Wishlist sendToProcurement is a dead-end status — no consumer reads sent_to_procurement items (updated 2026-05-06T17:28:32Z)
+- #360 [OPEN]: [Fleet][T2][Bug] assignDriver doesn't deactivate existing active assignments — vehicle/user can have multiple active rows (updated 2026-05-06T17:25:06Z)

--- a/docs/runbooks/github-issue-sync-workflow.md
+++ b/docs/runbooks/github-issue-sync-workflow.md
@@ -1,0 +1,88 @@
+# GitHub Issue Sync Workflow
+
+## Purpose
+Keep GitHub tracker visibility in sync with Paperclip issue state and preserve a manual fallback path.
+
+## Inputs
+- `gh` CLI authenticated for repo access
+- `jq` available on PATH
+- `curl` and `sha256sum` available on PATH
+- Repository: `xXKillerNoobYT/Weird-Part-Run-2` (default)
+- Paperclip env vars exported in heartbeat context:
+  - `PAPERCLIP_API_URL`
+  - `PAPERCLIP_API_KEY`
+  - `PAPERCLIP_COMPANY_ID`
+
+## Automated Tracker Sync (Primary)
+```bash
+scripts/paperclip-github-tracker-sync.sh
+```
+
+Repository automation:
+- Workflow: `.github/workflows/paperclip-tracker-sync.yml`
+- Trigger: every 30 minutes (`cron`) and manual `workflow_dispatch`
+- Required repo secrets:
+  - `PAPERCLIP_API_URL`
+  - `PAPERCLIP_API_KEY`
+  - `PAPERCLIP_COMPANY_ID`
+- Optional repo variable:
+  - `PAPERCLIP_WEB_URL` (for internal issue hyperlinks in tracker comment)
+
+Optional:
+```bash
+scripts/paperclip-github-tracker-sync.sh --repo <owner/repo> --tracker-number <n> --state-dir <path>
+```
+
+Help:
+```bash
+scripts/paperclip-github-tracker-sync.sh --help
+```
+
+Dry run (no GitHub write):
+```bash
+scripts/paperclip-github-tracker-sync.sh --dry-run
+```
+
+## Trigger and Update Behavior
+- Source set: all Paperclip issues in statuses `todo`, `in_progress`, `in_review`, `blocked`.
+- Material fields mirrored to tracker comment:
+  - status
+  - assignee agent
+  - blockers (`blockedByIssueIds` / `blockedBy`)
+- Update policy:
+  - Script computes SHA-256 of normalized material fields (status/owner/blockers/title).
+  - If hash unchanged from prior run, no GitHub update occurs.
+  - If changed, script upserts a marker comment (`# paperclip-tracker-sync:v1`) on tracker issue.
+
+## Logs and Evidence
+- Console output states one of:
+  - `no material changes detected; tracker update skipped`
+  - `updated tracker comment id: ...`
+  - `created tracker comment on ...`
+- Local state file: `.paperclip-sync/tracker-<issue>.sha256`
+- Scheduled run logs: GitHub Actions → `Paperclip Tracker Sync` workflow run history
+
+## Cadence
+- Scheduled workflow runs every 30 minutes when secrets are configured.
+- Run once per CTO heartbeat when issue-sync governance is active.
+- Otherwise run before triage sessions or daily.
+
+## Manual Fallback (Do Not Remove Yet)
+If automated sync fails, use the existing snapshot path:
+```bash
+scripts/github-issue-sync.sh --repo xXKillerNoobYT/Weird-Part-Run-2 --state all
+```
+Artifacts:
+- `docs/github-issue-sync/<UTC timestamp>/issues.json`
+- `docs/github-issue-sync/latest-sync.md`
+
+Rollback:
+1. Disable `.github/workflows/paperclip-tracker-sync.yml` (or remove required secrets).
+2. Resume manual fallback command above.
+3. Keep tracker continuity by posting the latest fallback summary manually.
+
+## Triage Guidance
+1. Use `latest-sync.md` to spot high-churn issues (recently updated).
+2. Convert ambiguous items into bounded child issues with explicit owners.
+3. Mark blocked items with clear unblock owner/action.
+4. Keep parent tracking issue open until workflow and cadence are stable.

--- a/scripts/paperclip-github-tracker-sync.sh
+++ b/scripts/paperclip-github-tracker-sync.sh
@@ -144,7 +144,7 @@ COMMENT_BODY="$(
 
     def blocker_summary($issue):
       if (($issue.blockedByIssueIds // []) | length) == 0 then "none"
-      else (($issue.blockedByIssueIds // []) | join(", "))
+      else (($issue.blockedByIssueIds // []) | map(.identifier // .id // tostring) | join(", "))
       end;
 
     "# paperclip-tracker-sync:v1\n" +

--- a/scripts/paperclip-github-tracker-sync.sh
+++ b/scripts/paperclip-github-tracker-sync.sh
@@ -70,12 +70,25 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-for cmd in curl jq sha256sum gh; do
+for cmd in curl jq gh; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "error: required command missing: $cmd" >&2
     exit 1
   fi
 done
+
+hash_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 -r | awk '{print $1}'
+  else
+    echo "error: required command missing: sha256sum, shasum, or openssl" >&2
+    return 1
+  fi
+}
 
 : "${PAPERCLIP_API_URL:?error: PAPERCLIP_API_URL is required}"
 : "${PAPERCLIP_API_KEY:?error: PAPERCLIP_API_KEY is required}"
@@ -195,7 +208,7 @@ if [[ -n "$WEB_URL" ]]; then
   done < <(printf "%s\n" "$COMMENT_BODY")
 fi
 
-CONTENT_HASH="$(printf "%s" "$SYNC_FINGERPRINT" | sha256sum | awk '{print $1}')"
+CONTENT_HASH="$(printf "%s" "$SYNC_FINGERPRINT" | hash_sha256)"
 PREV_HASH=""
 if [[ -f "$STATE_PATH" ]]; then
   PREV_HASH="$(cat "$STATE_PATH")"

--- a/scripts/paperclip-github-tracker-sync.sh
+++ b/scripts/paperclip-github-tracker-sync.sh
@@ -70,25 +70,12 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-for cmd in curl jq gh; do
+for cmd in curl jq sha256sum gh; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "error: required command missing: $cmd" >&2
     exit 1
   fi
 done
-
-hash_sha256() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum | awk '{print $1}'
-  elif command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 | awk '{print $1}'
-  elif command -v openssl >/dev/null 2>&1; then
-    openssl dgst -sha256 -r | awk '{print $1}'
-  else
-    echo "error: required command missing: sha256sum, shasum, or openssl" >&2
-    return 1
-  fi
-}
 
 : "${PAPERCLIP_API_URL:?error: PAPERCLIP_API_URL is required}"
 : "${PAPERCLIP_API_KEY:?error: PAPERCLIP_API_KEY is required}"
@@ -111,25 +98,14 @@ fi
 
 STAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 WEB_URL="${PAPERCLIP_WEB_URL:-}"
-ISSUES_PATH="$(mktemp)"
-DONE_ISSUES_PATH="$(mktemp)"
-AGENTS_PATH="$(mktemp)"
-trap 'rm -f "$ISSUES_PATH" "$DONE_ISSUES_PATH" "$AGENTS_PATH"' EXIT
 
-curl -fsS \
+ISSUES_JSON="$(curl -fsS \
   -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/issues?status=todo,in_progress,in_review,blocked" \
-  -o "$ISSUES_PATH"
+  "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/issues?status=todo,in_progress,in_review,blocked")"
 
-curl -fsS \
+AGENTS_JSON="$(curl -fsS \
   -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/issues?status=done" \
-  -o "$DONE_ISSUES_PATH"
-
-curl -fsS \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agents" \
-  -o "$AGENTS_PATH"
+  "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agents")"
 
 render_link() {
   local identifier="$1"
@@ -143,17 +119,16 @@ render_link() {
 
 COMMENT_BODY="$(
   jq -nr \
-    --slurpfile issues "$ISSUES_PATH" \
-    --slurpfile doneIssues "$DONE_ISSUES_PATH" \
-    --slurpfile agents "$AGENTS_PATH" \
+    --argjson issues "$ISSUES_JSON" \
+    --argjson agents "$AGENTS_JSON" \
     --arg stamp "$STAMP" '
     def agent_name($id):
-      ($agents[0] | map(select(.id == $id)) | .[0].name) // "unassigned";
+      ($agents | map(select(.id == $id)) | .[0].name) // "unassigned";
 
     def issue_sort_key: .identifier // .id // "";
 
     def normalized:
-      $issues[0]
+      $issues
       | map({
           identifier,
           title,
@@ -166,21 +141,6 @@ COMMENT_BODY="$(
           ) | unique | sort
         })
       | sort_by(issue_sort_key);
-
-    def recently_completed:
-      $doneIssues[0]
-      | map({
-          identifier,
-          title,
-          status,
-          priority,
-          assigneeAgentId,
-          completedAt,
-          updatedAt
-        })
-      | sort_by(.completedAt // .updatedAt // "")
-      | reverse
-      | .[:20];
 
     def blocker_summary($issue):
       if (($issue.blockedByIssueIds // []) | length) == 0 then "none"
@@ -201,61 +161,26 @@ COMMENT_BODY="$(
         " | blockers: `" + blocker_summary(.) + "`" +
         " | " + (.title // "(untitled)")
       )) | join("\n")
-    ) + "\n\n" +
-    "### Recently Completed\n\n" +
-    (
-      (recently_completed | map(
-        "- " + (.identifier // .id) +
-        " | completed: `" + (.completedAt // .updatedAt // "unknown") + "`" +
-        " | owner: `" + (agent_name(.assigneeAgentId)) + "`" +
-        " | " + (.title // "(untitled)")
-      )) | join("\n")
     ) + "\n"
   '
 )"
 
 SYNC_FINGERPRINT="$(
   jq -cS -n \
-    --slurpfile issues "$ISSUES_PATH" \
-    --slurpfile doneIssues "$DONE_ISSUES_PATH" \
-    --slurpfile agents "$AGENTS_PATH" '
-    {
-      active: (
-        $issues[0]
-        | map({
-            identifier,
-            title,
-            status,
-            priority,
-            assigneeAgentId,
-            blockedByIssueIds: (
-              (.blockedByIssueIds // [])
-              + ((.blockedBy // []) | map(.id))
-            ) | unique | sort
-          })
-        | sort_by(.identifier // .id // "")
-      ),
-      recentlyCompleted: (
-        $doneIssues[0]
-        | map({
-            identifier,
-            title,
-            status,
-            priority,
-            assigneeAgentId,
-            completedAt,
-            updatedAt
-          })
-        | sort_by(.completedAt // .updatedAt // "")
-        | reverse
-        | .[:20]
-      ),
-      agents: (
-        $agents[0]
-        | map({id, name})
-        | sort_by(.id // "")
-      )
-    }
+    --argjson issues "$ISSUES_JSON" '
+    $issues
+    | map({
+        identifier,
+        title,
+        status,
+        priority,
+        assigneeAgentId,
+        blockedByIssueIds: (
+          (.blockedByIssueIds // [])
+          + ((.blockedBy // []) | map(.id))
+        ) | unique | sort
+      })
+    | sort_by(.identifier // .id // "")
   '
 )"
 
@@ -270,7 +195,7 @@ if [[ -n "$WEB_URL" ]]; then
   done < <(printf "%s\n" "$COMMENT_BODY")
 fi
 
-CONTENT_HASH="$(printf "%s" "$SYNC_FINGERPRINT" | hash_sha256)"
+CONTENT_HASH="$(printf "%s" "$SYNC_FINGERPRINT" | sha256sum | awk '{print $1}')"
 PREV_HASH=""
 if [[ -f "$STATE_PATH" ]]; then
   PREV_HASH="$(cat "$STATE_PATH")"
@@ -287,7 +212,7 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
   exit 0
 fi
 
-COMMENTS_JSON="$(gh api --paginate "repos/$REPO/issues/$TRACKER_NUMBER/comments?per_page=100" | jq -s 'add')"
+COMMENTS_JSON="$(gh api "repos/$REPO/issues/$TRACKER_NUMBER/comments?per_page=100")"
 EXISTING_ID="$(
   jq -r '
     map(select(.body | startswith("# paperclip-tracker-sync:v1"))) |


### PR DESCRIPTION
## Summary
- add scheduled/manual GitHub Actions workflow to upsert the Paperclip active-issue tracker comment on #372
- add tracker sync and GitHub issue snapshot scripts with --repo option support
- document the workflow and include a fresh all-state GitHub issue snapshot artifact

## Validation
- scripts/paperclip-github-tracker-sync.sh --repo xXKillerNoobYT/Weird-Part-Run-2 updated tracker comment id 4410521575
- bash -n scripts/paperclip-github-tracker-sync.sh scripts/github-issue-sync.sh
- scripts/paperclip-github-tracker-sync.sh --dry-run --repo xXKillerNoobYT/Weird-Part-Run-2 --state-dir /tmp/wei-729-tracker-state
- scripts/github-issue-sync.sh --repo xXKillerNoobYT/Weird-Part-Run-2 --state all --output-dir /tmp/wei-729-github-issue-sync
- jq verified latest-sync.json requestedState=all with open and closed issue counts