### PR TITLE
Fix warehouse walking path deleted stops

### DIFF
--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -2806,9 +2806,13 @@ public final class WarehouseService: Sendable {
                 .fetchOne(dbConn)
             else { return nil }
 
-            try pruneOrphanedStops(floorPlanId: floorPlanId, dbConn: dbConn)
-            let stops = try activeWalkingPathStops(pathId: path.id ?? 0, dbConn: dbConn)
-            return WalkingPathWithStops(path: path, stops: stops)
+            let pathId = path.id ?? 0
+            let prunedCount = try pruneOrphanedStops(floorPlanId: floorPlanId, dbConn: dbConn)
+            let currentPath = prunedCount > 0
+                ? try WarehouseWalkingPath.fetchOne(dbConn, key: pathId) ?? path
+                : path
+            let stops = try activeWalkingPathStops(pathId: pathId, dbConn: dbConn)
+            return WalkingPathWithStops(path: currentPath, stops: stops)
         }
     }
 

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -2450,6 +2450,53 @@ public final class WarehouseService: Sendable {
             .fetchAll(dbConn)
     }
 
+    @discardableResult
+    private func pruneOrphanedStops(floorPlanId: Int64, dbConn: Database) throws -> Int {
+        let orphanIds = try Int64.fetchAll(dbConn, sql: """
+            SELECT s.id
+            FROM warehouse_walking_path_stops s
+            JOIN warehouse_walking_paths p
+                ON p.id = s.path_id
+               AND p.floor_plan_id = ?
+               AND p.deleted_at IS NULL
+               AND p.is_active = 1
+            LEFT JOIN warehouse_storage_areas a
+                ON a.id = s.area_id
+            LEFT JOIN warehouse_storage_levels l
+                ON l.id = a.level_id
+            LEFT JOIN warehouse_storage_units u
+                ON u.id = l.unit_id
+            WHERE s.deleted_at IS NULL
+              AND s.is_active = 1
+              AND (
+                a.id IS NULL OR a.deleted_at IS NOT NULL OR
+                l.id IS NULL OR l.deleted_at IS NOT NULL OR
+                u.id IS NULL OR u.deleted_at IS NOT NULL OR
+                u.floor_plan_id != p.floor_plan_id
+              )
+            """, arguments: [floorPlanId])
+
+        for stopId in orphanIds {
+            try dbConn.execute(
+                sql: "UPDATE warehouse_walking_path_stops SET deleted_at = datetime('now'), is_active = 0 WHERE id = ?",
+                arguments: [stopId]
+            )
+        }
+
+        if !orphanIds.isEmpty {
+            let affectedPathIds = try Int64.fetchAll(dbConn, sql: """
+                SELECT DISTINCT path_id FROM warehouse_walking_path_stops
+                WHERE id IN (\(orphanIds.map { _ in "?" }.joined(separator: ",")))
+                """, arguments: StatementArguments(orphanIds))
+            for pathId in affectedPathIds {
+                try normalizeWalkingPathOrder(pathId: pathId, dbConn: dbConn)
+                try touchWalkingPath(pathId: pathId, dbConn: dbConn)
+            }
+        }
+
+        return orphanIds.count
+    }
+
     private func ensureWalkingPathExists(pathId: Int64, dbConn: Database) throws {
         let exists = (try Int.fetchOne(dbConn, sql: """
             SELECT COUNT(*) FROM warehouse_walking_paths
@@ -2747,7 +2794,7 @@ public final class WarehouseService: Sendable {
 
     /// Fetch the default active walking path for a floor plan with active stops in order.
     public func getDefaultWalkingPath(floorPlanId: Int64) throws -> WalkingPathWithStops? {
-        try db.writer.read { dbConn in
+        try db.writer.write { dbConn in
             guard let path = try WarehouseWalkingPath
                 .filter(
                     Column("floor_plan_id") == floorPlanId &&
@@ -2759,6 +2806,7 @@ public final class WarehouseService: Sendable {
                 .fetchOne(dbConn)
             else { return nil }
 
+            try pruneOrphanedStops(floorPlanId: floorPlanId, dbConn: dbConn)
             let stops = try activeWalkingPathStops(pathId: path.id ?? 0, dbConn: dbConn)
             return WalkingPathWithStops(path: path, stops: stops)
         }
@@ -2945,49 +2993,7 @@ public final class WarehouseService: Sendable {
     @discardableResult
     public func pruneOrphanedStops(floorPlanId: Int64) throws -> Int {
         try db.writer.write { dbConn in
-            let orphanIds = try Int64.fetchAll(dbConn, sql: """
-                SELECT s.id
-                FROM warehouse_walking_path_stops s
-                JOIN warehouse_walking_paths p
-                    ON p.id = s.path_id
-                   AND p.floor_plan_id = ?
-                   AND p.deleted_at IS NULL
-                   AND p.is_active = 1
-                LEFT JOIN warehouse_storage_areas a
-                    ON a.id = s.area_id
-                LEFT JOIN warehouse_storage_levels l
-                    ON l.id = a.level_id
-                LEFT JOIN warehouse_storage_units u
-                    ON u.id = l.unit_id
-                WHERE s.deleted_at IS NULL
-                  AND s.is_active = 1
-                  AND (
-                    a.id IS NULL OR a.deleted_at IS NOT NULL OR
-                    l.id IS NULL OR l.deleted_at IS NOT NULL OR
-                    u.id IS NULL OR u.deleted_at IS NOT NULL OR
-                    u.floor_plan_id != p.floor_plan_id
-                  )
-                """, arguments: [floorPlanId])
-
-            for stopId in orphanIds {
-                try dbConn.execute(
-                    sql: "UPDATE warehouse_walking_path_stops SET deleted_at = datetime('now'), is_active = 0 WHERE id = ?",
-                    arguments: [stopId]
-                )
-            }
-
-            if !orphanIds.isEmpty {
-                let affectedPathIds = try Int64.fetchAll(dbConn, sql: """
-                    SELECT DISTINCT path_id FROM warehouse_walking_path_stops
-                    WHERE id IN (\(orphanIds.map { _ in "?" }.joined(separator: ",")))
-                    """, arguments: StatementArguments(orphanIds))
-                for pathId in affectedPathIds {
-                    try normalizeWalkingPathOrder(pathId: pathId, dbConn: dbConn)
-                    try touchWalkingPath(pathId: pathId, dbConn: dbConn)
-                }
-            }
-
-            return orphanIds.count
+            try pruneOrphanedStops(floorPlanId: floorPlanId, dbConn: dbConn)
         }
     }
 

--- a/core/Tests/WiredPartCoreTests/WarehouseWalkingPathTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseWalkingPathTests.swift
@@ -107,18 +107,18 @@ struct WarehouseWalkingPathTests {
         )
         let pathId = try #require(path.id)
 
-        try env.warehouse.setWalkingPathStops(pathId: pathId, areaIds: [fixture.areas[0], fixture.areas[1]])
+        try env.warehouse.setWalkingPathStops(pathId: pathId, areaIds: [fixture.areas[0], fixture.areas[1], fixture.areas[2]])
         try env.warehouse.deleteStorageArea(id: fixture.areas[1])
 
         let reloaded = try #require(try env.warehouse.getDefaultWalkingPath(floorPlanId: fixture.floorPlanId))
-        #expect(reloaded.stops.map(\.areaId) == [fixture.areas[0]])
-        #expect(reloaded.stops.map(\.sortOrder) == [0])
+        #expect(reloaded.stops.map(\.areaId) == [fixture.areas[0], fixture.areas[2]])
+        #expect(reloaded.stops.map(\.sortOrder) == [0, 1])
 
-        try env.warehouse.setWalkingPathStops(pathId: pathId, areaIds: reloaded.stops.map(\.areaId) + [fixture.areas[2]])
+        try env.warehouse.setWalkingPathStops(pathId: pathId, areaIds: reloaded.stops.map(\.areaId) + [fixture.areas[3]])
         let saved = try #require(try env.warehouse.getDefaultWalkingPath(floorPlanId: fixture.floorPlanId))
 
-        #expect(saved.stops.map(\.areaId) == [fixture.areas[0], fixture.areas[2]])
-        #expect(saved.stops.map(\.sortOrder) == [0, 1])
+        #expect(saved.stops.map(\.areaId) == [fixture.areas[0], fixture.areas[2], fixture.areas[3]])
+        #expect(saved.stops.map(\.sortOrder) == [0, 1, 2])
     }
 
     @Test("moveWalkingPathStop reorders active stops")

--- a/core/Tests/WiredPartCoreTests/WarehouseWalkingPathTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseWalkingPathTests.swift
@@ -96,6 +96,31 @@ struct WarehouseWalkingPathTests {
         #expect(loaded.stops.map(\.areaId) == [fixture.areas[0], fixture.areas[3]])
     }
 
+    @Test("reloading default walking path prunes deleted area stops before save")
+    func reloadingDefaultWalkingPathPrunesDeletedStopsBeforeSave() throws {
+        let env = try freshEnv()
+        let fixture = try makeAreaFixture(env)
+        let path = try env.warehouse.createWalkingPath(
+            floorPlanId: fixture.floorPlanId,
+            name: "Default",
+            userId: env.adminUserId
+        )
+        let pathId = try #require(path.id)
+
+        try env.warehouse.setWalkingPathStops(pathId: pathId, areaIds: [fixture.areas[0], fixture.areas[1]])
+        try env.warehouse.deleteStorageArea(id: fixture.areas[1])
+
+        let reloaded = try #require(try env.warehouse.getDefaultWalkingPath(floorPlanId: fixture.floorPlanId))
+        #expect(reloaded.stops.map(\.areaId) == [fixture.areas[0]])
+        #expect(reloaded.stops.map(\.sortOrder) == [0])
+
+        try env.warehouse.setWalkingPathStops(pathId: pathId, areaIds: reloaded.stops.map(\.areaId) + [fixture.areas[2]])
+        let saved = try #require(try env.warehouse.getDefaultWalkingPath(floorPlanId: fixture.floorPlanId))
+
+        #expect(saved.stops.map(\.areaId) == [fixture.areas[0], fixture.areas[2]])
+        #expect(saved.stops.map(\.sortOrder) == [0, 1])
+    }
+
     @Test("moveWalkingPathStop reorders active stops")
     func moveWalkingPathStopReordersStops() throws {
         let env = try freshEnv()


### PR DESCRIPTION
## Summary
- prune orphaned/deleted walking-path stops before hydrating the default path
- keep the public prune API on the same shared pruning helper
- add regression coverage for delete/reload/add/save behavior from GH #469

Fixes #469

## Verification
- swift test --package-path core --filter WarehouseWalkingPathTests