### PR TITLE
Fix audit adjustment movement deltas

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
@@ -647,7 +647,11 @@ struct WarehouseDashboardPage: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    if let from = movement.fromLocationType, let to = movement.toLocationType {
+                    if let auditSummary = auditSummaryText(for: movement) {
+                        Text(auditSummary)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    } else if let from = movement.fromLocationType, let to = movement.toLocationType {
                         Text("\(from.capitalized) → \(to.capitalized)")
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
@@ -658,7 +662,7 @@ struct WarehouseDashboardPage: View {
             Spacer()
 
             VStack(alignment: .trailing, spacing: 3) {
-                Text("\(movement.qty)")
+                Text(quantityLabel(for: movement))
                     .font(.subheadline)
                     .fontWeight(.semibold)
                 Text(formatDate(movement.createdAt))
@@ -747,6 +751,18 @@ struct WarehouseDashboardPage: View {
         case "adjustment": "Adjustment"
         default: type.capitalized
         }
+    }
+
+    private func auditSummaryText(for movement: WarehouseService.MovementRow) -> String? {
+        guard movement.movementType == "adjustment",
+              let notes = movement.notes,
+              notes.hasPrefix("Audit count adjustment:") else { return nil }
+        return notes.replacingOccurrences(of: "Audit count adjustment:", with: "Audit:")
+    }
+
+    private func quantityLabel(for movement: WarehouseService.MovementRow) -> String {
+        guard movement.movementType == "adjustment" else { return "\(movement.qty)" }
+        return movement.qty >= 0 ? "+\(movement.qty)" : "\(movement.qty)"
     }
 
     private func formatDate(_ dateStr: String?) -> String {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
@@ -761,7 +761,8 @@ struct WarehouseDashboardPage: View {
     }
 
     private func quantityLabel(for movement: WarehouseService.MovementRow) -> String {
-        guard movement.movementType == "adjustment" else { return "\(movement.qty)" }
+        guard movement.movementType == "adjustment",
+              auditSummaryText(for: movement) != nil else { return "\(movement.qty)" }
         return movement.qty >= 0 ? "+\(movement.qty)" : "\(movement.qty)"
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
@@ -309,7 +309,11 @@ struct WarehouseMovementsPage: View {
                         .background(movementColor(movement.movementType).opacity(0.1))
                         .clipShape(Capsule())
 
-                    if let from = movement.fromLocationType, let to = movement.toLocationType {
+                    if let auditSummary = auditSummaryText(for: movement) {
+                        Text(auditSummary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else if let from = movement.fromLocationType, let to = movement.toLocationType {
                         Text("\(from.capitalized) → \(to.capitalized)")
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -320,7 +324,7 @@ struct WarehouseMovementsPage: View {
             Spacer()
 
             VStack(alignment: .trailing, spacing: 3) {
-                Text("×\(movement.qty)")
+                Text(quantityLabel(for: movement))
                     .font(.subheadline)
                     .fontWeight(.semibold)
                 Text(formatDate(movement.createdAt))
@@ -421,6 +425,18 @@ struct WarehouseMovementsPage: View {
         case "adjustment": "Adjustment"
         default: type.capitalized
         }
+    }
+
+    private func auditSummaryText(for movement: WarehouseService.MovementRow) -> String? {
+        guard movement.movementType == "adjustment",
+              let notes = movement.notes,
+              notes.hasPrefix("Audit count adjustment:") else { return nil }
+        return notes.replacingOccurrences(of: "Audit count adjustment:", with: "Audit:")
+    }
+
+    private func quantityLabel(for movement: WarehouseService.MovementRow) -> String {
+        guard movement.movementType == "adjustment" else { return "×\(movement.qty)" }
+        return movement.qty >= 0 ? "+\(movement.qty)" : "\(movement.qty)"
     }
 
     private func formatDate(_ dateStr: String?) -> String {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
@@ -435,7 +435,8 @@ struct WarehouseMovementsPage: View {
     }
 
     private func quantityLabel(for movement: WarehouseService.MovementRow) -> String {
-        guard movement.movementType == "adjustment" else { return "×\(movement.qty)" }
+        guard movement.movementType == "adjustment",
+              auditSummaryText(for: movement) != nil else { return "×\(movement.qty)" }
         return movement.qty >= 0 ? "+\(movement.qty)" : "\(movement.qty)"
     }
 

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -1714,6 +1714,8 @@ public final class WarehouseService: Sendable {
                 arguments: [partId, locationType, locationId]
             ) ?? 0
             let delta = newQty - currentQty
+            guard delta != 0 else { return }
+            let signedDelta = delta >= 0 ? "+\(delta)" : "\(delta)"
 
             // Update the stock record
             try dbConn.execute(

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -1908,10 +1908,9 @@ public final class WarehouseService: Sendable {
                 arguments: [partId, locationType, locationId]
             ) ?? 0
             let delta = newQty - currentQty
-            guard delta != 0 else { return }
-            let signedDelta = delta >= 0 ? "+\(delta)" : "\(delta)"
 
-            // Update the stock record
+            // Update the stock record even when the counted quantity is unchanged,
+            // because a zero-delta audit still refreshes the count timestamp.
             try dbConn.execute(
                 sql: """
                     UPDATE stock SET qty = ?, last_counted = datetime('now'), updated_at = datetime('now')

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -1696,16 +1696,18 @@ public final class WarehouseService: Sendable {
                 arguments: [partId, locationType, locationId]
             ) ?? 0
             let delta = newQty - currentQty
-            let signedDelta = delta >= 0 ? "+\(delta)" : "\(delta)"
 
             // Update the stock record
             try dbConn.execute(
                 sql: """
                     UPDATE stock SET qty = ?, last_counted = datetime('now'), updated_at = datetime('now')
                     WHERE part_id = ? AND location_type = ? AND location_id = ? AND deleted_at IS NULL
-                    """,
+                """,
                 arguments: [newQty, partId, locationType, locationId]
             )
+
+            guard delta != 0 else { return }
+            let signedDelta = delta >= 0 ? "+\(delta)" : "\(delta)"
 
             // Record audit adjustments as the signed quantity delta, not the absolute new count.
             try dbConn.execute(

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -1687,6 +1687,17 @@ public final class WarehouseService: Sendable {
                     """, arguments: [uid]) ?? 0) > 0
                 guard userExists else { throw WarehouseError.userNotFound(uid) }
             }
+            let currentQty = try Int.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT qty FROM stock
+                    WHERE part_id = ? AND location_type = ? AND location_id = ? AND deleted_at IS NULL
+                    """,
+                arguments: [partId, locationType, locationId]
+            ) ?? 0
+            let delta = newQty - currentQty
+            let signedDelta = delta >= 0 ? "+\(delta)" : "\(delta)"
+
             // Update the stock record
             try dbConn.execute(
                 sql: """
@@ -1696,13 +1707,23 @@ public final class WarehouseService: Sendable {
                 arguments: [newQty, partId, locationType, locationId]
             )
 
-            // Record the adjustment as a movement
+            // Record audit adjustments as the signed quantity delta, not the absolute new count.
             try dbConn.execute(
                 sql: """
                     INSERT INTO stock_movements (part_id, qty, from_location_type, from_location_id, to_location_type, to_location_id, movement_type, reason, notes, performed_by, created_at)
-                    VALUES (?, ?, ?, ?, ?, ?, 'adjustment', ?, 'Audit count adjustment', ?, datetime('now'))
+                    VALUES (?, ?, ?, ?, ?, ?, 'adjustment', ?, ?, ?, datetime('now'))
                     """,
-                arguments: [partId, newQty, locationType, locationId, locationType, locationId, reason ?? "Audit adjustment", performedBy]
+                arguments: [
+                    partId,
+                    delta,
+                    locationType,
+                    locationId,
+                    locationType,
+                    locationId,
+                    reason ?? "Audit adjustment",
+                    "Audit count adjustment: \(currentQty) -> \(newQty) (\(signedDelta))",
+                    performedBy,
+                ]
             )
         }
     }
@@ -4486,17 +4507,16 @@ public final class WarehouseService: Sendable {
                 try conf.update(dbConn)
             }
 
-            // Update the latest active audit session if one exists. Use a subquery
-            // instead of UPDATE ... ORDER BY ... LIMIT because the bundled SQLite
-            // build used by tests does not enable UPDATE_LIMIT syntax.
+            // Update the most recently started active audit session for this user, if one exists.
+            // SQLite builds do not consistently allow ORDER BY/LIMIT directly on UPDATE,
+            // so select the target row in a subquery first.
             try dbConn.execute(sql: """
                 UPDATE audit_sessions_v2
                 SET misplaced_found = misplaced_found + 1
                 WHERE id = (
                     SELECT id FROM audit_sessions_v2
                     WHERE status = 'active' AND started_by = ?
-                    ORDER BY started_at DESC
-                    LIMIT 1
+                    ORDER BY started_at DESC LIMIT 1
                 )
                 """, arguments: [foundBy])
 

--- a/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
@@ -676,6 +676,39 @@ struct WarehouseAuditTests {
         #expect((movement?["notes"] as String?) == "Audit count adjustment: 10 -> 14 (+4)")
     }
 
+    @Test("adjustAuditCount with unchanged quantity updates count timestamp and skips adjustment movement")
+    func testAdjustAuditCountSkipsZeroDeltaMovement() throws {
+        let env = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10)
+
+        try env.warehouse.adjustAuditCount(
+            partId: partId,
+            locationType: "warehouse",
+            locationId: 1,
+            newQty: 10,
+            reason: "Physical count",
+            performedBy: env.adminUserId
+        )
+
+        let stockAndMovement = try env.db.writer.read { db in
+            let stock = try Row.fetchOne(db, sql: """
+                SELECT qty, last_counted FROM stock
+                WHERE part_id = ? AND location_type = 'warehouse' AND location_id = 1
+                """, arguments: [partId])
+            let movementCount = try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM stock_movements
+                WHERE part_id = ? AND movement_type = 'adjustment'
+                """, arguments: [partId]) ?? 0
+            return (stock, movementCount)
+        }
+
+        #expect((stockAndMovement.0?["qty"] as Int?) == 10)
+        #expect((stockAndMovement.0?["last_counted"] as String?) != nil)
+        #expect(stockAndMovement.1 == 0)
+    }
+
     @Test("recordAuditRecount updates last_counted timestamp for stock row")
     func testRecordAuditRecount() throws {
         let env = try freshEnv()

--- a/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
@@ -619,7 +619,7 @@ struct WarehouseAuditTests {
         #expect((row?["status"] as String?) == "completed")
     }
 
-    @Test("adjustAuditCount updates stock qty and records adjustment movement")
+    @Test("adjustAuditCount updates stock qty and records negative delta adjustment movement")
     func testAdjustAuditCount() throws {
         let env = try freshEnv()
         let catId = try E2ETestHelpers.seedCategory(env)
@@ -638,9 +638,42 @@ struct WarehouseAuditTests {
         let qty = try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1)
         #expect(qty == 7)
 
-        // Verify the adjustment movement was recorded
-        let movements = try env.warehouse.listMovements(movementType: "adjustment")
-        #expect(movements.contains { $0.partId == partId })
+        let movement = try env.db.writer.read { db in
+            try Row.fetchOne(db, sql: """
+                SELECT qty, notes FROM stock_movements
+                WHERE part_id = ? AND movement_type = 'adjustment'
+                ORDER BY id DESC LIMIT 1
+                """, arguments: [partId])
+        }
+        #expect((movement?["qty"] as Int?) == -3)
+        #expect((movement?["notes"] as String?) == "Audit count adjustment: 10 -> 7 (-3)")
+    }
+
+    @Test("adjustAuditCount records positive delta adjustment movement")
+    func testAdjustAuditCountRecordsPositiveDelta() throws {
+        let env = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10)
+
+        try env.warehouse.adjustAuditCount(
+            partId: partId,
+            locationType: "warehouse",
+            locationId: 1,
+            newQty: 14,
+            reason: "Physical count",
+            performedBy: env.adminUserId
+        )
+
+        let movement = try env.db.writer.read { db in
+            try Row.fetchOne(db, sql: """
+                SELECT qty, notes FROM stock_movements
+                WHERE part_id = ? AND movement_type = 'adjustment'
+                ORDER BY id DESC LIMIT 1
+                """, arguments: [partId])
+        }
+        #expect((movement?["qty"] as Int?) == 4)
+        #expect((movement?["notes"] as String?) == "Audit count adjustment: 10 -> 14 (+4)")
     }
 
     @Test("recordAuditRecount updates last_counted timestamp for stock row")

--- a/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
@@ -853,7 +853,6 @@ struct WarehouseAuditTests {
         let catId = try E2ETestHelpers.seedCategory(env)
         let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
         _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10)
-
         try env.warehouse.adjustAuditCount(
             partId: partId,
             locationType: "warehouse",


### PR DESCRIPTION
## Summary
- record audit count adjustments as signed quantity deltas instead of the final absolute stock count
- include audit adjustment notes showing previous count, new count, and delta
- show audit adjustment summaries and signed quantities in warehouse movement rows
- fix an SQLite-compatible misplaced-parts audit-session update uncovered by the warehouse audit test suite

Closes #354

## Tests
- `swift test --package-path core --filter "WarehouseAuditTests/testAdjustAuditCount|WarehouseAuditTests/testAdjustAuditCountRecordsPositiveDelta"`
- `swift test --package-path core --filter WarehouseAuditTests`
- `swift test --package-path core` was also started, but timed out after 600s while still running with no failure shown in the captured output.