### PR TITLE
[codex] Add wishlist routing and status filters

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSWishlistPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSWishlistPage.swift
@@ -12,6 +12,8 @@ struct IOSWishlistPage: View {
     // MARK: - State
 
     @State private var sections = WishlistService.WishlistSections()
+    @State private var statusCounts = WishlistService.StatusCounts()
+    @State private var selectedStatus: StatusFilter = .all
     @State private var isLoading = true
     @State private var searchText = ""
     @State private var loadError: String?
@@ -31,9 +33,69 @@ struct IOSWishlistPage: View {
         }
     }
 
+    /// Status filter for the smart-card strip.
+    /// `.all` shows every item across all sections.
+    /// Other cases narrow rows to a single `wishlist_items.status` value while
+    /// preserving the 3-section grouping (User Added / Forecast / System).
+    private enum StatusFilter: String, CaseIterable, Identifiable {
+        case all
+        case pending
+        case approved
+        case dismissed
+        case sentToProcurement
+
+        var id: String { rawValue }
+
+        /// User-facing label. Kept short to fit a 96pt-wide card at 375pt viewport.
+        var title: String {
+            switch self {
+            case .all: "All"
+            case .pending: "Pending"
+            case .approved: "Approved"
+            case .dismissed: "Dismissed"
+            case .sentToProcurement: "Procured"
+            }
+        }
+
+        /// Accessibility label — spells out abbreviations for VoiceOver.
+        var accessibilityTitle: String {
+            switch self {
+            case .all: "All items"
+            case .pending: "Pending"
+            case .approved: "Approved"
+            case .dismissed: "Dismissed"
+            case .sentToProcurement: "Sent to procurement"
+            }
+        }
+
+        /// SF Symbol — mirrors the icon vocabulary used in `statusBadge`.
+        var icon: String {
+            switch self {
+            case .all: "tray.full"
+            case .pending: "clock"
+            case .approved: "checkmark.circle"
+            case .dismissed: "xmark.circle"
+            case .sentToProcurement: "shippingbox"
+            }
+        }
+
+        /// The DB `status` string this filter maps to, or `nil` for `.all`
+        /// which means "no filter".
+        var dbStatus: String? {
+            switch self {
+            case .all: nil
+            case .pending: "pending"
+            case .approved: "approved"
+            case .dismissed: "dismissed"
+            case .sentToProcurement: "sent_to_procurement"
+            }
+        }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             OnboardingBanner(pageId: "orders-wishlist")
+            smartCardFilters
             contentView
         }
         .task { appCore.onboardingManager?.markCompleted("wishlist-view") }
@@ -61,6 +123,7 @@ struct IOSWishlistPage: View {
                     title: "Wishlist Help",
                     sections: [
                         ("What This Page Does", "Tracks parts that should be procured. Items can be added manually or generated automatically by forecasting when stock levels need attention."),
+                        ("Status Filters", "The cards at the top filter by status: All, Pending, Approved, Dismissed, and Procured. Each shows a live count. Tap a card to focus on one status — sections collapse automatically when empty."),
                         ("3 Sections", "User Added — items you or your team added manually (auto-approve after 14 days). Forecast Demand — system suggestions based on usage patterns. System Auto-Added — below MIN with no stock at shop."),
                         ("Item Flow", "Pending (needs review) → Approved (ready for procurement) → Sent to Procurement. Dismissed items can be reopened if needed."),
                         ("Dismissing Items", "Swipe left to dismiss. A reason is required so the team knows why an item was passed over."),
@@ -96,6 +159,87 @@ struct IOSWishlistPage: View {
         }
     }
 
+    // MARK: - Smart Card Filters
+
+    /// Horizontal scroll of status filter cards: All / Pending / Approved / Dismissed / Procured.
+    /// Always rendered (no totalCount gate) so users can see status counts even when the
+    /// currently-filtered view is empty — this is the cue that drives them to switch filters.
+    private var smartCardFilters: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 10) {
+                ForEach(StatusFilter.allCases) { filter in
+                    smartCard(for: filter)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
+        .background(Color(.systemBackground))
+    }
+
+    private func smartCard(for filter: StatusFilter) -> some View {
+        let isSelected = selectedStatus == filter
+        let color = filterColor(filter)
+        let count = filterCount(filter)
+        let isZero = count == 0 && filter != .all
+
+        return Button {
+            Haptics.impact(.light)
+            selectedStatus = filter
+        } label: {
+            VStack(spacing: 4) {
+                HStack(spacing: 4) {
+                    Image(systemName: filter.icon)
+                        .font(.caption)
+                        .accessibilityHidden(true)
+                    Text("\(count)")
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .monospacedDigit()
+                }
+                Text(filter.title)
+                    .font(.caption2)
+                    .lineLimit(1)
+            }
+            .frame(minWidth: 80, minHeight: 44)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(isSelected ? color.opacity(0.18) : Color.secondary.opacity(0.08))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(isSelected ? color : Color.clear, lineWidth: 1.5)
+            )
+            .foregroundStyle(isSelected ? color : (isZero ? Color.secondary : .primary))
+            .opacity(isZero ? 0.55 : 1.0)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(filter.accessibilityTitle), \(count) items")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    private func filterColor(_ filter: StatusFilter) -> Color {
+        switch filter {
+        case .all: .accentColor
+        case .pending: .orange
+        case .approved: .green
+        case .dismissed: .secondary
+        case .sentToProcurement: .purple
+        }
+    }
+
+    private func filterCount(_ filter: StatusFilter) -> Int {
+        switch filter {
+        case .all: statusCounts.total
+        case .pending: statusCounts.pending
+        case .approved: statusCounts.approved
+        case .dismissed: statusCounts.dismissed
+        case .sentToProcurement: statusCounts.sentToProcurement
+        }
+    }
+
     // MARK: - Content View
 
     @ViewBuilder
@@ -111,8 +255,76 @@ struct IOSWishlistPage: View {
                 title: "No Wishlist Items",
                 message: "Add parts to your wishlist to track procurement needs."
             )
+        } else if filteredIsEmpty {
+            filteredEmptyState
         } else {
             sectionsView
+        }
+    }
+
+    /// Empty state when DB has items but the current filter+search combo matches nothing.
+    /// Offers a one-tap "Show All" escape so the user never gets stuck on an empty filter.
+    @ViewBuilder
+    private var filteredEmptyState: some View {
+        let hasSearch = !searchText.isEmpty
+        let isAll = selectedStatus == .all
+
+        VStack(spacing: 12) {
+            Image(systemName: selectedStatus == .all ? "heart.text.clipboard" : selectedStatus.icon)
+                .font(.system(size: 44))
+                .foregroundStyle(.secondary)
+            Text(filteredEmptyTitle(hasSearch: hasSearch, isAll: isAll))
+                .font(.headline)
+                .multilineTextAlignment(.center)
+            Text(filteredEmptyMessage(hasSearch: hasSearch, isAll: isAll))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+            if !isAll {
+                Button {
+                    selectedStatus = .all
+                } label: {
+                    Text("Show All")
+                        .fontWeight(.semibold)
+                        .frame(minWidth: 120, minHeight: 44)
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 4)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    private func filteredEmptyTitle(hasSearch: Bool, isAll: Bool) -> String {
+        if hasSearch { return "No Matches" }
+        switch selectedStatus {
+        case .all: return "No Wishlist Items"
+        case .pending: return "Nothing Pending"
+        case .approved: return "Nothing Approved"
+        case .dismissed: return "Nothing Dismissed"
+        case .sentToProcurement: return "Nothing Sent to Procurement"
+        }
+    }
+
+    private func filteredEmptyMessage(hasSearch: Bool, isAll: Bool) -> String {
+        if hasSearch {
+            return isAll
+                ? "No items match your search."
+                : "No \(selectedStatus.title.lowercased()) items match your search."
+        }
+        switch selectedStatus {
+        case .all:
+            return "Add parts to your wishlist to track procurement needs."
+        case .pending:
+            return "Everything has been reviewed. New items will appear here when added."
+        case .approved:
+            return "No approved items waiting. Approve a pending item to see it here."
+        case .dismissed:
+            return "Nothing has been dismissed yet."
+        case .sentToProcurement:
+            return "No items have been sent to procurement yet."
         }
     }
 
@@ -178,15 +390,6 @@ struct IOSWishlistPage: View {
                 }
             }
 
-            // Empty search state
-            if filteredUserAdded.isEmpty && filteredForecast.isEmpty && filteredAutoAdded.isEmpty {
-                Section {
-                    Text("No items match your search.")
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 20)
-                }
-            }
         }
         .listStyle(.insetGrouped)
     }
@@ -213,20 +416,31 @@ struct IOSWishlistPage: View {
 
     // MARK: - Filtering
 
-    private func applySearch(_ items: [WishlistItem]) -> [WishlistItem] {
-        guard !searchText.isEmpty else { return items }
-        let query = searchText.lowercased()
-        return items.filter {
-            $0.partName.lowercased().contains(query) ||
-            ($0.reason?.lowercased().contains(query) ?? false) ||
-            ($0.notes?.lowercased().contains(query) ?? false) ||
-            ($0.requestedBy?.lowercased().contains(query) ?? false)
+    private func applyFilters(_ items: [WishlistItem]) -> [WishlistItem] {
+        var result = items
+        if let status = selectedStatus.dbStatus {
+            result = result.filter { $0.status == status }
         }
+        if !searchText.isEmpty {
+            let query = searchText.lowercased()
+            result = result.filter {
+                $0.partName.lowercased().contains(query) ||
+                ($0.reason?.lowercased().contains(query) ?? false) ||
+                ($0.notes?.lowercased().contains(query) ?? false) ||
+                ($0.requestedBy?.lowercased().contains(query) ?? false)
+            }
+        }
+        return result
     }
 
-    private var filteredUserAdded: [WishlistItem] { applySearch(sections.userAdded) }
-    private var filteredForecast: [WishlistItem] { applySearch(sections.forecastDemand) }
-    private var filteredAutoAdded: [WishlistItem] { applySearch(sections.autoAdded) }
+    private var filteredUserAdded: [WishlistItem] { applyFilters(sections.userAdded) }
+    private var filteredForecast: [WishlistItem] { applyFilters(sections.forecastDemand) }
+    private var filteredAutoAdded: [WishlistItem] { applyFilters(sections.autoAdded) }
+
+    /// True when the active filter+search combination has nothing to show.
+    private var filteredIsEmpty: Bool {
+        filteredUserAdded.isEmpty && filteredForecast.isEmpty && filteredAutoAdded.isEmpty
+    }
 
     // MARK: - Swipe Actions
 
@@ -509,6 +723,7 @@ struct IOSWishlistPage: View {
                 autoAdded: [updatedItem] + newAutoAdded
             )
         }
+        recomputeStatusCounts()
     }
 
     /// Remove a deleted item from whichever section holds it, with no DB fetch.
@@ -518,6 +733,29 @@ struct IOSWishlistPage: View {
             userAdded: sections.userAdded.filter { $0.id != id },
             forecastDemand: sections.forecastDemand.filter { $0.id != id },
             autoAdded: sections.autoAdded.filter { $0.id != id }
+        )
+        recomputeStatusCounts()
+    }
+
+    /// Recompute status counts from current in-memory sections so smart cards
+    /// stay accurate after partial updates without hitting the DB.
+    private func recomputeStatusCounts() {
+        var pending = 0, approved = 0, dismissed = 0, sent = 0
+        let all = sections.userAdded + sections.forecastDemand + sections.autoAdded
+        for item in all {
+            switch item.status {
+            case "pending": pending += 1
+            case "approved": approved += 1
+            case "dismissed": dismissed += 1
+            case "sent_to_procurement": sent += 1
+            default: break
+            }
+        }
+        statusCounts = WishlistService.StatusCounts(
+            pending: pending,
+            approved: approved,
+            dismissed: dismissed,
+            sentToProcurement: sent
         )
     }
 
