### PR TITLE
WEI-1112: Add People Office Reports AI contexts

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
+++ b/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
@@ -79,6 +79,19 @@ struct IOSAIAssistantPanel: View {
     @State private var dispatchContext: String?
     @State private var scheduleCalendarContext: String?
     @State private var employeesContext: String?
+    @State private var peopleDashboardContext: String?
+    @State private var customersContext: String?
+    @State private var contactsContext: String?
+    @State private var officeDashboardContext: String?
+    @State private var officeApprovalsContext: String?
+    @State private var officeSpendingContext: String?
+    @State private var reportsLaborContext: String?
+    @State private var reportsSpendingContext: String?
+    @State private var reportsProfitabilityContext: String?
+    @State private var reportsTimesheetsContext: String?
+    @State private var reportsPrebillingContext: String?
+    @State private var reportsBookkeeperContext: String?
+    @State private var reportsDailySummaryContext: String?
     @State private var vehiclesContext: String?
     @State private var toolRegistryContext: String?
     @State private var notebooksListContext: String?
@@ -300,6 +313,21 @@ struct IOSAIAssistantPanel: View {
             toolRegistryContext: $toolRegistryContext,
             notebooksListContext: $notebooksListContext,
             settingsContext: $settingsContext
+        ))
+        .modifier(PeopleOfficeReportsContextObservers(
+            peopleDashboardContext: $peopleDashboardContext,
+            customersContext: $customersContext,
+            contactsContext: $contactsContext,
+            officeDashboardContext: $officeDashboardContext,
+            officeApprovalsContext: $officeApprovalsContext,
+            officeSpendingContext: $officeSpendingContext,
+            reportsLaborContext: $reportsLaborContext,
+            reportsSpendingContext: $reportsSpendingContext,
+            reportsProfitabilityContext: $reportsProfitabilityContext,
+            reportsTimesheetsContext: $reportsTimesheetsContext,
+            reportsPrebillingContext: $reportsPrebillingContext,
+            reportsBookkeeperContext: $reportsBookkeeperContext,
+            reportsDailySummaryContext: $reportsDailySummaryContext
         ))
         .modifier(ActivePageIdTracker(activePageId: $activePageId))
     }
@@ -673,6 +701,45 @@ struct IOSAIAssistantPanel: View {
             }
             if let ctx = employeesContext {
                 navContext += "\n\nEmployees Context: \(ctx)"
+            }
+            if let ctx = peopleDashboardContext {
+                navContext += "\n\nPeople Dashboard Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = customersContext {
+                navContext += "\n\nCustomers Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = contactsContext {
+                navContext += "\n\nContacts Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = officeDashboardContext {
+                navContext += "\n\nOffice Dashboard Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = officeApprovalsContext {
+                navContext += "\n\nOffice Approvals Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = officeSpendingContext {
+                navContext += "\n\nOffice Spending Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = reportsLaborContext {
+                navContext += "\n\nReports Labor Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = reportsSpendingContext {
+                navContext += "\n\nReports Spending Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = reportsProfitabilityContext {
+                navContext += "\n\nReports Profitability Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = reportsTimesheetsContext {
+                navContext += "\n\nReports Timesheets Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = reportsPrebillingContext {
+                navContext += "\n\nReports Pre-Billing Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = reportsBookkeeperContext {
+                navContext += "\n\nReports Bookkeeper Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = reportsDailySummaryContext {
+                navContext += "\n\nReports Daily Summary Context (READ-ONLY): \(ctx)"
             }
             if let ctx = vehiclesContext {
                 navContext += "\n\nVehicles Context: \(ctx)"
@@ -1485,6 +1552,164 @@ private struct FeaturePageContextObserversGroupB: ViewModifier {
     }
 }
 
