### PR TITLE
Add people office tail AI contexts

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
+++ b/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
@@ -82,9 +82,16 @@ struct IOSAIAssistantPanel: View {
     @State private var peopleDashboardContext: String?
     @State private var customersContext: String?
     @State private var contactsContext: String?
+    @State private var contractorsContext: String?
+    @State private var teamsContext: String?
+    @State private var hatsContext: String?
+    @State private var permissionsContext: String?
     @State private var officeDashboardContext: String?
     @State private var officeApprovalsContext: String?
     @State private var officeSpendingContext: String?
+    @State private var officeManageJobsContext: String?
+    @State private var officeEstimationSettingsContext: String?
+    @State private var officePipelineContext: String?
     @State private var reportsLaborContext: String?
     @State private var reportsSpendingContext: String?
     @State private var reportsProfitabilityContext: String?
@@ -318,9 +325,16 @@ struct IOSAIAssistantPanel: View {
             peopleDashboardContext: $peopleDashboardContext,
             customersContext: $customersContext,
             contactsContext: $contactsContext,
+            contractorsContext: $contractorsContext,
+            teamsContext: $teamsContext,
+            hatsContext: $hatsContext,
+            permissionsContext: $permissionsContext,
             officeDashboardContext: $officeDashboardContext,
             officeApprovalsContext: $officeApprovalsContext,
             officeSpendingContext: $officeSpendingContext,
+            officeManageJobsContext: $officeManageJobsContext,
+            officeEstimationSettingsContext: $officeEstimationSettingsContext,
+            officePipelineContext: $officePipelineContext,
             reportsLaborContext: $reportsLaborContext,
             reportsSpendingContext: $reportsSpendingContext,
             reportsProfitabilityContext: $reportsProfitabilityContext,
@@ -711,6 +725,18 @@ struct IOSAIAssistantPanel: View {
             if let ctx = contactsContext {
                 navContext += "\n\nContacts Context (READ-ONLY): \(ctx)"
             }
+            if let ctx = contractorsContext {
+                navContext += "\n\nContractors Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = teamsContext {
+                navContext += "\n\nTeams Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = hatsContext {
+                navContext += "\n\nHats Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = permissionsContext {
+                navContext += "\n\nPermissions Context (READ-ONLY): \(ctx)"
+            }
             if let ctx = officeDashboardContext {
                 navContext += "\n\nOffice Dashboard Context (READ-ONLY): \(ctx)"
             }
@@ -719,6 +745,15 @@ struct IOSAIAssistantPanel: View {
             }
             if let ctx = officeSpendingContext {
                 navContext += "\n\nOffice Spending Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = officeManageJobsContext {
+                navContext += "\n\nOffice Manage Jobs Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = officeEstimationSettingsContext {
+                navContext += "\n\nOffice Estimation Settings Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = officePipelineContext {
+                navContext += "\n\nOffice Pipeline Context (READ-ONLY): \(ctx)"
             }
             if let ctx = reportsLaborContext {
                 navContext += "\n\nReports Labor Context (READ-ONLY): \(ctx)"
@@ -1557,9 +1592,16 @@ private struct PeopleOfficeReportsContextObservers: ViewModifier {
     @Binding var peopleDashboardContext: String?
     @Binding var customersContext: String?
     @Binding var contactsContext: String?
+    @Binding var contractorsContext: String?
+    @Binding var teamsContext: String?
+    @Binding var hatsContext: String?
+    @Binding var permissionsContext: String?
     @Binding var officeDashboardContext: String?
     @Binding var officeApprovalsContext: String?
     @Binding var officeSpendingContext: String?
+    @Binding var officeManageJobsContext: String?
+    @Binding var officeEstimationSettingsContext: String?
+    @Binding var officePipelineContext: String?
     @Binding var reportsLaborContext: String?
     @Binding var reportsSpendingContext: String?
     @Binding var reportsProfitabilityContext: String?
@@ -1574,9 +1616,16 @@ private struct PeopleOfficeReportsContextObservers: ViewModifier {
                 peopleDashboardContext: $peopleDashboardContext,
                 customersContext: $customersContext,
                 contactsContext: $contactsContext,
+                contractorsContext: $contractorsContext,
+                teamsContext: $teamsContext,
+                hatsContext: $hatsContext,
+                permissionsContext: $permissionsContext,
                 officeDashboardContext: $officeDashboardContext,
                 officeApprovalsContext: $officeApprovalsContext,
-                officeSpendingContext: $officeSpendingContext
+                officeSpendingContext: $officeSpendingContext,
+                officeManageJobsContext: $officeManageJobsContext,
+                officeEstimationSettingsContext: $officeEstimationSettingsContext,
+                officePipelineContext: $officePipelineContext
             ))
             .modifier(ReportsContextObservers(
                 reportsLaborContext: $reportsLaborContext,
@@ -1594,9 +1643,47 @@ private struct PeopleOfficeContextObservers: ViewModifier {
     @Binding var peopleDashboardContext: String?
     @Binding var customersContext: String?
     @Binding var contactsContext: String?
+    @Binding var contractorsContext: String?
+    @Binding var teamsContext: String?
+    @Binding var hatsContext: String?
+    @Binding var permissionsContext: String?
     @Binding var officeDashboardContext: String?
     @Binding var officeApprovalsContext: String?
     @Binding var officeSpendingContext: String?
+    @Binding var officeManageJobsContext: String?
+    @Binding var officeEstimationSettingsContext: String?
+    @Binding var officePipelineContext: String?
+
+    func body(content: Content) -> some View {
+        content
+            .modifier(PeopleOfficeContextObserversPrimary(
+                peopleDashboardContext: $peopleDashboardContext,
+                customersContext: $customersContext,
+                contactsContext: $contactsContext,
+                contractorsContext: $contractorsContext,
+                teamsContext: $teamsContext
+            ))
+            .modifier(PeopleOfficeContextObserversSecondary(
+                hatsContext: $hatsContext,
+                permissionsContext: $permissionsContext,
+                officeDashboardContext: $officeDashboardContext,
+                officeApprovalsContext: $officeApprovalsContext,
+                officeSpendingContext: $officeSpendingContext
+            ))
+            .modifier(PeopleOfficeContextObserversOfficeTail(
+                officeManageJobsContext: $officeManageJobsContext,
+                officeEstimationSettingsContext: $officeEstimationSettingsContext,
+                officePipelineContext: $officePipelineContext
+            ))
+    }
+}
+
+private struct PeopleOfficeContextObserversPrimary: ViewModifier {
+    @Binding var peopleDashboardContext: String?
+    @Binding var customersContext: String?
+    @Binding var contactsContext: String?
+    @Binding var contractorsContext: String?
+    @Binding var teamsContext: String?
 
     func body(content: Content) -> some View {
         content
@@ -1618,6 +1705,42 @@ private struct PeopleOfficeContextObservers: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .contactsPageInactive)) { _ in
                 contactsContext = nil
             }
+            .onReceive(NotificationCenter.default.publisher(for: .contractorsPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { contractorsContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .contractorsPageInactive)) { _ in
+                contractorsContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .teamsPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { teamsContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .teamsPageInactive)) { _ in
+                teamsContext = nil
+            }
+    }
+}
+
+private struct PeopleOfficeContextObserversSecondary: ViewModifier {
+    @Binding var hatsContext: String?
+    @Binding var permissionsContext: String?
+    @Binding var officeDashboardContext: String?
+    @Binding var officeApprovalsContext: String?
+    @Binding var officeSpendingContext: String?
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .hatsPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { hatsContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .hatsPageInactive)) { _ in
+                hatsContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .permissionsPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { permissionsContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .permissionsPageInactive)) { _ in
+                permissionsContext = nil
+            }
             .onReceive(NotificationCenter.default.publisher(for: .officeDashboardPageActive)) { notification in
                 if let ctx = notification.userInfo?["context"] as? String { officeDashboardContext = ctx }
             }
@@ -1635,6 +1758,34 @@ private struct PeopleOfficeContextObservers: ViewModifier {
             }
             .onReceive(NotificationCenter.default.publisher(for: .officeSpendingPageInactive)) { _ in
                 officeSpendingContext = nil
+            }
+    }
+}
+
+private struct PeopleOfficeContextObserversOfficeTail: ViewModifier {
+    @Binding var officeManageJobsContext: String?
+    @Binding var officeEstimationSettingsContext: String?
+    @Binding var officePipelineContext: String?
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .officeManageJobsPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { officeManageJobsContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .officeManageJobsPageInactive)) { _ in
+                officeManageJobsContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .officeEstimationSettingsPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { officeEstimationSettingsContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .officeEstimationSettingsPageInactive)) { _ in
+                officeEstimationSettingsContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .officePipelinePageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { officePipelineContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .officePipelinePageInactive)) { _ in
+                officePipelineContext = nil
             }
     }
 }
@@ -1941,6 +2092,22 @@ private struct ActivePageIdTrackerPeopleOfficeReports: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .contactsPageInactive)) { _ in if activePageId == "people-contacts" { activePageId = nil } }
             .onReceive(NotificationCenter.default.publisher(for: .officeDashboardPageActive)) { _ in activePageId = "office-dashboard" }
             .onReceive(NotificationCenter.default.publisher(for: .officeDashboardPageInactive)) { _ in if activePageId == "office-dashboard" { activePageId = nil } }