@@ -539,8 +777,12 @@ struct IOSWishlistPage: View {
             _ = try? service.processAutoApprovals(byUserId: currentUserId)
             do {
                 let result = try service.getSectionedItems()
+                // Counts are computed independently so card totals reflect ALL items,
+                // not just the currently-filtered subset.
+                let counts = (try? service.getStatusCounts()) ?? WishlistService.StatusCounts()
                 await MainActor.run {
                     sections = result
+                    statusCounts = counts
                     isLoading = false
                     postAIContext()
                 }
@@ -557,6 +799,8 @@ struct IOSWishlistPage: View {
         let context = [
             "Orders wishlist page is open.",
             "User-added items: \(sections.userAdded.count), forecast demand: \(sections.forecastDemand.count), system auto-added: \(sections.autoAdded.count).",
+            "Status counts — pending: \(statusCounts.pending), approved: \(statusCounts.approved), dismissed: \(statusCounts.dismissed), sent to procurement: \(statusCounts.sentToProcurement).",
+            "Active status filter: \(selectedStatus.title).",
             "Filtered visible items: \(filteredUserAdded.count + filteredForecast.count + filteredAutoAdded.count).",
             "Search text is \(searchText.isEmpty ? "empty" : "active").",
             "This context is read-only; explain wishlist sections, approval state, confidence scores, dismissal requirements, and procurement handoff without changing items."

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
@@ -1122,6 +1122,7 @@ struct PartsCatalogPage: View {
                     totalStock: stock,
                     partType: pwd.part.partType,
                     isActive: pwd.part.isActive ?? 1,
+                    autoAddToWishlistWhenLow: pwd.part.autoAddToWishlistWhenLow != 0,
                     isLowStock: minStock.map { stock < $0 } ?? false
                 )
             }
@@ -1235,6 +1236,7 @@ struct CatalogPartRow: Identifiable, Sendable {
     let totalStock: Int
     let partType: String
     let isActive: Int
+    let autoAddToWishlistWhenLow: Bool
     let isLowStock: Bool
 }
 
@@ -1399,6 +1401,7 @@ private struct PartFormSheet: View {
     @State private var partType = "standard"
     @State private var costPrice = ""
     @State private var markupPercent = ""
+    @State private var autoAddToWishlistWhenLow = false
     @State private var saveError: String?
     @State private var isSaving = false
 
@@ -1451,6 +1454,12 @@ private struct PartFormSheet: View {
                     }
                     .frame(minHeight: 44)
                 }
+
+                if appCore.hasPermission("edit_parts_catalog") {
+                    Section("Automation") {
+                        Toggle("Auto-add to wishlist when low", isOn: $autoAddToWishlistWhenLow)
+                    }
+                }
             }
             .navigationTitle(part == nil ? "New Part" : "Edit Part")
             .navigationBarTitleDisplayMode(.inline)
@@ -1488,6 +1497,7 @@ private struct PartFormSheet: View {
                     partType = p.partType
                     costPrice = String(format: "%.2f", p.companyCostPrice)
                     markupPercent = String(format: "%.1f", p.companyMarkupPercent)
+                    autoAddToWishlistWhenLow = p.autoAddToWishlistWhenLow
                 }
             }
             .alert("Save Failed", isPresented: Binding(
@@ -1512,6 +1522,7 @@ private struct PartFormSheet: View {
         }
 
         do {
+            let savedPartId: Int64
             if let p = part {
                 try service.updatePart(
                     id: p.id,
@@ -1523,8 +1534,9 @@ private struct PartFormSheet: View {
                     companyCostPrice: cost,
                     companyMarkupPercent: markup
                 )
+                savedPartId = p.id
             } else {
-                _ = try service.createPart(
+                savedPartId = try service.createPart(
                     categoryId: selectedCategoryId,
                     name: trimmedName,
                     partType: partType,
@@ -1532,6 +1544,13 @@ private struct PartFormSheet: View {
                     brandId: selectedBrandId,
                     companyCostPrice: cost,
                     companyMarkupPercent: markup
+                )
+            }
+            if appCore.hasPermission("edit_parts_catalog"), let userId = appCore.currentUser?.id {
+                try service.setAutoAddToWishlistWhenLow(
+                    partId: savedPartId,
+                    enabled: autoAddToWishlistWhenLow,
+                    byUserId: userId
                 )
             }
         } catch {
@@ -1576,6 +1595,10 @@ private struct PartDetailSheet: View {
                         LabeledContent("Brand", value: brand)
                     }
                     LabeledContent("Status", value: partRow.isActive == 1 ? "Active" : "Inactive")
+                    LabeledContent(
+                        "Auto Wishlist",
+                        value: partRow.autoAddToWishlistWhenLow ? "Enabled" : "Disabled"
+                    )
                 }
 
                 if appCore.hasPermission("show_dollar_values") {

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
@@ -50,6 +50,9 @@ struct AppModule: Identifiable, Hashable, Sendable {
 
 // MARK: - Module Definitions
 
+let officeAccessPermission = "manage_jobs"
+let financialValuesPermission = "view_financials"
+
 /// Complete ordered list of all application modules.
 ///
 /// Ordered by usage frequency: daily use → work tools → management.

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
@@ -51,7 +51,7 @@ struct AppModule: Identifiable, Hashable, Sendable {
 // MARK: - Module Definitions
 
 let officeAccessPermission = "manage_jobs"
-let financialValuesPermission = "view_financials"
+let financialValuesPermission = "show_dollar_values"
 
 /// Complete ordered list of all application modules.
 ///

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -930,7 +930,6 @@ extension AppDatabase {
                 t.column("forecast_target_qty", .integer).defaults(to: 0)
                 t.column("forecast_suggested_order", .integer).defaults(to: 0)
                 t.column("forecast_days_until_low", .integer).defaults(to: 999)
-                t.column("auto_add_to_wishlist_when_low", .integer).notNull().defaults(to: 0)
                 t.column("is_deprecated", .integer).defaults(to: 0)
                 t.column("deprecation_reason", .text)
                 t.column("is_qr_tagged", .integer).defaults(to: 0)

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -122,6 +122,7 @@ extension AppDatabase {
         registerMigration083WarehouseWalkingPaths(&migrator)
         registerMigration084WarehouseOnboardingCompletedSteps(&migrator)
         registerMigration085AuditSessionEvents(&migrator)
+        registerMigration086PartAutoWishlistOptIn(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -929,6 +930,7 @@ extension AppDatabase {
                 t.column("forecast_target_qty", .integer).defaults(to: 0)
                 t.column("forecast_suggested_order", .integer).defaults(to: 0)
                 t.column("forecast_days_until_low", .integer).defaults(to: 999)
+                t.column("auto_add_to_wishlist_when_low", .integer).notNull().defaults(to: 0)
                 t.column("is_deprecated", .integer).defaults(to: 0)
                 t.column("deprecation_reason", .text)
                 t.column("is_qr_tagged", .integer).defaults(to: 0)
@@ -5114,6 +5116,18 @@ extension AppDatabase {
                 CREATE INDEX idx_audit_session_events_session
                 ON audit_session_events(session_id, recorded_at)
                 """)
+        }
+    }
+
+    private static func registerMigration086PartAutoWishlistOptIn(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("086_part_auto_wishlist_opt_in") { db in
+            try addColumnIfMissing(
+                db,
+                table: "parts",
+                column: "auto_add_to_wishlist_when_low",
+                type: .integer,
+                defaultValue: 0
+            )
         }
     }
 

--- a/core/Sources/WiredPartCore/Models/Parts/PartsModels.swift
+++ b/core/Sources/WiredPartCore/Models/Parts/PartsModels.swift
@@ -393,6 +393,7 @@ public struct Part: Codable, FetchableRecord, MutablePersistableRecord, Sendable
     public var forecastTargetQty: Int?
     public var forecastSuggestedOrder: Int?
     public var forecastDaysUntilLow: Int?
+    public var autoAddToWishlistWhenLow: Int = 0
     public var isDeprecated: Int?
     public var deprecationReason: String?
     public var isQrTagged: Int?
@@ -433,6 +434,7 @@ public struct Part: Codable, FetchableRecord, MutablePersistableRecord, Sendable
         case forecastTargetQty = "forecast_target_qty"
         case forecastSuggestedOrder = "forecast_suggested_order"
         case forecastDaysUntilLow = "forecast_days_until_low"
+        case autoAddToWishlistWhenLow = "auto_add_to_wishlist_when_low"
         case isDeprecated = "is_deprecated"
         case deprecationReason = "deprecation_reason"
         case isQrTagged = "is_qr_tagged"

--- a/core/Sources/WiredPartCore/Services/BackgroundTaskService.swift
+++ b/core/Sources/WiredPartCore/Services/BackgroundTaskService.swift
@@ -93,6 +93,86 @@ public final class BackgroundTaskService: Sendable {
         }
     }
 
+    public enum OfficeStatus: String, Sendable {
+        case completed
+        case failed
+        case running
+        case neverRun
+        case unavailable
+    }
+
+    public struct OfficeStatusRow: Identifiable, Sendable {
+        public let id: String
+        public let title: String
+        public let status: OfficeStatus
+        public let statusLabel: String
+        public let detail: String
+        public let systemImage: String
+
+        public init(
+            id: String,
+            title: String,
+            status: OfficeStatus,
+            statusLabel: String,
+            detail: String,
+            systemImage: String
+        ) {
+            self.id = id
+            self.title = title
+            self.status = status
+            self.statusLabel = statusLabel
+            self.detail = detail
+            self.systemImage = systemImage
+        }
+
+        public static func unavailableRows() -> [OfficeStatusRow] {
+            BackgroundTaskService.officeTaskDefinitions.map {
+                OfficeStatusRow(
+                    id: $0.id,
+                    title: $0.title,
+                    status: .unavailable,
+                    statusLabel: "Unavailable",
+                    detail: "Task log unavailable on this device.",
+                    systemImage: $0.systemImage
+                )
+            }
+        }
+    }
+
+    private struct OfficeTaskDefinition: Sendable {
+        let id: String
+        let title: String
+        let taskTypes: [String]
+        let systemImage: String
+    }
+
+    private static let officeTaskDefinitions: [OfficeTaskDefinition] = [
+        OfficeTaskDefinition(
+            id: "forecast_recalculation",
+            title: "Forecast Recalculation",
+            taskTypes: ["forecast_recalculation", "forecast", "forecasting"],
+            systemImage: "chart.line.uptrend.xyaxis"
+        ),
+        OfficeTaskDefinition(
+            id: "companion_discovery",
+            title: "Companion Discovery",
+            taskTypes: ["companion_discovery"],
+            systemImage: "link"
+        ),
+        OfficeTaskDefinition(
+            id: "audit",
+            title: "Audit",
+            taskTypes: ["audit", "inventory_audit"],
+            systemImage: "checkmark.shield"
+        ),
+        OfficeTaskDefinition(
+            id: "sync",
+            title: "Sync",
+            taskTypes: ["sync", "remote_sync", "peer_sync"],
+            systemImage: "arrow.triangle.2.circlepath"
+        ),
+    ]
+
     // =========================================================================
     // MARK: - Task Lifecycle
     // =========================================================================
@@ -232,6 +312,39 @@ public final class BackgroundTaskService: Sendable {
         }
     }
 
+    /// Dashboard-ready status rows for office-visible background operations.
+    public func officeStatusRows() throws -> [OfficeStatusRow] {
+        do {
+            return try db.writer.read { dbConn in
+                try Self.officeTaskDefinitions.map { definition in
+                    guard let entry = try latestTask(dbConn, matchingTypes: definition.taskTypes) else {
+                        return OfficeStatusRow(
+                            id: definition.id,
+                            title: definition.title,
+                            status: .neverRun,
+                            statusLabel: "Never run",
+                            detail: "No \(definition.title.lowercased()) task has run on this device.",
+                            systemImage: definition.systemImage
+                        )
+                    }
+
+                    let status = officeStatus(for: entry.status)
+                    return OfficeStatusRow(
+                        id: definition.id,
+                        title: definition.title,
+                        status: status,
+                        statusLabel: officeStatusLabel(for: status),
+                        detail: officeStatusDetail(for: entry, status: status),
+                        systemImage: definition.systemImage
+                    )
+                }
+            }
+        } catch {
+            if isTableNotFoundError(error) { return OfficeStatusRow.unavailableRows() }
+            throw error
+        }
+    }
+
     // =========================================================================
     // MARK: - Cleanup
     // =========================================================================
@@ -289,5 +402,54 @@ public final class BackgroundTaskService: Sendable {
     private func isTableNotFoundError(_ error: Error) -> Bool {
         let message = String(describing: error)
         return message.contains("no such table") || message.contains("no such column")
+    }
+
+    private func latestTask(_ dbConn: Database, matchingTypes taskTypes: [String]) throws -> TaskLogEntry? {
+        guard !taskTypes.isEmpty else { return nil }
+        let placeholders = Array(repeating: "?", count: taskTypes.count).joined(separator: ", ")
+        return try TaskLogEntry.fetchOne(dbConn, sql: """
+            SELECT *
+            FROM background_task_log
+            WHERE task_type IN (\(placeholders))
+            ORDER BY started_at DESC, id DESC
+            LIMIT 1
+        """, arguments: StatementArguments(taskTypes))
+    }
+
+    private func officeStatus(for rawStatus: String) -> OfficeStatus {
+        switch rawStatus {
+        case "completed": return .completed
+        case "failed": return .failed
+        case "running": return .running
+        default: return .unavailable
+        }
+    }
+
+    private func officeStatusLabel(for status: OfficeStatus) -> String {
+        switch status {
+        case .completed: return "Completed"
+        case .failed: return "Failed"
+        case .running: return "Running"
+        case .neverRun: return "Never run"
+        case .unavailable: return "Unavailable"
+        }
+    }
+
+    private func officeStatusDetail(for entry: TaskLogEntry, status: OfficeStatus) -> String {
+        let timestamp = entry.completedAt ?? entry.startedAt
+        let timestampText = timestamp.formatted(date: .abbreviated, time: .shortened)
+        switch status {
+        case .completed:
+            let summary = entry.resultSummary ?? "Processed \(entry.itemsProcessed) item\(entry.itemsProcessed == 1 ? "" : "s")."
+            return "Last completed \(timestampText). \(summary)"
+        case .failed:
+            return "Last failed \(timestampText). \(entry.errorMessage ?? "No error details recorded.")"
+        case .running:
+            return "Started \(timestampText)."
+        case .neverRun:
+            return "No task has run on this device."
+        case .unavailable:
+            return "Latest status could not be read."
+        }
     }
 }

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -1264,6 +1264,7 @@ public final class PartsService: Sendable {
         maxStockLevel: Int? = nil,
         targetStockLevel: Int? = nil,
         reorderPoint: Int? = nil,
+        autoAddToWishlistWhenLow: Bool = false,
         notes: String? = nil,
         imageUrl: String? = nil,
         shelfLocation: String? = nil,
@@ -1329,6 +1330,7 @@ public final class PartsService: Sendable {
             maxStockLevel: maxStockLevel,
             targetStockLevel: targetStockLevel,
             reorderPoint: reorderPoint,
+            autoAddToWishlistWhenLow: autoAddToWishlistWhenLow ? 1 : 0,
             notes: notes,
             imageUrl: imageUrl,
             shelfLocation: shelfLocation,
@@ -1369,6 +1371,7 @@ public final class PartsService: Sendable {
         maxStockLevel: Int? = nil,
         targetStockLevel: Int? = nil,
         reorderPoint: Int? = nil,
+        autoAddToWishlistWhenLow: Bool? = nil,
         isDeprecated: Int? = nil,
         deprecationReason: String? = nil,
         notes: String? = nil,
@@ -1403,6 +1406,10 @@ public final class PartsService: Sendable {
             if let maxStockLevel { setClauses.append("max_stock_level = ?"); args.append(maxStockLevel) }
             if let targetStockLevel { setClauses.append("target_stock_level = ?"); args.append(targetStockLevel) }
             if let reorderPoint { setClauses.append("reorder_point = ?"); args.append(reorderPoint) }
+            if let autoAddToWishlistWhenLow {
+                setClauses.append("auto_add_to_wishlist_when_low = ?")
+                args.append(autoAddToWishlistWhenLow ? 1 : 0)
+            }
             if let isDeprecated { setClauses.append("is_deprecated = ?"); args.append(isDeprecated) }
             if let deprecationReason { setClauses.append("deprecation_reason = ?"); args.append(deprecationReason) }
             if let notes { setClauses.append("notes = ?"); args.append(notes) }
@@ -1446,6 +1453,7 @@ public final class PartsService: Sendable {
             track("max_stock", "max_stock_level", maxStockLevel.map { "\($0)" })
             track("target_stock", "target_stock_level", targetStockLevel.map { "\($0)" })
             track("reorder_point", "reorder_point", reorderPoint.map { "\($0)" })
+            track("auto_add_to_wishlist_when_low", "auto_add_to_wishlist_when_low", autoAddToWishlistWhenLow.map { $0 ? "1" : "0" })
             track("notes", "notes", notes)
             track("shelf_location", "shelf_location", shelfLocation)
             track("bin_location", "bin_location", binLocation)
@@ -1454,6 +1462,47 @@ public final class PartsService: Sendable {
                 try? logPartFieldChanges(partId: id, userId: nil, userName: nil, changes: changes, context: "Catalog Edit")
             }
         }
+    }
+
+    public func getAutoAddToWishlistWhenLow(partId: Int64) throws -> Bool {
+        try db.writer.read { dbConn in
+            guard let value = try Int.fetchOne(
+                dbConn,
+                sql: "SELECT auto_add_to_wishlist_when_low FROM parts WHERE id = ? AND deleted_at IS NULL",
+                arguments: [partId]
+            ) else {
+                throw PartsError.partNotFound(partId)
+            }
+            return value != 0
+        }
+    }
+
+    public func setAutoAddToWishlistWhenLow(partId: Int64, enabled: Bool, byUserId: Int64) throws {
+        guard try auth.hasPermission(byUserId, permissionKey: "edit_parts_catalog") else {
+            throw PartsError.insufficientPermissions(required: "edit_parts_catalog")
+        }
+        let changed = try db.writer.write { dbConn in
+            try dbConn.execute(
+                sql: """
+                    UPDATE parts
+                    SET auto_add_to_wishlist_when_low = ?, updated_at = datetime('now')
+                    WHERE id = ? AND deleted_at IS NULL
+                    """,
+                arguments: [enabled ? 1 : 0, partId]
+            )
+            return dbConn.changesCount
+        }
+        guard changed > 0 else { throw PartsError.partNotFound(partId) }
+        try? logPartChange(
+            partId: partId,
+            userId: byUserId,
+            userName: nil,
+            action: "updated",
+            fieldName: "auto_add_to_wishlist_when_low",
+            oldValue: nil,
+            newValue: enabled ? "1" : "0",
+            context: "Catalog"
+        )
     }
 
     /// Soft-delete a part.

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -1264,7 +1264,6 @@ public final class PartsService: Sendable {
         maxStockLevel: Int? = nil,
         targetStockLevel: Int? = nil,
         reorderPoint: Int? = nil,
-        autoAddToWishlistWhenLow: Bool = false,
         notes: String? = nil,
         imageUrl: String? = nil,
         shelfLocation: String? = nil,
@@ -1330,7 +1329,7 @@ public final class PartsService: Sendable {
             maxStockLevel: maxStockLevel,
             targetStockLevel: targetStockLevel,
             reorderPoint: reorderPoint,
-            autoAddToWishlistWhenLow: autoAddToWishlistWhenLow ? 1 : 0,
+            autoAddToWishlistWhenLow: 0,
             notes: notes,
             imageUrl: imageUrl,
             shelfLocation: shelfLocation,
@@ -1371,7 +1370,6 @@ public final class PartsService: Sendable {
         maxStockLevel: Int? = nil,
         targetStockLevel: Int? = nil,
         reorderPoint: Int? = nil,
-        autoAddToWishlistWhenLow: Bool? = nil,
         isDeprecated: Int? = nil,
         deprecationReason: String? = nil,
         notes: String? = nil,
@@ -1406,10 +1404,6 @@ public final class PartsService: Sendable {
             if let maxStockLevel { setClauses.append("max_stock_level = ?"); args.append(maxStockLevel) }
             if let targetStockLevel { setClauses.append("target_stock_level = ?"); args.append(targetStockLevel) }
             if let reorderPoint { setClauses.append("reorder_point = ?"); args.append(reorderPoint) }
-            if let autoAddToWishlistWhenLow {
-                setClauses.append("auto_add_to_wishlist_when_low = ?")
-                args.append(autoAddToWishlistWhenLow ? 1 : 0)
-            }
             if let isDeprecated { setClauses.append("is_deprecated = ?"); args.append(isDeprecated) }
             if let deprecationReason { setClauses.append("deprecation_reason = ?"); args.append(deprecationReason) }
             if let notes { setClauses.append("notes = ?"); args.append(notes) }
@@ -1453,7 +1447,6 @@ public final class PartsService: Sendable {
             track("max_stock", "max_stock_level", maxStockLevel.map { "\($0)" })
             track("target_stock", "target_stock_level", targetStockLevel.map { "\($0)" })
             track("reorder_point", "reorder_point", reorderPoint.map { "\($0)" })
-            track("auto_add_to_wishlist_when_low", "auto_add_to_wishlist_when_low", autoAddToWishlistWhenLow.map { $0 ? "1" : "0" })
             track("notes", "notes", notes)
             track("shelf_location", "shelf_location", shelfLocation)
             track("bin_location", "bin_location", binLocation)
@@ -1481,6 +1474,17 @@ public final class PartsService: Sendable {
         guard try auth.hasPermission(byUserId, permissionKey: "edit_parts_catalog") else {
             throw PartsError.insufficientPermissions(required: "edit_parts_catalog")
         }
+        let oldValue = try db.writer.read { dbConn -> String in
+            guard let value = try Int.fetchOne(
+                dbConn,
+                sql: "SELECT auto_add_to_wishlist_when_low FROM parts WHERE id = ? AND deleted_at IS NULL",
+                arguments: [partId]
+            ) else {
+                throw PartsError.partNotFound(partId)
+            }
+            return value == 0 ? "0" : "1"
+        }
+        let newValue = enabled ? "1" : "0"
         let changed = try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
@@ -1493,14 +1497,15 @@ public final class PartsService: Sendable {
             return dbConn.changesCount
         }
         guard changed > 0 else { throw PartsError.partNotFound(partId) }
+        guard oldValue != newValue else { return }
         try? logPartChange(
             partId: partId,
             userId: byUserId,
             userName: nil,
             action: "updated",
             fieldName: "auto_add_to_wishlist_when_low",
-            oldValue: nil,
-            newValue: enabled ? "1" : "0",
+            oldValue: oldValue,
+            newValue: newValue,
             context: "Catalog"
         )
     }

--- a/core/Sources/WiredPartCore/Services/WishlistService.swift
+++ b/core/Sources/WiredPartCore/Services/WishlistService.swift
@@ -283,23 +283,6 @@ public final class WishlistService: Sendable {
             if locationType == "truck" || locationType == "trailer" {
                 let shopStock = try currentShopStock(dbConn, partId: partId)
                 if shopStock > 0 {
-                    if let existingMovementId = try existingShopTransferId(dbConn, marker: marker) {
-                        return BelowMinimumRoutingResult(
-                            partId: partId,
-                            partName: partName,
-                            locationType: locationType,
-                            locationId: locationId,
-                            currentStock: currentStock,
-                            minStock: target.minStock,
-                            targetStock: target.targetStock,
-                            certaintyScore: certainty,
-                            action: "shop_transfer",
-                            quantity: min(qtyNeeded, shopStock),
-                            movementId: existingMovementId,
-                            reusedExistingAction: true
-                        )
-                    }
-
                     let movementQty = min(qtyNeeded, shopStock)
                     let movementId = try createShopTransfer(
                         dbConn,
@@ -437,6 +420,7 @@ public final class WishlistService: Sendable {
                 JOIN parts p ON p.id = lst.part_id
                 WHERE lst.deleted_at IS NULL
                   AND p.deleted_at IS NULL
+                  AND COALESCE(p.is_active, 1) = 1
                   AND COALESCE(p.auto_add_to_wishlist_when_low, 0) = 1
                   AND lst.min_stock > 0
                   AND COALESCE(lst.do_not_restock, 0) = 0
@@ -731,7 +715,7 @@ public final class WishlistService: Sendable {
     private func fetchPartName(_ dbConn: Database, partId: Int64) throws -> String {
         guard let name = try String.fetchOne(
             dbConn,
-            sql: "SELECT name FROM parts WHERE id = ? AND deleted_at IS NULL",
+            sql: "SELECT name FROM parts WHERE id = ? AND deleted_at IS NULL AND COALESCE(is_active, 1) = 1",
             arguments: [partId]
         ) else {
             throw WishlistError.partNotFound(partId)
@@ -760,7 +744,7 @@ public final class WishlistService: Sendable {
         if let row = try Row.fetchOne(dbConn, sql: """
             SELECT min_stock_level, target_stock_level
             FROM parts
-            WHERE id = ? AND deleted_at IS NULL
+            WHERE id = ? AND deleted_at IS NULL AND COALESCE(is_active, 1) = 1
             """, arguments: [partId]) {
             return BelowMinimumTarget(
                 minStock: row["min_stock_level"] ?? 0,
@@ -778,48 +762,21 @@ public final class WishlistService: Sendable {
         locationType: String,
         locationId: Int64
     ) throws -> Int {
-        switch locationType {
-        case "truck":
-            return try Int.fetchOne(dbConn, sql: """
-                SELECT COALESCE(SUM(quantity), 0)
-                FROM vehicle_stock
-                WHERE part_id = ? AND vehicle_id = ? AND stock_type = 'truck_stock' AND deleted_at IS NULL
-                """, arguments: [partId, locationId]) ?? 0
-        case "trailer":
-            return try Int.fetchOne(dbConn, sql: """
-                SELECT COALESCE(SUM(quantity), 0)
-                FROM trailer_stock
-                WHERE part_id = ? AND trailer_id = ? AND deleted_at IS NULL
-                """, arguments: [partId, locationId]) ?? 0
-        default:
-            return try Int.fetchOne(dbConn, sql: """
-                SELECT COALESCE(SUM(qty), 0)
-                FROM stock
-                WHERE part_id = ? AND location_type = ? AND location_id = ? AND deleted_at IS NULL
-                """, arguments: [partId, locationType, locationId]) ?? 0
-        }
+        try Int.fetchOne(dbConn, sql: """
+            SELECT COALESCE(SUM(qty), 0)
+            FROM stock
+            WHERE part_id = ? AND location_type = ? AND location_id = ? AND deleted_at IS NULL
+            """, arguments: [partId, locationType, locationId]) ?? 0
     }
 
     private func currentShopStock(_ dbConn: Database, partId: Int64) throws -> Int {
         try Int.fetchOne(dbConn, sql: """
-            SELECT COALESCE(MAX(qty), 0)
+            SELECT COALESCE(SUM(qty), 0)
             FROM stock
             WHERE part_id = ?
               AND location_type IN ('shop', 'warehouse')
               AND deleted_at IS NULL
             """, arguments: [partId]) ?? 0
-    }
-
-    private func existingShopTransferId(_ dbConn: Database, marker: String) throws -> Int64? {
-        try Int64.fetchOne(dbConn, sql: """
-            SELECT id
-            FROM stock_movements
-            WHERE movement_type = 'restock_from_shop'
-              AND notes LIKE ?
-              AND deleted_at IS NULL
-            ORDER BY id DESC
-            LIMIT 1
-            """, arguments: ["%\(marker)%"])
     }
 
     private func createShopTransfer(
@@ -831,22 +788,31 @@ public final class WishlistService: Sendable {
         performedBy: Int64,
         marker: String
     ) throws -> Int64 {
-        let source = try shopSourceLocation(dbConn, partId: partId, quantity: quantity)
-        try dbConn.execute(sql: """
-            INSERT INTO stock_movements
-            (part_id, qty, from_location_type, from_location_id, to_location_type, to_location_id,
-             movement_type, reason, notes, performed_by, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, 'restock_from_shop', 'Below MIN restock from shop', ?, ?, datetime('now'))
-            """, arguments: [
-                partId, quantity, source.locationType, source.locationId,
-                toLocationType, toLocationId, "\(marker) Generated below-MIN shop restock.", performedBy
-            ])
-        let movementId = dbConn.lastInsertedRowID
+        let sources = try shopSourceLocations(dbConn, partId: partId)
+        var remaining = quantity
+        var firstMovementId: Int64?
 
-        try dbConn.execute(sql: """
-            UPDATE stock SET qty = qty - ?, updated_at = datetime('now')
-            WHERE part_id = ? AND location_type = ? AND location_id = ? AND deleted_at IS NULL
-            """, arguments: [quantity, partId, source.locationType, source.locationId])
+        for source in sources where remaining > 0 {
+            let transferQty = min(remaining, source.qty)
+            try dbConn.execute(sql: """
+                INSERT INTO stock_movements
+                (part_id, qty, from_location_type, from_location_id, to_location_type, to_location_id,
+                 movement_type, reason, notes, performed_by, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, 'restock_from_shop', 'Below MIN restock from shop', ?, ?, datetime('now'))
+                """, arguments: [
+                    partId, transferQty, source.locationType, source.locationId,
+                    toLocationType, toLocationId, "\(marker) Generated below-MIN shop restock.", performedBy
+                ])
+            if firstMovementId == nil {
+                firstMovementId = dbConn.lastInsertedRowID
+            }
+
+            try dbConn.execute(sql: """
+                UPDATE stock SET qty = qty - ?, updated_at = datetime('now')
+                WHERE part_id = ? AND location_type = ? AND location_id = ? AND deleted_at IS NULL
+                """, arguments: [transferQty, partId, source.locationType, source.locationId])
+            remaining -= transferQty
+        }
 
         try dbConn.execute(sql: """
             UPDATE stock SET qty = qty + ?, updated_at = datetime('now')
@@ -887,35 +853,26 @@ public final class WishlistService: Sendable {
             }
         }
 
-        return movementId
+        return firstMovementId ?? 0
     }
 
-    private func shopSourceLocation(_ dbConn: Database, partId: Int64, quantity: Int) throws -> (locationType: String, locationId: Int64) {
-        if let row = try Row.fetchOne(dbConn, sql: """
-            SELECT location_type, location_id
-            FROM stock
-            WHERE part_id = ?
-              AND location_type IN ('shop', 'warehouse')
-              AND qty >= ?
-              AND deleted_at IS NULL
-            ORDER BY CASE location_type WHEN 'shop' THEN 0 ELSE 1 END, location_id
-            LIMIT 1
-            """, arguments: [partId, quantity]) {
-            return (row["location_type"] ?? "warehouse", row["location_id"] ?? 1)
-        }
-
-        let row = try Row.fetchOne(dbConn, sql: """
-            SELECT location_type, location_id
+    private func shopSourceLocations(_ dbConn: Database, partId: Int64) throws -> [(locationType: String, locationId: Int64, qty: Int)] {
+        let rows = try Row.fetchAll(dbConn, sql: """
+            SELECT location_type, location_id, qty
             FROM stock
             WHERE part_id = ?
               AND location_type IN ('shop', 'warehouse')
               AND qty > 0
               AND deleted_at IS NULL
-            ORDER BY qty DESC
-            LIMIT 1
+            ORDER BY CASE location_type WHEN 'shop' THEN 0 ELSE 1 END, location_id
             """, arguments: [partId])
-        guard let row else { return ("warehouse", 1) }
-        return (row["location_type"] ?? "warehouse", row["location_id"] ?? 1)
+        return rows.map { row in
+            (
+                locationType: row["location_type"] ?? "warehouse",
+                locationId: row["location_id"] ?? 1,
+                qty: row["qty"] ?? 0
+            )
+        }
     }
 
     private func existingWishlistItem(_ dbConn: Database, marker: String) throws -> WishlistItem? {
@@ -936,7 +893,7 @@ public final class WishlistService: Sendable {
             sql: """
                 SELECT auto_add_to_wishlist_when_low
                 FROM parts
-                WHERE id = ? AND deleted_at IS NULL
+                WHERE id = ? AND deleted_at IS NULL AND COALESCE(is_active, 1) = 1
                 """,
             arguments: [partId]
         ) else {

--- a/core/Sources/WiredPartCore/Services/WishlistService.swift
+++ b/core/Sources/WiredPartCore/Services/WishlistService.swift
@@ -27,6 +27,8 @@ public final class WishlistService: Sendable {
         case alreadyProcessed(Int64, String)
         case dismissReasonRequired
         case insufficientPermissions(required: String)
+        case restrictedToAssignedTruckUser(locationId: Int64)
+        case partNotFound(Int64)
 
         public var errorDescription: String? {
             switch self {
@@ -38,6 +40,10 @@ public final class WishlistService: Sendable {
                 "A dismiss reason is required"
             case .insufficientPermissions(let required):
                 "You don't have permission to perform this action (required: \(required))"
+            case .restrictedToAssignedTruckUser(let locationId):
+                "Only the assigned truck user can route a physical audit for truck #\(locationId)"
+            case .partNotFound(let id):
+                "Part #\(id) not found"
             }
         }
     }
@@ -60,6 +66,56 @@ public final class WishlistService: Sendable {
             self.dismissed = dismissed
             self.sentToProcurement = sentToProcurement
             self.total = pending + approved + dismissed + sentToProcurement
+        }
+    }
+
+    /// Result from evaluating one part/location against MIN stock routing rules.
+    public struct BelowMinimumRoutingResult: Sendable {
+        public let partId: Int64
+        public let partName: String
+        public let locationType: String
+        public let locationId: Int64
+        public let currentStock: Int
+        public let minStock: Int
+        public let targetStock: Int
+        public let certaintyScore: Double
+        public let action: String
+        public let quantity: Int
+        public let movementId: Int64?
+        public let wishlistItem: WishlistItem?
+        public let auditSessionId: Int64?
+        public let reusedExistingAction: Bool
+
+        public init(
+            partId: Int64,
+            partName: String,
+            locationType: String,
+            locationId: Int64,
+            currentStock: Int,
+            minStock: Int,
+            targetStock: Int,
+            certaintyScore: Double,
+            action: String,
+            quantity: Int,
+            movementId: Int64? = nil,
+            wishlistItem: WishlistItem? = nil,
+            auditSessionId: Int64? = nil,
+            reusedExistingAction: Bool = false
+        ) {
+            self.partId = partId
+            self.partName = partName
+            self.locationType = locationType
+            self.locationId = locationId
+            self.currentStock = currentStock
+            self.minStock = minStock
+            self.targetStock = targetStock
+            self.certaintyScore = certaintyScore
+            self.action = action
+            self.quantity = quantity
+            self.movementId = movementId
+            self.wishlistItem = wishlistItem
+            self.auditSessionId = auditSessionId
+            self.reusedExistingAction = reusedExistingAction
         }
     }
 
@@ -175,6 +231,184 @@ public final class WishlistService: Sendable {
             )
             try item.insert(dbConn)
             return item
+        }
+    }
+
+    // =========================================================================
+    // MARK: - Below-MIN Routing
+    // =========================================================================
+
+    /// Evaluate a part/location against MIN stock and route the operational action.
+    ///
+    /// Routing order:
+    /// 1. If the target location is not below MIN, no action.
+    /// 2. For truck/trailer shortages, pull available shop stock before procurement.
+    /// 3. If shop cannot cover the field shortage and confidence is at least 80%,
+    ///    create/approve one deduped system wishlist item.
+    /// 4. If confidence is below 80%, route one deduped physical-count audit.
+    @discardableResult
+    public func routeBelowMinimumStock(
+        partId: Int64,
+        locationType rawLocationType: String,
+        locationId: Int64,
+        actorUserId: Int64,
+        certaintyOverride: Double? = nil
+    ) throws -> BelowMinimumRoutingResult {
+        let locationType = normalizeLocationType(rawLocationType)
+
+        return try db.writer.write { dbConn in
+            let partName = try fetchPartName(dbConn, partId: partId)
+            let target = try fetchLocationTarget(dbConn, partId: partId, locationType: locationType, locationId: locationId)
+            let currentStock = try currentStock(dbConn, partId: partId, locationType: locationType, locationId: locationId)
+            let certainty = certaintyOverride ?? target.certainty
+            let qtyNeeded = max(0, max(target.targetStock, target.minStock) - currentStock)
+
+            guard target.minStock > 0, currentStock < target.minStock else {
+                return BelowMinimumRoutingResult(
+                    partId: partId,
+                    partName: partName,
+                    locationType: locationType,
+                    locationId: locationId,
+                    currentStock: currentStock,
+                    minStock: target.minStock,
+                    targetStock: target.targetStock,
+                    certaintyScore: certainty,
+                    action: "none",
+                    quantity: 0
+                )
+            }
+
+            let marker = Self.belowMinimumMarker(partId: partId, locationType: locationType, locationId: locationId)
+
+            if locationType == "truck" || locationType == "trailer" {
+                let shopStock = try currentShopStock(dbConn, partId: partId)
+                if shopStock > 0 {
+                    if let existingMovementId = try existingShopTransferId(dbConn, marker: marker) {
+                        return BelowMinimumRoutingResult(
+                            partId: partId,
+                            partName: partName,
+                            locationType: locationType,
+                            locationId: locationId,
+                            currentStock: currentStock,
+                            minStock: target.minStock,
+                            targetStock: target.targetStock,
+                            certaintyScore: certainty,
+                            action: "shop_transfer",
+                            quantity: min(qtyNeeded, shopStock),
+                            movementId: existingMovementId,
+                            reusedExistingAction: true
+                        )
+                    }
+
+                    let movementQty = min(qtyNeeded, shopStock)
+                    let movementId = try createShopTransfer(
+                        dbConn,
+                        partId: partId,
+                        quantity: movementQty,
+                        toLocationType: locationType,
+                        toLocationId: locationId,
+                        performedBy: actorUserId,
+                        marker: marker
+                    )
+                    return BelowMinimumRoutingResult(
+                        partId: partId,
+                        partName: partName,
+                        locationType: locationType,
+                        locationId: locationId,
+                        currentStock: currentStock,
+                        minStock: target.minStock,
+                        targetStock: target.targetStock,
+                        certaintyScore: certainty,
+                        action: "shop_transfer",
+                        quantity: movementQty,
+                        movementId: movementId
+                    )
+                }
+            }
+
+            guard certainty >= 0.8 else {
+                try assertCanRoutePhysicalAudit(dbConn, actorUserId: actorUserId, locationType: locationType, locationId: locationId)
+                if let existingAuditId = try existingAuditSessionId(dbConn, marker: marker) {
+                    return BelowMinimumRoutingResult(
+                        partId: partId,
+                        partName: partName,
+                        locationType: locationType,
+                        locationId: locationId,
+                        currentStock: currentStock,
+                        minStock: target.minStock,
+                        targetStock: target.targetStock,
+                        certaintyScore: certainty,
+                        action: "physical_audit",
+                        quantity: qtyNeeded,
+                        auditSessionId: existingAuditId,
+                        reusedExistingAction: true
+                    )
+                }
+
+                let auditId = try createPhysicalAuditSession(
+                    dbConn,
+                    partId: partId,
+                    partName: partName,
+                    locationType: locationType,
+                    locationId: locationId,
+                    startedBy: actorUserId,
+                    marker: marker
+                )
+                return BelowMinimumRoutingResult(
+                    partId: partId,
+                    partName: partName,
+                    locationType: locationType,
+                    locationId: locationId,
+                    currentStock: currentStock,
+                    minStock: target.minStock,
+                    targetStock: target.targetStock,
+                    certaintyScore: certainty,
+                    action: "physical_audit",
+                    quantity: qtyNeeded,
+                    auditSessionId: auditId
+                )
+            }
+
+            if let existing = try existingWishlistItem(dbConn, marker: marker) {
+                return BelowMinimumRoutingResult(
+                    partId: partId,
+                    partName: partName,
+                    locationType: locationType,
+                    locationId: locationId,
+                    currentStock: currentStock,
+                    minStock: target.minStock,
+                    targetStock: target.targetStock,
+                    certaintyScore: certainty,
+                    action: "wishlist",
+                    quantity: qtyNeeded,
+                    wishlistItem: existing,
+                    reusedExistingAction: true
+                )
+            }
+
+            let item = try createApprovedBelowMinimumWishlist(
+                dbConn,
+                partId: partId,
+                partName: partName,
+                quantity: qtyNeeded,
+                certaintyScore: certainty,
+                locationType: locationType,
+                locationId: locationId,
+                marker: marker
+            )
+            return BelowMinimumRoutingResult(
+                partId: partId,
+                partName: partName,
+                locationType: locationType,
+                locationId: locationId,
+                currentStock: currentStock,
+                minStock: target.minStock,
+                targetStock: target.targetStock,
+                certaintyScore: certainty,
+                action: "wishlist",
+                quantity: qtyNeeded,
+                wishlistItem: item
+            )
         }
     }
 
@@ -423,6 +657,330 @@ public final class WishlistService: Sendable {
             if isTableNotFoundError(error) { return 0 }
             throw error
         }
+    }
+
+    private struct BelowMinimumTarget {
+        let minStock: Int
+        let targetStock: Int
+        let certainty: Double
+    }
+
+    private static func belowMinimumMarker(partId: Int64, locationType: String, locationId: Int64) -> String {
+        "[below-min part:\(partId) location:\(locationType):\(locationId)]"
+    }
+
+    private func normalizeLocationType(_ locationType: String) -> String {
+        let trimmed = locationType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return trimmed == "vehicle" ? "truck" : trimmed
+    }
+
+    private func fetchPartName(_ dbConn: Database, partId: Int64) throws -> String {
+        guard let name = try String.fetchOne(
+            dbConn,
+            sql: "SELECT name FROM parts WHERE id = ? AND deleted_at IS NULL",
+            arguments: [partId]
+        ) else {
+            throw WishlistError.partNotFound(partId)
+        }
+        return name
+    }
+
+    private func fetchLocationTarget(
+        _ dbConn: Database,
+        partId: Int64,
+        locationType: String,
+        locationId: Int64
+    ) throws -> BelowMinimumTarget {
+        if let row = try Row.fetchOne(dbConn, sql: """
+            SELECT min_stock, target_stock, certainty_rating
+            FROM location_stock_targets
+            WHERE part_id = ? AND location_type = ? AND location_id = ? AND deleted_at IS NULL
+            """, arguments: [partId, locationType, locationId]) {
+            return BelowMinimumTarget(
+                minStock: row["min_stock"] ?? 0,
+                targetStock: row["target_stock"] ?? 0,
+                certainty: row["certainty_rating"] ?? 0.0
+            )
+        }
+
+        if let row = try Row.fetchOne(dbConn, sql: """
+            SELECT min_stock_level, target_stock_level
+            FROM parts
+            WHERE id = ? AND deleted_at IS NULL
+            """, arguments: [partId]) {
+            return BelowMinimumTarget(
+                minStock: row["min_stock_level"] ?? 0,
+                targetStock: row["target_stock_level"] ?? 0,
+                certainty: 0.0
+            )
+        }
+
+        throw WishlistError.partNotFound(partId)
+    }
+
+    private func currentStock(
+        _ dbConn: Database,
+        partId: Int64,
+        locationType: String,
+        locationId: Int64
+    ) throws -> Int {
+        switch locationType {
+        case "truck":
+            return try Int.fetchOne(dbConn, sql: """
+                SELECT COALESCE(SUM(quantity), 0)
+                FROM vehicle_stock
+                WHERE part_id = ? AND vehicle_id = ? AND stock_type = 'truck_stock' AND deleted_at IS NULL
+                """, arguments: [partId, locationId]) ?? 0
+        case "trailer":
+            return try Int.fetchOne(dbConn, sql: """
+                SELECT COALESCE(SUM(quantity), 0)
+                FROM trailer_stock
+                WHERE part_id = ? AND trailer_id = ? AND deleted_at IS NULL
+                """, arguments: [partId, locationId]) ?? 0
+        default:
+            return try Int.fetchOne(dbConn, sql: """
+                SELECT COALESCE(SUM(qty), 0)
+                FROM stock
+                WHERE part_id = ? AND location_type = ? AND location_id = ? AND deleted_at IS NULL
+                """, arguments: [partId, locationType, locationId]) ?? 0
+        }
+    }
+
+    private func currentShopStock(_ dbConn: Database, partId: Int64) throws -> Int {
+        try Int.fetchOne(dbConn, sql: """
+            SELECT COALESCE(MAX(qty), 0)
+            FROM stock
+            WHERE part_id = ?
+              AND location_type IN ('shop', 'warehouse')
+              AND deleted_at IS NULL
+            """, arguments: [partId]) ?? 0
+    }
+
+    private func existingShopTransferId(_ dbConn: Database, marker: String) throws -> Int64? {
+        try Int64.fetchOne(dbConn, sql: """
+            SELECT id
+            FROM stock_movements
+            WHERE movement_type = 'restock_from_shop'
+              AND notes LIKE ?
+              AND deleted_at IS NULL
+            ORDER BY id DESC
+            LIMIT 1
+            """, arguments: ["%\(marker)%"])
+    }
+
+    private func createShopTransfer(
+        _ dbConn: Database,
+        partId: Int64,
+        quantity: Int,
+        toLocationType: String,
+        toLocationId: Int64,
+        performedBy: Int64,
+        marker: String
+    ) throws -> Int64 {
+        let source = try shopSourceLocation(dbConn, partId: partId, quantity: quantity)
+        try dbConn.execute(sql: """
+            INSERT INTO stock_movements
+            (part_id, qty, from_location_type, from_location_id, to_location_type, to_location_id,
+             movement_type, reason, notes, performed_by, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, 'restock_from_shop', 'Below MIN restock from shop', ?, ?, datetime('now'))
+            """, arguments: [
+                partId, quantity, source.locationType, source.locationId,
+                toLocationType, toLocationId, "\(marker) Generated below-MIN shop restock.", performedBy
+            ])
+        let movementId = dbConn.lastInsertedRowID
+
+        try dbConn.execute(sql: """
+            UPDATE stock SET qty = qty - ?, updated_at = datetime('now')
+            WHERE part_id = ? AND location_type = ? AND location_id = ? AND deleted_at IS NULL
+            """, arguments: [quantity, partId, source.locationType, source.locationId])
+
+        try dbConn.execute(sql: """
+            UPDATE stock SET qty = qty + ?, updated_at = datetime('now')
+            WHERE part_id = ? AND location_type = ? AND location_id = ? AND deleted_at IS NULL
+            """, arguments: [quantity, partId, toLocationType, toLocationId])
+        if dbConn.changesCount == 0 {
+            try dbConn.execute(sql: """
+                INSERT INTO stock (part_id, location_type, location_id, qty, updated_at)
+                VALUES (?, ?, ?, ?, datetime('now'))
+                """, arguments: [partId, toLocationType, toLocationId, quantity])
+        }
+
+        if toLocationType == "truck" {
+            try dbConn.execute(sql: """
+                UPDATE vehicle_stock SET quantity = quantity + ?, updated_at = datetime('now')
+                WHERE part_id = ? AND vehicle_id = ? AND stock_type = 'truck_stock' AND deleted_at IS NULL
+                """, arguments: [quantity, partId, toLocationId])
+            if dbConn.changesCount == 0 {
+                let partName = try fetchPartName(dbConn, partId: partId)
+                try dbConn.execute(sql: """
+                    INSERT INTO vehicle_stock
+                    (vehicle_id, part_id, part_name, quantity, stock_type, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, 'truck_stock', datetime('now'), datetime('now'))
+                    """, arguments: [toLocationId, partId, partName, quantity])
+            }
+        } else if toLocationType == "trailer" {
+            try dbConn.execute(sql: """
+                UPDATE trailer_stock SET quantity = quantity + ?, updated_at = datetime('now')
+                WHERE part_id = ? AND trailer_id = ? AND deleted_at IS NULL
+                """, arguments: [quantity, partId, toLocationId])
+            if dbConn.changesCount == 0 {
+                let partName = try fetchPartName(dbConn, partId: partId)
+                try dbConn.execute(sql: """
+                    INSERT INTO trailer_stock
+                    (trailer_id, part_id, part_name, quantity, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+                    """, arguments: [toLocationId, partId, partName, quantity])
+            }
+        }
+
+        return movementId
+    }
+
+    private func shopSourceLocation(_ dbConn: Database, partId: Int64, quantity: Int) throws -> (locationType: String, locationId: Int64) {
+        if let row = try Row.fetchOne(dbConn, sql: """
+            SELECT location_type, location_id
+            FROM stock
+            WHERE part_id = ?
+              AND location_type IN ('shop', 'warehouse')
+              AND qty >= ?
+              AND deleted_at IS NULL
+            ORDER BY CASE location_type WHEN 'shop' THEN 0 ELSE 1 END, location_id
+            LIMIT 1
+            """, arguments: [partId, quantity]) {
+            return (row["location_type"] ?? "warehouse", row["location_id"] ?? 1)
+        }
+
+        let row = try Row.fetchOne(dbConn, sql: """
+            SELECT location_type, location_id
+            FROM stock
+            WHERE part_id = ?
+              AND location_type IN ('shop', 'warehouse')
+              AND qty > 0
+              AND deleted_at IS NULL
+            ORDER BY qty DESC
+            LIMIT 1
+            """, arguments: [partId])
+        guard let row else { return ("warehouse", 1) }
+        return (row["location_type"] ?? "warehouse", row["location_id"] ?? 1)
+    }
+
+    private func existingWishlistItem(_ dbConn: Database, marker: String) throws -> WishlistItem? {
+        try WishlistItem.fetchOne(dbConn, sql: """
+            SELECT *
+            FROM wishlist_items
+            WHERE source_type = 'system'
+              AND status IN ('pending', 'approved')
+              AND notes LIKE ?
+            ORDER BY id DESC
+            LIMIT 1
+            """, arguments: ["%\(marker)%"])
+    }
+
+    private func createApprovedBelowMinimumWishlist(
+        _ dbConn: Database,
+        partId: Int64,
+        partName: String,
+        quantity: Int,
+        certaintyScore: Double,
+        locationType: String,
+        locationId: Int64,
+        marker: String
+    ) throws -> WishlistItem {
+        let nowString = Self.nowString()
+        var item = WishlistItem(
+            id: nil,
+            partId: partId,
+            partName: partName,
+            qtySuggested: quantity,
+            reason: "Below MIN at \(locationType) #\(locationId)",
+            priority: "high",
+            sourceType: "system",
+            status: "approved",
+            requestedBy: "System (Below MIN)",
+            approvedBy: "System (Below MIN)",
+            approvedAt: nowString,
+            dismissedBy: nil,
+            dismissedAt: nil,
+            dismissReason: nil,
+            notes: "\(marker) Shop stock unavailable; confidence \(Int(certaintyScore * 100))%.",
+            createdAt: nowString,
+            updatedAt: nowString,
+            autoApproveAt: nil,
+            certaintyScore: certaintyScore
+        )
+        try item.insert(dbConn)
+        return item
+    }
+
+    private func assertCanRoutePhysicalAudit(
+        _ dbConn: Database,
+        actorUserId: Int64,
+        locationType: String,
+        locationId: Int64
+    ) throws {
+        guard try userHasPermission(dbConn, userId: actorUserId, permissionKey: "perform_audit") else {
+            throw WishlistError.insufficientPermissions(required: "perform_audit")
+        }
+
+        guard locationType == "truck" else { return }
+        if try userHasPermission(dbConn, userId: actorUserId, permissionKey: "manage_trucks") { return }
+
+        let isAssigned = try Int.fetchOne(dbConn, sql: """
+            SELECT COUNT(*)
+            FROM vehicle_assignments
+            WHERE vehicle_id = ? AND user_id = ? AND is_active = 1 AND deleted_at IS NULL
+            """, arguments: [locationId, actorUserId]) ?? 0
+        guard isAssigned > 0 else {
+            throw WishlistError.restrictedToAssignedTruckUser(locationId: locationId)
+        }
+    }
+
+    private func userHasPermission(_ dbConn: Database, userId: Int64, permissionKey: String) throws -> Bool {
+        let count = try Int.fetchOne(dbConn, sql: """
+            SELECT COUNT(*)
+            FROM user_hats uh
+            JOIN users u ON u.id = uh.user_id
+            JOIN hat_permissions hp ON hp.hat_id = uh.hat_id
+            WHERE uh.user_id = ?
+              AND uh.is_active = 1 AND uh.deleted_at IS NULL
+              AND u.deleted_at IS NULL AND u.is_active = 1
+              AND hp.permission_key = ?
+            LIMIT 1
+            """, arguments: [userId, permissionKey]) ?? 0
+        return count > 0
+    }
+
+    private func existingAuditSessionId(_ dbConn: Database, marker: String) throws -> Int64? {
+        try Int64.fetchOne(dbConn, sql: """
+            SELECT id
+            FROM audit_sessions_v2
+            WHERE session_type = 'physical_count'
+              AND status = 'active'
+              AND notes LIKE ?
+              AND deleted_at IS NULL
+            ORDER BY id DESC
+            LIMIT 1
+            """, arguments: ["%\(marker)%"])
+    }
+
+    private func createPhysicalAuditSession(
+        _ dbConn: Database,
+        partId: Int64,
+        partName: String,
+        locationType: String,
+        locationId: Int64,
+        startedBy: Int64,
+        marker: String
+    ) throws -> Int64 {
+        try dbConn.execute(sql: """
+            INSERT INTO audit_sessions_v2
+            (session_type, started_by, status, notes, started_at)
+            VALUES ('physical_count', ?, 'active', ?, datetime('now'))
+            """, arguments: [
+                startedBy,
+                "\(marker) Count \(partName) (part #\(partId)) at \(locationType) #\(locationId) before wishlist generation."
+            ])
+        return dbConn.lastInsertedRowID
     }
 
     // =========================================================================

--- a/core/Sources/WiredPartCore/Services/WishlistService.swift
+++ b/core/Sources/WiredPartCore/Services/WishlistService.swift
@@ -412,6 +412,42 @@ public final class WishlistService: Sendable {
         }
     }
 
+    /// Generate routing actions for every configured part/location target currently below MIN.
+    @discardableResult
+    public func routeAllBelowMinimumStock(actorUserId: Int64) throws -> [BelowMinimumRoutingResult] {
+        let targets = try db.writer.read { dbConn in
+            try Row.fetchAll(dbConn, sql: """
+                SELECT part_id, location_type, location_id
+                FROM location_stock_targets
+                WHERE deleted_at IS NULL
+                  AND min_stock > 0
+                  AND COALESCE(do_not_restock, 0) = 0
+                ORDER BY part_id, location_type, location_id
+                """)
+                .map { row -> (partId: Int64, locationType: String, locationId: Int64) in
+                    (
+                        partId: row["part_id"] ?? 0,
+                        locationType: row["location_type"] ?? "",
+                        locationId: row["location_id"] ?? 0
+                    )
+                }
+        }
+
+        var results: [BelowMinimumRoutingResult] = []
+        for target in targets {
+            let result = try routeBelowMinimumStock(
+                partId: target.partId,
+                locationType: target.locationType,
+                locationId: target.locationId,
+                actorUserId: actorUserId
+            )
+            if result.action != "none" {
+                results.append(result)
+            }
+        }
+        return results
+    }
+
     // =========================================================================
     // MARK: - Update
     // =========================================================================

--- a/core/Sources/WiredPartCore/Services/WishlistService.swift
+++ b/core/Sources/WiredPartCore/Services/WishlistService.swift
@@ -369,6 +369,21 @@ public final class WishlistService: Sendable {
                 )
             }
 
+            guard try partAutoAddsToWishlistWhenLow(dbConn, partId: partId) else {
+                return BelowMinimumRoutingResult(
+                    partId: partId,
+                    partName: partName,
+                    locationType: locationType,
+                    locationId: locationId,
+                    currentStock: currentStock,
+                    minStock: target.minStock,
+                    targetStock: target.targetStock,
+                    certaintyScore: certainty,
+                    action: "none",
+                    quantity: 0
+                )
+            }
+
             if let existing = try existingWishlistItem(dbConn, marker: marker) {
                 return BelowMinimumRoutingResult(
                     partId: partId,
@@ -417,12 +432,15 @@ public final class WishlistService: Sendable {
     public func routeAllBelowMinimumStock(actorUserId: Int64) throws -> [BelowMinimumRoutingResult] {
         let targets = try db.writer.read { dbConn in
             try Row.fetchAll(dbConn, sql: """
-                SELECT part_id, location_type, location_id
-                FROM location_stock_targets
-                WHERE deleted_at IS NULL
-                  AND min_stock > 0
-                  AND COALESCE(do_not_restock, 0) = 0
-                ORDER BY part_id, location_type, location_id
+                SELECT lst.part_id, lst.location_type, lst.location_id
+                FROM location_stock_targets lst
+                JOIN parts p ON p.id = lst.part_id
+                WHERE lst.deleted_at IS NULL
+                  AND p.deleted_at IS NULL
+                  AND COALESCE(p.auto_add_to_wishlist_when_low, 0) = 1
+                  AND lst.min_stock > 0
+                  AND COALESCE(lst.do_not_restock, 0) = 0
+                ORDER BY lst.part_id, lst.location_type, lst.location_id
                 """)
                 .map { row -> (partId: Int64, locationType: String, locationId: Int64) in
                     (
@@ -910,6 +928,21 @@ public final class WishlistService: Sendable {
             ORDER BY id DESC
             LIMIT 1
             """, arguments: ["%\(marker)%"])
+    }
+
+    private func partAutoAddsToWishlistWhenLow(_ dbConn: Database, partId: Int64) throws -> Bool {
+        guard let value = try Int.fetchOne(
+            dbConn,
+            sql: """
+                SELECT auto_add_to_wishlist_when_low
+                FROM parts
+                WHERE id = ? AND deleted_at IS NULL
+                """,
+            arguments: [partId]
+        ) else {
+            throw WishlistError.partNotFound(partId)
+        }
+        return value != 0
     }
 
     private func createApprovedBelowMinimumWishlist(

--- a/core/Tests/WiredPartCoreTests/BackgroundTaskServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/BackgroundTaskServiceTests.swift
@@ -86,6 +86,25 @@ struct BackgroundTaskServiceTests {
         #expect(running[0].id == t1)
     }
 
+    @Test("Office status rows expose known background tasks")
+    func testOfficeStatusRowsExposeKnownTasks() throws {
+        let svc = try freshService()
+
+        let forecast = try svc.startTask(name: "Forecast Recalculation", type: "forecast_recalculation")
+        try svc.completeTask(id: forecast, summary: "Forecasts refreshed", itemsProcessed: 3)
+        let companion = try svc.startTask(name: "Companion Auto-Discovery", type: "companion_discovery")
+        try svc.failTask(id: companion, error: "Model unavailable")
+        _ = try svc.startTask(name: "Peer Sync", type: "sync")
+
+        let rows = Dictionary(uniqueKeysWithValues: try svc.officeStatusRows().map { ($0.id, $0) })
+        #expect(rows["forecast_recalculation"]?.status == .completed)
+        #expect(rows["forecast_recalculation"]?.detail.contains("Forecasts refreshed") == true)
+        #expect(rows["companion_discovery"]?.status == .failed)
+        #expect(rows["companion_discovery"]?.detail.contains("Model unavailable") == true)
+        #expect(rows["sync"]?.status == .running)
+        #expect(rows["audit"]?.status == .neverRun)
+    }
+
     // MARK: - Summary
 
     @Test("24-hour summary aggregates correctly")

--- a/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
@@ -493,6 +493,110 @@ struct DashboardServiceTests {
         #expect(briefing.summary.hasPrefix("Good morning."))
     }
 
+    @Test("getOfficeSmartCards returns command center counts")
+    func testOfficeSmartCardsCommandCenterCounts() throws {
+        let (env, dash) = try freshEnv()
+        let categoryId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, name: "Low Stock Coupling", categoryId: categoryId)
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-OFFICE-CARDS", name: "Office Cards Job")
+        let supplierId = try E2ETestHelpers.seedSupplier(env)
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE parts SET min_stock_level = 10 WHERE id = ?", arguments: [partId])
+            try db.execute(sql: """
+                INSERT INTO labor_entries (user_id, job_id, clock_in, work_type)
+                VALUES (?, ?, datetime('now'), 'regular')
+                """, arguments: [env.adminUserId, jobId])
+            try db.execute(sql: """
+                INSERT INTO job_parts_orders (job_id, order_number, status, order_type, requested_by)
+                VALUES (?, 'JPO-OFFICE-CARDS', 'submitted', 'job', ?)
+                """, arguments: [jobId, env.adminUserId])
+            try db.execute(sql: """
+                INSERT INTO purchase_orders (po_number, supplier_id, status, expected_delivery, submitted_by)
+                VALUES ('PO-OFFICE-CARDS', ?, 'submitted', date('now', '-1 day'), ?)
+                """, arguments: [supplierId, env.adminUserId])
+            try db.execute(sql: """
+                UPDATE jobs
+                SET status = 'payment_hold',
+                    due_date = date('now', '-1 day'),
+                    warranty_end_date = date('now', '+10 days')
+                WHERE id = ?
+                """, arguments: [jobId])
+            try db.execute(sql: """
+                INSERT INTO tool_maintenance_types (name)
+                VALUES ('Office Card Calibration')
+                """)
+            let maintenanceTypeId = db.lastInsertedRowID
+            try db.execute(sql: """
+                INSERT INTO tools (tool_number, name, category, calibration_due_date)
+                VALUES ('TOOL-OFFICE-CARDS', 'Office Card Meter', 'meter', date('now', '+2 days'))
+                """)
+            let toolId = db.lastInsertedRowID
+            try db.execute(sql: """
+                INSERT INTO tool_maintenance_schedules (tool_id, maintenance_type_id, next_due_date)
+                VALUES (?, ?, date('now', '+2 days'))
+                """, arguments: [toolId, maintenanceTypeId])
+        }
+
+        let cards = Dictionary(uniqueKeysWithValues: try dash.getOfficeSmartCards().map { ($0.id, $0.count) })
+        #expect(cards["approvals_pending"] == 1)
+        #expect(cards["working_today"] == 1)
+        #expect(cards["jpos_pending"] == 1)
+        #expect(cards["payment_overdue"] == 1)
+        #expect(cards["parts_below_min"] == 1)
+        #expect(cards["maintenance_due"] == 2)
+        #expect(cards["callbacks_overdue"] == 1)
+        #expect(cards["warranty_expiring"] == 1)
+    }
+
+    @Test("getAttentionItems includes command center attention sources")
+    func testAttentionItemsIncludeCommandCenterSources() throws {
+        let (env, dash) = try freshEnv()
+        let categoryId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, name: "Attention Low Stock Part", categoryId: categoryId)
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-ATTENTION-SOURCES", name: "Attention Sources Job")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE parts SET min_stock_level = 5 WHERE id = ?", arguments: [partId])
+            try db.execute(sql: """
+                INSERT INTO qa_threads (job_id, asked_by, subject, status, priority)
+                VALUES (?, ?, 'Need office decision', 'open', 'normal')
+                """, arguments: [jobId, env.adminUserId])
+            try db.execute(sql: """
+                UPDATE jobs
+                SET due_date = date('now', '-1 day'),
+                    warranty_end_date = date('now', '+20 days')
+                WHERE id = ?
+                """, arguments: [jobId])
+            try db.execute(sql: """
+                INSERT INTO certifications (user_id, cert_type, cert_name, expiry_date, is_active)
+                VALUES (?, 'safety', 'Lift Cert', date('now', '+15 days'), 1)
+                """, arguments: [env.adminUserId])
+            try db.execute(sql: """
+                INSERT INTO tool_maintenance_types (name)
+                VALUES ('Attention Maintenance')
+                """)
+            let maintenanceTypeId = db.lastInsertedRowID
+            try db.execute(sql: """
+                INSERT INTO tools (tool_number, name, category)
+                VALUES ('TOOL-ATTENTION', 'Attention Meter', 'meter')
+                """)
+            let toolId = db.lastInsertedRowID
+            try db.execute(sql: """
+                INSERT INTO tool_maintenance_schedules (tool_id, maintenance_type_id, next_due_date)
+                VALUES (?, ?, date('now', '+1 day'))
+                """, arguments: [toolId, maintenanceTypeId])
+        }
+
+        let itemTypes = Set(try dash.getAttentionItems().map(\.itemType))
+        #expect(itemTypes.contains("low_stock"))
+        #expect(itemTypes.contains("open_qa"))
+        #expect(itemTypes.contains("overdue_job"))
+        #expect(itemTypes.contains("maintenance_due"))
+        #expect(itemTypes.contains("expiring_cert"))
+        #expect(itemTypes.contains("warranty_expiring"))
+    }
+
     // MARK: - Financial Snapshot
 
     @Test("getFinancialSnapshot returns zeroes on fresh DB")

--- a/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
@@ -62,6 +62,33 @@ struct PartsServiceExtTests {
         try env.parts.deletePart(id: partId)
     }
 
+    @Test("auto-add-to-wishlist flag defaults off and can be toggled by catalog editor")
+    func testAutoAddToWishlistWhenLowToggle() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "AutoWishlistCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Auto Wishlist Part", categoryId: catId)
+
+        #expect(try env.parts.getAutoAddToWishlistWhenLow(partId: partId) == false)
+        #expect(try env.parts.getPart(id: partId).part.autoAddToWishlistWhenLow == 0)
+
+        try env.parts.setAutoAddToWishlistWhenLow(partId: partId, enabled: true, byUserId: env.adminUserId)
+
+        #expect(try env.parts.getAutoAddToWishlistWhenLow(partId: partId))
+        #expect(try env.parts.getPart(id: partId).part.autoAddToWishlistWhenLow == 1)
+    }
+
+    @Test("auto-add-to-wishlist toggle rejects users without edit_parts_catalog")
+    func testAutoAddToWishlistWhenLowRequiresCatalogEditPermission() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "AutoWishlistPermCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Auto Wishlist Restricted", categoryId: catId)
+        let unprivilegedId = try env.auth.createUser(displayName: "NoCatalogEdit", pin: "7777")
+
+        #expect(throws: PartsService.PartsError.insufficientPermissions(required: "edit_parts_catalog")) {
+            try env.parts.setAutoAddToWishlistWhenLow(partId: partId, enabled: true, byUserId: unprivilegedId)
+        }
+    }
+
     @Test("getPart throws partNotFound for soft-deleted parts")
     func testGetPart_throwsForDeletedPart() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
@@ -77,6 +77,22 @@ struct PartsServiceExtTests {
         #expect(try env.parts.getPart(id: partId).part.autoAddToWishlistWhenLow == 1)
     }
 
+    @Test("auto-add-to-wishlist toggle audit records old and new values")
+    func testAutoAddToWishlistWhenLowToggleAuditValues() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "AutoWishlistAuditCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Auto Wishlist Audit", categoryId: catId)
+
+        try env.parts.setAutoAddToWishlistWhenLow(partId: partId, enabled: true, byUserId: env.adminUserId)
+        try env.parts.setAutoAddToWishlistWhenLow(partId: partId, enabled: false, byUserId: env.adminUserId)
+
+        let entries = try env.parts.getPartChangeLog(partId: partId)
+            .filter { $0.fieldName == "auto_add_to_wishlist_when_low" }
+        #expect(entries.count == 2)
+        #expect(entries.contains { $0.oldValue == "0" && $0.newValue == "1" })
+        #expect(entries.contains { $0.oldValue == "1" && $0.newValue == "0" })
+    }
+
     @Test("auto-add-to-wishlist toggle rejects users without edit_parts_catalog")
     func testAutoAddToWishlistWhenLowRequiresCatalogEditPermission() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/WishlistServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/WishlistServiceTests.swift
@@ -566,6 +566,16 @@ struct WishlistServiceTests {
             targetStock: 9,
             maxStock: 16
         )
+        try env.db.writer.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE location_stock_targets
+                    SET certainty_rating = 0.88
+                    WHERE part_id = ? AND location_type = 'shop' AND location_id = 1
+                    """,
+                arguments: [partId]
+            )
+        }
 
         let first = try wishlist.routeBelowMinimumStock(
             partId: partId,
@@ -589,6 +599,11 @@ struct WishlistServiceTests {
         #expect(second.action == "wishlist")
         #expect(second.reusedExistingAction)
         #expect(second.wishlistItem?.id == first.wishlistItem?.id)
+
+        let batchResults = try wishlist.routeAllBelowMinimumStock(actorUserId: env.adminUserId)
+        #expect(batchResults.count == 1)
+        #expect(batchResults[0].action == "wishlist")
+        #expect(batchResults[0].reusedExistingAction)
 
         let count = try env.db.writer.read { db in
             try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wishlist_items WHERE part_id = ?", arguments: [partId]) ?? 0

--- a/core/Tests/WiredPartCoreTests/WishlistServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/WishlistServiceTests.swift
@@ -471,4 +471,238 @@ struct WishlistServiceTests {
         #expect(approved?.status == "approved")
         #expect(approved?.approvedBy == "System (Auto)")
     }
+
+    // MARK: - Below-MIN Routing
+
+    @Test("Below-MIN truck stock pulls from shop before creating wishlist demand")
+    func testBelowMinTruckRoutesShopTransferFirst() throws {
+        let (env, wishlist) = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "BelowMinTruckCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Truck Fuse", categoryId: catId)
+        let vehicleId = try env.fleet.createVehicle(
+            actorId: env.adminUserId,
+            vehicleNumber: "TRK-MIN-1",
+            vehicleName: "Minimum Truck",
+            vehicleType: "truck",
+            make: nil,
+            model: nil,
+            year: nil,
+            color: nil,
+            vin: nil,
+            licensePlate: nil,
+            notes: nil
+        )
+
+        try env.parts.setLocationStockTarget(
+            partId: partId,
+            locationType: "truck",
+            locationId: vehicleId,
+            minStock: 5,
+            targetStock: 10,
+            maxStock: 20
+        )
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 20, locationType: "shop", locationId: 1)
+        try env.fleet.addVehicleStockItem(
+            actorId: env.adminUserId,
+            vehicleId: vehicleId,
+            partName: "Truck Fuse",
+            quantity: 2,
+            stockType: "truck_stock",
+            partId: partId
+        )
+
+        let result = try wishlist.routeBelowMinimumStock(
+            partId: partId,
+            locationType: "truck",
+            locationId: vehicleId,
+            actorUserId: env.adminUserId,
+            certaintyOverride: 0.95
+        )
+
+        #expect(result.action == "shop_transfer")
+        #expect(result.quantity == 8)
+        #expect(result.movementId != nil)
+
+        let counts = try env.db.writer.read { db in
+            let shopQty = try Int.fetchOne(db, sql: """
+                SELECT qty FROM stock
+                WHERE part_id = ? AND location_type = 'shop' AND location_id = 1
+                """, arguments: [partId]) ?? 0
+            let truckQty = try Int.fetchOne(db, sql: """
+                SELECT quantity FROM vehicle_stock
+                WHERE part_id = ? AND vehicle_id = ? AND stock_type = 'truck_stock'
+                """, arguments: [partId, vehicleId]) ?? 0
+            let wishlistCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wishlist_items WHERE part_id = ?", arguments: [partId]) ?? 0
+            let movementCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM stock_movements WHERE part_id = ? AND movement_type = 'restock_from_shop'", arguments: [partId]) ?? 0
+            return (shopQty, truckQty, wishlistCount, movementCount)
+        }
+
+        #expect(counts.0 == 12)
+        #expect(counts.1 == 10)
+        #expect(counts.2 == 0)
+        #expect(counts.3 == 1)
+
+        let second = try wishlist.routeBelowMinimumStock(
+            partId: partId,
+            locationType: "truck",
+            locationId: vehicleId,
+            actorUserId: env.adminUserId,
+            certaintyOverride: 0.95
+        )
+        #expect(second.action == "none")
+    }
+
+    @Test("Below-MIN high-certainty shortage creates one approved wishlist item with location context")
+    func testBelowMinHighCertaintyCreatesDedupedWishlist() throws {
+        let (env, wishlist) = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "BelowMinWishlistCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Shop Breaker", categoryId: catId)
+
+        try env.parts.setLocationStockTarget(
+            partId: partId,
+            locationType: "shop",
+            locationId: 1,
+            minStock: 4,
+            targetStock: 9,
+            maxStock: 16
+        )
+
+        let first = try wishlist.routeBelowMinimumStock(
+            partId: partId,
+            locationType: "shop",
+            locationId: 1,
+            actorUserId: env.adminUserId,
+            certaintyOverride: 0.88
+        )
+        let second = try wishlist.routeBelowMinimumStock(
+            partId: partId,
+            locationType: "shop",
+            locationId: 1,
+            actorUserId: env.adminUserId,
+            certaintyOverride: 0.88
+        )
+
+        #expect(first.action == "wishlist")
+        #expect(first.wishlistItem?.status == "approved")
+        #expect(first.wishlistItem?.qtySuggested == 9)
+        #expect(first.wishlistItem?.reason == "Below MIN at shop #1")
+        #expect(second.action == "wishlist")
+        #expect(second.reusedExistingAction)
+        #expect(second.wishlistItem?.id == first.wishlistItem?.id)
+
+        let count = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wishlist_items WHERE part_id = ?", arguments: [partId]) ?? 0
+        }
+        #expect(count == 1)
+    }
+
+    @Test("Below-MIN low-certainty shortage routes one physical audit before wishlist")
+    func testBelowMinLowCertaintyRoutesDedupedAudit() throws {
+        let (env, wishlist) = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "BelowMinAuditCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Audit Coupling", categoryId: catId)
+
+        try env.parts.setLocationStockTarget(
+            partId: partId,
+            locationType: "warehouse",
+            locationId: 3,
+            minStock: 3,
+            targetStock: 7,
+            maxStock: 12
+        )
+
+        let first = try wishlist.routeBelowMinimumStock(
+            partId: partId,
+            locationType: "warehouse",
+            locationId: 3,
+            actorUserId: env.adminUserId,
+            certaintyOverride: 0.42
+        )
+        let second = try wishlist.routeBelowMinimumStock(
+            partId: partId,
+            locationType: "warehouse",
+            locationId: 3,
+            actorUserId: env.adminUserId,
+            certaintyOverride: 0.42
+        )
+
+        #expect(first.action == "physical_audit")
+        #expect(first.auditSessionId != nil)
+        #expect(second.action == "physical_audit")
+        #expect(second.reusedExistingAction)
+        #expect(second.auditSessionId == first.auditSessionId)
+
+        let counts = try env.db.writer.read { db in
+            let audits = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM audit_sessions_v2 WHERE session_type = 'physical_count'") ?? 0
+            let wishlistItems = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wishlist_items WHERE part_id = ?", arguments: [partId]) ?? 0
+            return (audits, wishlistItems)
+        }
+        #expect(counts.0 == 1)
+        #expect(counts.1 == 0)
+    }
+
+    @Test("Below-MIN truck audit is restricted to assigned truck user without manager override")
+    func testBelowMinTruckAuditRequiresAssignedTruckUser() throws {
+        let (env, wishlist) = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "TruckAuditPermissionCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Truck Audit Clamp", categoryId: catId)
+        let userId = try env.auth.createUser(displayName: "Truck Auditor", pin: "2468")
+        let vehicleId = try env.fleet.createVehicle(
+            actorId: env.adminUserId,
+            vehicleNumber: "TRK-AUD-1",
+            vehicleName: "Audit Truck",
+            vehicleType: "truck",
+            make: nil,
+            model: nil,
+            year: nil,
+            color: nil,
+            vin: nil,
+            licensePlate: nil,
+            notes: nil
+        )
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "INSERT INTO hats (name, level) VALUES ('Audit Only', 5)")
+            let hatId = db.lastInsertedRowID
+            try db.execute(sql: "INSERT INTO hat_permissions (hat_id, permission_key) VALUES (?, 'perform_audit')", arguments: [hatId])
+            try db.execute(sql: "INSERT INTO user_hats (user_id, hat_id, is_active) VALUES (?, ?, 1)", arguments: [userId, hatId])
+        }
+
+        try env.parts.setLocationStockTarget(
+            partId: partId,
+            locationType: "truck",
+            locationId: vehicleId,
+            minStock: 2,
+            targetStock: 5,
+            maxStock: 8
+        )
+
+        #expect(throws: WishlistService.WishlistError.restrictedToAssignedTruckUser(locationId: vehicleId)) {
+            try wishlist.routeBelowMinimumStock(
+                partId: partId,
+                locationType: "truck",
+                locationId: vehicleId,
+                actorUserId: userId,
+                certaintyOverride: 0.25
+            )
+        }
+
+        try env.fleet.assignDriver(
+            actorId: env.adminUserId,
+            vehicleId: vehicleId,
+            userId: userId,
+            assignmentType: "primary",
+            isTakeHome: false
+        )
+
+        let result = try wishlist.routeBelowMinimumStock(
+            partId: partId,
+            locationType: "truck",
+            locationId: vehicleId,
+            actorUserId: userId,
+            certaintyOverride: 0.25
+        )
+        #expect(result.action == "physical_audit")
+        #expect(result.auditSessionId != nil)
+    }
 }

--- a/core/Tests/WiredPartCoreTests/WishlistServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/WishlistServiceTests.swift
@@ -557,6 +557,7 @@ struct WishlistServiceTests {
         let (env, wishlist) = try freshEnv()
         let catId = try E2ETestHelpers.seedCategory(env, name: "BelowMinWishlistCat")
         let partId = try E2ETestHelpers.seedPart(env, name: "Shop Breaker", categoryId: catId)
+        try env.parts.setAutoAddToWishlistWhenLow(partId: partId, enabled: true, byUserId: env.adminUserId)
 
         try env.parts.setLocationStockTarget(
             partId: partId,
@@ -609,6 +610,37 @@ struct WishlistServiceTests {
             try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wishlist_items WHERE part_id = ?", arguments: [partId]) ?? 0
         }
         #expect(count == 1)
+    }
+
+    @Test("Below-MIN high-certainty shortage skips wishlist when part is not opted in")
+    func testBelowMinHighCertaintySkipsWishlistWithoutPartOptIn() throws {
+        let (env, wishlist) = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "BelowMinOptOutCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Opt Out Breaker", categoryId: catId)
+
+        try env.parts.setLocationStockTarget(
+            partId: partId,
+            locationType: "shop",
+            locationId: 1,
+            minStock: 4,
+            targetStock: 9,
+            maxStock: 16
+        )
+
+        let result = try wishlist.routeBelowMinimumStock(
+            partId: partId,
+            locationType: "shop",
+            locationId: 1,
+            actorUserId: env.adminUserId,
+            certaintyOverride: 0.9
+        )
+
+        #expect(result.action == "none")
+        let count = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wishlist_items WHERE part_id = ?", arguments: [partId]) ?? 0
+        }
+        #expect(count == 0)
+        #expect(try wishlist.routeAllBelowMinimumStock(actorUserId: env.adminUserId).isEmpty)
     }
 
     @Test("Below-MIN low-certainty shortage routes one physical audit before wishlist")

--- a/core/Tests/WiredPartCoreTests/WishlistServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/WishlistServiceTests.swift
@@ -501,7 +501,9 @@ struct WishlistServiceTests {
             targetStock: 10,
             maxStock: 20
         )
-        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 20, locationType: "shop", locationId: 1)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 4, locationType: "shop", locationId: 1)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 16, locationType: "warehouse", locationId: 2)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 2, locationType: "truck", locationId: vehicleId)
         try env.fleet.addVehicleStockItem(
             actorId: env.adminUserId,
             vehicleId: vehicleId,
@@ -528,19 +530,29 @@ struct WishlistServiceTests {
                 SELECT qty FROM stock
                 WHERE part_id = ? AND location_type = 'shop' AND location_id = 1
                 """, arguments: [partId]) ?? 0
+            let warehouseQty = try Int.fetchOne(db, sql: """
+                SELECT qty FROM stock
+                WHERE part_id = ? AND location_type = 'warehouse' AND location_id = 2
+                """, arguments: [partId]) ?? 0
+            let truckStockQty = try Int.fetchOne(db, sql: """
+                SELECT qty FROM stock
+                WHERE part_id = ? AND location_type = 'truck' AND location_id = ?
+                """, arguments: [partId, vehicleId]) ?? 0
             let truckQty = try Int.fetchOne(db, sql: """
                 SELECT quantity FROM vehicle_stock
                 WHERE part_id = ? AND vehicle_id = ? AND stock_type = 'truck_stock'
                 """, arguments: [partId, vehicleId]) ?? 0
             let wishlistCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wishlist_items WHERE part_id = ?", arguments: [partId]) ?? 0
             let movementCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM stock_movements WHERE part_id = ? AND movement_type = 'restock_from_shop'", arguments: [partId]) ?? 0
-            return (shopQty, truckQty, wishlistCount, movementCount)
+            return (shopQty, warehouseQty, truckStockQty, truckQty, wishlistCount, movementCount)
         }
 
