### PR TITLE
[codex] Publish focused job notebook slice

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailTabView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailTabView.swift
@@ -27,6 +27,8 @@ struct IOSJobDetailTabView: View {
     @State private var teamMembers: [JobsService.TeamMemberRow] = []
     @State private var jobParts: [JobsService.JobPartRow] = []
     @State private var jobSupplierChannels: [ChatService.SupplierChannelRow] = []
+    @State private var jobNotebookId: Int64?
+    @State private var isLoadingJobNotebook = false
     @State private var tabError: String?
     /// Job stages with computed statuses (Rough-in, Prep/Makeup, Trim-out).
     @State private var jobStages: [JobsService.JobStageStatus] = []
@@ -171,31 +173,47 @@ struct IOSJobDetailTabView: View {
 
     @ViewBuilder
     private func tabContent(_ job: JobsService.JobDetail) -> some View {
-        ScrollView {
-            switch selectedTab {
-            case "overview":
+        switch selectedTab {
+        case "overview":
+            ScrollView {
                 overviewTab(job)
-            case "team":
-                teamTab(job)
-            case "labor":
-                laborTab(job)
-            case "parts":
-                partsTab(job)
-            case "orders":
-                ordersTab(job)
-            case "notebooks":
-                notebooksTab(job)
-            case "chat":
-                chatTab(job)
-            case "qa":
-                qaTab(job)
-            case "costs":
-                costsTab(job)
-            case "estimate":
-                estimateTab(job)
-            default:
-                Text("Unknown tab")
             }
+        case "team":
+            ScrollView {
+                teamTab(job)
+            }
+        case "labor":
+            ScrollView {
+                laborTab(job)
+            }
+        case "parts":
+            ScrollView {
+                partsTab(job)
+            }
+        case "orders":
+            ScrollView {
+                ordersTab(job)
+            }
+        case "notebooks":
+            notebooksTab(job)
+        case "chat":
+            ScrollView {
+                chatTab(job)
+            }
+        case "qa":
+            ScrollView {
+                qaTab(job)
+            }
+        case "costs":
+            ScrollView {
+                costsTab(job)
+            }
+        case "estimate":
+            ScrollView {
+                estimateTab(job)
+            }
+        default:
+            Text("Unknown tab")
         }
     }
 
@@ -861,29 +879,45 @@ struct IOSJobDetailTabView: View {
     // MARK: - Notebooks Tab
 
     private func notebooksTab(_ job: JobsService.JobDetail) -> some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack {
-                Text("Job Notebooks")
-                    .font(.headline)
-                Spacer()
-            }
+        Group {
+            if let notebookId = jobNotebookId {
+                IOSNotebookDetailPage(notebookId: notebookId)
+                    .environmentObject(appCore)
+            } else {
+                VStack(alignment: .leading, spacing: 16) {
+                    if isLoadingJobNotebook {
+                        ProgressView("Loading job notebook...")
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    } else {
+                        ContentUnavailableView {
+                            Label("This job does not have a notebook yet", systemImage: "note.text.badge.plus")
+                        } description: {
+                            Text("Create a job notebook for \(job.jobName), or retry loading if it was just created on another device.")
+                        } actions: {
+                            HStack(spacing: 12) {
+                                Button {
+                                    createMissingJobNotebook(for: job)
+                                } label: {
+                                    Label("Create job notebook", systemImage: "plus.circle")
+                                        .frame(minHeight: 44)
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .accessibilityIdentifier("jobNotebookCreateRecovery")
 
-            Text("Notebooks for \(job.jobName) can be viewed in the Notebooks module.")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-
-            Button {
-                NotificationCenter.default.post(
-                    name: .navigateToModule,
-                    object: nil,
-                    userInfo: ["moduleId": "notebooks", "tabId": "notebooks-job-notebooks"]
-                )
-            } label: {
-                Label("Open Job Notebooks", systemImage: "note.text")
+                                Button {
+                                    loadJobNotebook()
+                                } label: {
+                                    Label("Retry", systemImage: "arrow.clockwise")
+                                        .frame(minHeight: 44)
+                                }
+                                .buttonStyle(.bordered)
+                            }
+                        }
+                    }
+                }
+                .padding()
             }
-            .buttonStyle(.bordered)
         }
-        .padding()
     }
 
     // MARK: - Chat Tab
@@ -1051,6 +1085,7 @@ struct IOSJobDetailTabView: View {
             job = try service.getJob(id: jobId)
             // Load job stages with computed statuses
             jobStages = try service.listJobStages(forJobId: jobId)
+            loadJobNotebook()
             // Load flex pool status for managers
             if appCore.hasPermission("manage_flex_pool"),
                let svc = appCore.schedulingService {
@@ -1060,6 +1095,39 @@ struct IOSJobDetailTabView: View {
             loadError = userFriendlyError(error, context: "load job data")
         }
         isLoading = false
+    }
+
+    private func loadJobNotebook() {
+        guard let service = appCore.notebooksService else {
+            tabError = "Notebooks service not available"
+            isLoadingJobNotebook = false
+            return
+        }
+        isLoadingJobNotebook = jobNotebookId == nil
+        do {
+            jobNotebookId = try service.listNotebooks(notebookType: "job", jobId: jobId).first?.id
+        } catch {
+            tabError = userFriendlyError(error, context: "load job notebook")
+        }
+        isLoadingJobNotebook = false
+    }
+
+    private func createMissingJobNotebook(for job: JobsService.JobDetail) {
+        guard let service = appCore.notebooksService,
+              let userId = appCore.currentUser?.id else {
+            tabError = "Not logged in. Please log in and try again."
+            return
+        }
+        do {
+            jobNotebookId = try service.createNotebook(
+                title: "\(job.jobName) Job Notebook",
+                notebookType: "job",
+                jobId: job.id,
+                createdBy: userId
+            )
+        } catch {
+            tabError = userFriendlyError(error, context: "create job notebook")
+        }
     }
 
     private func toggleFlexPool(job: JobsService.JobDetail) {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSJobNotebooksPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSJobNotebooksPage.swift
@@ -105,7 +105,10 @@ struct IOSJobNotebooksPage: View {
             }
         } else {
             List(filteredNotebooks, id: \.id) { notebook in
-                notebookRow(notebook)
+                NavigationLink(destination: IOSNotebookDetailPage(notebookId: notebook.id).environmentObject(appCore)) {
+                    notebookRow(notebook)
+                }
+                .accessibilityIdentifier("jobNotebookRow_\(notebook.id)")
             }
             .listStyle(.insetGrouped)
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -4,6 +4,7 @@ import WiredPartCore
 /// Notebook detail page with hierarchical structure: Groups → Sections → Block Entries.
 struct IOSNotebookDetailPage: View {
     @EnvironmentObject private var appCore: AppCore
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     let notebookId: Int64
 
     // MARK: - State
@@ -65,6 +66,7 @@ struct IOSNotebookDetailPage: View {
         case editGroup(groupId: Int64, name: String)
         case panelScheduleEditor
         case conflictResolution
+        case notebookSections
         case help
 
         var id: String {
@@ -77,6 +79,7 @@ struct IOSNotebookDetailPage: View {
             case .editGroup(let id, _): return "editGroup-\(id)"
             case .panelScheduleEditor: return "panelSchedule"
             case .conflictResolution: return "conflictResolution"
+            case .notebookSections: return "notebookSections"
             case .help: return "help"
             }
         }
@@ -92,11 +95,22 @@ struct IOSNotebookDetailPage: View {
             } else if let error = loadError {
                 ErrorStateView(message: error) { loadData() }
             } else {
-                contentList
+                notebookShell
             }
         }
         .navigationTitle(notebook?.title ?? "Notebook")
         .toolbar {
+            if horizontalSizeClass == .compact {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        activeSheet = .notebookSections
+                    } label: {
+                        Image(systemName: "sidebar.left")
+                    }
+                    .frame(width: 44, height: 44)
+                    .accessibilityLabel("Notebook sections")
+                }
+            }
             ToolbarItem(placement: .primaryAction) {
                 Menu {
                     Button {
@@ -112,7 +126,10 @@ struct IOSNotebookDetailPage: View {
                 } label: {
                     Image(systemName: "plus")
                 }
+                .frame(width: 44, height: 44)
                 .accessibilityLabel("Add content")
+                .accessibilityIdentifier("notebookToolbar_addBlock")
+                .disabled(isReadOnly)
             }
             ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .help } label: {
@@ -144,6 +161,200 @@ struct IOSNotebookDetailPage: View {
         }
         .refreshable { loadData() }
         .task { loadData() }
+    }
+
+    // MARK: - Responsive Shell
+
+    private var isReadOnly: Bool {
+        notebook?.status == "locked" || notebook?.status == "archived"
+    }
+
+    @ViewBuilder
+    private var notebookShell: some View {
+        if horizontalSizeClass == .regular {
+            HStack(spacing: 0) {
+                notebookSidebar
+                    .frame(width: 292)
+                    .background(Color(.secondarySystemGroupedBackground))
+                Divider()
+                contentList
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .background(Color(.systemGroupedBackground))
+        } else {
+            contentList
+        }
+    }
+
+    private var notebookSidebar: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                notebookSummaryCard
+                sidebarRow(
+                    id: "overview",
+                    title: "Overview",
+                    systemImage: "doc.text",
+                    badge: nil,
+                    isSelected: true
+                )
+                sidebarRow(
+                    id: "dailyLogs",
+                    title: "Daily Logs",
+                    systemImage: "calendar",
+                    badge: nil,
+                    isSelected: false
+                )
+                sidebarRow(
+                    id: "todos",
+                    title: "To-Dos",
+                    systemImage: "checklist",
+                    badge: todoBadgeText,
+                    isSelected: false
+                )
+                sidebarRow(
+                    id: "photos",
+                    title: "Photos",
+                    systemImage: "photo.on.rectangle",
+                    badge: nil,
+                    isSelected: false
+                )
+                sidebarRow(
+                    id: "panelSchedules",
+                    title: "Panel Schedules",
+                    systemImage: "bolt.rectangle",
+                    badge: nil,
+                    isSelected: false
+                )
+                if !blockConflicts.isEmpty {
+                    sidebarRow(
+                        id: "openConflicts",
+                        title: "Open conflicts",
+                        systemImage: "exclamationmark.triangle",
+                        badge: "\(blockConflicts.count)",
+                        isSelected: false
+                    )
+                }
+                hierarchySidebarContent
+            }
+            .padding(14)
+        }
+        .accessibilityIdentifier("notebookSidebar")
+    }
+
+    private var notebookSummaryCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(notebook?.jobName ?? "Job notebook", systemImage: "hammer")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+            Text(notebook?.title ?? "Notebook")
+                .font(.headline)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 8) {
+                statusBadge(notebook?.status ?? "active")
+                if let updated = notebook?.updatedAt {
+                    Text("Updated \(String(updated.prefix(10)))")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    @ViewBuilder
+    private var hierarchySidebarContent: some View {
+        if let groups = hierarchy?.groups, !groups.isEmpty {
+            Text("Sections")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+                .padding(.top, 4)
+            ForEach(groups) { group in
+                Text(group.name)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.top, 4)
+                ForEach(group.sections) { section in
+                    sidebarRow(
+                        id: "section_\(section.id)",
+                        title: section.name,
+                        systemImage: "doc.text",
+                        badge: "\(section.entries.count)",
+                        isSelected: false
+                    )
+                }
+            }
+        }
+        if let sections = hierarchy?.ungroupedSections, !sections.isEmpty {
+            Text("Pages")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+                .padding(.top, 4)
+            ForEach(sections) { section in
+                sidebarRow(
+                    id: "section_\(section.id)",
+                    title: section.name,
+                    systemImage: "doc.text",
+                    badge: "\(section.entries.count)",
+                    isSelected: false
+                )
+            }
+        }
+    }
+
+    private func sidebarRow(id: String, title: String, systemImage: String, badge: String?, isSelected: Bool) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: systemImage)
+                .frame(width: 20)
+                .accessibilityHidden(true)
+            Text(title)
+                .font(.subheadline)
+                .lineLimit(2)
+            Spacer()
+            if let badge {
+                Text(badge)
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 3)
+                    .background(Capsule().fill(Color.secondary.opacity(0.15)))
+            }
+        }
+        .foregroundStyle(isSelected ? Color.accentColor : Color.primary)
+        .frame(minHeight: 44)
+        .padding(.horizontal, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isSelected ? Color.accentColor.opacity(0.14) : Color.clear)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabelForSidebarRow(title: title, badge: badge, isSelected: isSelected))
+        .accessibilityIdentifier("notebookSidebar_\(id)")
+    }
+
+    private var todoBadgeText: String? {
+        let count = allEntries.filter { $0.blockType == "todo" && !$0.isCompleted }.count
+        return count > 0 ? "\(count)" : nil
+    }
+
+    private var allEntries: [NotebooksService.NotebookEntryRow] {
+        var entries: [NotebooksService.NotebookEntryRow] = notebook?.entries ?? []
+        hierarchy?.groups.forEach { group in
+            group.sections.forEach { entries.append(contentsOf: $0.entries) }
+        }
+        hierarchy?.ungroupedSections.forEach { entries.append(contentsOf: $0.entries) }
+        return entries
+    }
+
+    private func accessibilityLabelForSidebarRow(title: String, badge: String?, isSelected: Bool) -> String {
+        [title, badge.map { "\($0) items" }, isSelected ? "selected" : nil]
+            .compactMap { $0 }
+            .joined(separator: ", ")
     }
 
     // MARK: - Content List
@@ -233,7 +444,9 @@ struct IOSNotebookDetailPage: View {
                                 Label("Add Section", systemImage: "plus")
                                     .font(.caption)
                                     .foregroundStyle(.blue)
+                                    .frame(minHeight: 44)
                             }
+                            .disabled(isReadOnly)
                         } label: {
                             HStack {
                                 Image(systemName: "folder.fill")
@@ -282,9 +495,16 @@ struct IOSNotebookDetailPage: View {
                 Section {
                     EmptyStateView(
                         icon: "note.text",
-                        title: "No Content",
-                        message: "Add section groups and sections to organize this notebook."
+                        title: "No sections yet",
+                        message: "Create a section to organize this job notebook."
                     )
+                    Button {
+                        activeSheet = .addSection(groupId: nil)
+                    } label: {
+                        Label("Create section", systemImage: "doc.badge.plus")
+                            .frame(minHeight: 44)
+                    }
+                    .disabled(isReadOnly)
                 }
             }
 
@@ -334,8 +554,12 @@ struct IOSNotebookDetailPage: View {
             Section {
                 if let nb = notebook {
                     detailRow("Type", nb.notebookType)
+                    detailRow("Status", nb.status.capitalized)
                     if let created = nb.createdAt {
                         detailRow("Created", String(created.prefix(10)))
+                    }
+                    if let updated = nb.updatedAt {
+                        detailRow("Updated", String(updated.prefix(10)))
                     }
                     if let jobName = nb.jobName {
                         detailRow("Job", jobName)
@@ -346,6 +570,22 @@ struct IOSNotebookDetailPage: View {
             }
         }
         .listStyle(.insetGrouped)
+    }
+
+    private func statusBadge(_ status: String) -> some View {
+        let color: Color = switch status {
+        case "active": .green
+        case "locked": .red
+        case "archived": .secondary
+        default: .secondary
+        }
+        return Text(status.capitalized)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(color.opacity(0.15)))
+            .foregroundStyle(color)
     }
 
     // MARK: - Section Row
@@ -363,7 +603,9 @@ struct IOSNotebookDetailPage: View {
                 Label("Add Block", systemImage: "plus.circle")
                     .font(.caption)
                     .foregroundStyle(.blue)
+                    .frame(minHeight: 44)
             }
+            .disabled(isReadOnly)
         } label: {
             HStack {
                 Image(systemName: "doc.text")
@@ -770,6 +1012,66 @@ struct IOSNotebookDetailPage: View {
                     resolveAllConflicts(keepVersion: keepVersion)
                 }
             )
+
+        case .notebookSections:
+            NavigationStack {
+                List {
+                    Section {
+                        notebookSummaryCard
+                            .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    }
+                    Section("Notebook") {
+                        sidebarRow(id: "overview", title: "Overview", systemImage: "doc.text", badge: nil, isSelected: true)
+                        sidebarRow(id: "dailyLogs", title: "Daily Logs", systemImage: "calendar", badge: nil, isSelected: false)
+                        sidebarRow(id: "todos", title: "To-Dos", systemImage: "checklist", badge: todoBadgeText, isSelected: false)
+                        sidebarRow(id: "photos", title: "Photos", systemImage: "photo.on.rectangle", badge: nil, isSelected: false)
+                        sidebarRow(id: "panelSchedules", title: "Panel Schedules", systemImage: "bolt.rectangle", badge: nil, isSelected: false)
+                        if !blockConflicts.isEmpty {
+                            sidebarRow(id: "openConflicts", title: "Open conflicts", systemImage: "exclamationmark.triangle", badge: "\(blockConflicts.count)", isSelected: false)
+                        }
+                    }
+                    if let groups = hierarchy?.groups, !groups.isEmpty {
+                        Section("Sections") {
+                            ForEach(groups) { group in
+                                Text(group.name)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                ForEach(group.sections) { section in
+                                    sidebarRow(
+                                        id: "section_\(section.id)",
+                                        title: section.name,
+                                        systemImage: "doc.text",
+                                        badge: "\(section.entries.count)",
+                                        isSelected: false
+                                    )
+                                    .accessibilityIdentifier("notebookSectionSheet_section_\(section.id)")
+                                }
+                            }
+                        }
+                    }
+                    if let sections = hierarchy?.ungroupedSections, !sections.isEmpty {
+                        Section("Pages") {
+                            ForEach(sections) { section in
+                                sidebarRow(
+                                    id: "section_\(section.id)",
+                                    title: section.name,
+                                    systemImage: "doc.text",
+                                    badge: "\(section.entries.count)",
+                                    isSelected: false
+                                )
+                                .accessibilityIdentifier("notebookSectionSheet_section_\(section.id)")
+                            }
+                        }
+                    }
+                }
+                .navigationTitle("Notebook Sections")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Done") { activeSheet = nil }
+                    }
+                }
+            }
 
         case .help:
             PageHelpSheet(title: "Notebook Detail Help", sections: [

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -567,8 +567,31 @@ public final class JobsService: Sendable {
                     jobClassification
                 ]
             )
-            return dbConn.lastInsertedRowID
+            let jobId = dbConn.lastInsertedRowID
+            let notebookCreatorId = try resolveJobNotebookCreatorId(dbConn: dbConn, preferredUserId: createdBy)
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO notebooks
+                    (title, notebook_type, job_id, created_by, status, created_at, updated_at)
+                    VALUES (?, 'job', ?, ?, 'active', datetime('now'), datetime('now'))
+                    """,
+                arguments: ["\(jobName) Job Notebook", jobId, notebookCreatorId]
+            )
+            return jobId
         }
+    }
+
+    private func resolveJobNotebookCreatorId(dbConn: Database, preferredUserId: Int64?) throws -> Int64 {
+        if let preferredUserId {
+            return preferredUserId
+        }
+        if let fallbackUserId = try Int64.fetchOne(
+            dbConn,
+            sql: "SELECT id FROM users WHERE deleted_at IS NULL ORDER BY id ASC LIMIT 1"
+        ) {
+            return fallbackUserId
+        }
+        throw JobsError.requiredFieldEmpty
     }
 
     /// Update an existing job. Only non-nil fields are updated.

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -24,6 +24,55 @@ struct JobsServiceTests {
         #expect(jobs.contains(where: { $0.jobNumber == "J-TEST" }))
     }
 
+    @Test("Create job creates exactly one active linked job notebook")
+    func testCreateJobCreatesLinkedNotebook() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try env.jobs.createJob(
+            jobNumber: "J-NB-001",
+            jobName: "Notebook Atomic Job",
+            createdBy: env.adminUserId
+        )
+
+        let notebooks = try env.notebooks.listNotebooks(notebookType: "job", jobId: jobId)
+        #expect(notebooks.count == 1)
+        #expect(notebooks.first?.status == "active")
+        #expect(notebooks.first?.title == "Notebook Atomic Job Job Notebook")
+    }
+
+    @Test("Create job rolls back when linked notebook cannot be created")
+    func testCreateJobRollsBackWhenNotebookCreationFails() throws {
+        let env = try E2ETestHelpers.setUp()
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE users SET deleted_at = datetime('now')")
+        }
+
+        var threw = false
+        do {
+            _ = try env.jobs.createJob(jobNumber: "J-NB-ROLLBACK", jobName: "Rollback Job")
+        } catch JobsService.JobsError.requiredFieldEmpty {
+            threw = true
+        } catch {}
+
+        let jobCount = try env.db.writer.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM jobs WHERE job_number = ?",
+                arguments: ["J-NB-ROLLBACK"]
+            ) ?? 0
+        }
+        let notebookCount = try env.db.writer.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM notebooks WHERE title = ?",
+                arguments: ["Rollback Job Job Notebook"]
+            ) ?? 0
+        }
+
+        #expect(threw)
+        #expect(jobCount == 0)
+        #expect(notebookCount == 0)
+    }
+
     @Test("Get job detail")
     func testGetJobDetail() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary

Publishes the focused GitHub #398 job notebook implementation against `main` without the broad/conflicting PR #411/#415 workspace changes.

## Changes

- Creates the job-linked notebook inside `JobsService.createJob` transactionally and rolls the job back if notebook creation cannot complete.
- Adds the job detail Notebooks tab behavior to open the linked job notebook directly, with create/retry recovery when the notebook is missing.
- Adds a responsive notebook detail shell and job notebook row deep-linking.
- Adds focused JobsService coverage for atomic notebook creation and rollback.

## Validation

- `swift test --filter JobsServiceTests.testCreateJobCreatesLinkedNotebook`
- `swift test --filter JobsServiceTests.testCreateJobRollsBackWhenNotebookCreationFails`
- `xcodebuild -workspace 'Wierd Parts.xcworkspace' -scheme 'WiredPart-iOS' -destination 'generic/platform=iOS Simulator' -derivedDataPath .paperclip/DerivedData-WEI-1315 build`\n\n## Notes\n\nThe broader `swift test --filter JobsServiceTests` command built successfully but did not emit test progress after about one minute of execution, so I stopped it and ran the two atomic notebook tests by exact function filter.