### PR TITLE
[WEI-1112] Close settings AI page-context gap

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSOfficeDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSOfficeDashboardPage.swift
@@ -13,7 +13,7 @@ struct IOSOfficeDashboardPage: View {
     @State private var attentionItems: [DashboardService.AttentionItem] = []
     @State private var todaySchedule: [DashboardService.ScheduleItem] = []
     @State private var financialSnapshot: DashboardService.FinancialSnapshot?
-    @State private var backgroundTaskStatuses: [BackgroundTaskService.OfficeStatusRow] = []
+    @State private var backgroundTaskStatuses: [OfficeBackgroundStatusRow] = []
     @State private var loadError: String?
     @State private var isLoading = true
     @State private var activeSheet: ActiveSheet?
@@ -27,6 +27,58 @@ struct IOSOfficeDashboardPage: View {
             case .help: "help"
             case .attentionDetail(let item): "attention-\(item.id)"
             }
+        }
+    }
+
+    private enum OfficeBackgroundStatus {
+        case completed
+        case running
+        case failed
+        case unavailable
+
+        init(statusString: String) {
+            switch statusString {
+            case "completed": self = .completed
+            case "running": self = .running
+            case "failed": self = .failed
+            default: self = .unavailable
+            }
+        }
+    }
+
+    private struct OfficeBackgroundStatusRow: Identifiable {
+        let id: String
+        let title: String
+        let detail: String
+        let status: OfficeBackgroundStatus
+        let systemImage: String
+        let statusLabel: String
+
+        static func rows(from entries: [BackgroundTaskService.TaskLogEntry]) -> [OfficeBackgroundStatusRow] {
+            entries.prefix(4).map { entry in
+                let status = OfficeBackgroundStatus(statusString: entry.status)
+                return OfficeBackgroundStatusRow(
+                    id: entry.id.map(String.init) ?? "\(entry.taskName)-\(entry.startedAt.timeIntervalSince1970)",
+                    title: entry.taskName,
+                    detail: entry.resultSummary ?? entry.errorMessage ?? entry.taskType,
+                    status: status,
+                    systemImage: entry.statusIcon,
+                    statusLabel: entry.status.replacingOccurrences(of: "_", with: " ").capitalized
+                )
+            }
+        }
+
+        static func unavailableRows() -> [OfficeBackgroundStatusRow] {
+            [
+                OfficeBackgroundStatusRow(
+                    id: "background-unavailable",
+                    title: "Background Tasks",
+                    detail: "Background task status is not available.",
+                    status: .unavailable,
+                    systemImage: "clock.badge.questionmark",
+                    statusLabel: "Unavailable"
+                )
+            ]
         }
     }
 
@@ -491,12 +543,12 @@ struct IOSOfficeDashboardPage: View {
         }
     }
 
-    private func colorForBackgroundStatus(_ status: BackgroundTaskService.OfficeStatus) -> Color {
+    private func colorForBackgroundStatus(_ status: OfficeBackgroundStatus) -> Color {
         switch status {
         case .completed: return .green
         case .running: return .blue
         case .failed: return .red
-        case .neverRun, .unavailable: return .secondary
+        case .unavailable: return .secondary
         }
     }
 
@@ -523,7 +575,14 @@ struct IOSOfficeDashboardPage: View {
 
             attentionItems = try service.getAttentionItems()
             todaySchedule = try service.getTodaySchedule()
-            backgroundTaskStatuses = try appCore.backgroundTaskService?.officeStatusRows() ?? BackgroundTaskService.OfficeStatusRow.unavailableRows()
+            if let backgroundTaskService = appCore.backgroundTaskService {
+                backgroundTaskStatuses = try OfficeBackgroundStatusRow.rows(from: backgroundTaskService.recentTasks(limit: 4))
+                if backgroundTaskStatuses.isEmpty {
+                    backgroundTaskStatuses = OfficeBackgroundStatusRow.unavailableRows()
+                }
+            } else {
+                backgroundTaskStatuses = OfficeBackgroundStatusRow.unavailableRows()
+            }
 
             if appCore.hasPermission(financialValuesPermission) {
                 financialSnapshot = try service.getFinancialSnapshot()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/AppConfigPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/AppConfigPage.swift
@@ -129,6 +129,9 @@ struct AppConfigPage: View {
             ])
         }
         .task { loadConfig() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .settingsPageInactive, object: nil)
+        }
         .alert("Error", isPresented: Binding(get: { loadError != nil || actionError != nil }, set: { if !$0 { loadError = nil; actionError = nil } })) {
             Button("OK") { loadError = nil; actionError = nil }
         } message: {
@@ -161,6 +164,7 @@ struct AppConfigPage: View {
                 overdueWarningDays = paySettings?.warningDays ?? 7
                 autoPaymentHold = paySettings?.autoHold ?? false
             }
+            postAIContext()
         } catch {
             loadError = userFriendlyError(error, context: "load settings")
         }
