### PR TITLE
Fix My Questions filter leaking all threads (GH #500 / WEI-1380)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSQuestionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSQuestionsPage.swift
@@ -98,7 +98,8 @@ struct IOSQuestionsPage: View {
         case .all: return threads.count
         case .open: return threads.filter { QAThreadStatusBuckets.isOpen($0.status) }.count
         case .myQuestions:
-            return threads.count // All shown for now — user-specific filtering added later
+            guard let currentUserId = appCore.currentUser?.id else { return 0 }
+            return threads.filter { $0.askedById == currentUserId }.count
         case .needsMyReview: return threads.filter { $0.status == "open" }.count
         case .resolved: return threads.filter { QAThreadStatusBuckets.isResolved($0.status) }.count
         }
@@ -189,7 +190,12 @@ struct IOSQuestionsPage: View {
         switch statusFilter {
         case .all: break
         case .open: items = items.filter { QAThreadStatusBuckets.isOpen($0.status) }
-        case .myQuestions: break // Show all for now
+        case .myQuestions:
+            guard let currentUserId = appCore.currentUser?.id else {
+                items = []
+                break
+            }
+            items = items.filter { $0.askedById == currentUserId }
         case .needsMyReview: items = items.filter { $0.status == "open" }
         case .resolved: items = items.filter { QAThreadStatusBuckets.isResolved($0.status) }
         }

--- a/core/Sources/WiredPartCore/Services/ChatService.swift
+++ b/core/Sources/WiredPartCore/Services/ChatService.swift
@@ -196,6 +196,7 @@ public final class ChatService: Sendable {
     public struct QAThreadRow: Sendable, Identifiable {
         public let id: Int64
         public let jobId: Int64
+        public let askedById: Int64?
         public let question: String
         public let askedByName: String
         public let currentLevel: String
@@ -205,12 +206,14 @@ public final class ChatService: Sendable {
         public let answeredByName: String?
 
         public init(
-            id: Int64, jobId: Int64 = 0, question: String, askedByName: String,
+            id: Int64, jobId: Int64 = 0, askedById: Int64? = nil,
+            question: String, askedByName: String,
             currentLevel: String, status: String, priority: String,
             answer: String?, answeredByName: String?
         ) {
             self.id = id
             self.jobId = jobId
+            self.askedById = askedById
             self.question = question
             self.askedByName = askedByName
             self.currentLevel = currentLevel
@@ -396,7 +399,7 @@ public final class ChatService: Sendable {
                 }
 
                 let sql = """
-                    SELECT qa.id, COALESCE(qa.job_id, 0) AS job_id, qa.subject, qa.current_level, qa.status, qa.priority,
+                    SELECT qa.id, COALESCE(qa.job_id, 0) AS job_id, qa.asked_by, qa.subject, qa.current_level, qa.status, qa.priority,
                            qa.answer_text,
                            COALESCE(ua.display_name, ua.email, 'Unknown') AS asked_by_name,
                            COALESCE(ub.display_name, ub.email) AS answered_by_name
@@ -412,6 +415,7 @@ public final class ChatService: Sendable {
                     QAThreadRow(
                         id: row["id"] ?? 0,
                         jobId: row["job_id"] ?? 0,
+                        askedById: row["asked_by"] as Int64?,
                         question: row["subject"] ?? "",
                         askedByName: row["asked_by_name"] ?? "Unknown",
                         currentLevel: row["current_level"] ?? "field",
@@ -441,7 +445,7 @@ public final class ChatService: Sendable {
                 }
 
                 let sql = """
-                    SELECT qa.id, COALESCE(qa.job_id, 0) AS job_id, qa.subject, qa.current_level, qa.status, qa.priority,
+                    SELECT qa.id, COALESCE(qa.job_id, 0) AS job_id, qa.asked_by, qa.subject, qa.current_level, qa.status, qa.priority,
                            qa.answer_text,
                            COALESCE(ua.display_name, ua.email, 'Unknown') AS asked_by_name,
                            COALESCE(ub.display_name, ub.email) AS answered_by_name
@@ -457,6 +461,7 @@ public final class ChatService: Sendable {
                     QAThreadRow(
                         id: row["id"] ?? 0,
                         jobId: row["job_id"] ?? 0,
+                        askedById: row["asked_by"] as Int64?,
                         question: row["subject"] ?? "",
                         askedByName: row["asked_by_name"] ?? "Unknown",
                         currentLevel: row["current_level"] ?? "field",

--- a/core/Tests/WiredPartCoreTests/ChatServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ChatServiceTests.swift
@@ -96,6 +96,7 @@ struct ChatServiceTests {
         let threads = try env.chat.listQAThreads(status: nil)
         #expect(threads.count >= 1)
         #expect(threads.first?.question == "Where are the 12 AWG connectors?")
+        #expect(threads.first?.askedById == env.adminUserId)
     }
 
     @Test("Filter QA threads by job")
@@ -110,6 +111,7 @@ struct ChatServiceTests {
         let job1Threads = try env.chat.listQAThreads(jobId: job1, status: nil)
         #expect(job1Threads.count == 1)
         #expect(job1Threads.first?.question == "Q for Job 1")
+        #expect(job1Threads.first?.askedById == env.adminUserId)
     }
 
     @Test("Escalate and resolve QA thread")


### PR DESCRIPTION
## Summary
- scope My Questions thread filtering to the signed-in user by carrying `asked_by` through `QAThreadRow`
- apply the user-specific filter/count in `IOSQuestionsPage` when `showMineOnly` is selected
- extend `ChatServiceTests` assertions to verify `askedById` is returned for listed QA threads

## Verification
- `swift test --package-path core --filter ChatServiceTests`

## Links
- Closes #500
- WEI-1380
