### PR TITLE
fix(tools): run scheduled maintenance on startup

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -248,6 +248,33 @@ final class AppCore: ObservableObject {
                 _ = try? backgroundTaskService?.cleanupOldEntries()
             }
 
+            // Run scheduled Tools maintenance on launch so expired trades and
+            // confidence-score decay are handled even when users do not open a tool detail page.
+            Task.detached { [toolsService, backgroundTaskService] in
+                let taskId = try? backgroundTaskService?.startTask(
+                    name: "Tools Scheduled Maintenance",
+                    type: "tools_maintenance"
+                )
+                do {
+                    let result = try toolsService?.runScheduledMaintenance()
+                    if let taskId {
+                        let expiredTrades = result?.expiredTrades ?? 0
+                        let updatedScores = result?.updatedConfidenceScores ?? 0
+                        try? backgroundTaskService?.completeTask(
+                            id: taskId,
+                            summary: "Expired \(expiredTrades) trade(s); updated \(updatedScores) confidence score(s)"
+                        )
+                    }
+                } catch {
+                    if let taskId {
+                        try? backgroundTaskService?.failTask(
+                            id: taskId,
+                            error: error.localizedDescription
+                        )
+                    }
+                }
+            }
+
             // Run companion auto-discovery cycle in the background (logged)
             Task.detached { [partsService, backgroundTaskService] in
                 let taskId = try? backgroundTaskService?.startTask(

--- a/core/Sources/WiredPartCore/Services/ToolsService.swift
+++ b/core/Sources/WiredPartCore/Services/ToolsService.swift
@@ -19,6 +19,17 @@ public final class ToolsService: Sendable {
     // MARK: - Result Types
     // =========================================================================
 
+    /// Counts returned by automatic Tools maintenance jobs.
+    public struct ScheduledMaintenanceResult: Sendable, Equatable {
+        public let expiredTrades: Int
+        public let updatedConfidenceScores: Int
+
+        public init(expiredTrades: Int, updatedConfidenceScores: Int) {
+            self.expiredTrades = expiredTrades
+            self.updatedConfidenceScores = updatedConfidenceScores
+        }
+    }
+
     /// A tool row for list views with assignment info.
     public struct ToolListItem: Sendable, Identifiable {
         public let id: Int64
@@ -1213,6 +1224,17 @@ public final class ToolsService: Sendable {
                                      String(fromUserId), String(toUserId)])
             }
         }
+    }
+
+    /// Run all Tools maintenance jobs that should be performed automatically on app startup.
+    @discardableResult
+    public func runScheduledMaintenance() throws -> ScheduledMaintenanceResult {
+        let expiredTrades = try expireOldTrades()
+        let updatedConfidenceScores = try updateConfidenceScores()
+        return ScheduledMaintenanceResult(
+            expiredTrades: expiredTrades,
+            updatedConfidenceScores: updatedConfidenceScores
+        )
     }
 
     /// Expire old trades that passed 7-day window.

--- a/core/Tests/WiredPartCoreTests/ToolsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ToolsServiceTests.swift
@@ -1313,6 +1313,54 @@ struct ToolsServiceTests {
         #expect(abs(score - 0.9) < 0.0001, "Confidence score should decay from 1.0 to 0.9 with decay_rate=0.1")
     }
 
+    @Test("runScheduledMaintenance expires old trades and updates confidence scores")
+    func testRunScheduledMaintenance_runsAllToolsMaintenanceJobs() throws {
+        let env = try E2ETestHelpers.setUp()
+        let tradeToolId = try insertTool(
+            env, toolNumber: "T-SCHED-TRADE", name: "Scheduled Trade Tool",
+            status: "checked_out", assignedTo: env.adminUserId
+        )
+        let decayToolId = try insertTool(env, toolNumber: "T-SCHED-DECAY", name: "Scheduled Decay Tool")
+        let recipientId = try env.db.writer.write { db -> Int64 in
+            try db.execute(sql: """
+                INSERT INTO users (display_name, pin_hash, is_active, created_at, updated_at)
+                VALUES ('ScheduledTradeRecipient', 'hash', 1, datetime('now'), datetime('now'))
+                """)
+            return db.lastInsertedRowID
+        }
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO tool_trades
+                    (tool_id, from_user_id, to_user_id, condition_at_send, status, expires_at, created_at)
+                VALUES (?, ?, ?, 'Good', 'pending', datetime('now', '-1 day'), datetime('now'))
+                """, arguments: [tradeToolId, env.adminUserId, recipientId])
+            try db.execute(sql: "UPDATE tools SET confidence_score = 1.0 WHERE id = ?", arguments: [decayToolId])
+            try db.execute(sql: """
+                INSERT INTO tool_maintenance_configs
+                    (tool_id, maintenance_type, decay_rate, is_active, created_at)
+                VALUES (?, 'decreasing_based', 0.25, 1, datetime('now'))
+                """, arguments: [decayToolId])
+        }
+
+        let result = try env.tools.runScheduledMaintenance()
+
+        #expect(result.expiredTrades == 1)
+        #expect(result.updatedConfidenceScores == 1)
+
+        let row = try env.db.writer.read { db in
+            try Row.fetchOne(db, sql: """
+                SELECT
+                    (SELECT status FROM tool_trades WHERE tool_id = ?) AS trade_status,
+                    (SELECT confidence_score FROM tools WHERE id = ?) AS confidence_score
+                """, arguments: [tradeToolId, decayToolId])
+        }
+        let tradeStatus: String? = row?["trade_status"]
+        let confidenceScore: Double = row?["confidence_score"] ?? -1
+        #expect(tradeStatus == "expired")
+        #expect(abs(confidenceScore - 0.75) < 0.0001)
+    }
+
     // MARK: - ratingToCondition (pure static)
 
     @Test("ratingToCondition maps 5 to Excellent")


### PR DESCRIPTION
## Summary
- Add a ToolsService scheduled-maintenance entry point that runs trade expiration and confidence-score decay together.
- Run Tools scheduled maintenance from AppCore startup with background task logging.
- Add regression coverage proving scheduled maintenance expires old trades and updates confidence scores.

## Test Plan
- swift test --filter ToolsServiceTests/testRunScheduledMaintenance_runsAllToolsMaintenanceJobs
- swift test --filter ToolsServiceTests
- swift test (timed out after 600s while still running; no failures observed before timeout)

Refs WEI-365