-        #expect(counts.0 == 12)
-        #expect(counts.1 == 10)
-        #expect(counts.2 == 0)
-        #expect(counts.3 == 1)
+        #expect(counts.0 == 0)
+        #expect(counts.1 == 12)
+        #expect(counts.2 == 10)
+        #expect(counts.3 == 10)
+        #expect(counts.4 == 0)
+        #expect(counts.5 == 2)
 
         let second = try wishlist.routeBelowMinimumStock(
             partId: partId,
@@ -640,6 +652,36 @@ struct WishlistServiceTests {
             try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wishlist_items WHERE part_id = ?", arguments: [partId]) ?? 0
         }
         #expect(count == 0)
+        #expect(try wishlist.routeAllBelowMinimumStock(actorUserId: env.adminUserId).isEmpty)
+    }
+
+    @Test("Below-MIN routing ignores inactive parts")
+    func testBelowMinRoutingIgnoresInactiveParts() throws {
+        let (env, wishlist) = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "InactiveBelowMinCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Inactive Breaker", categoryId: catId)
+        try env.parts.setAutoAddToWishlistWhenLow(partId: partId, enabled: true, byUserId: env.adminUserId)
+        try env.parts.setLocationStockTarget(
+            partId: partId,
+            locationType: "shop",
+            locationId: 1,
+            minStock: 4,
+            targetStock: 9,
+            maxStock: 16
+        )
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE parts SET is_active = 0 WHERE id = ?", arguments: [partId])
+        }
+
+        #expect(throws: WishlistService.WishlistError.partNotFound(partId)) {
+            try wishlist.routeBelowMinimumStock(
+                partId: partId,
+                locationType: "shop",
+                locationId: 1,
+                actorUserId: env.adminUserId,
+                certaintyOverride: 0.9
+            )
+        }
         #expect(try wishlist.routeAllBelowMinimumStock(actorUserId: env.adminUserId).isEmpty)
     }
 