+            .modifier(ActivePageIdTrackerPeopleTail(activePageId: $activePageId))
+    }
+}
+
+private struct ActivePageIdTrackerPeopleTail: ViewModifier {
+    @Binding var activePageId: String?
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .contractorsPageActive)) { _ in activePageId = "people-contractors" }
+            .onReceive(NotificationCenter.default.publisher(for: .contractorsPageInactive)) { _ in if activePageId == "people-contractors" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .teamsPageActive)) { _ in activePageId = "people-teams" }
+            .onReceive(NotificationCenter.default.publisher(for: .teamsPageInactive)) { _ in if activePageId == "people-teams" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .hatsPageActive)) { _ in activePageId = "people-hats" }
+            .onReceive(NotificationCenter.default.publisher(for: .hatsPageInactive)) { _ in if activePageId == "people-hats" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .permissionsPageActive)) { _ in activePageId = "people-permissions" }
+            .onReceive(NotificationCenter.default.publisher(for: .permissionsPageInactive)) { _ in if activePageId == "people-permissions" { activePageId = nil } }
             .modifier(ActivePageIdTrackerOfficeReports(activePageId: $activePageId))
     }
 }
@@ -1953,6 +2120,12 @@ private struct ActivePageIdTrackerOfficeReports: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .officeApprovalsPageInactive)) { _ in if activePageId == "office-approvals" { activePageId = nil } }
             .onReceive(NotificationCenter.default.publisher(for: .officeSpendingPageActive)) { _ in activePageId = "office-spending" }
             .onReceive(NotificationCenter.default.publisher(for: .officeSpendingPageInactive)) { _ in if activePageId == "office-spending" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .officeManageJobsPageActive)) { _ in activePageId = "office-manage-jobs" }