+/// People, Office, and Reports observers kept separate from the legacy feature observer groups.
+private struct PeopleOfficeReportsContextObservers: ViewModifier {
+    @Binding var peopleDashboardContext: String?
+    @Binding var customersContext: String?
+    @Binding var contactsContext: String?
+    @Binding var officeDashboardContext: String?
+    @Binding var officeApprovalsContext: String?
+    @Binding var officeSpendingContext: String?
+    @Binding var reportsLaborContext: String?
+    @Binding var reportsSpendingContext: String?
+    @Binding var reportsProfitabilityContext: String?
+    @Binding var reportsTimesheetsContext: String?
+    @Binding var reportsPrebillingContext: String?
+    @Binding var reportsBookkeeperContext: String?
+    @Binding var reportsDailySummaryContext: String?
+
+    func body(content: Content) -> some View {
+        content
+            .modifier(PeopleOfficeContextObservers(
+                peopleDashboardContext: $peopleDashboardContext,
+                customersContext: $customersContext,
+                contactsContext: $contactsContext,
+                officeDashboardContext: $officeDashboardContext,
+                officeApprovalsContext: $officeApprovalsContext,
+                officeSpendingContext: $officeSpendingContext
+            ))
+            .modifier(ReportsContextObservers(
+                reportsLaborContext: $reportsLaborContext,
+                reportsSpendingContext: $reportsSpendingContext,
+                reportsProfitabilityContext: $reportsProfitabilityContext,
+                reportsTimesheetsContext: $reportsTimesheetsContext,
+                reportsPrebillingContext: $reportsPrebillingContext,
+                reportsBookkeeperContext: $reportsBookkeeperContext,
+                reportsDailySummaryContext: $reportsDailySummaryContext
+            ))
+    }
+}
+
+private struct PeopleOfficeContextObservers: ViewModifier {
+    @Binding var peopleDashboardContext: String?
+    @Binding var customersContext: String?
+    @Binding var contactsContext: String?
+    @Binding var officeDashboardContext: String?
+    @Binding var officeApprovalsContext: String?
+    @Binding var officeSpendingContext: String?
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .peopleDashboardPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { peopleDashboardContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .peopleDashboardPageInactive)) { _ in
+                peopleDashboardContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .customersPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { customersContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .customersPageInactive)) { _ in
+                customersContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .contactsPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { contactsContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .contactsPageInactive)) { _ in
+                contactsContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .officeDashboardPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { officeDashboardContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .officeDashboardPageInactive)) { _ in
+                officeDashboardContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .officeApprovalsPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { officeApprovalsContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .officeApprovalsPageInactive)) { _ in
+                officeApprovalsContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .officeSpendingPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { officeSpendingContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .officeSpendingPageInactive)) { _ in
+                officeSpendingContext = nil
+            }
+    }
+}
+
+private struct ReportsContextObservers: ViewModifier {
+    @Binding var reportsLaborContext: String?
+    @Binding var reportsSpendingContext: String?
+    @Binding var reportsProfitabilityContext: String?
+    @Binding var reportsTimesheetsContext: String?
+    @Binding var reportsPrebillingContext: String?
+    @Binding var reportsBookkeeperContext: String?
+    @Binding var reportsDailySummaryContext: String?
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .reportsLaborPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { reportsLaborContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsLaborPageInactive)) { _ in
+                reportsLaborContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsSpendingPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { reportsSpendingContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsSpendingPageInactive)) { _ in
+                reportsSpendingContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsProfitabilityPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { reportsProfitabilityContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsProfitabilityPageInactive)) { _ in
+                reportsProfitabilityContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsTimesheetsPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { reportsTimesheetsContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsTimesheetsPageInactive)) { _ in
+                reportsTimesheetsContext = nil
+            }
+            .modifier(ReportsContextObserversTail(
+                reportsPrebillingContext: $reportsPrebillingContext,
+                reportsBookkeeperContext: $reportsBookkeeperContext,
+                reportsDailySummaryContext: $reportsDailySummaryContext
+            ))
+    }
+}
+
+private struct ReportsContextObserversTail: ViewModifier {
+    @Binding var reportsPrebillingContext: String?
+    @Binding var reportsBookkeeperContext: String?
+    @Binding var reportsDailySummaryContext: String?
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .reportsPrebillingPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { reportsPrebillingContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsPrebillingPageInactive)) { _ in
+                reportsPrebillingContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsBookkeeperPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { reportsBookkeeperContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsBookkeeperPageInactive)) { _ in
+                reportsBookkeeperContext = nil
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsDailySummaryPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { reportsDailySummaryContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsDailySummaryPageInactive)) { _ in
+                reportsDailySummaryContext = nil
+            }
+    }
+}
+
 // MARK: - Active Page ID Tracker (prompt 60N)
 
 /// Tracks which page the user is currently viewing by listening to all page-active/inactive
@@ -1501,6 +1726,7 @@ private struct ActivePageIdTracker: ViewModifier {
             .modifier(ActivePageIdTrackerDashJobs(activePageId: $activePageId))
             .modifier(ActivePageIdTrackerOrdersWarehouse(activePageId: $activePageId))
             .modifier(ActivePageIdTrackerSchedulePeopleMore(activePageId: $activePageId))
+            .modifier(ActivePageIdTrackerPeopleOfficeReports(activePageId: $activePageId))
     }
 }
 
@@ -1700,6 +1926,55 @@ private struct ActivePageIdTrackerFleetToolsNotebooks: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .notebooksListPageInactive)) { _ in if activePageId == "notebooks-all" { activePageId = nil } }
             .onReceive(NotificationCenter.default.publisher(for: .settingsPageActive)) { _ in activePageId = "settings-app-config" }
             .onReceive(NotificationCenter.default.publisher(for: .settingsPageInactive)) { _ in if activePageId == "settings-app-config" { activePageId = nil } }
+    }
+}
+
+private struct ActivePageIdTrackerPeopleOfficeReports: ViewModifier {
+    @Binding var activePageId: String?
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .peopleDashboardPageActive)) { _ in activePageId = "people-dashboard" }
+            .onReceive(NotificationCenter.default.publisher(for: .peopleDashboardPageInactive)) { _ in if activePageId == "people-dashboard" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .customersPageActive)) { _ in activePageId = "people-customers" }
+            .onReceive(NotificationCenter.default.publisher(for: .customersPageInactive)) { _ in if activePageId == "people-customers" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .contactsPageActive)) { _ in activePageId = "people-contacts" }
+            .onReceive(NotificationCenter.default.publisher(for: .contactsPageInactive)) { _ in if activePageId == "people-contacts" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .officeDashboardPageActive)) { _ in activePageId = "office-dashboard" }
+            .onReceive(NotificationCenter.default.publisher(for: .officeDashboardPageInactive)) { _ in if activePageId == "office-dashboard" { activePageId = nil } }
+            .modifier(ActivePageIdTrackerOfficeReports(activePageId: $activePageId))
+    }
+}
+
+private struct ActivePageIdTrackerOfficeReports: ViewModifier {
+    @Binding var activePageId: String?
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .officeApprovalsPageActive)) { _ in activePageId = "office-approvals" }
+            .onReceive(NotificationCenter.default.publisher(for: .officeApprovalsPageInactive)) { _ in if activePageId == "office-approvals" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .officeSpendingPageActive)) { _ in activePageId = "office-spending" }
+            .onReceive(NotificationCenter.default.publisher(for: .officeSpendingPageInactive)) { _ in if activePageId == "office-spending" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsLaborPageActive)) { _ in activePageId = "reports-labor" }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsLaborPageInactive)) { _ in if activePageId == "reports-labor" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsSpendingPageActive)) { _ in activePageId = "reports-spending" }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsSpendingPageInactive)) { _ in if activePageId == "reports-spending" { activePageId = nil } }
+            .modifier(ActivePageIdTrackerReportsTail(activePageId: $activePageId))
+    }
+}
+
+private struct ActivePageIdTrackerReportsTail: ViewModifier {
+    @Binding var activePageId: String?
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .reportsProfitabilityPageActive)) { _ in activePageId = "reports-profitability" }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsProfitabilityPageInactive)) { _ in if activePageId == "reports-profitability" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsTimesheetsPageActive)) { _ in activePageId = "reports-timesheets" }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsTimesheetsPageInactive)) { _ in if activePageId == "reports-timesheets" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsPrebillingPageActive)) { _ in activePageId = "reports-prebilling" }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsPrebillingPageInactive)) { _ in if activePageId == "reports-prebilling" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsBookkeeperPageActive)) { _ in activePageId = "reports-bookkeeper" }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsBookkeeperPageInactive)) { _ in if activePageId == "reports-bookkeeper" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsDailySummaryPageActive)) { _ in activePageId = "reports-daily-summary" }
+            .onReceive(NotificationCenter.default.publisher(for: .reportsDailySummaryPageInactive)) { _ in if activePageId == "reports-daily-summary" { activePageId = nil } }
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSOfficeDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSOfficeDashboardPage.swift
@@ -118,6 +118,10 @@ struct IOSOfficeDashboardPage: View {
             appCore.onboardingManager?.markCompleted("office-view")
             loadData()
         }
