### PR TITLE
[codex] Harden local auth sessions

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Auth/BiometricAuthService.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/BiometricAuthService.swift
@@ -79,8 +79,9 @@ final class BiometricAuthService {
             defaults.set(true, forKey: optInKey)
             defaults.set(userId, forKey: Keys.preferredUserId)
         } else {
+            let rawPreferredUserId = (defaults.object(forKey: Keys.preferredUserId) as? NSNumber)?.int64Value
             defaults.removeObject(forKey: optInKey)
-            if preferredBiometricUserId == userId {
+            if rawPreferredUserId == userId {
                 defaults.removeObject(forKey: Keys.preferredUserId)
             }
         }

--- a/Weird Parts IOS/Weird Parts IOS/Auth/BiometricAuthService.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/BiometricAuthService.swift
@@ -1,0 +1,112 @@
+import Foundation
+import LocalAuthentication
+
+protocol BiometricEvaluator {
+    func canEvaluate(policy: LAPolicy) -> (Bool, Error?)
+    var biometryType: LABiometryType { get }
+    func evaluatePolicy(_ policy: LAPolicy, localizedReason: String) async throws -> Bool
+}
+
+struct LocalAuthenticationBiometricEvaluator: BiometricEvaluator {
+    private let context: LAContext
+
+    init(context: LAContext = LAContext()) {
+        self.context = context
+    }
+
+    func canEvaluate(policy: LAPolicy) -> (Bool, Error?) {
+        var error: NSError?
+        let canEvaluate = context.canEvaluatePolicy(policy, error: &error)
+        return (canEvaluate, error)
+    }
+
+    var biometryType: LABiometryType {
+        context.biometryType
+    }
+
+    func evaluatePolicy(_ policy: LAPolicy, localizedReason: String) async throws -> Bool {
+        try await context.evaluatePolicy(policy, localizedReason: localizedReason)
+    }
+}
+
+enum BiometricAuthResult: Equatable {
+    case success(userId: Int64)
+    case fallback(userId: Int64)
+    case notAvailable
+}
+
+@MainActor
+final class BiometricAuthService {
+    private enum Keys {
+        static let preferredUserId = "biometric.preferredUserId"
+
+        static func optIn(_ userId: Int64) -> String {
+            "biometric.optIn.\(userId)"
+        }
+    }
+
+    private let evaluator: BiometricEvaluator
+    private let defaults: UserDefaults
+
+    init(
+        evaluator: BiometricEvaluator = LocalAuthenticationBiometricEvaluator(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.evaluator = evaluator
+        self.defaults = defaults
+    }
+
+    var preferredBiometricUserId: Int64? {
+        guard let value = defaults.object(forKey: Keys.preferredUserId) as? NSNumber else {
+            return nil
+        }
+        let userId = value.int64Value
+        return isOptedIn(userId: userId) ? userId : nil
+    }
+
+    var availableBiometry: LABiometryType {
+        let result = evaluator.canEvaluate(policy: .deviceOwnerAuthenticationWithBiometrics)
+        return result.0 ? evaluator.biometryType : .none
+    }
+
+    var isBiometryAvailable: Bool {
+        availableBiometry != .none
+    }
+
+    func setOptIn(userId: Int64, enabled: Bool) {
+        let optInKey = Keys.optIn(userId)
+        if enabled {
+            defaults.set(true, forKey: optInKey)
+            defaults.set(userId, forKey: Keys.preferredUserId)
+        } else {
+            defaults.removeObject(forKey: optInKey)
+            if preferredBiometricUserId == userId {
+                defaults.removeObject(forKey: Keys.preferredUserId)
+            }
+        }
+    }
+
+    func isOptedIn(userId: Int64) -> Bool {
+        defaults.bool(forKey: Keys.optIn(userId))
+    }
+
+    func attemptBiometricAuth() async -> BiometricAuthResult {
+        guard let userId = preferredBiometricUserId else {
+            return .notAvailable
+        }
+
+        guard isBiometryAvailable else {
+            return .fallback(userId: userId)
+        }
+
+        do {
+            let success = try await evaluator.evaluatePolicy(
+                .deviceOwnerAuthenticationWithBiometrics,
+                localizedReason: "Use biometrics to unlock WiredPart."
+            )
+            return success ? .success(userId: userId) : .fallback(userId: userId)
+        } catch {
+            return .fallback(userId: userId)
+        }
+    }
+}

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -117,6 +117,7 @@ extension AppDatabase {
         registerMigration078ForecastingPermissionBackfill(&migrator)
         registerMigration079LogFleetPermission(&migrator)
         registerMigration080ToolMovementsIndex(&migrator)
+        registerMigration081AuthTokenSessions(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -4998,6 +4999,22 @@ extension AppDatabase {
                 CREATE INDEX IF NOT EXISTS idx_tool_movements_type
                 ON tool_movements (movement_type, deleted_at, created_at)
                 """)
+        }
+    }
+
+    // MARK: - Migration 081: Auth token sessions
+
+    private static func registerMigration081AuthTokenSessions(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("081_auth_token_sessions") { db in
+            try db.create(table: "auth_token_sessions", ifNotExists: true) { t in
+                t.column("token_id", .text).primaryKey()
+                t.column("user_id", .integer).notNull()
+                t.column("token_type", .text).notNull()
+                t.column("parent_refresh_id", .text)
+                t.column("expires_at_ms", .double).notNull()
+                t.column("revoked_at", .text)
+                t.column("created_at", .text).notNull()
+            }
         }
     }
 

--- a/core/Sources/WiredPartCore/Services/AuthService.swift
+++ b/core/Sources/WiredPartCore/Services/AuthService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CommonCrypto
 import CryptoKit
 import GRDB
 import Security
@@ -11,7 +12,7 @@ import os.log
 ///   1. `seedFirstAdmin()` — the very first device in a new company
 ///   2. Sync from another device — all subsequent devices
 ///
-/// PIN verification uses SHA-256 hashes stored locally. Session tokens
+/// PIN verification uses PBKDF2-HMAC-SHA256 hashes stored locally. Session tokens
 /// are base64-encoded JSON payloads (24-hour expiry).
 ///
 /// Ported from: `src/local/services/auth-service.ts`
@@ -25,6 +26,19 @@ public final class AuthService: Sendable {
 
     public init(db: AppDatabase) {
         self.db = db
+        try? db.writer.write { dbConn in
+            try dbConn.execute(sql: """
+                CREATE TABLE IF NOT EXISTS auth_token_sessions (
+                    token_id TEXT PRIMARY KEY,
+                    user_id INTEGER NOT NULL,
+                    token_type TEXT NOT NULL,
+                    parent_refresh_id TEXT,
+                    expires_at_ms REAL NOT NULL,
+                    revoked_at TEXT,
+                    created_at TEXT NOT NULL
+                )
+            """)
+        }
     }
 
     // MARK: - Types
@@ -34,12 +48,14 @@ public final class AuthService: Sendable {
         public let success: Bool
         public let user: User?
         public let token: String?
+        public let refreshToken: String?
         public let message: String
     }
 
     /// Decoded session token payload.
     public struct TokenPayload: Codable, Sendable {
         public let sub: Int64
+        public let jti: String
         public let iat: Double
         public let exp: Double
         public let type: String
@@ -138,7 +154,7 @@ public final class AuthService: Sendable {
     public func authenticateByPin(userId: Int64, pin: String) throws -> AuthResult {
         // Check lockout before attempting authentication
         if let seconds = Self.lockoutSecondsRemaining(userId: userId) {
-            return AuthResult(success: false, user: nil, token: nil, message: "Too many failed attempts. Try again in \(seconds)s.")
+            return AuthResult(success: false, user: nil, token: nil, refreshToken: nil, message: "Too many failed attempts. Try again in \(seconds)s.")
         }
 
         let user: User? = try db.writer.read { dbConnection in
@@ -150,28 +166,30 @@ public final class AuthService: Sendable {
         }
 
         guard let user else {
-            return AuthResult(success: false, user: nil, token: nil, message: "User not found or inactive")
+            return AuthResult(success: false, user: nil, token: nil, refreshToken: nil, message: "User not found or inactive")
         }
 
         guard let pinHash = user.pinHash, pinHash != "__PLACEHOLDER_HASH__" else {
-            return AuthResult(success: false, user: nil, token: nil, message: "PIN not configured. Sync with shop first.")
+            return AuthResult(success: false, user: nil, token: nil, refreshToken: nil, message: "PIN not configured. Sync with shop first.")
         }
 
         let isValid = Self.verifyPinLocally(pin: pin, storedHash: pinHash, salt: user.pinSalt)
         guard isValid else {
             if let lockoutSeconds = Self.recordFailedAttempt(userId: userId) {
-                return AuthResult(success: false, user: nil, token: nil, message: "Invalid PIN. Locked for \(lockoutSeconds)s.")
+                return AuthResult(success: false, user: nil, token: nil, refreshToken: nil, message: "Invalid PIN. Locked for \(lockoutSeconds)s.")
             }
-            return AuthResult(success: false, user: nil, token: nil, message: "Invalid PIN")
+            return AuthResult(success: false, user: nil, token: nil, refreshToken: nil, message: "Invalid PIN")
         }
 
         guard let userId = user.id else {
-            return AuthResult(success: false, user: nil, token: nil, message: "User record missing ID")
+            return AuthResult(success: false, user: nil, token: nil, refreshToken: nil, message: "User record missing ID")
         }
 
-        // Migration path: re-hash legacy PINs with a per-user salt on successful login
-        if user.pinSalt == nil {
-            let newSalt = Self.generateSalt()
+        // Migration path: upgrade legacy hashes to PBKDF2 on successful login.
+        // Tier 1 (no salt) and Tier 2 (iterated SHA-256) both get upgraded transparently.
+        let needsUpgrade = user.pinSalt == nil || !Self.isPBKDF2Hash(pinHash)
+        if needsUpgrade {
+            let newSalt = user.pinSalt ?? Self.generateSalt()
             let newHash = Self.hashPin(pin, salt: newSalt)
             let now = Self.currentTimestamp()
             try db.writer.write { dbConn in
@@ -183,8 +201,8 @@ public final class AuthService: Sendable {
         }
 
         Self.clearFailedAttempts(userId: userId)
-        let token = Self.generateLocalToken(userId: userId)
-        return AuthResult(success: true, user: user, token: token, message: "Authenticated")
+        let session = try issueSessionTokens(forUserId: userId, parentRefreshId: nil)
+        return AuthResult(success: true, user: user, token: session.accessToken, refreshToken: session.refreshToken, message: "Authenticated")
     }
 
     /// Get list of active users for the login screen.
@@ -216,7 +234,7 @@ public final class AuthService: Sendable {
         }
 
         if existingCount > 0 {
-            return AuthResult(success: false, user: nil, token: nil, message: "Users already exist. Seed aborted.")
+            return AuthResult(success: false, user: nil, token: nil, refreshToken: nil, message: "Users already exist. Seed aborted.")
         }
 
         let now = Self.currentTimestamp()
@@ -316,11 +334,11 @@ public final class AuthService: Sendable {
         }
 
         guard let user, let userId = user.id else {
-            return AuthResult(success: false, user: nil, token: nil, message: "Failed to create admin user")
+            return AuthResult(success: false, user: nil, token: nil, refreshToken: nil, message: "Failed to create admin user")
         }
 
-        let token = Self.generateLocalToken(userId: userId)
-        return AuthResult(success: true, user: user, token: token, message: "Company database initialized. Welcome!")
+        let session = try issueSessionTokens(forUserId: userId, parentRefreshId: nil)
+        return AuthResult(success: true, user: user, token: session.accessToken, refreshToken: session.refreshToken, message: "Company database initialized. Welcome!")
     }
 
     // MARK: - User Queries
@@ -505,13 +523,16 @@ public final class AuthService: Sendable {
 
     /// Build a full UserProfile from a local token.
     public func getLocalUserProfile(token: String) throws -> UserProfile {
-        guard let payload = Self.parseLocalToken(token) else {
+        guard let payload = Self.parseLocalToken(token), payload.type == "local_access" else {
             throw AuthError.invalidToken
         }
 
         let nowMs = Date().timeIntervalSince1970 * 1000
         guard payload.exp > nowMs else {
             throw AuthError.tokenExpired
+        }
+        guard try isTokenActive(tokenId: payload.jti, expectedType: "local_access") else {
+            throw AuthError.sessionRevoked
         }
 
         guard let user = try getUser(payload.sub) else {
@@ -552,9 +573,35 @@ public final class AuthService: Sendable {
         case invalidToken
         case tokenExpired
         case userNotFound
+        case sessionRevoked
         case requiredFieldEmpty(String)
         case invalidPin(String)
         case hatNotFound(Int64)
+    }
+
+    /// Rotate a refresh token and return a fresh access+refresh pair.
+    public func refreshLocalSession(refreshToken: String) throws -> (accessToken: String, refreshToken: String) {
+        guard let payload = Self.parseLocalToken(refreshToken), payload.type == "local_refresh" else {
+            throw AuthError.invalidToken
+        }
+        let nowMs = Date().timeIntervalSince1970 * 1000
+        guard payload.exp > nowMs else {
+            throw AuthError.tokenExpired
+        }
+        guard try isTokenActive(tokenId: payload.jti, expectedType: "local_refresh") else {
+            throw AuthError.sessionRevoked
+        }
+
+        try revokeTokenById(payload.jti)
+        return try issueSessionTokens(forUserId: payload.sub, parentRefreshId: payload.jti)
+    }
+
+    /// Revoke an access or refresh token string.
+    public func revokeLocalSession(token: String) throws {
+        guard let payload = Self.parseLocalToken(token) else {
+            throw AuthError.invalidToken
+        }
+        try revokeTokenById(payload.jti)
     }
 
     // MARK: - Security & Device Administration
@@ -652,9 +699,10 @@ public final class AuthService: Sendable {
 
     // MARK: - PIN Upgrade Tracking
 
-    /// Count of active users still using the legacy fixed-salt PIN hash (pre-migration 023).
+    /// Count of active users NOT yet on the current PBKDF2 KDF.
+    /// Includes both legacy tier 1 (no salt) and tier 2 (iterated SHA-256).
     /// These users will be upgraded automatically on their next successful login.
-    /// Returns 0 once all users have logged in since the migration.
+    /// Returns 0 once all users have logged in since the PBKDF2 upgrade.
     ///
     /// Admins can use this to monitor upgrade progress in the People → Permissions area.
     public func getLegacyHashedUserCount() throws -> Int {
@@ -665,7 +713,7 @@ public final class AuthService: Sendable {
                     SELECT COUNT(*) FROM users
                     WHERE is_active = 1
                       AND deleted_at IS NULL
-                      AND pin_salt IS NULL
+                      AND pin_hash NOT LIKE 'pbkdf2$%'
                       AND pin_hash NOT LIKE '$2b$%'
                       AND pin_hash != '__PLACEHOLDER_HASH__'
                     """
@@ -673,9 +721,9 @@ public final class AuthService: Sendable {
         }
     }
 
-    /// Active users still on the legacy fixed-salt PIN hash, returned as (id, displayName) pairs.
+    /// Active users not yet on PBKDF2, returned as (id, displayName) pairs.
     /// Admins can surface these in the People → Permissions area to prompt affected users to log in
-    /// and trigger the automatic per-user migration.
+    /// and trigger the automatic PBKDF2 migration.
     public func getLegacyHashedUsers() throws -> [(id: Int64, displayName: String)] {
         try db.writer.read { dbConn in
             let rows = try Row.fetchAll(
@@ -684,7 +732,7 @@ public final class AuthService: Sendable {
                     SELECT id, display_name FROM users
                     WHERE is_active = 1
                       AND deleted_at IS NULL
-                      AND pin_salt IS NULL
+                      AND pin_hash NOT LIKE 'pbkdf2$%'
                       AND pin_hash NOT LIKE '$2b$%'
                       AND pin_hash != '__PLACEHOLDER_HASH__'
                     ORDER BY display_name
@@ -783,26 +831,90 @@ public final class AuthService: Sendable {
     // MARK: - Internal Helpers
 
     /// Verify a PIN against a stored hash.
-    /// Supports both legacy (fixed salt) and new (per-user salt + key stretching) formats.
+    /// Supports three formats in order of preference:
+    ///   1. PBKDF2  — `pbkdf2$<iterations>$<hex>`  (current, per-user salt in `pin_salt`)
+    ///   2. Iterated SHA-256 — 64-char hex with per-user salt (legacy tier 2)
+    ///   3. Single SHA-256 — 64-char hex with fixed "wiredpart" salt (legacy tier 1, no `pin_salt`)
+    /// Bcrypt hashes (synced from another system) are not verifiable locally.
     static func verifyPinLocally(pin: String, storedHash: String, salt: String?) -> Bool {
-        // If it's a bcrypt hash, we can't verify offline
+        // Bcrypt — can't verify offline
         if storedHash.hasPrefix("$2b$") || storedHash.hasPrefix("$2a$") {
             return false
         }
 
+        // PBKDF2 format: pbkdf2$<iterations>$<hex>
+        if storedHash.hasPrefix("pbkdf2$"), let salt {
+            return verifyPBKDF2(pin: pin, storedHash: storedHash, salt: salt)
+        }
+
         if let salt {
-            // New per-user salted hash with key stretching
-            let computed = hashPin(pin, salt: salt)
+            // Legacy tier 2: iterated SHA-256 with per-user salt
+            let computed = iteratedSHA256Pin(pin, salt: salt)
             return computed == storedHash
         } else {
-            // Legacy fixed-salt hash (pre-migration 023)
+            // Legacy tier 1: single SHA-256 with fixed salt
             let computed = legacyHashPin(pin)
             return computed == storedHash
         }
     }
 
-    /// Hash a PIN with a per-user salt using iterated SHA-256 for key stretching.
+    // MARK: - PBKDF2 Hashing (current)
+
+    /// Default PBKDF2 iteration count — OWASP 2023 minimum for HMAC-SHA256.
+    static let pbkdf2Iterations: UInt32 = 600_000
+
+    /// Hash a PIN with PBKDF2-HMAC-SHA256. Returns `pbkdf2$<iterations>$<hex>`.
+    /// The per-user salt is stored separately in the `pin_salt` column.
     static func hashPin(_ pin: String, salt: String) -> String {
+        let password = Array((pin + ":" + salt).utf8)
+        let saltBytes = Array(salt.utf8)
+        var derivedKey = [UInt8](repeating: 0, count: 32) // 256-bit output
+        let status = CCKeyDerivationPBKDF(
+            CCPBKDFAlgorithm(kCCPBKDF2),
+            password, password.count,
+            saltBytes, saltBytes.count,
+            CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+            pbkdf2Iterations,
+            &derivedKey, derivedKey.count
+        )
+        guard status == kCCSuccess else {
+            // Fallback should never happen — log and use iterated SHA-256
+            Self.logger.error("PBKDF2 failed with status \(status, privacy: .public), falling back to iterated SHA-256")
+            return iteratedSHA256Pin(pin, salt: salt)
+        }
+        let hex = derivedKey.map { String(format: "%02x", $0) }.joined()
+        return "pbkdf2$\(pbkdf2Iterations)$\(hex)"
+    }
+
+    /// Verify a PIN against a PBKDF2 hash string.
+    private static func verifyPBKDF2(pin: String, storedHash: String, salt: String) -> Bool {
+        let parts = storedHash.split(separator: "$")
+        guard parts.count == 3,
+              parts[0] == "pbkdf2",
+              let iterations = UInt32(parts[1]) else { return false }
+        let expectedHex = String(parts[2])
+
+        let password = Array((pin + ":" + salt).utf8)
+        let saltBytes = Array(salt.utf8)
+        var derivedKey = [UInt8](repeating: 0, count: 32)
+        let status = CCKeyDerivationPBKDF(
+            CCPBKDFAlgorithm(kCCPBKDF2),
+            password, password.count,
+            saltBytes, saltBytes.count,
+            CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+            iterations,
+            &derivedKey, derivedKey.count
+        )
+        guard status == kCCSuccess else { return false }
+        let computedHex = derivedKey.map { String(format: "%02x", $0) }.joined()
+        return computedHex == expectedHex
+    }
+
+    // MARK: - Legacy Hash Functions (verification only)
+
+    /// Iterated SHA-256 with per-user salt (legacy tier 2, pre-PBKDF2).
+    /// Kept for verifying existing hashes; new hashes use PBKDF2.
+    static func iteratedSHA256Pin(_ pin: String, salt: String) -> String {
         let input = Data((pin + ":" + salt).utf8)
         var hash = SHA256.hash(data: input)
         for _ in 0..<10_000 {
@@ -812,7 +924,7 @@ public final class AuthService: Sendable {
     }
 
     /// Legacy fixed-salt hash for backward compatibility during migration.
-    /// Used only to verify old PINs before re-hashing with a per-user salt.
+    /// Used only to verify old PINs before re-hashing with PBKDF2.
     static func legacyHashPin(_ pin: String) -> String {
         let data = Data((pin + ":wiredpart").utf8)
         let digest = SHA256.hash(data: data)
@@ -823,6 +935,11 @@ public final class AuthService: Sendable {
     static func generateSalt() -> String {
         let bytes = (0..<16).map { _ in UInt8.random(in: 0...255) }
         return Data(bytes).base64EncodedString()
+    }
+
+    /// Check if a stored hash is already using the current PBKDF2 KDF.
+    static func isPBKDF2Hash(_ hash: String) -> Bool {
+        hash.hasPrefix("pbkdf2$")
     }
 
     /// Device-specific signing key. Persisted in the Keychain so tokens survive app
@@ -878,12 +995,21 @@ public final class AuthService: Sendable {
 
     /// Generate a signed local session token (base64 payload + HMAC-SHA256 signature).
     static func generateLocalToken(userId: Int64) -> String? {
+        generateToken(userId: userId, type: "local_access", ttlMs: 15 * 60 * 1000)
+    }
+
+    static func generateLocalRefreshToken(userId: Int64) -> String? {
+        generateToken(userId: userId, type: "local_refresh", ttlMs: 7 * 24 * 60 * 60 * 1000)
+    }
+
+    private static func generateToken(userId: Int64, type: String, ttlMs: Double) -> String? {
         let nowMs = Date().timeIntervalSince1970 * 1000
         let payload = TokenPayload(
             sub: userId,
+            jti: UUID().uuidString.lowercased(),
             iat: nowMs,
-            exp: nowMs + 24 * 60 * 60 * 1000, // 24 hours
-            type: "local"
+            exp: nowMs + ttlMs,
+            type: type
         )
         guard let data = try? JSONEncoder().encode(payload) else {
             return nil
@@ -909,8 +1035,64 @@ public final class AuthService: Sendable {
 
         guard let data = Data(base64Encoded: payloadB64) else { return nil }
         guard let payload = try? JSONDecoder().decode(TokenPayload.self, from: data) else { return nil }
-        guard payload.type == "local" else { return nil }
+        guard payload.type == "local_access" || payload.type == "local_refresh" else { return nil }
         return payload
+    }
+
+    private func issueSessionTokens(forUserId userId: Int64, parentRefreshId: String?) throws -> (accessToken: String, refreshToken: String) {
+        guard let access = Self.generateLocalToken(userId: userId),
+              let refresh = Self.generateLocalRefreshToken(userId: userId),
+              let accessPayload = Self.parseLocalToken(access),
+              let refreshPayload = Self.parseLocalToken(refresh) else {
+            throw AuthError.invalidToken
+        }
+
+        try db.writer.write { dbConn in
+            let now = Self.currentTimestamp()
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO auth_token_sessions (token_id, user_id, token_type, parent_refresh_id, expires_at_ms, revoked_at, created_at)
+                    VALUES (?, ?, 'local_access', ?, ?, NULL, ?)
+                """,
+                arguments: [accessPayload.jti, userId, refreshPayload.jti, accessPayload.exp, now]
+            )
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO auth_token_sessions (token_id, user_id, token_type, parent_refresh_id, expires_at_ms, revoked_at, created_at)
+                    VALUES (?, ?, 'local_refresh', ?, ?, NULL, ?)
+                """,
+                arguments: [refreshPayload.jti, userId, parentRefreshId, refreshPayload.exp, now]
+            )
+        }
+        return (access, refresh)
+    }
+
+    private func revokeTokenById(_ tokenId: String) throws {
+        try db.writer.write { dbConn in
+            try dbConn.execute(
+                sql: "UPDATE auth_token_sessions SET revoked_at = ? WHERE token_id = ?",
+                arguments: [Self.currentTimestamp(), tokenId]
+            )
+        }
+    }
+
+    private func isTokenActive(tokenId: String, expectedType: String) throws -> Bool {
+        try db.writer.read { dbConn in
+            let row = try Row.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT revoked_at, expires_at_ms
+                    FROM auth_token_sessions
+                    WHERE token_id = ? AND token_type = ?
+                """,
+                arguments: [tokenId, expectedType]
+            )
+            guard let row else { return false }
+            if (row["revoked_at"] as String?) != nil { return false }
+            let nowMs = Date().timeIntervalSince1970 * 1000
+            let expMs = row["expires_at_ms"] as Double? ?? 0
+            return expMs > nowMs
+        }
     }
 
     /// Current ISO-8601-ish timestamp (matching the TS format: "YYYY-MM-DD HH:MM:SS").

--- a/core/Sources/WiredPartCore/Services/AuthService.swift
+++ b/core/Sources/WiredPartCore/Services/AuthService.swift
@@ -26,19 +26,6 @@ public final class AuthService: Sendable {
 
     public init(db: AppDatabase) {
         self.db = db
-        try? db.writer.write { dbConn in
-            try dbConn.execute(sql: """
-                CREATE TABLE IF NOT EXISTS auth_token_sessions (
-                    token_id TEXT PRIMARY KEY,
-                    user_id INTEGER NOT NULL,
-                    token_type TEXT NOT NULL,
-                    parent_refresh_id TEXT,
-                    expires_at_ms REAL NOT NULL,
-                    revoked_at TEXT,
-                    created_at TEXT NOT NULL
-                )
-            """)
-        }
     }
 
     // MARK: - Types
@@ -592,8 +579,13 @@ public final class AuthService: Sendable {
             throw AuthError.sessionRevoked
         }
 
-        try revokeTokenById(payload.jti)
-        return try issueSessionTokens(forUserId: payload.sub, parentRefreshId: payload.jti)
+        let tokens = try Self.makeSessionTokens(forUserId: payload.sub)
+        try db.writer.write { dbConn in
+            let now = Self.currentTimestamp()
+            try Self.revokeTokenById(payload.jti, in: dbConn, revokedAt: now)
+            try Self.insertSessionTokens(tokens, userId: payload.sub, parentRefreshId: payload.jti, createdAt: now, in: dbConn)
+        }
+        return (tokens.access, tokens.refresh)
     }
 
     /// Revoke an access or refresh token string.
@@ -866,7 +858,7 @@ public final class AuthService: Sendable {
     /// Hash a PIN with PBKDF2-HMAC-SHA256. Returns `pbkdf2$<iterations>$<hex>`.
     /// The per-user salt is stored separately in the `pin_salt` column.
     static func hashPin(_ pin: String, salt: String) -> String {
-        let password = Array((pin + ":" + salt).utf8)
+        let password = Array(pin.utf8)
         let saltBytes = Array(salt.utf8)
         var derivedKey = [UInt8](repeating: 0, count: 32) // 256-bit output
         let status = CCKeyDerivationPBKDF(
@@ -894,9 +886,10 @@ public final class AuthService: Sendable {
               let iterations = UInt32(parts[1]) else { return false }
         let expectedHex = String(parts[2])
 
-        let password = Array((pin + ":" + salt).utf8)
+        guard let expectedBytes = hexBytes(expectedHex) else { return false }
+        let password = Array(pin.utf8)
         let saltBytes = Array(salt.utf8)
-        var derivedKey = [UInt8](repeating: 0, count: 32)
+        var derivedKey = [UInt8](repeating: 0, count: expectedBytes.count)
         let status = CCKeyDerivationPBKDF(
             CCPBKDFAlgorithm(kCCPBKDF2),
             password, password.count,
@@ -906,8 +899,7 @@ public final class AuthService: Sendable {
             &derivedKey, derivedKey.count
         )
         guard status == kCCSuccess else { return false }
-        let computedHex = derivedKey.map { String(format: "%02x", $0) }.joined()
-        return computedHex == expectedHex
+        return constantTimeEqual(derivedKey, expectedBytes)
     }
 
     // MARK: - Legacy Hash Functions (verification only)
@@ -1030,8 +1022,7 @@ public final class AuthService: Sendable {
         let payloadB64 = String(parts[0])
         let sigB64 = String(parts[1])
         guard let sigData = Data(base64Encoded: sigB64) else { return nil }
-        let expected = HMAC<SHA256>.authenticationCode(for: Data(payloadB64.utf8), using: signingKey)
-        guard Data(sigData) == Data(expected) else { return nil }
+        guard HMAC<SHA256>.isValidAuthenticationCode(sigData, authenticating: Data(payloadB64.utf8), using: signingKey) else { return nil }
 
         guard let data = Data(base64Encoded: payloadB64) else { return nil }
         guard let payload = try? JSONDecoder().decode(TokenPayload.self, from: data) else { return nil }
@@ -1039,41 +1030,67 @@ public final class AuthService: Sendable {
         return payload
     }
 
-    private func issueSessionTokens(forUserId userId: Int64, parentRefreshId: String?) throws -> (accessToken: String, refreshToken: String) {
+    private struct SessionTokenPair {
+        let access: String
+        let refresh: String
+        let accessPayload: TokenPayload
+        let refreshPayload: TokenPayload
+    }
+
+    private static func makeSessionTokens(forUserId userId: Int64) throws -> SessionTokenPair {
         guard let access = Self.generateLocalToken(userId: userId),
               let refresh = Self.generateLocalRefreshToken(userId: userId),
               let accessPayload = Self.parseLocalToken(access),
               let refreshPayload = Self.parseLocalToken(refresh) else {
             throw AuthError.invalidToken
         }
+        return SessionTokenPair(access: access, refresh: refresh, accessPayload: accessPayload, refreshPayload: refreshPayload)
+    }
+
+    private func issueSessionTokens(forUserId userId: Int64, parentRefreshId: String?) throws -> (accessToken: String, refreshToken: String) {
+        let tokens = try Self.makeSessionTokens(forUserId: userId)
 
         try db.writer.write { dbConn in
             let now = Self.currentTimestamp()
-            try dbConn.execute(
-                sql: """
-                    INSERT INTO auth_token_sessions (token_id, user_id, token_type, parent_refresh_id, expires_at_ms, revoked_at, created_at)
-                    VALUES (?, ?, 'local_access', ?, ?, NULL, ?)
-                """,
-                arguments: [accessPayload.jti, userId, refreshPayload.jti, accessPayload.exp, now]
-            )
-            try dbConn.execute(
-                sql: """
-                    INSERT INTO auth_token_sessions (token_id, user_id, token_type, parent_refresh_id, expires_at_ms, revoked_at, created_at)
-                    VALUES (?, ?, 'local_refresh', ?, ?, NULL, ?)
-                """,
-                arguments: [refreshPayload.jti, userId, parentRefreshId, refreshPayload.exp, now]
-            )
+            try Self.insertSessionTokens(tokens, userId: userId, parentRefreshId: parentRefreshId, createdAt: now, in: dbConn)
         }
-        return (access, refresh)
+        return (tokens.access, tokens.refresh)
     }
 
     private func revokeTokenById(_ tokenId: String) throws {
         try db.writer.write { dbConn in
-            try dbConn.execute(
-                sql: "UPDATE auth_token_sessions SET revoked_at = ? WHERE token_id = ?",
-                arguments: [Self.currentTimestamp(), tokenId]
-            )
+            try Self.revokeTokenById(tokenId, in: dbConn, revokedAt: Self.currentTimestamp())
         }
+    }
+
+    private static func insertSessionTokens(
+        _ tokens: SessionTokenPair,
+        userId: Int64,
+        parentRefreshId: String?,
+        createdAt: String,
+        in dbConn: Database
+    ) throws {
+        try dbConn.execute(
+            sql: """
+                INSERT INTO auth_token_sessions (token_id, user_id, token_type, parent_refresh_id, expires_at_ms, revoked_at, created_at)
+                VALUES (?, ?, 'local_access', ?, ?, NULL, ?)
+            """,
+            arguments: [tokens.accessPayload.jti, userId, tokens.refreshPayload.jti, tokens.accessPayload.exp, createdAt]
+        )
+        try dbConn.execute(
+            sql: """
+                INSERT INTO auth_token_sessions (token_id, user_id, token_type, parent_refresh_id, expires_at_ms, revoked_at, created_at)
+                VALUES (?, ?, 'local_refresh', ?, ?, NULL, ?)
+            """,
+            arguments: [tokens.refreshPayload.jti, userId, parentRefreshId, tokens.refreshPayload.exp, createdAt]
+        )
+    }
+
+    private static func revokeTokenById(_ tokenId: String, in dbConn: Database, revokedAt: String) throws {
+        try dbConn.execute(
+            sql: "UPDATE auth_token_sessions SET revoked_at = ? WHERE token_id = ?",
+            arguments: [revokedAt, tokenId]
+        )
     }
 
     private func isTokenActive(tokenId: String, expectedType: String) throws -> Bool {
@@ -1101,6 +1118,29 @@ public final class AuthService: Sendable {
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         formatter.timeZone = TimeZone(identifier: "UTC")
         return formatter.string(from: Date())
+    }
+
+    private static func hexBytes(_ hex: String) -> [UInt8]? {
+        guard hex.count.isMultiple(of: 2) else { return nil }
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(hex.count / 2)
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let next = hex.index(index, offsetBy: 2)
+            guard let byte = UInt8(hex[index..<next], radix: 16) else { return nil }
+            bytes.append(byte)
+            index = next
+        }
+        return bytes
+    }
+
+    private static func constantTimeEqual(_ lhs: [UInt8], _ rhs: [UInt8]) -> Bool {
+        guard lhs.count == rhs.count else { return false }
+        var difference: UInt8 = 0
+        for (left, right) in zip(lhs, rhs) {
+            difference |= left ^ right
+        }
+        return difference == 0
     }
 
     // MARK: - Default Permission Map

--- a/core/Tests/WiredPartCoreTests/AuthServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/AuthServiceTests.swift
@@ -11,14 +11,24 @@ struct AuthServiceTests {
         try AppDatabase.openInMemoryDatabase()
     }
 
-    // MARK: - PIN Hashing
+    // MARK: - PIN Hashing (PBKDF2)
 
-    @Test("hashPin produces consistent SHA-256 hex")
+    @Test("hashPin produces PBKDF2 prefixed output")
+    func testHashPinPBKDF2Format() throws {
+        let hash = AuthService.hashPin("1234", salt: "test-salt")
+        #expect(hash.hasPrefix("pbkdf2$"))
+        let parts = hash.split(separator: "$")
+        #expect(parts.count == 3)
+        #expect(parts[0] == "pbkdf2")
+        #expect(parts[1] == "600000")
+        #expect(parts[2].count == 64) // 32 bytes = 64 hex chars
+    }
+
+    @Test("hashPin produces consistent output")
     func testHashPinConsistent() throws {
         let hash1 = AuthService.hashPin("1234", salt: "test-salt")
         let hash2 = AuthService.hashPin("1234", salt: "test-salt")
         #expect(hash1 == hash2)
-        #expect(hash1.count == 64) // SHA-256 = 32 bytes = 64 hex chars
     }
 
     @Test("hashPin produces different hashes for different PINs")
@@ -28,7 +38,7 @@ struct AuthServiceTests {
         #expect(hash1 != hash2)
     }
 
-    @Test("verifyPinLocally returns true for correct PIN")
+    @Test("verifyPinLocally returns true for correct PBKDF2 PIN")
     func testVerifyPinCorrect() throws {
         let pin = "9876"
         let hash = AuthService.hashPin(pin, salt: "test-salt")
@@ -44,6 +54,16 @@ struct AuthServiceTests {
     @Test("verifyPinLocally returns false for bcrypt hash")
     func testVerifyPinBcrypt() throws {
         #expect(!AuthService.verifyPinLocally(pin: "1234", storedHash: "$2b$12$someBcryptHash", salt: "test-salt"))
+    }
+
+    @Test("verifyPinLocally verifies legacy iterated SHA-256 hashes")
+    func testVerifyPinLegacyIteratedSHA256() throws {
+        // Simulate a hash created by the old iteratedSHA256Pin function
+        let pin = "4567"
+        let salt = "old-salt"
+        let legacyHash = AuthService.iteratedSHA256Pin(pin, salt: salt)
+        #expect(AuthService.verifyPinLocally(pin: pin, storedHash: legacyHash, salt: salt))
+        #expect(!AuthService.verifyPinLocally(pin: "0000", storedHash: legacyHash, salt: salt))
     }
 
     // MARK: - Token Generation & Parsing
@@ -65,7 +85,7 @@ struct AuthServiceTests {
         let payload = AuthService.parseLocalToken(token)
         #expect(payload != nil)
         #expect(payload?.sub == 42)
-        #expect(payload?.type == "local")
+        #expect(payload?.type == "local_access")
         #expect(payload?.exp ?? 0 > payload?.iat ?? 0)
     }
 
@@ -78,7 +98,7 @@ struct AuthServiceTests {
     func testParseTokenRejectsUnsigned() throws {
         // Simulate a pre-PE-008a unsigned token: plain base64 payload with no signature.
         // These should now be rejected since the shim was removed 2026-04-08.
-        let payload = AuthService.TokenPayload(sub: 42, iat: 1000, exp: 9999999999999, type: "local")
+        let payload = AuthService.TokenPayload(sub: 42, jti: UUID().uuidString, iat: 1000, exp: 9999999999999, type: "local_access")
         let data = try JSONEncoder().encode(payload)
         let unsignedToken = data.base64EncodedString()  // no "." separator — legacy format
         #expect(AuthService.parseLocalToken(unsignedToken) == nil)
@@ -169,6 +189,7 @@ struct AuthServiceTests {
         #expect(result.success)
         #expect(result.user?.displayName == "Admin")
         #expect(result.token != nil)
+        #expect(result.refreshToken != nil)
     }
 
     @Test("authenticateByPin rejects wrong PIN")
@@ -375,6 +396,21 @@ struct AuthServiceTests {
         }
     }
 
+    @Test("revoked local session token is denied by getLocalUserProfile")
+    func testRevokedTokenDenied() throws {
+        let db = try freshDB()
+        let auth = AuthService(db: db)
+        let seed = try auth.seedFirstAdmin(displayName: "Admin", pin: "1234")
+        let token = try #require(seed.token)
+
+        _ = try auth.getLocalUserProfile(token: token) // precondition: token valid
+        try auth.revokeLocalSession(token: token)
+
+        #expect(throws: AuthService.AuthError.self) {
+            _ = try auth.getLocalUserProfile(token: token)
+        }
+    }
+
     // MARK: - Legacy PIN Hash Tracking (PE-008c)
 
     @Test("getLegacyHashedUserCount returns 0 when all users have pin_salt")
@@ -400,6 +436,25 @@ struct AuthServiceTests {
         #expect(try auth.getLegacyHashedUserCount() == 1)
     }
 
+    @Test("getLegacyHashedUserCount returns 1 for user with iterated SHA-256 hash")
+    func testLegacyCountIteratedSHA256User() throws {
+        let db = try freshDB()
+        let auth = AuthService(db: db)
+        _ = try auth.seedFirstAdmin(displayName: "Admin", pin: "1234")
+
+        // Insert a user with iterated SHA-256 (has salt but no pbkdf2$ prefix)
+        let oldHash = AuthService.iteratedSHA256Pin("5555", salt: "some-salt")
+        try db.writer.write { dbConn in
+            try dbConn.execute(
+                sql: "INSERT INTO users (display_name, pin_hash, pin_salt, is_active) VALUES ('OldSalted', ?, 'some-salt', 1)",
+                arguments: [oldHash]
+            )
+        }
+
+        // Should count as legacy (not yet PBKDF2)
+        #expect(try auth.getLegacyHashedUserCount() == 1)
+    }
+
     @Test("getLegacyHashedUserCount ignores placeholder hashes and inactive users")
     func testLegacyCountIgnoresPlaceholdersAndInactive() throws {
         let db = try freshDB()
@@ -417,7 +472,7 @@ struct AuthServiceTests {
         #expect(try auth.getLegacyHashedUserCount() == 0)
     }
 
-    @Test("getLegacyHashedUserCount drops to 0 after legacy user logs in")
+    @Test("getLegacyHashedUserCount drops to 0 after legacy user logs in (upgrades to PBKDF2)")
     func testLegacyCountDecrementOnLogin() throws {
         let db = try freshDB()
         let auth = AuthService(db: db)
@@ -438,10 +493,50 @@ struct AuthServiceTests {
 
         #expect(try auth.getLegacyHashedUserCount() == 1)
 
-        // Login triggers automatic re-hash with a per-user salt
+        // Login triggers automatic re-hash to PBKDF2
         let result = try auth.authenticateByPin(userId: legacyUserId, pin: "9999")
         #expect(result.success)
         #expect(try auth.getLegacyHashedUserCount() == 0)
+
+        // Verify the stored hash is now PBKDF2 format
+        let updatedHash = try db.writer.read { dbConn -> String? in
+            try String.fetchOne(dbConn, sql: "SELECT pin_hash FROM users WHERE id = ?", arguments: [legacyUserId])
+        }
+        #expect(updatedHash?.hasPrefix("pbkdf2$") == true)
+    }
+
+    @Test("Iterated SHA-256 user upgrades to PBKDF2 on login")
+    func testIteratedSHA256UpgradesToPBKDF2OnLogin() throws {
+        AuthService.resetAllLoginAttempts()
+        let db = try freshDB()
+        let auth = AuthService(db: db)
+        _ = try auth.seedFirstAdmin(displayName: "Admin", pin: "0000")
+
+        // Insert a user with iterated SHA-256 hash (has salt, but not PBKDF2)
+        let salt = AuthService.generateSalt()
+        let oldHash = AuthService.iteratedSHA256Pin("7777", salt: salt)
+        var userId: Int64 = 0
+        try db.writer.write { dbConn in
+            try dbConn.execute(
+                sql: "INSERT INTO users (display_name, pin_hash, pin_salt, is_active) VALUES ('OldWorker', ?, ?, 1)",
+                arguments: [oldHash, salt]
+            )
+            userId = dbConn.lastInsertedRowID
+        }
+
+        // Login should succeed with old hash and transparently upgrade
+        let result = try auth.authenticateByPin(userId: userId, pin: "7777")
+        #expect(result.success)
+
+        // Verify upgrade to PBKDF2
+        let updatedHash = try db.writer.read { dbConn -> String? in
+            try String.fetchOne(dbConn, sql: "SELECT pin_hash FROM users WHERE id = ?", arguments: [userId])
+        }
+        #expect(updatedHash?.hasPrefix("pbkdf2$") == true)
+
+        // Re-login should still work with the new PBKDF2 hash
+        let result2 = try auth.authenticateByPin(userId: userId, pin: "7777")
+        #expect(result2.success)
     }
 
     // MARK: - Active Users

--- a/core/Tests/WiredPartCoreTests/AuthServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/AuthServiceTests.swift
@@ -406,7 +406,7 @@ struct AuthServiceTests {
         _ = try auth.getLocalUserProfile(token: token) // precondition: token valid
         try auth.revokeLocalSession(token: token)
 
-        #expect(throws: AuthService.AuthError.self) {
+        #expect(throws: AuthService.AuthError.sessionRevoked) {
             _ = try auth.getLocalUserProfile(token: token)
         }
     }
@@ -1133,4 +1133,3 @@ struct AuthServiceTests {
         #expect(duplicates == 0, "INSERT OR IGNORE must not create duplicate hat_permissions rows")
     }
 }
-


### PR DESCRIPTION
## Summary
- upgrades local PIN hashing to PBKDF2 while preserving legacy SHA-256 verification and transparent migration on successful login
- issues tracked local access/refresh tokens with refresh rotation and token revocation checks
- adds a biometric auth helper for opt-in persistence, availability checks, and fallback behavior

## Validation
- `swift test --filter AuthServiceTests` from `core`
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "id=9064C33E-8312-4D9A-B459-CA785C10AC91" -only-testing:"Weird PartsTests/BiometricOptInPersistenceTests" -only-testing:"Weird PartsTests/BiometricAvailabilityTests" -only-testing:"Weird PartsTests/BiometricAttemptTests"`

## Notes
This is stacked on `codex/wei-1026-paperclip-github-sync` so the review diff stays limited to the auth slice.