### PR TITLE
Recover WarehouseService contract for GitHub #74

### DIFF
--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -411,9 +411,29 @@ public final class WarehouseService: Sendable {
         }
     }
 
+    /// Legacy sort order for movement list queries.
+    public enum MovementSortOrder: Sendable, Equatable {
+        case newestFirst
+        case oldestFirst
+
+        fileprivate var sql: String {
+            switch self {
+            case .newestFirst: return "DESC"
+            case .oldestFirst: return "ASC"
+            }
+        }
+    }
+
     public enum MovementSortDirection: Sendable, Equatable {
         case ascending
         case descending
+
+        fileprivate var sql: String {
+            switch self {
+            case .ascending: return "ASC"
+            case .descending: return "DESC"
+            }
+        }
     }
 
     public enum MovementCompletionFilter: Sendable, Equatable {
@@ -565,7 +585,7 @@ public final class WarehouseService: Sendable {
         movementTypes: [String] = [],
         startDate: Date? = nil,
         endDate: Date? = nil,
-        sortDirection: MovementSortDirection = .descending,
+        sortDirection: MovementSortDirection? = nil,
         completionFilter: MovementCompletionFilter = .all,
         limit: Int = 100,
         offset: Int = 0,
@@ -612,7 +632,7 @@ public final class WarehouseService: Sendable {
 
                 args.append(limit)
                 args.append(offset)
-                let orderDirection = sortDirection == .ascending ? "ASC" : "DESC"
+                let orderDirection = sortDirection?.sql ?? sortOrder.sql
 
                 let sql = """
                     SELECT sm.*,
@@ -1870,12 +1890,6 @@ public final class WarehouseService: Sendable {
         reason: String?,
         performedBy: Int64?
     ) throws {
-        if let performedBy {
-            try db.writer.read { dbConn in
-                try ServicePermissionGate.requirePermission(dbConn, userId: performedBy, permissionKey: "perform_audit")
-            }
-        }
-
         guard newQty >= 0 else { throw WarehouseError.invalidQuantity }
         try db.writer.write { dbConn in
             if let uid = performedBy {
@@ -1883,6 +1897,7 @@ public final class WarehouseService: Sendable {
                     SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
                     """, arguments: [uid]) ?? 0) > 0
                 guard userExists else { throw WarehouseError.userNotFound(uid) }
+                try ServicePermissionGate.requirePermission(dbConn, userId: uid, permissionKey: "perform_audit")
             }
             // Update the stock record
             try dbConn.execute(

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -64,6 +64,16 @@ public final class WarehouseService: Sendable {
         public let pendingReturns: Int
     }
 
+    /// Smart-card counts and alert/warning totals for the dashboard.
+    public struct DashboardSmartCardSummary: Sendable {
+        public let movesToday: Int
+        public let activeReceiving: Int
+        public let auditDue: Int
+        public let lowConfidenceAreas: Int
+        public let stagedReady: Int
+        public let lowStockWarnings: Int
+    }
+
     /// A single recent activity entry for the dashboard feed.
     public struct ActivityEntry: Sendable {
         public let id: Int64
@@ -145,6 +155,37 @@ public final class WarehouseService: Sendable {
             pendingStagingCount: pendingStaging,
             activeReceivingSessions: activeReceiving,
             pendingReturns: pendingReturns
+        )
+    }
+
+    /// Fetch dashboard smart-card counts and warnings through one service call.
+    public func getDashboardSmartCardSummary(auditThreshold: Double = 80.0) throws -> DashboardSmartCardSummary {
+        let kpis = try getWarehouseKPIs()
+        let activeReceiving = try safeCount(
+            sql: "SELECT COUNT(*) FROM receiving_sessions WHERE status = 'in_progress' AND deleted_at IS NULL"
+        )
+        let stagedReady = try safeCount(
+            sql: "SELECT COUNT(*) FROM pulled_staging_tags WHERE deleted_at IS NULL"
+        )
+        let auditDue = try safeCount(
+            sql: "SELECT COUNT(*) FROM part_confidence WHERE confidence_percent < ?",
+            arguments: StatementArguments([auditThreshold])
+        )
+        let lowConfidenceAreas = try safeCount(
+            sql: """
+                SELECT COUNT(DISTINCT area_id) FROM part_confidence
+                WHERE confidence_percent < ?
+                """,
+            arguments: StatementArguments([auditThreshold])
+        )
+
+        return DashboardSmartCardSummary(
+            movesToday: kpis.todayMovements,
+            activeReceiving: activeReceiving,
+            auditDue: auditDue,
+            lowConfidenceAreas: lowConfidenceAreas,
+            stagedReady: stagedReady,
+            lowStockWarnings: kpis.shortfallCount
         )
     }
 
@@ -334,6 +375,10 @@ public final class WarehouseService: Sendable {
         public let notes: String?
         public let performedBy: Int64
         public let performedByName: String?
+        public let verifiedBy: Int64?
+        public let scanConfirmed: Bool
+        public let gpsLat: Double?
+        public let gpsLng: Double?
         public let createdAt: String?
 
         public init(
@@ -341,7 +386,9 @@ public final class WarehouseService: Sendable {
             fromLocationType: String?, fromLocationId: Int64?,
             toLocationType: String?, toLocationId: Int64?,
             movementType: String, reason: String?, notes: String?,
-            performedBy: Int64, performedByName: String?, createdAt: String?
+            performedBy: Int64, performedByName: String?, verifiedBy: Int64? = nil,
+            scanConfirmed: Bool = false, gpsLat: Double? = nil, gpsLng: Double? = nil,
+            createdAt: String?
         ) {
             self.id = id
             self.partId = partId
@@ -356,21 +403,72 @@ public final class WarehouseService: Sendable {
             self.notes = notes
             self.performedBy = performedBy
             self.performedByName = performedByName
+            self.verifiedBy = verifiedBy
+            self.scanConfirmed = scanConfirmed
+            self.gpsLat = gpsLat
+            self.gpsLng = gpsLng
             self.createdAt = createdAt
         }
     }
 
-    /// Sort order for movement list queries.
-    public enum MovementSortOrder: Sendable {
-        case newestFirst
-        case oldestFirst
+    public enum MovementSortDirection: Sendable, Equatable {
+        case ascending
+        case descending
+    }
 
-        fileprivate var sql: String {
+    public enum MovementCompletionFilter: Sendable, Equatable {
+        case all
+        case active
+        case completed
+    }
+
+    public enum MovementType: String, Sendable, CaseIterable {
+        case transfer
+        case receive
+        case consume
+        case returnToSupplier = "return_to_supplier"
+        case adjustment
+
+        public var aliases: [String] {
             switch self {
-            case .newestFirst: "DESC"
-            case .oldestFirst: "ASC"
+            case .transfer:
+                return ["transfer"]
+            case .receive:
+                return ["receive", "received", "receipt"]
+            case .consume:
+                return ["consume", "consumed", "consumption", "pull", "usage", "job_pull"]
+            case .returnToSupplier:
+                return ["return_to_supplier", "return", "returned"]
+            case .adjustment:
+                return ["adjustment", "adjust", "add_stock", "write_off"]
             }
         }
+    }
+
+    public static func normalizeMovementType(_ movementType: String) -> String {
+        let normalized = movementType
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: " ", with: "_")
+        for type in MovementType.allCases where type.aliases.contains(normalized) {
+            return type.rawValue
+        }
+        return normalized
+    }
+
+    private static func movementTypeAliases(for movementType: String) -> [String] {
+        let canonical = normalizeMovementType(movementType)
+        guard let type = MovementType(rawValue: canonical) else { return [canonical] }
+        return type.aliases
+    }
+
+    private static func sqliteDateString(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter.string(from: date)
     }
 
     /// Movement validation result.
@@ -464,6 +562,11 @@ public final class WarehouseService: Sendable {
     public func listMovements(
         search: String? = nil,
         movementType: String? = nil,
+        movementTypes: [String] = [],
+        startDate: Date? = nil,
+        endDate: Date? = nil,
+        sortDirection: MovementSortDirection = .descending,
+        completionFilter: MovementCompletionFilter = .all,
         limit: Int = 100,
         offset: Int = 0,
         sortOrder: MovementSortOrder = .newestFirst
@@ -480,12 +583,36 @@ public final class WarehouseService: Sendable {
                     args.append(pattern)
                 }
                 if let movementType, !movementType.isEmpty {
-                    whereClauses.append("sm.movement_type = ?")
-                    args.append(movementType)
+                    let aliases = Self.movementTypeAliases(for: movementType)
+                    whereClauses.append("sm.movement_type IN (\(aliases.map { _ in "?" }.joined(separator: ", ")))")
+                    args.append(contentsOf: aliases.map { $0 as DatabaseValueConvertible? })
+                } else if !movementTypes.isEmpty {
+                    let aliases = movementTypes.flatMap { Self.movementTypeAliases(for: $0) }
+                    if !aliases.isEmpty {
+                        whereClauses.append("sm.movement_type IN (\(aliases.map { _ in "?" }.joined(separator: ", ")))")
+                        args.append(contentsOf: aliases.map { $0 as DatabaseValueConvertible? })
+                    }
+                }
+                if let startDate {
+                    whereClauses.append("datetime(sm.created_at) >= datetime(?)")
+                    args.append(Self.sqliteDateString(startDate))
+                }
+                if let endDate {
+                    whereClauses.append("datetime(sm.created_at) <= datetime(?)")
+                    args.append(Self.sqliteDateString(endDate))
+                }
+                switch completionFilter {
+                case .all:
+                    break
+                case .active:
+                    whereClauses.append("sm.movement_type IN ('receiving_staged')")
+                case .completed:
+                    whereClauses.append("sm.movement_type NOT IN ('receiving_staged')")
                 }
 
                 args.append(limit)
                 args.append(offset)
+                let orderDirection = sortDirection == .ascending ? "ASC" : "DESC"
 
                 let sql = """
                     SELECT sm.*,
@@ -495,7 +622,7 @@ public final class WarehouseService: Sendable {
                     LEFT JOIN parts p ON p.id = sm.part_id AND p.deleted_at IS NULL
                     LEFT JOIN users u ON u.id = sm.performed_by AND u.deleted_at IS NULL
                     WHERE \(whereClauses.joined(separator: " AND "))
-                    ORDER BY sm.created_at \(sortOrder.sql)
+                    ORDER BY sm.created_at \(orderDirection), sm.id \(orderDirection)
                     LIMIT ? OFFSET ?
                     """
 
@@ -515,6 +642,10 @@ public final class WarehouseService: Sendable {
                         notes: row["notes"] as String?,
                         performedBy: row["performed_by"] as Int64,
                         performedByName: row["performed_by_name"] as String?,
+                        verifiedBy: row["verified_by"] as Int64?,
+                        scanConfirmed: ((row["scan_confirmed"] as Int?) ?? 0) == 1,
+                        gpsLat: row["gps_lat"] as Double?,
+                        gpsLng: row["gps_lng"] as Double?,
                         createdAt: row["created_at"] as String?
                     )
                 }
@@ -554,6 +685,10 @@ public final class WarehouseService: Sendable {
                 notes: row["notes"] as String?,
                 performedBy: row["performed_by"] as Int64,
                 performedByName: row["performed_by_name"] as String?,
+                verifiedBy: row["verified_by"] as Int64?,
+                scanConfirmed: ((row["scan_confirmed"] as Int?) ?? 0) == 1,
+                gpsLat: row["gps_lat"] as Double?,
+                gpsLng: row["gps_lng"] as Double?,
                 createdAt: row["created_at"] as String?
             )
         }
@@ -578,7 +713,12 @@ public final class WarehouseService: Sendable {
         photoPath: String? = nil,
         referenceNumber: String? = nil,
         unitCostAtMove: Double? = nil,
-        unitSellAtMove: Double? = nil
+        unitSellAtMove: Double? = nil,
+        occurredAt: Date? = nil,
+        verifiedBy: Int64? = nil,
+        scanConfirmed: Bool = false,
+        gpsLat: Double? = nil,
+        gpsLng: Double? = nil
     ) throws -> Int64 {
         try db.writer.read { dbConn in
             try ServicePermissionGate.requirePermission(dbConn, userId: performedBy, permissionKey: "move_stock_warehouse")
@@ -620,13 +760,15 @@ public final class WarehouseService: Sendable {
                      to_location_type, to_location_id, movement_type,
                      reason, notes, performed_by, job_id, photo_path,
                      reference_number, unit_cost_at_move, unit_sell_at_move,
-                     created_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                     verified_by, scan_confirmed, gps_lat, gps_lng, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                 arguments: [partId, qty, fromLocationType, fromLocationId,
                             toLocationType, toLocationId, movementType,
                             reason, notes, performedBy, jobId, photoPath,
-                            referenceNumber, unitCostAtMove, unitSellAtMove]
+                            referenceNumber, unitCostAtMove, unitSellAtMove,
+                            verifiedBy, scanConfirmed ? 1 : 0, gpsLat, gpsLng,
+                            occurredAt.map(Self.sqliteDateString) ?? Self.sqliteDateString(Date())]
             )
             let movementId = dbConn.lastInsertedRowID
 
@@ -686,6 +828,43 @@ public final class WarehouseService: Sendable {
 
             return movementId
         }
+    }
+
+    @discardableResult
+    public func createQuickLogMovement(
+        partId: Int64,
+        qty: Int,
+        movementType: String,
+        occurredAt: Date,
+        fromLocationType: String? = nil,
+        fromLocationId: Int64? = nil,
+        toLocationType: String? = nil,
+        toLocationId: Int64? = nil,
+        reason: String? = nil,
+        notes: String? = nil,
+        performedBy: Int64,
+        verifiedBy: Int64? = nil,
+        scanConfirmed: Bool = false,
+        gpsLat: Double? = nil,
+        gpsLng: Double? = nil
+    ) throws -> Int64 {
+        try createMovement(
+            partId: partId,
+            qty: qty,
+            fromLocationType: fromLocationType,
+            fromLocationId: fromLocationId,
+            toLocationType: toLocationType,
+            toLocationId: toLocationId,
+            movementType: Self.normalizeMovementType(movementType),
+            reason: reason,
+            notes: notes,
+            performedBy: performedBy,
+            occurredAt: occurredAt,
+            verifiedBy: verifiedBy,
+            scanConfirmed: scanConfirmed,
+            gpsLat: gpsLat,
+            gpsLng: gpsLng
+        )
     }
 
     /// Input spec for a single movement in a batch. Mirrors `createMovement` parameters

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -54,6 +54,166 @@ struct WarehouseServiceExtTests {
         #expect(movements.count >= 1)
     }
 
+    @Test("Dashboard smart card summary counts service-backed warehouse slices")
+    func testDashboardSmartCardSummary() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        let supplierId = try E2ETestHelpers.seedSupplier(env)
+        let poId = try env.orders.createPurchaseOrder(poNumber: "PO-DASH", supplierId: supplierId, notes: nil)
+
+        _ = try env.warehouse.createMovement(
+            partId: partId,
+            qty: 5,
+            fromLocationType: nil,
+            fromLocationId: nil,
+            toLocationType: "warehouse",
+            toLocationId: 1,
+            movementType: "received",
+            reason: "Dashboard count",
+            performedBy: env.adminUserId
+        )
+        _ = try env.warehouse.startReceivingSession(poId: poId, startedBy: env.adminUserId)
+
+        let stockId: Int64 = try env.db.writer.read { dbConn in
+            try Row.fetchOne(dbConn, sql: "SELECT id FROM stock WHERE part_id = ? LIMIT 1", arguments: [partId])?["id"] ?? 0
+        }
+        _ = try env.warehouse.createStagingTag(
+            stockId: stockId,
+            destinationType: "job",
+            destinationId: 1,
+            destinationLabel: "Ready",
+            taggedBy: env.adminUserId
+        )
+        try env.db.writer.write { dbConn in
+            try dbConn.execute(sql: """
+                INSERT INTO warehouse_floor_plans (id, name, width_inches, length_inches)
+                VALUES (1, 'Main', 600, 400)
+                """)
+            try dbConn.execute(sql: """
+                INSERT INTO warehouse_storage_units (id, floor_plan_id, name, unit_type)
+                VALUES (1, 1, 'Shelf A', 'shelf')
+                """)
+            try dbConn.execute(sql: """
+                INSERT INTO warehouse_storage_levels (id, unit_id, level_code, level_order)
+                VALUES (1, 1, 'L1', 1)
+                """)
+            try dbConn.execute(sql: """
+                INSERT INTO warehouse_storage_areas (id, level_id, area_code, area_number)
+                VALUES (1, 1, 'A1', 1)
+                """)
+        }
+        try env.warehouse.setPartConfidence(partId: partId, areaId: 1, percent: 25)
+
+        let summary = try env.warehouse.getDashboardSmartCardSummary()
+        #expect(summary.movesToday >= 1)
+        #expect(summary.activeReceiving == 1)
+        #expect(summary.stagedReady == 1)
+        #expect(summary.auditDue == 1)
+        #expect(summary.lowConfidenceAreas == 1)
+    }
+
+    @Test("Movement query filters by date type completion group and sort order")
+    func testMovementQueryFilters() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        let now = Date()
+        let twoDaysAgo = Calendar.current.date(byAdding: .day, value: -2, to: now)!
+        let tenDaysAgo = Calendar.current.date(byAdding: .day, value: -10, to: now)!
+
+        _ = try env.warehouse.createQuickLogMovement(
+            partId: partId,
+            qty: 1,
+            movementType: "received",
+            occurredAt: tenDaysAgo,
+            toLocationType: "warehouse",
+            toLocationId: 1,
+            reason: "Old receive",
+            performedBy: env.adminUserId
+        )
+        _ = try env.warehouse.createQuickLogMovement(
+            partId: partId,
+            qty: 2,
+            movementType: "return",
+            occurredAt: twoDaysAgo,
+            reason: "Recent return",
+            performedBy: env.adminUserId
+        )
+        _ = try env.warehouse.createQuickLogMovement(
+            partId: partId,
+            qty: 3,
+            movementType: "receiving_staged",
+            occurredAt: now,
+            reason: "Active staged",
+            performedBy: env.adminUserId
+        )
+
+        let recentReturns = try env.warehouse.listMovements(
+            movementType: "return_to_supplier",
+            startDate: Calendar.current.date(byAdding: .day, value: -7, to: now),
+            endDate: now,
+            sortDirection: .ascending
+        )
+        #expect(recentReturns.map(\.movementType) == ["return_to_supplier"])
+
+        let completedHistory = try env.warehouse.listMovements(
+            startDate: Calendar.current.date(byAdding: .day, value: -7, to: now),
+            endDate: now,
+            completionFilter: .completed
+        )
+        #expect(completedHistory.contains { $0.reason == "Recent return" })
+        #expect(!completedHistory.contains { $0.reason == "Old receive" })
+        #expect(!completedHistory.contains { $0.reason == "Active staged" })
+
+        let active = try env.warehouse.listMovements(completionFilter: .active)
+        #expect(active.count == 1)
+        #expect(active.first?.movementType == "receiving_staged")
+    }
+
+    @Test("Quick Log persists happened-at and audit trail fields")
+    func testQuickLogPersistence() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        let happenedAt = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let movementId = try env.warehouse.createQuickLogMovement(
+            partId: partId,
+            qty: 4,
+            movementType: "consumed",
+            occurredAt: happenedAt,
+            reason: "Already happened",
+            notes: "Logged from quick entry",
+            performedBy: env.adminUserId,
+            verifiedBy: env.adminUserId,
+            scanConfirmed: true,
+            gpsLat: 39.7392,
+            gpsLng: -104.9903
+        )
+
+        let movement = try env.warehouse.getMovement(id: movementId)
+        #expect(movement?.movementType == "consume")
+        #expect(movement?.createdAt == "2023-11-14 22:13:20")
+        #expect(movement?.verifiedBy == env.adminUserId)
+        #expect(movement?.scanConfirmed == true)
+        #expect(movement?.gpsLat == 39.7392)
+        #expect(movement?.gpsLng == -104.9903)
+    }
+
+    @Test("Movement service returns empty defaults when movement table is missing")
+    func testMovementMissingTableDefaults() throws {
+        let env = try E2ETestHelpers.setUp()
+        try env.db.writer.write { dbConn in
+            try dbConn.execute(sql: "DROP TABLE stock_movements")
+        }
+
+        let movements = try env.warehouse.listMovements()
+        let summary = try env.warehouse.getDashboardSmartCardSummary()
+        #expect(movements.isEmpty)
+        #expect(summary.movesToday == 0)
+    }
+
     @Test("Validate movement")
     func testValidateMovement() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Recovers the WEI-1268 WarehouseService contract work onto a clean branch from origin/main.
- Adds dashboard smart-card summary counts, movement query date/type/group/sort filters, movement type normalization, and Quick Log happened-at/audit metadata persistence.
- Adds focused WarehouseServiceExtTests coverage and carries a narrow SQLite-compatible audit session update fix needed by the existing test suite.

## Validation
- `git diff --check -- core/Sources/WiredPartCore/Services/WarehouseService.swift core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift`
- `rg "import GRDB" "Weird Parts IOS/Weird Parts IOS/Features/Warehouse"` returned no matches
- `swift test --filter WarehouseServiceExtTests` passed: 104 tests

Co-Authored-By: Paperclip <noreply@paperclip.ing>