+        .onAppear { postPageContext() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .officeDashboardPageInactive, object: nil)
+        }
     }
 
     // MARK: - AI Summary Section
@@ -531,6 +535,17 @@ struct IOSOfficeDashboardPage: View {
         }
 
         isLoading = false
+        postPageContext()
+    }
+
+    private func postPageContext() {
+        NotificationCenter.default.post(
+            name: .officeDashboardPageActive,
+            object: nil,
+            userInfo: [
+                "context": "Office Dashboard: \(smartCards.count) smart cards, \(attentionItems.count) attention items, \(todaySchedule.count) schedule items, financial snapshot visible: \(financialSnapshot != nil), background rows: \(backgroundTaskStatuses.count)."
+            ]
+        )
     }
 
     private func scheduleDailyBriefingNotificationIfAllowed() {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSSpendingDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSSpendingDashboardPage.swift
@@ -96,6 +96,10 @@ struct IOSSpendingDashboardPage: View {
         }
         .refreshable { loadData() }
         .task { loadData() }
+        .onAppear { postPageContext() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .officeSpendingPageInactive, object: nil)
+        }
         .onChange(of: dateRange) { loadData() }
         .onChange(of: customStart) { loadData() }
         .onChange(of: customEnd) { loadData() }
@@ -133,6 +137,17 @@ struct IOSSpendingDashboardPage: View {
             loadError = userFriendlyError(error, context: "load spending data")
         }
         isLoading = false
