### PR TITLE
fix(people): expand Employee Detail tab touch targets

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeeDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeeDetailPage.swift
@@ -166,6 +166,10 @@ struct IOSEmployeeDetailPage: View {
                                 Capsule().fill(selectedTab == tab ? Color.accentColor : Color.secondary.opacity(0.15))
                             )
                             .foregroundStyle(selectedTab == tab ? .white : .primary)
+                            .frame(minWidth: 44, minHeight: 44)
+                            .contentShape(Rectangle())
+                            .accessibilityLabel(Text("\(tab.capitalized) tab"))
+                            .accessibilityAddTraits(selectedTab == tab ? .isSelected : [])
                     }
                     .buttonStyle(.plain)
                 }


### PR DESCRIPTION
## Summary
- Reuses the existing `wei-1252-employee-certifications` branch/PR to avoid creating a new branch while the repo is at the branch hard cap.
- Cleans the stale draft branch down to the remaining GitHub #77 closeout fix: Employee Detail tab chips now have an explicit 44pt minimum hit target.
- Adds a full rectangular content shape and selected-state accessibility trait/label while preserving compact chip styling.

## GitHub #77 closeout context
Current `main` already has the PeopleService layer plus Employee Detail Skills, Certifications, Activity, Hats, Permissions Granted, and Help coverage. GitHub #475 identified the only remaining #77 blocker: the horizontal tab chips lacked explicit 44pt touch targets.

## Validation
- Static implementation check: `IOSEmployeeDetailPage.swift` imports `SwiftUI` and `WiredPartCore`, not `GRDB`; tabs include Profile/Hats/Skills/Teams/Certifications/Activity; `Permissions Granted` remains present; tab chips now include `.frame(minWidth: 44, minHeight: 44)`, `.contentShape(Rectangle())`, selected trait, and accessibility labels.
- Attempted: `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" -derivedDataPath "/tmp/DerivedData-WEI-436" CODE_SIGNING_ALLOWED=NO build`
  - Result: failed in pre-existing/unrelated `JobsListPage.swift:128:13: error: switch must be exhaustive`; the failure is outside Employee Detail and this one-file change.

Closes #77.
Refs #475.
Paperclip: WEI-436.