### PR DESCRIPTION
## Summary

- Adds below-MIN wishlist routing that chooses shop-stock movement, approved wishlist demand, or physical audit based on location stock and certainty.
- Adds the per-part `autoAddToWishlistWhenLow` model/service/migration support and catalog toggle plumbing.
- Adds Wishlist smart-card status filters for All, Pending, Approved, Dismissed, and Sent to Procurement while preserving the existing three source sections.

Closes #423.
Closes #424.
Closes #425.

## PR Strategy

Opened this as a clean branch from `origin/main` instead of reusing `WEI-1227-keep-github-issue-work-moving`, because that routine branch contains unrelated prior commits and dirty files from other lanes.

The Office Dashboard/background-task commits are included because the wishlist PR needed the WEI-1288 compile recovery to make app-level verification possible on the current iOS workspace. The Office permission constant now uses the existing seeded `show_dollar_values` key.

## Review Feedback Disposition

Addressed Copilot review feedback in commit `31ad96c7a`:

- Kept prior migrations immutable; migration 086 remains the only migration that adds `auto_add_to_wishlist_when_low`.
- Restricted below-MIN routing and batch routing to active, non-deleted parts.
- Switched truck/trailer current-stock evaluation to the canonical `stock` table used by location stock targets.
- Changed shop availability from `MAX(qty)` to combined shop/warehouse quantity and split generated transfer movements across source locations without negative source stock.
- Removed stale historical movement dedupe for shop transfers; wishlist items and physical audits still dedupe against active outstanding records.
- Removed ungated `autoAddToWishlistWhenLow` mutation from generic create/update APIs; the permissioned setter is the mutation path.
- Captured old/new values in the auto-wishlist toggle audit log and skipped no-op audit entries.

## Validation

Re-verified after review feedback commit `31ad96c7a`:

- `swift test --package-path core --filter WishlistServiceTests` (38 tests passed)
- `swift test --package-path core --filter PartsServiceExtTests` (72 tests passed)
- `git diff --check`
- `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'generic/platform=iOS Simulator' -derivedDataPath .paperclip/DerivedData-WEI-1289-review -quiet build`

## Residual Risk

- CodeQL `Analyze (swift)` is pending again for the new PR head and must finish before merge.
- There are no existing Wishlist UI tests in `Weird Parts IOSUITests`; Wishlist filter behavior is covered by `WishlistServiceTests` and app build coverage, with manual simulator QA still recommended before release if the reviewer wants visual confirmation.