+        postPageContext()
+    }
+
+    private func postPageContext() {
+        NotificationCenter.default.post(
+            name: .officeSpendingPageActive,
+            object: nil,
+            userInfo: [
+                "context": "Office Spending Dashboard: range \(dateRange.rawValue), parts cost \(formatCurrency(totalPartsCost)), labor hours \(String(format: "%.1f", totalLaborHours)), active jobs \(activeJobCount), total jobs \(totalJobs)."
+            ]
+        )
     }
 
     private func formatCurrency(_ value: Double) -> String {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSUnifiedApprovalsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSUnifiedApprovalsPage.swift
@@ -199,6 +199,10 @@ struct IOSUnifiedApprovalsPage: View {
             loadData()
             appCore.onboardingManager?.markCompleted("approvals-view")
         }
+        .onAppear { postPageContext() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .officeApprovalsPageInactive, object: nil)
+        }
         .alert("Error", isPresented: Binding(
             get: { actionError != nil },
             set: { if !$0 { actionError = nil } }
@@ -764,5 +768,17 @@ struct IOSUnifiedApprovalsPage: View {
         }
 
         isLoading = false
+        postPageContext()
+    }
+
+    private func postPageContext() {
+        let filterLabel = activeFilter?.label ?? "All"
+        NotificationCenter.default.post(
+            name: .officeApprovalsPageActive,
+            object: nil,
+            userInfo: [
+                "context": "Office Approvals: \(totalCount) pending, \(filteredItems.count) visible, filter: \(filterLabel), search active: \(!searchText.isEmpty)."
+            ]
+        )
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactsPage.swift
@@ -45,6 +45,10 @@ struct IOSContactsPage: View {
         .onChange(of: sortOption) { loadData() }
         .refreshable { loadData() }
         .task { loadData() }
+        .onAppear { postPageContext() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .contactsPageInactive, object: nil)
+        }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 HStack(spacing: 12) {
@@ -277,6 +281,17 @@ struct IOSContactsPage: View {
             loadError = userFriendlyError(error, context: "load contacts")
         }
         isLoading = false
+        postPageContext()
+    }
+
+    private func postPageContext() {
+        NotificationCenter.default.post(
+            name: .contactsPageActive,
+            object: nil,
+            userInfo: [
+                "context": "Contacts Page: \(activeContacts.count) active, \(inactiveContacts.count) inactive, filter: \(displayName(typeFilter)), sort: \(sortOption.rawValue), search active: \(!searchText.isEmpty)."
+            ]
+        )
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSCustomersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSCustomersPage.swift
@@ -32,6 +32,10 @@ struct IOSCustomersPage: View {
             .onChange(of: searchText) { loadData() }
             .refreshable { loadData() }
             .task { loadData() }
+            .onAppear { postPageContext() }
+            .onDisappear {
+                NotificationCenter.default.post(name: .customersPageInactive, object: nil)
+            }
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button { activeSheet = .addCustomer } label: {
@@ -153,6 +157,17 @@ struct IOSCustomersPage: View {
             loadError = userFriendlyError(error, context: "load customers")
         }
         isLoading = false
+        postPageContext()
+    }
+
+    private func postPageContext() {
+        NotificationCenter.default.post(
+            name: .customersPageActive,
+            object: nil,
+            userInfo: [
+                "context": "Customers Page: \(customers.count) customers, \(filteredCustomers.count) visible, search active: \(!searchText.isEmpty)."
+            ]
+        )
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSPeopleDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSPeopleDashboardPage.swift
@@ -42,6 +42,10 @@ struct IOSPeopleDashboardPage: View {
             loadData()
             appCore.onboardingManager?.markCompleted("people-dashboard-view")
         }
+        .onAppear { postPageContext() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .peopleDashboardPageInactive, object: nil)
+        }
         .refreshable { loadData() }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
@@ -309,5 +313,16 @@ struct IOSPeopleDashboardPage: View {
             loadError = userFriendlyError(error, context: "load people dashboard")
         }
         isLoading = false
+        postPageContext()
+    }
+
+    private func postPageContext() {
+        NotificationCenter.default.post(
+            name: .peopleDashboardPageActive,
+            object: nil,
+            userInfo: [
+                "context": "People Dashboard: \(workingNow.count) working now, \(offToday.count) off today, \(expiringCerts.count) expiring certifications, \(teamAssignments.count) team assignments, \(overdueCustomers.count) overdue customers."
+            ]
+        )
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSBookkeeperExportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSBookkeeperExportPage.swift
@@ -68,6 +68,10 @@ struct IOSBookkeeperExportPage: View {
         .searchable(text: $searchText, prompt: "Search employees or POs...")
         .refreshable { loadData() }
         .task { loadData() }
+        .onAppear { postPageContext() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .reportsBookkeeperPageInactive, object: nil)
+        }
         .onChange(of: startDate) { _, _ in loadData() }
         .onChange(of: endDate) { _, _ in loadData() }
     }
@@ -217,5 +221,17 @@ struct IOSBookkeeperExportPage: View {
             loadError = userFriendlyError(error, context: "load reports")
         }
         isLoading = false
+        postPageContext()
+    }
+
+    private func postPageContext() {
+        let materialTotal = materialRows.reduce(0) { $0 + $1.totalAmount }
+        NotificationCenter.default.post(
+            name: .reportsBookkeeperPageActive,
+            object: nil,
+            userInfo: [
+                "context": "Bookkeeper Export Report: \(startDateString) to \(endDateString), \(laborRows.count) labor rows, \(materialRows.count) material rows, material total \(String(format: "$%.2f", materialTotal)), search active: \(!searchText.isEmpty)."
+            ]
+        )
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSDailyReportsSummaryPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSDailyReportsSummaryPage.swift
@@ -69,6 +69,10 @@ struct IOSDailyReportsSummaryPage: View {
         }
         .refreshable { loadData() }
         .task { loadData() }
+        .onAppear { postPageContext() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .reportsDailySummaryPageInactive, object: nil)
+        }
         .onChange(of: dateRange) { loadData() }
         .onChange(of: customStart) { loadData() }
         .onChange(of: customEnd) { loadData() }
@@ -236,5 +240,18 @@ struct IOSDailyReportsSummaryPage: View {
             loadError = userFriendlyError(error, context: "load reports")
         }
         isLoading = false
+        postPageContext()
+    }
+
+    private func postPageContext() {
+        let workerCount = rows.reduce(0) { $0 + $1.workerCount }
+        let totalHours = rows.reduce(0) { $0 + $1.totalHours }
+        NotificationCenter.default.post(
+            name: .reportsDailySummaryPageActive,
+            object: nil,
+            userInfo: [
+                "context": "Daily Reports Summary: date \(dateString), \(rows.count) jobs, \(filteredRows.count) visible, \(workerCount) workers, \(String(format: "%.1f", totalHours)) hours."
+            ]
+        )
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSLaborOverviewPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSLaborOverviewPage.swift
@@ -61,6 +61,10 @@ struct IOSLaborOverviewPage: View {
         }
         .refreshable { loadData() }
         .task { loadData() }
+        .onAppear { postPageContext() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .reportsLaborPageInactive, object: nil)
+        }
         .onChange(of: dateRange) { loadData() }
         .onChange(of: customStart) { loadData() }
         .onChange(of: customEnd) { loadData() }
@@ -175,5 +179,16 @@ struct IOSLaborOverviewPage: View {
             loadError = userFriendlyError(error, context: "load labor data")
         }
         isLoading = false
+        postPageContext()
+    }
+
+    private func postPageContext() {
+        NotificationCenter.default.post(
+            name: .reportsLaborPageActive,
+            object: nil,
+            userInfo: [
+                "context": "Labor Overview Report: range \(dateRange.rawValue), \(String(format: "%.1f", totalHours)) total hours, \(String(format: "%.1f", totalOvertime)) overtime, \(uniqueWorkers) active workers, \(filteredTimesheetRows.count) visible rows."
+            ]
+        )
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSPreBillingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSPreBillingPage.swift
@@ -60,6 +60,10 @@ struct IOSPreBillingPage: View {
         .searchable(text: $searchText, prompt: "Search jobs...")
         .refreshable { loadData() }
         .task { loadData() }
+        .onAppear { postPageContext() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .reportsPrebillingPageInactive, object: nil)
+        }
         .onChange(of: startDate) { _, _ in loadData() }
         .onChange(of: endDate) { _, _ in loadData() }
     }
@@ -180,5 +184,18 @@ struct IOSPreBillingPage: View {
             loadError = userFriendlyError(error, context: "load reports")
         }
         isLoading = false