@@ -189,6 +193,7 @@ struct AppConfigPage: View {
                 )
             }
             saved = true
+            postAIContext()
             Task { @MainActor in
                 try? await Task.sleep(for: .seconds(2))
                 saved = false
@@ -196,5 +201,20 @@ struct AppConfigPage: View {
         } catch {
             actionError = userFriendlyError(error, context: "complete action")
         }
+    }
+
+    private func postAIContext() {
+        let context = """
+        App Config settings page. Read-only context.
+        Auto-lock minutes: \(autoLockMinutes), stale data warning hours: \(staleDataHours), archive completed jobs days: \(archiveDays), default warranty days: \(warrantyDays).
+        Payment tracking enabled: \(paymentTrackingEnabled), payment terms days: \(paymentTermsDays), overdue warning days: \(overdueWarningDays), auto payment hold: \(autoPaymentHold).
+        Form valid: \(isFormValid), saved confirmation visible: \(saved), load error present: \(loadError != nil), action error present: \(actionError != nil).
+        Available read-only guidance: explain each setting, current visible values, validation state, payment tracking options, and where Save/Restart App Tour/help controls are located. Do not save or change settings directly.
+        """
+        NotificationCenter.default.post(
+            name: .settingsPageActive,
+            object: nil,
+            userInfo: ["context": context]
+        )
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Shared/HelpContentRegistry.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/HelpContentRegistry.swift
@@ -139,6 +139,7 @@ struct HelpContentRegistry {
         "WiredPart.vehiclesPageActive": "fleet-vehicles",
         "WiredPart.toolRegistryPageActive": "tools-registry",
         "WiredPart.notebooksListPageActive": "notebooks-all",
+        "WiredPart.settingsPageActive": "settings-app-config",
     ]
 
     // MARK: - All Entries (extracted from PageHelpSheet usages)
@@ -156,6 +157,16 @@ struct HelpContentRegistry {
                 ("Overview", "Your daily command center. See clock status, KPI stats, charts, alerts, and quick actions all in one place."),
                 ("KPI Cards", "Tap any KPI card to see detailed breakdowns. Cards show part types, total stock, active jobs, pending orders, and low stock warnings."),
                 ("Quick Actions", "Use the quick action buttons at the bottom to scan QR codes, clock in/out, view the daily report, move stock, or create new orders."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "settings-app-config",
+            title: "App Config Help",
+            sections: [
+                ("What This Page Does", "General application configuration including auto-lock timeout, stale data warnings, archive retention, warranty defaults, and payment tracking settings."),
+                ("How to Use It", "Adjust values for each setting and tap Save. Auto-lock controls how long before the app locks. Stale data warning triggers when sync data is old."),
+                ("Payment Tracking", "When enabled, customer payment tracking shows payment status, terms, overdue warnings, and automatic payment holds."),
             ]
         ),
 

--- a/docs/testing/ai-page-context-coverage.md
+++ b/docs/testing/ai-page-context-coverage.md
@@ -11,9 +11,9 @@ Complete the 87-page page-context coverage set by adding read-only page-active/p
 
 Implemented page-context notifications observed by `IOSAIAssistantPanel`: 60 page contexts.
 
-Help registry mappings with matching help entries: 59 page contexts.
+Help registry mappings with matching help entries: 60 page contexts.
 
-Known gap: `settingsPageActive` is observed by the AI panel and active-page tracker, but `HelpContentRegistry` does not yet contain a `settings-app-config` entry. That should be handled in the settings slice rather than mapped to a missing help entry.
+Known gap: none in the currently observed AI page-context set. Remaining work is additional unobserved functional pages, not broken mappings.
 
 ## Covered Pages
 
@@ -78,7 +78,7 @@ Known gap: `settingsPageActive` is observed by the AI panel and active-page trac
 | Fleet | Vehicles | `vehiclesPageActive` | `fleet-vehicles` |
 | Tools | Tool Registry | `toolRegistryPageActive` | `tools-registry` |
 | Notebooks | Notebooks List | `notebooksListPageActive` | `notebooks-all` |
-| Settings | Settings/App Config observer only | `settingsPageActive` | missing help entry |
+| Settings | App Config | `settingsPageActive` | `settings-app-config` |
 
 ## WEI-1194 Slice
 
@@ -157,10 +157,17 @@ Added the next People, Office, and Reports page-context slice:
 
 All payloads are read-only summaries of visible state, selected filters, lifecycle state, and report totals. They do not expose mutating commands, action IDs, or write intents.
 
+## Settings Gap Closure Slice
+
+Closed the known settings mapping gap:
+
+- `AppConfigPage`: auto-lock, stale-data warning, archive retention, warranty default, payment tracking, validation, saved/error state.
+
+The payload is a read-only summary of visible settings and validation state. It does not expose mutating commands, action IDs, or write intents.
+
 ## Next Highest-Traffic Remaining Slices
 
 1. People/Office/Reports tail: contractors, teams, hats, permissions, office manage-jobs, warehouse exec, estimation settings, pipeline, teams, reports router, and specialized fleet/scheduling/warehouse report pages.
-2. Settings: add missing help entries and page context for the high-use settings pages before mapping them to help content.
 
 ## Validation
 
@@ -193,6 +200,13 @@ Validated People/Office/Reports slice in the shared workspace on 2026-05-15:
 
 - People/Office/Reports notification names are declared, posted by their pages, observed by `IOSAIAssistantPanel`, tracked for active help page selection, and mapped in `HelpContentRegistry`.
 - Help registry mapping check returned no missing mapped page IDs.
+- `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` passed. Remaining output was pre-existing warnings only.
+
+Validated Settings gap closure slice in the clean WEI-1112 settings worktree on 2026-05-15:
+
+- `settingsPageActive` is posted by `AppConfigPage`, observed by `IOSAIAssistantPanel`, tracked for active help page selection, and mapped in `HelpContentRegistry`.
+- Help registry mapping check returned no missing mapped page IDs.
+- First build exposed a recovered-branch compile issue in `IOSOfficeDashboardPage` background task status rows; the page now uses existing `BackgroundTaskService.TaskLogEntry` data instead of unavailable types.
 - `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` passed. Remaining output was pre-existing warnings only.
 
 Static validation:


### PR DESCRIPTION
## Summary
- maps settingsPageActive to settings-app-config help content
- posts read-only App Config settings context from AppConfigPage
- fixes recovered branch Office Dashboard background-task status rows to use existing BackgroundTaskService APIs so the iOS build passes
- updates AI page-context coverage artifact to 60/60 mapped observed contexts

## Validation
- static settings notification/help mapping checks passed
- help registry mapping check returned no missing mapped page IDs
- xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build passed with warnings only