+            .onReceive(NotificationCenter.default.publisher(for: .officeManageJobsPageInactive)) { _ in if activePageId == "office-manage-jobs" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .officeEstimationSettingsPageActive)) { _ in activePageId = "office-estimation-settings" }
+            .onReceive(NotificationCenter.default.publisher(for: .officeEstimationSettingsPageInactive)) { _ in if activePageId == "office-estimation-settings" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .officePipelinePageActive)) { _ in activePageId = "office-pipeline" }
+            .onReceive(NotificationCenter.default.publisher(for: .officePipelinePageInactive)) { _ in if activePageId == "office-pipeline" { activePageId = nil } }
             .onReceive(NotificationCenter.default.publisher(for: .reportsLaborPageActive)) { _ in activePageId = "reports-labor" }
             .onReceive(NotificationCenter.default.publisher(for: .reportsLaborPageInactive)) { _ in if activePageId == "reports-labor" { activePageId = nil } }
             .onReceive(NotificationCenter.default.publisher(for: .reportsSpendingPageActive)) { _ in activePageId = "reports-spending" }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSEstimationSettingsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSEstimationSettingsPage.swift
@@ -78,6 +78,10 @@ struct IOSEstimationSettingsPage: View {
         }
         .refreshable { await loadData() }
         .task { await loadData() }
+        .onChange(of: showEffectiveness) { _, _ in postAIContext() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .officeEstimationSettingsPageInactive, object: nil)
+        }
     }
 
     // MARK: - Settings List
@@ -258,6 +262,7 @@ struct IOSEstimationSettingsPage: View {
             loadError = userFriendlyError(error, context: "load estimation settings")
         }
         isLoading = false