+        postPageContext()
+    }
+
+    private func postPageContext() {
+        let regularHours = rows.reduce(0) { $0 + $1.regularHours }
+        let overtimeHours = rows.reduce(0) { $0 + $1.overtimeHours }
+        NotificationCenter.default.post(
+            name: .reportsPrebillingPageActive,
+            object: nil,
+            userInfo: [
+                "context": "Pre-Billing Report: \(startDateString) to \(endDateString), \(rows.count) jobs, \(filteredRows.count) visible, \(String(format: "%.1f", regularHours)) regular hours, \(String(format: "%.1f", overtimeHours)) overtime."
+            ]
+        )
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSProfitabilityPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSProfitabilityPage.swift
@@ -58,6 +58,10 @@ struct IOSProfitabilityPage: View {
             .searchable(text: $searchText, prompt: "Search jobs...")
             .refreshable { loadData() }
             .task { loadData() }
+            .onAppear { postPageContext() }
+            .onDisappear {
+                NotificationCenter.default.post(name: .reportsProfitabilityPageInactive, object: nil)
+            }
             .onChange(of: dateRange) { loadData() }
             .onChange(of: customStart) { loadData() }
             .onChange(of: customEnd) { loadData() }
@@ -171,5 +175,17 @@ struct IOSProfitabilityPage: View {
             loadError = userFriendlyError(error, context: "load reports")
         }
         isLoading = false
+        postPageContext()
+    }
+
+    private func postPageContext() {
+        let totalProfit = rows.reduce(0) { $0 + $1.profit }
+        NotificationCenter.default.post(
+            name: .reportsProfitabilityPageActive,
+            object: nil,
+            userInfo: [
+                "context": "Profitability Report: range \(dateRange.rawValue), \(rows.count) jobs, \(filteredRows.count) visible, total profit \(formatCurrency(totalProfit)), search active: \(!searchText.isEmpty)."
+            ]
+        )
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSSpendingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSSpendingPage.swift
@@ -65,6 +65,10 @@ struct IOSSpendingPage: View {
         }
         .refreshable { loadData() }
         .task { loadData() }
+        .onAppear { postPageContext() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .reportsSpendingPageInactive, object: nil)
+        }
         .onChange(of: dateRange) { loadData() }
         .onChange(of: customStart) { loadData() }
         .onChange(of: customEnd) { loadData() }
@@ -220,5 +224,19 @@ struct IOSSpendingPage: View {
             loadError = userFriendlyError(error, context: "load reports")
         }
         isLoading = false
+        postPageContext()
+    }
+
+    private func postPageContext() {
+        let totalSpend = summary.map { formatCurrency($0.totalSpend) } ?? "$0.00"
+        let poCount = summary?.poCount ?? 0
+        let topSupplier = summary?.topSupplierName ?? "none"
+        NotificationCenter.default.post(
+            name: .reportsSpendingPageActive,
+            object: nil,
+            userInfo: [
+                "context": "Spending Report: range \(dateRange.rawValue), period \(selectedDays)d, total spend \(totalSpend), PO count \(poCount), top supplier \(topSupplier)."
+            ]
+        )
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
@@ -62,6 +62,10 @@ struct IOSTimesheetsPage: View {
         .searchable(text: $searchText, prompt: "Search employees...")
         .refreshable { loadData() }
         .task { loadData() }
+        .onAppear { postPageContext() }
+        .onDisappear {
+            NotificationCenter.default.post(name: .reportsTimesheetsPageInactive, object: nil)
+        }
         .onChange(of: startDate) { _, _ in loadData() }
         .onChange(of: endDate) { _, _ in loadData() }
     }
@@ -157,5 +161,18 @@ struct IOSTimesheetsPage: View {
             loadError = userFriendlyError(error, context: "load reports")
         }
         isLoading = false
+        postPageContext()
+    }
+
+    private func postPageContext() {
+        let totalHours = rows.reduce(0) { $0 + $1.totalHours }
+        let overtimeHours = rows.reduce(0) { $0 + $1.overtimeHours }
+        NotificationCenter.default.post(
+            name: .reportsTimesheetsPageActive,
+            object: nil,
+            userInfo: [
+                "context": "Timesheets Report: \(startDateString) to \(endDateString), \(rows.count) employees, \(filteredRows.count) visible, \(String(format: "%.1f", totalHours)) total hours, \(String(format: "%.1f", overtimeHours)) overtime."
+            ]
+        )
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
@@ -177,16 +177,16 @@ let appModules: [AppModule] = [
     ], permission: "view_people"),
     // 12. Office — dashboard, approvals, pipeline, teams, reports
     AppModule(id: "office", label: "Office", icon: "briefcase.fill", tabs: [
-        AppTab(id: "office-dashboard", label: "Dashboard", icon: "gauge.with.dots.needle.50percent", path: "/office/dashboard", permission: "manage_jobs"),
-        AppTab(id: "office-approvals", label: "Approvals", icon: "checkmark.seal.fill", path: "/office/approvals", permission: "manage_jobs"),
+        AppTab(id: "office-dashboard", label: "Dashboard", icon: "gauge.with.dots.needle.50percent", path: "/office/dashboard", permission: officeAccessPermission),
+        AppTab(id: "office-approvals", label: "Approvals", icon: "checkmark.seal.fill", path: "/office/approvals", permission: officeAccessPermission),
         AppTab(id: "office-manage-jobs", label: "Manage Jobs", icon: "hammer.fill", path: "/office/manage-jobs", permission: "manage_jobs"),
         AppTab(id: "office-warehouse-exec", label: "Warehouse", icon: "building.fill", path: "/office/warehouse-exec", permission: "manage_warehouse"),
         AppTab(id: "office-estimation-settings", label: "Estimation", icon: "chart.bar.doc.horizontal", path: "/office/estimation-settings", permission: "manage_jobs"),
         AppTab(id: "office-pipeline", label: "Pipeline", icon: "chart.bar.xaxis", path: "/office/pipeline", permission: "manage_jobs"),
-        AppTab(id: "office-spending", label: "Spending", icon: "dollarsign.circle.fill", path: "/office/spending", permission: "show_dollar_values"),
+        AppTab(id: "office-spending", label: "Spending", icon: "dollarsign.circle.fill", path: "/office/spending", permission: financialValuesPermission),
         AppTab(id: "office-teams", label: "Teams", icon: "person.3.fill", path: "/office/teams"),
         AppTab(id: "office-reports", label: "Reports", icon: "chart.pie.fill", path: "/office/reports", permission: "view_reports"),
-    ], permission: "manage_jobs"),
+    ], permission: officeAccessPermission),
     // 13. Settings — app config, security
     AppModule(id: "settings", label: "Settings", icon: "gearshape.fill", tabs: [
         AppTab(id: "settings-themes", label: "Themes", icon: "paintpalette.fill", path: "/settings/themes"),
@@ -477,6 +477,88 @@ extension Notification.Name {
 
     /// Posted when the Employees page disappears.
     static let employeesPageInactive = Notification.Name("WiredPart.employeesPageInactive")
+
+    /// Posted when the People Dashboard page appears, with workforce summary context for AI.
+    static let peopleDashboardPageActive = Notification.Name("WiredPart.peopleDashboardPageActive")
+
+    /// Posted when the People Dashboard page disappears.
+    static let peopleDashboardPageInactive = Notification.Name("WiredPart.peopleDashboardPageInactive")
+
+    /// Posted when the Customers page appears, with customer list context for AI.
+    static let customersPageActive = Notification.Name("WiredPart.customersPageActive")
+
+    /// Posted when the Customers page disappears.
+    static let customersPageInactive = Notification.Name("WiredPart.customersPageInactive")
+
+    /// Posted when the Contacts page appears, with contact list context for AI.
+    static let contactsPageActive = Notification.Name("WiredPart.contactsPageActive")
+
+    /// Posted when the Contacts page disappears.
+    static let contactsPageInactive = Notification.Name("WiredPart.contactsPageInactive")
+
+    // MARK: - Office
+
+    /// Posted when the Office Dashboard page appears, with command-center context for AI.
+    static let officeDashboardPageActive = Notification.Name("WiredPart.officeDashboardPageActive")
+
+    /// Posted when the Office Dashboard page disappears.
+    static let officeDashboardPageInactive = Notification.Name("WiredPart.officeDashboardPageInactive")
+
+    /// Posted when the Unified Approvals page appears, with approval queue context for AI.
+    static let officeApprovalsPageActive = Notification.Name("WiredPart.officeApprovalsPageActive")
+
+    /// Posted when the Unified Approvals page disappears.
+    static let officeApprovalsPageInactive = Notification.Name("WiredPart.officeApprovalsPageInactive")
+
+    /// Posted when the Office Spending dashboard appears, with read-only spending context for AI.
+    static let officeSpendingPageActive = Notification.Name("WiredPart.officeSpendingPageActive")
+
+    /// Posted when the Office Spending dashboard disappears.
+    static let officeSpendingPageInactive = Notification.Name("WiredPart.officeSpendingPageInactive")
+
+    // MARK: - Reports
+
+    /// Posted when the Labor Overview report appears, with read-only labor report context for AI.
+    static let reportsLaborPageActive = Notification.Name("WiredPart.reportsLaborPageActive")
+
+    /// Posted when the Labor Overview report disappears.
+    static let reportsLaborPageInactive = Notification.Name("WiredPart.reportsLaborPageInactive")
+
+    /// Posted when the Spending report appears, with read-only spending report context for AI.
+    static let reportsSpendingPageActive = Notification.Name("WiredPart.reportsSpendingPageActive")
+
+    /// Posted when the Spending report disappears.
+    static let reportsSpendingPageInactive = Notification.Name("WiredPart.reportsSpendingPageInactive")
+
+    /// Posted when the Profitability report appears, with read-only profitability context for AI.
+    static let reportsProfitabilityPageActive = Notification.Name("WiredPart.reportsProfitabilityPageActive")
+
+    /// Posted when the Profitability report disappears.
+    static let reportsProfitabilityPageInactive = Notification.Name("WiredPart.reportsProfitabilityPageInactive")
+
+    /// Posted when the Timesheets report appears, with read-only timesheet context for AI.
+    static let reportsTimesheetsPageActive = Notification.Name("WiredPart.reportsTimesheetsPageActive")
+
+    /// Posted when the Timesheets report disappears.
+    static let reportsTimesheetsPageInactive = Notification.Name("WiredPart.reportsTimesheetsPageInactive")
+
+    /// Posted when the Pre-Billing report appears, with read-only billing context for AI.
+    static let reportsPrebillingPageActive = Notification.Name("WiredPart.reportsPrebillingPageActive")
+
+    /// Posted when the Pre-Billing report disappears.
+    static let reportsPrebillingPageInactive = Notification.Name("WiredPart.reportsPrebillingPageInactive")
+
+    /// Posted when the Bookkeeper Export report appears, with read-only export context for AI.
+    static let reportsBookkeeperPageActive = Notification.Name("WiredPart.reportsBookkeeperPageActive")
+
+    /// Posted when the Bookkeeper Export report disappears.
+    static let reportsBookkeeperPageInactive = Notification.Name("WiredPart.reportsBookkeeperPageInactive")
+
+    /// Posted when the Daily Reports Summary appears, with read-only daily report context for AI.
+    static let reportsDailySummaryPageActive = Notification.Name("WiredPart.reportsDailySummaryPageActive")
+
+    /// Posted when the Daily Reports Summary disappears.
+    static let reportsDailySummaryPageInactive = Notification.Name("WiredPart.reportsDailySummaryPageInactive")
 
     // MARK: - Fleet
 

--- a/Weird Parts IOS/Weird Parts IOS/Shared/HelpContentRegistry.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/HelpContentRegistry.swift
@@ -123,6 +123,19 @@ struct HelpContentRegistry {
         "WiredPart.dispatchPageActive": "scheduling-dispatch",
         "WiredPart.scheduleCalendarPageActive": "scheduling-calendar",
         "WiredPart.employeesPageActive": "people-employees",
+        "WiredPart.peopleDashboardPageActive": "people-dashboard",
+        "WiredPart.customersPageActive": "people-customers",
+        "WiredPart.contactsPageActive": "people-contacts",
+        "WiredPart.officeDashboardPageActive": "office-dashboard",
+        "WiredPart.officeApprovalsPageActive": "office-approvals",
+        "WiredPart.officeSpendingPageActive": "office-spending",
+        "WiredPart.reportsLaborPageActive": "reports-labor",
+        "WiredPart.reportsSpendingPageActive": "reports-spending",
+        "WiredPart.reportsProfitabilityPageActive": "reports-profitability",
+        "WiredPart.reportsTimesheetsPageActive": "reports-timesheets",
+        "WiredPart.reportsPrebillingPageActive": "reports-prebilling",
+        "WiredPart.reportsBookkeeperPageActive": "reports-bookkeeper",
+        "WiredPart.reportsDailySummaryPageActive": "reports-daily-summary",
         "WiredPart.vehiclesPageActive": "fleet-vehicles",
         "WiredPart.toolRegistryPageActive": "tools-registry",
         "WiredPart.notebooksListPageActive": "notebooks-all",
@@ -619,6 +632,39 @@ struct HelpContentRegistry {
         ),
 
         HelpEntry(
+            pageId: "people-dashboard",
+            title: "People Dashboard Help",
+            sections: [
+                ("What This Page Does", "The People Dashboard gives you a real-time overview of your workforce. See who is clocked in, who is off today, which certifications are expiring, and which teams are assigned to jobs."),
+                ("How to Use It", "The smart cards at the top summarize key numbers at a glance. Scroll down to see details for Working Now, Off Today, Certifications Expiring Soon, and Team Assignments Today."),
+                ("Payment Alerts", "When payment tracking is enabled, overdue customer invoices appear at the bottom with the amount and number of days overdue."),
+                ("Tips", "Pull down to refresh the dashboard with the latest data. Tap into other People pages from the navigation menu to manage employees, customers, contractors, teams, and contacts."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "people-customers",
+            title: "Customers Help",
+            sections: [
+                ("What This Page Does", "View and manage all customers. Each row shows the company name, primary contact, email, and phone number."),
+                ("How to Use It", "Type in the search bar to filter customers by company name, contact name, or email. Tap a customer to see their full detail page with contacts, job history, billing, and communication logs. Tap the + button to add a new customer."),
+                ("Adding a Customer", "The contact name is required. You can also add a company name, email, phone, and address. Customers appear in the list immediately after saving."),
+                ("Tips", "Pull down to refresh the customer list. Tap into a customer to add additional contacts, record payments, or log communications like calls and meetings."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "people-contacts",
+            title: "Contacts Help",
+            sections: [
+                ("What This Page Does", "View and manage all contacts across your organization. Contacts include GCs, suppliers, contractors, owners, vendors, and other external people you work with."),
+                ("Smart Card Filters", "Tap the type cards at the top to filter by contact type: All, GC, Supplier, Contractor, Owner, Vendor, Active, or Inactive. The count on each card shows how many contacts match that type."),
+                ("Sorting & Search", "Use the sort button to order contacts by Recently Updated, Name, or Type. The search bar filters by first name, last name, company, or email."),
+                ("Tips", "Pull down to refresh. Contact type badges are color-coded by type. Tap the + button to add a new contact with a first name and phone number."),
+            ]
+        ),
+
+        HelpEntry(
             pageId: "people-employee-detail",
             title: "Employee Detail Help",
             sections: [
@@ -716,6 +762,16 @@ struct HelpContentRegistry {
                 ("What This Page Does", "Shows all items waiting for manager approval in one place. This includes JPO requests from field workers, scheduled part deletions, time-off requests, and tool edit verifications."),
                 ("How to Use It", "Use the filter cards at the top to narrow by type (JPOs, Deletions, Time-Off, Tool Edits). Search by name or requester. For each item, tap Approve or Reject. Rejections require a reason that gets sent back to the requester."),
                 ("Tips", "Pull down to refresh the list. Items disappear from this page once approved or rejected. If you reject a JPO, the field worker gets notified with your reason so they can revise and resubmit. This same page is accessible from both Office > Approvals and Orders > Approvals."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "office-spending",
+            title: "Spending Dashboard Help",
+            sections: [
+                ("Overview", "Aggregate spending data across all jobs. See total parts costs, labor costs, and budget utilization at a glance."),
+                ("Breakdown", "Cards show spending by category. Tap for detailed breakdowns by job, supplier, or time period."),
+                ("Permissions", "This page requires the show dollar values permission. Contact your admin if you cannot see cost data."),
             ]
         ),
 

--- a/docs/testing/ai-page-context-coverage.md
+++ b/docs/testing/ai-page-context-coverage.md
@@ -1,7 +1,7 @@
 # AI Page Context Coverage Inventory
 
 Issue: WEI-1112 / WEI-1194 / GitHub #86 T1-19
-Updated: 2026-05-14
+Updated: 2026-05-15
 
 ## Success Condition
 
@@ -9,9 +9,9 @@ Complete the 87-page page-context coverage set by adding read-only page-active/p
 
 ## Current Coverage
 
-Implemented page-context notifications observed by `IOSAIAssistantPanel`: 47 page contexts.
+Implemented page-context notifications observed by `IOSAIAssistantPanel`: 60 page contexts.
 
-Help registry mappings with matching help entries: 46 page contexts.
+Help registry mappings with matching help entries: 59 page contexts.
 
 Known gap: `settingsPageActive` is observed by the AI panel and active-page tracker, but `HelpContentRegistry` does not yet contain a `settings-app-config` entry. That should be handled in the settings slice rather than mapped to a missing help entry.
 
@@ -61,7 +61,20 @@ Known gap: `settingsPageActive` is observed by the AI panel and active-page trac
 | Warehouse | Warehouse Leaderboard | `warehouseLeaderboardPageActive` | `warehouse-leaderboard` |
 | Scheduling | Dispatch | `dispatchPageActive` | `scheduling-dispatch` |
 | Scheduling | Schedule Calendar | `scheduleCalendarPageActive` | `scheduling-calendar` |
+| People | People Dashboard | `peopleDashboardPageActive` | `people-dashboard` |
 | People | Employees | `employeesPageActive` | `people-employees` |
+| People | Customers | `customersPageActive` | `people-customers` |
+| People | Contacts | `contactsPageActive` | `people-contacts` |
+| Office | Office Dashboard | `officeDashboardPageActive` | `office-dashboard` |
+| Office | Unified Approvals | `officeApprovalsPageActive` | `office-approvals` |
+| Office | Spending Dashboard | `officeSpendingPageActive` | `office-spending` |
+| Reports | Labor Overview | `reportsLaborPageActive` | `reports-labor` |
+| Reports | Spending | `reportsSpendingPageActive` | `reports-spending` |
+| Reports | Profitability | `reportsProfitabilityPageActive` | `reports-profitability` |
+| Reports | Timesheets | `reportsTimesheetsPageActive` | `reports-timesheets` |
+| Reports | Pre-Billing | `reportsPrebillingPageActive` | `reports-prebilling` |
+| Reports | Bookkeeper Export | `reportsBookkeeperPageActive` | `reports-bookkeeper` |
+| Reports | Daily Reports Summary | `reportsDailySummaryPageActive` | `reports-daily-summary` |
 | Fleet | Vehicles | `vehiclesPageActive` | `fleet-vehicles` |
 | Tools | Tool Registry | `toolRegistryPageActive` | `tools-registry` |
 | Notebooks | Notebooks List | `notebooksListPageActive` | `notebooks-all` |
@@ -124,9 +137,29 @@ Added the jobs completion page-context slice:
 
 All payloads are read-only summaries of visible state, selected filters, lifecycle state, and available entry points. They do not expose mutating commands, action IDs, or write intents.
 
+## People/Office/Reports Slice
+
+Added the next People, Office, and Reports page-context slice:
+
+- `IOSPeopleDashboardPage`: working-now, off-today, certification, team assignment, and overdue customer counts.
+- `IOSCustomersPage`: loaded/visible customer counts and search state.
+- `IOSContactsPage`: active/inactive contact counts, selected type filter, sort, and search state.
+- `IOSOfficeDashboardPage`: smart card, attention item, schedule, financial snapshot, and background task row counts.
+- `IOSUnifiedApprovalsPage`: pending/visible approval counts, selected filter, and search state.
+- `IOSSpendingDashboardPage`: selected range, parts cost, labor hours, active job count, and total job count.
+- `IOSLaborOverviewPage`: selected range, total/overtime hours, active worker count, and visible row count.
+- `IOSSpendingPage`: selected range/period, total spend, PO count, and top supplier.
+- `IOSProfitabilityPage`: selected range, loaded/visible job counts, total profit, and search state.
+- `IOSTimesheetsPage`: selected dates, employee count, visible row count, total hours, and overtime.
+- `IOSPreBillingPage`: selected dates, job count, visible row count, regular hours, and overtime.
+- `IOSBookkeeperExportPage`: selected dates, labor/material row counts, material total, and search state.
+- `IOSDailyReportsSummaryPage`: selected date, job/visible row counts, worker count, and total hours.
+
+All payloads are read-only summaries of visible state, selected filters, lifecycle state, and report totals. They do not expose mutating commands, action IDs, or write intents.
+
 ## Next Highest-Traffic Remaining Slices
 
-1. People/Office/Reports: Contacts, customers, contractors, teams, office dashboard, approvals, spending, warehouse exec, all report pages.
+1. People/Office/Reports tail: contractors, teams, hats, permissions, office manage-jobs, warehouse exec, estimation settings, pipeline, teams, reports router, and specialized fleet/scheduling/warehouse report pages.
 2. Settings: add missing help entries and page context for the high-use settings pages before mapping them to help content.
 
 ## Validation
@@ -155,6 +188,12 @@ Validated jobs completion slice in the shared workspace on 2026-05-14:
 - Jobs completion notification names are declared, posted by their pages, observed by `IOSAIAssistantPanel`, tracked for active help page selection, and mapped in `HelpContentRegistry`.
 - Help registry mapping check returned no missing mapped page IDs.
 - `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` passed. Remaining output was warnings only.
+
+Validated People/Office/Reports slice in the shared workspace on 2026-05-15:
+
+- People/Office/Reports notification names are declared, posted by their pages, observed by `IOSAIAssistantPanel`, tracked for active help page selection, and mapped in `HelpContentRegistry`.
+- Help registry mapping check returned no missing mapped page IDs.
+- `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` passed. Remaining output was pre-existing warnings only.
 
 Static validation:
 


### PR DESCRIPTION
## Summary
- Adds read-only AI page context lifecycle notifications for the People/Office/Reports slice.
- Wires IOSAIAssistantPanel observers and active help-page tracking for the new contexts.
- Updates HelpContentRegistry mappings/help entries and the coverage inventory to 60 observed contexts / 59 mapped help entries.

## Verification
- Help registry mapping check returned no missing mapped page IDs.
- xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build

GitHub issue: #86
Paperclip: WEI-1112