+        postAIContext()
     }
 
     private func loadEffectiveness() async {
@@ -268,6 +273,7 @@ struct IOSEstimationSettingsPage: View {
         do {
             effectiveness = try svc.analyzeQuestionEffectiveness()
             showEffectiveness = true
+            postAIContext()
         } catch {
             actionError = userFriendlyError(error, context: "save settings")
         }
@@ -313,6 +319,22 @@ struct IOSEstimationSettingsPage: View {
         case "punch_list": return "Punch List"
         default: return stage.capitalized
         }
+    }
+
+    private func postAIContext() {
+        let activeQuestions = questions.filter { $0.isActive == 1 }.count
+        let inactiveQuestions = questions.count - activeQuestions
+        let stageCounts = stages.map { stage in
+            "\(stageLabel(stage)): \(groupedByStage[stage]?.count ?? 0)"
+        }.joined(separator: ", ")
+        let typeCounts = Dictionary(grouping: questions, by: { $0.answerType })
+            .map { "\($0.key): \($0.value.count)" }
+            .sorted()
+            .joined(separator: ", ")
+        let context = """
+        Office Estimation Settings page. Questions loaded: \(questions.count). Active questions: \(activeQuestions). Inactive questions: \(inactiveQuestions). Stage counts: \(stageCounts). Answer type counts: \(typeCounts.isEmpty ? "none" : typeCounts). Effectiveness rows loaded: \(effectiveness.count). Effectiveness visible: \(showEffectiveness). Error state: \(loadError ?? actionError ?? "none"). Available read-only actions: summarize question coverage, explain stage balance, identify inactive or low-data analysis state.
+        """
+        NotificationCenter.default.post(name: .officeEstimationSettingsPageActive, object: nil, userInfo: ["context": context])
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSManageJobsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSManageJobsPage.swift
@@ -84,6 +84,7 @@ struct IOSManageJobsPage: View {
             }
         }
         .onChange(of: searchText) { loadData() }
+        .onChange(of: statusFilter) { _, _ in postAIContext() }
         .refreshable { loadData() }
         .task { loadData() }
         .onAppear {
@@ -101,6 +102,7 @@ struct IOSManageJobsPage: View {
         }
         .onDisappear {
             appCore.aiFilterRegistry.deregister(pageId: "manage-jobs")
+            NotificationCenter.default.post(name: .officeManageJobsPageInactive, object: nil)
         }
     }
 
@@ -259,6 +261,21 @@ struct IOSManageJobsPage: View {
             loadError = userFriendlyError(error, context: "load jobs")
         }
         isLoading = false
+        postAIContext()
+    }
+
+    private func postAIContext() {
+        let statusCounts = statusOptions.map { "\($0): \(countForStatus($0))" }.joined(separator: ", ")
+        let statsSummary: String
+        if let stats {
+            statsSummary = "stats active \(stats.active), completed \(stats.completed), total \(stats.total)"
+        } else {
+            statsSummary = "stats unavailable"
+        }
+        let context = """
+        Office Manage Jobs page. Loaded jobs: \(allJobs.count). Visible jobs: \(jobs.count). Selected status filter: \(statusFilter). Search: \(searchText.isEmpty ? "none" : searchText). \(statsSummary). Status counts: \(statusCounts). Available read-only actions: summarize job status mix, explain active filters, identify visible job counts.
+        """
+        NotificationCenter.default.post(name: .officeManageJobsPageActive, object: nil, userInfo: ["context": context])
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Office/OfficeRouter.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Office/OfficeRouter.swift
@@ -115,6 +115,19 @@ private struct OfficePipelineView: View {
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Pipeline")
+        .onAppear {
+            postAIContext()
+        }
+        .onDisappear {
+            NotificationCenter.default.post(name: .officePipelinePageInactive, object: nil)
+        }
+    }
+
+    private func postAIContext() {
+        let context = """
+        Office Pipeline page. Visible entry points: Short-Term Pipeline, Long-Term Pipeline, Dispatch Board. Purpose: route office users to scheduling pipeline and dispatch workflows. Data state: hub page only; detailed counts load after choosing an entry point. Available read-only actions: explain which pipeline view to open, summarize available routing options, clarify that this page does not mutate schedules directly.
+        """
+        NotificationCenter.default.post(name: .officePipelinePageActive, object: nil, userInfo: ["context": context])
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContractorsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContractorsPage.swift
@@ -50,6 +50,9 @@ struct IOSContractorsPage: View {
         .onChange(of: searchText) { _, _ in loadData() }
         .task { loadData() }
         .refreshable { loadData() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .contractorsPageInactive, object: nil)
+        }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .create } label: {
@@ -137,6 +140,17 @@ struct IOSContractorsPage: View {
             loadError = userFriendlyError(error, context: "load contractors")
         }
         isLoading = false
+        postAIContext()
+    }
+
+    private func postAIContext() {
+        let withPhone = contractors.filter { ($0.phone?.isEmpty == false) }.count
+        let withEmail = contractors.filter { ($0.email?.isEmpty == false) }.count
+        let withCompany = contractors.filter { ($0.company?.isEmpty == false) }.count
+        let context = """
+        Contractors page. Loaded contractors: \(contractors.count). Search: \(searchText.isEmpty ? "none" : searchText). With company: \(withCompany). With phone: \(withPhone). With email: \(withEmail). Available read-only actions: summarize contractor coverage, identify missing contact info, explain how to open contractor detail.
+        """
+        NotificationCenter.default.post(name: .contractorsPageActive, object: nil, userInfo: ["context": context])
     }
 }
 // MARK: - Add Contractor Sheet

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSHatsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSHatsPage.swift
@@ -37,9 +37,12 @@ struct IOSHatsPage: View {
             .task { appCore.onboardingManager?.markCompleted("hats-view") }
             .navigationTitle("Hats & Roles")
             .searchable(text: $searchText, prompt: "Search hats...")
-            .onChange(of: searchText) { /* local filter only */ }
+            .onChange(of: searchText) { _, _ in postAIContext() }
             .refreshable { loadData() }
             .task { loadData() }
+            .onDisappear {
+                NotificationCenter.default.post(name: .hatsPageInactive, object: nil)
+            }
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button { activeSheet = .addHat } label: {
@@ -217,6 +220,16 @@ struct IOSHatsPage: View {
             loadError = userFriendlyError(error, context: "load roles")
         }
         isLoading = false
+        postAIContext()
+    }
+
+    private func postAIContext() {
+        let assignedHats = hats.filter { $0.userCount > 0 }.count
+        let totalAssignments = hats.reduce(0) { $0 + $1.userCount }
+        let context = """
+        Hats and roles page. Loaded hats: \(hats.count). Visible hats: \(filteredHats.count). Hats assigned to at least one employee: \(assignedHats). Total hat assignments shown: \(totalAssignments). Search: \(searchText.isEmpty ? "none" : searchText). Detail sheet open: \(activeSheet != nil). Available read-only actions: summarize role coverage, identify unassigned hats, explain how hats relate to permissions.
+        """
+        NotificationCenter.default.post(name: .hatsPageActive, object: nil, userInfo: ["context": context])
     }
 }
 
@@ -555,4 +568,3 @@ private struct AddEmployeeToHatSheet: View {
         }
     }
 }
-

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSPermissionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSPermissionsPage.swift
@@ -99,8 +99,12 @@ struct IOSPermissionsPage: View {
         }
         .refreshable { loadData() }
         .task { loadData(); loadLegacyPinCount() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .permissionsPageInactive, object: nil)
+        }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             loadLegacyPinCount()
+            postAIContext()
         }
     }
 
@@ -210,6 +214,7 @@ struct IOSPermissionsPage: View {
     private func selectHat(_ hat: PeopleService.HatListItem) {
         selectedHat = hat
         loadHatPermissions(hatId: hat.id)
+        postAIContext()
     }
 
     private func loadHatPermissions(hatId: Int64) {
@@ -222,6 +227,7 @@ struct IOSPermissionsPage: View {
         } catch {
             loadError = userFriendlyError(error, context: "load permissions")
         }
+        postAIContext()
     }
 
     private func togglePermission(key: String, enabled: Bool) {
@@ -240,6 +246,7 @@ struct IOSPermissionsPage: View {
                 try auth.removeHatPermission(hatId: hat.id, permissionKey: key)
                 hatPermissions.removeAll { $0 == key }
             }
+            postAIContext()
         } catch {
             loadError = userFriendlyError(error, context: "update permission")
         }
@@ -247,6 +254,7 @@ struct IOSPermissionsPage: View {
 
     private func loadLegacyPinCount() {
         legacyPinCount = (try? appCore.authService?.getLegacyHashedUserCount()) ?? 0
+        postAIContext()
     }
 
     // MARK: - Data Loading
@@ -269,5 +277,17 @@ struct IOSPermissionsPage: View {
             loadError = userFriendlyError(error, context: "load permissions")
         }
         isLoading = false
+        postAIContext()
+    }
+
+    private func postAIContext() {
+        let permissionKeyCount = allPermissions.reduce(0) { $0 + $1.keys.count }
+        let selectedHatName = selectedHat?.name ?? "none"
+        let enabledCount = hatPermissions.count
+        let groupNames = allPermissions.map(\.name).joined(separator: ", ")
+        let context = """
+        Permissions page. Hats loaded: \(hats.count). Permission groups: \(allPermissions.count). Permission keys visible for selected hat: \(permissionKeyCount). Selected hat: \(selectedHatName). Enabled permissions for selected hat: \(enabledCount). Legacy PIN upgrades pending: \(legacyPinCount). Groups: \(groupNames). Available read-only actions: summarize selected hat access, explain permission groups, identify whether a hat is selected.
+        """
+        NotificationCenter.default.post(name: .permissionsPageActive, object: nil, userInfo: ["context": context])
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamsPage.swift
@@ -16,7 +16,7 @@ struct IOSTeamsPage: View {
     @State private var loadError: String?
     @State private var filter: TeamFilter = .all
 
-    private enum TeamFilter {
+    private enum TeamFilter: Equatable {
         case all, active, mine
     }
 
@@ -31,8 +31,13 @@ struct IOSTeamsPage: View {
         teamList
             .navigationTitle("Teams")
             .searchable(text: $searchText, prompt: "Search teams...")
+            .onChange(of: searchText) { _, _ in postAIContext() }
+            .onChange(of: filter) { _, _ in postAIContext() }
             .refreshable { loadData() }
             .task { loadData() }
+            .onDisappear {
+                NotificationCenter.default.post(name: .teamsPageInactive, object: nil)
+            }
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button { activeSheet = .addTeam } label: {
@@ -251,6 +256,21 @@ struct IOSTeamsPage: View {
             loadError = userFriendlyError(error, context: "load teams")
         }
         isLoading = false
+        postAIContext()
+    }
+
+    private func postAIContext() {
+        let totalMembers = teams.reduce(0) { $0 + $1.memberCount }
+        let withLeaders = teams.filter { $0.leaderName != nil }.count
+        let filterLabel: String = switch filter {
+        case .all: "all"
+        case .active: "active"
+        case .mine: "my teams"
+        }
+        let context = """
+        Teams page. Loaded teams: \(teams.count). Visible teams: \(filteredTeams.count). Active teams: \(activeTeams.count). Teams with leaders: \(withLeaders). Total listed members: \(totalMembers). Selected filter: \(filterLabel). Search: \(searchText.isEmpty ? "none" : searchText). Available read-only actions: summarize team coverage, explain visible filters, identify teams without listed members or leaders.
+        """
+        NotificationCenter.default.post(name: .teamsPageActive, object: nil, userInfo: ["context": context])
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
@@ -496,6 +496,30 @@ extension Notification.Name {
     /// Posted when the Contacts page disappears.
     static let contactsPageInactive = Notification.Name("WiredPart.contactsPageInactive")
 
+    /// Posted when the Contractors page appears, with contractor list context for AI.
+    static let contractorsPageActive = Notification.Name("WiredPart.contractorsPageActive")
+
+    /// Posted when the Contractors page disappears.
+    static let contractorsPageInactive = Notification.Name("WiredPart.contractorsPageInactive")
+
+    /// Posted when the Teams page appears, with team list context for AI.
+    static let teamsPageActive = Notification.Name("WiredPart.teamsPageActive")
+
+    /// Posted when the Teams page disappears.
+    static let teamsPageInactive = Notification.Name("WiredPart.teamsPageInactive")
+
+    /// Posted when the Hats page appears, with role list context for AI.
+    static let hatsPageActive = Notification.Name("WiredPart.hatsPageActive")
+
+    /// Posted when the Hats page disappears.
+    static let hatsPageInactive = Notification.Name("WiredPart.hatsPageInactive")
+
+    /// Posted when the Permissions page appears, with permission matrix context for AI.
+    static let permissionsPageActive = Notification.Name("WiredPart.permissionsPageActive")
+
+    /// Posted when the Permissions page disappears.
+    static let permissionsPageInactive = Notification.Name("WiredPart.permissionsPageInactive")
+
     // MARK: - Office
 
     /// Posted when the Office Dashboard page appears, with command-center context for AI.
@@ -515,6 +539,24 @@ extension Notification.Name {
 
     /// Posted when the Office Spending dashboard disappears.
     static let officeSpendingPageInactive = Notification.Name("WiredPart.officeSpendingPageInactive")
+
+    /// Posted when the Office Manage Jobs page appears, with job management context for AI.
+    static let officeManageJobsPageActive = Notification.Name("WiredPart.officeManageJobsPageActive")
+
+    /// Posted when the Office Manage Jobs page disappears.
+    static let officeManageJobsPageInactive = Notification.Name("WiredPart.officeManageJobsPageInactive")
+
+    /// Posted when the Office Estimation Settings page appears, with question settings context for AI.
+    static let officeEstimationSettingsPageActive = Notification.Name("WiredPart.officeEstimationSettingsPageActive")
+
+    /// Posted when the Office Estimation Settings page disappears.
+    static let officeEstimationSettingsPageInactive = Notification.Name("WiredPart.officeEstimationSettingsPageInactive")
+
+    /// Posted when the Office Pipeline page appears, with pipeline entry-point context for AI.
+    static let officePipelinePageActive = Notification.Name("WiredPart.officePipelinePageActive")
+
+    /// Posted when the Office Pipeline page disappears.
+    static let officePipelinePageInactive = Notification.Name("WiredPart.officePipelinePageInactive")
 
     // MARK: - Reports
 

--- a/Weird Parts IOS/Weird Parts IOS/Shared/HelpContentRegistry.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/HelpContentRegistry.swift
@@ -126,9 +126,16 @@ struct HelpContentRegistry {
         "WiredPart.peopleDashboardPageActive": "people-dashboard",
         "WiredPart.customersPageActive": "people-customers",
         "WiredPart.contactsPageActive": "people-contacts",
+        "WiredPart.contractorsPageActive": "people-contractors",
+        "WiredPart.teamsPageActive": "people-teams",
+        "WiredPart.hatsPageActive": "people-hats",
+        "WiredPart.permissionsPageActive": "people-permissions",
         "WiredPart.officeDashboardPageActive": "office-dashboard",
         "WiredPart.officeApprovalsPageActive": "office-approvals",
         "WiredPart.officeSpendingPageActive": "office-spending",
+        "WiredPart.officeManageJobsPageActive": "office-manage-jobs",
+        "WiredPart.officeEstimationSettingsPageActive": "office-estimation-settings",
+        "WiredPart.officePipelinePageActive": "office-pipeline",
         "WiredPart.reportsLaborPageActive": "reports-labor",
         "WiredPart.reportsSpendingPageActive": "reports-spending",
         "WiredPart.reportsProfitabilityPageActive": "reports-profitability",
@@ -676,6 +683,50 @@ struct HelpContentRegistry {
         ),
 
         HelpEntry(
+            pageId: "people-contractors",
+            title: "Contractors Help",
+            sections: [
+                ("What This Page Does", "View and manage sub-contractors your company works with. Each row shows the contractor's name, company, phone, and email."),
+                ("How to Use It", "Use the search bar to filter by name, company, phone, or email. Tap a contractor to see their detail page. Tap the + button to add a contractor."),
+                ("Adding a Contractor", "A company name is required. You can also add a contact name, phone, email, and trade or specialty."),
+                ("Tips", "Pull down to refresh the list. Contractor detail pages include qualification tracking, performance ratings, job history, and notes."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "people-teams",
+            title: "Teams Help",
+            sections: [
+                ("What This Page Does", "View and manage teams. Teams group employees together for job assignments and scheduling. Each row shows the team name, description, leader, and member count."),
+                ("Smart Card Filters", "Tap the filter cards at the top to narrow the list: All shows every team, Active shows teams with at least one member, and My Teams shows teams you belong to."),
+                ("How to Use It", "Use the search bar to find teams by name, description, or leader. Tap a team to see its members, assigned jobs, and management options."),
+                ("Tips", "Pull down to refresh. The member count badge on each row shows how many employees are in that team."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "people-hats",
+            title: "Hats & Roles Help",
+            sections: [
+                ("What This Page Does", "Manage hats (roles) that can be assigned to employees. Hats define what an employee is responsible for and control permissions in the system."),
+                ("How to Use It", "Search by hat name or description. Tap a hat to see its members and permissions. Tap the + button to create a new hat."),
+                ("Assigning Hats", "Hats are assigned to employees from the Employee Detail page's Hats tab. Each hat grants a set of permissions configured on the Permissions page."),
+                ("Tips", "Pull down to refresh. The badge on each hat shows how many employees are assigned to it."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "people-permissions",
+            title: "Permissions Help",
+            sections: [
+                ("What This Page Does", "Configure which permissions each hat (role) grants. This is a matrix editor where you select a hat and then toggle individual permissions on or off."),
+                ("How to Use It", "Tap a hat in the selector at the top. The permission list below updates to show all available permissions grouped by category."),
+                ("Permission Groups", "Permissions are organized into categories such as Parts & Warehouse, Jobs & Labor, Orders, Fleet & Tools, People, Scheduling, Chat, and Reports & Admin."),
+                ("Tips", "Pull down to refresh. The first hat is auto-selected when the page loads. Plan your permission structure carefully: give each hat only the permissions it needs."),
+            ]
+        ),
+
+        HelpEntry(
             pageId: "people-employee-detail",
             title: "Employee Detail Help",
             sections: [
@@ -783,6 +834,37 @@ struct HelpContentRegistry {
                 ("Overview", "Aggregate spending data across all jobs. See total parts costs, labor costs, and budget utilization at a glance."),
                 ("Breakdown", "Cards show spending by category. Tap for detailed breakdowns by job, supplier, or time period."),
                 ("Permissions", "This page requires the show dollar values permission. Contact your admin if you cannot see cost data."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "office-manage-jobs",
+            title: "Manage Jobs Help",
+            sections: [
+                ("Overview", "Admin-level job management with status changes, bulk actions, and advanced filtering by assignee, date, and type."),
+                ("Filters", "Use the status cards and search bar to narrow the job list by status, job number, job name, or customer."),
+                ("Permissions", "This page requires the manage jobs permission. Standard users should use the regular Jobs page."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "office-estimation-settings",
+            title: "Estimation Questions Help",
+            sections: [
+                ("What This Page Does", "Manage the questions asked during job estimation. Questions are grouped by stage and used to build accurate job estimates based on real project data."),
+                ("How to Use It", "Tap + to add a new question. Swipe left on any question to edit or deactivate it. Swipe right on an inactive question to reactivate it."),
+                ("AI Analysis", "Tap Analyze Question Effectiveness to see which questions correlate with accurate estimates. This requires at least 15 completed jobs with end-of-job reviews."),
+                ("Question Weight", "Weight controls how much a question's answer impacts the final estimate. Higher weight means the answer has more influence."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "office-pipeline",
+            title: "Pipeline Help",
+            sections: [
+                ("What This Page Does", "Routes office users to the short-term pipeline, long-term pipeline, and dispatch board."),
+                ("How to Use It", "Open Short-Term Pipeline for jobs ready to schedule, Long-Term Pipeline for multi-year planning, or Dispatch Board to assign crews to jobs."),
+                ("Tips", "This page is a hub. Detailed counts and scheduling controls load after you open one of the destination pages."),
             ]
         ),
 

--- a/docs/testing/ai-page-context-coverage.md
+++ b/docs/testing/ai-page-context-coverage.md
@@ -9,9 +9,9 @@ Complete the 87-page page-context coverage set by adding read-only page-active/p
 
 ## Current Coverage
 
-Implemented page-context notifications observed by `IOSAIAssistantPanel`: 60 page contexts.
+Implemented page-context notifications observed by `IOSAIAssistantPanel`: 67 page contexts.
 
-Help registry mappings with matching help entries: 60 page contexts.
+Help registry mappings with matching help entries: 67 page contexts.
 
 Known gap: none in the currently observed AI page-context set. Remaining work is additional unobserved functional pages, not broken mappings.
 
@@ -65,9 +65,16 @@ Known gap: none in the currently observed AI page-context set. Remaining work is
 | People | Employees | `employeesPageActive` | `people-employees` |
 | People | Customers | `customersPageActive` | `people-customers` |
 | People | Contacts | `contactsPageActive` | `people-contacts` |
+| People | Contractors | `contractorsPageActive` | `people-contractors` |
+| People | Teams | `teamsPageActive` | `people-teams` |
+| People | Hats & Roles | `hatsPageActive` | `people-hats` |
+| People | Permissions | `permissionsPageActive` | `people-permissions` |
 | Office | Office Dashboard | `officeDashboardPageActive` | `office-dashboard` |
 | Office | Unified Approvals | `officeApprovalsPageActive` | `office-approvals` |
 | Office | Spending Dashboard | `officeSpendingPageActive` | `office-spending` |
+| Office | Manage Jobs | `officeManageJobsPageActive` | `office-manage-jobs` |
+| Office | Estimation Questions | `officeEstimationSettingsPageActive` | `office-estimation-settings` |
+| Office | Pipeline Hub | `officePipelinePageActive` | `office-pipeline` |
 | Reports | Labor Overview | `reportsLaborPageActive` | `reports-labor` |
 | Reports | Spending | `reportsSpendingPageActive` | `reports-spending` |
 | Reports | Profitability | `reportsProfitabilityPageActive` | `reports-profitability` |
@@ -165,9 +172,23 @@ Closed the known settings mapping gap:
 
 The payload is a read-only summary of visible settings and validation state. It does not expose mutating commands, action IDs, or write intents.
 
+## People/Office Tail Slice
+
+Added the next People and Office tail page-context slice:
+
+- `IOSContractorsPage`: loaded contractor count, search state, and contact-info coverage counts.
+- `IOSTeamsPage`: loaded/visible team counts, selected smart-card filter, total members, and leader coverage.
+- `IOSHatsPage`: loaded/visible hat counts, assigned hat count, total assignments, search state, and detail-sheet state.
+- `IOSPermissionsPage`: loaded hats, selected hat, permission group/key counts, enabled permission count, and legacy PIN upgrade count.
+- `IOSManageJobsPage`: loaded/visible job counts, selected status filter, search state, status counts, and summary stats.
+- `IOSEstimationSettingsPage`: question counts by active state, stage, and answer type, effectiveness rows, and visible error state.
+- `OfficePipelineView`: read-only hub context for Short-Term Pipeline, Long-Term Pipeline, and Dispatch Board entry points.
+
+All payloads are read-only summaries of visible state, selected filters, lifecycle state, and available entry points. They do not expose mutating commands, action IDs, or write intents.
+
 ## Next Highest-Traffic Remaining Slices
 
-1. People/Office/Reports tail: contractors, teams, hats, permissions, office manage-jobs, warehouse exec, estimation settings, pipeline, teams, reports router, and specialized fleet/scheduling/warehouse report pages.
+1. People/Office/Reports tail remainder: office warehouse exec, office teams route alias, reports router, and specialized fleet/scheduling/warehouse report pages.
 
 ## Validation
 
@@ -207,6 +228,12 @@ Validated Settings gap closure slice in the clean WEI-1112 settings worktree on 
 - `settingsPageActive` is posted by `AppConfigPage`, observed by `IOSAIAssistantPanel`, tracked for active help page selection, and mapped in `HelpContentRegistry`.
 - Help registry mapping check returned no missing mapped page IDs.
 - First build exposed a recovered-branch compile issue in `IOSOfficeDashboardPage` background task status rows; the page now uses existing `BackgroundTaskService.TaskLogEntry` data instead of unavailable types.
+- `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` passed. Remaining output was pre-existing warnings only.
+
+Validated People/Office tail slice in the clean WEI-1112 tail worktree on 2026-05-15:
+
+- Tail slice notification names are declared, posted by their pages, observed by `IOSAIAssistantPanel`, tracked for active help page selection, and mapped in `HelpContentRegistry`.
+- Help registry mapping check returned no missing mapped page IDs.
 - `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` passed. Remaining output was pre-existing warnings only.
 
 Static validation:


### PR DESCRIPTION
## Summary
- Add read-only AI page-context notifications for People Contractors, Teams, Hats, Permissions and Office Manage Jobs, Estimation Settings, Pipeline
- Wire contexts through IOSAIAssistantPanel observers, active help page tracking, and HelpContentRegistry mappings/entries
- Update docs/testing/ai-page-context-coverage.md to 67 observed / 67 mapped contexts

## Verification
- Tracker sync for #372 succeeded before work
- Static notification/help mapping checks passed with no missing mapped page IDs
- git diff --check
- xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build