### PR TITLE
[Tools][UX] Add presentation detents to tools sheets

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolAdminPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolAdminPage.swift
@@ -49,6 +49,8 @@ struct IOSToolAdminPage: View {
                     ("Tips", "Use this page for audits and inventory checks. Sort through tools to verify serial numbers match physical tools. If a tool shows 'Checked Out' but is sitting on the shelf, open its detail page and return it to keep records accurate.")
                 ]
             )
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
         }
         .refreshable { await loadData() }
         .task { await loadData() }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolCheckoutsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolCheckoutsPage.swift
@@ -61,6 +61,8 @@ struct IOSToolCheckoutsPage: View {
                     }
                 }
                 .environmentObject(appCore)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
             case .help:
                 PageHelpSheet(
                     title: "Tool Checkouts Help",
@@ -73,6 +75,8 @@ struct IOSToolCheckoutsPage: View {
                         ("Tips", "Keep an eye on overdue tools. If a tool is overdue, contact the person who has it. Regular checkout tracking prevents lost tools and keeps the team accountable.")
                     ]
                 )
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
             }
         }
         .alert("Tool Scanned", isPresented: $showCheckoutConfirm) {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolDetailPage.swift
@@ -49,6 +49,15 @@ struct IOSToolDetailPage: View {
             case .help: "help"
             }
         }
+
+        var presentationDetents: Set<PresentationDetent> {
+            switch self {
+            case .help:
+                [.medium, .large]
+            default:
+                [.large]
+            }
+        }
     }
 
     var body: some View {
@@ -107,7 +116,7 @@ struct IOSToolDetailPage: View {
         }
         .sheet(item: $activeSheet) { sheet in
             sheetContent(sheet)
-                .presentationDetents([.large])
+                .presentationDetents(sheet.presentationDetents)
                 .presentationDragIndicator(.visible)
         }
         .refreshable { loadAllData() }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolDetailPage.swift
@@ -107,6 +107,8 @@ struct IOSToolDetailPage: View {
         }
         .sheet(item: $activeSheet) { sheet in
             sheetContent(sheet)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
         }
         .refreshable { loadAllData() }
         .task { loadAllData() }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolKitsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolKitsPage.swift
@@ -48,6 +48,8 @@ struct IOSToolKitsPage: View {
                         ("Tips", "Before heading to a job site, check that your kit shows 'Complete'. If it says 'Incomplete', open the kit detail to see which tools are missing and track them down before you leave.")
                     ]
                 )
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
             }
             .refreshable { await loadData() }
             .task { await loadData() }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolMaintenancePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolMaintenancePage.swift
@@ -53,6 +53,8 @@ struct IOSToolMaintenancePage: View {
                     ("Tips", "Check this page regularly. Tools stuck in maintenance for a long time may need follow-up with the repair shop. If this list is empty, all tools are in working order.")
                 ]
             )
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
         }
         .refreshable { await loadData() }
         .task { await loadData() }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolRegistryPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolRegistryPage.swift
@@ -76,6 +76,8 @@ struct IOSToolRegistryPage: View {
                     }
                 }
                 .environmentObject(appCore)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
             case .printLabels:
                 QRLabelPrintSheet(items: filteredTools.map { tool in
                     QRLabelContent(
@@ -87,6 +89,8 @@ struct IOSToolRegistryPage: View {
                         detail: tool.assignedToName
                     )
                 })
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
             case .help:
                 PageHelpSheet(
                     title: "All Tools Help",
@@ -99,6 +103,8 @@ struct IOSToolRegistryPage: View {
                         ("Tips", "Tools with a red 'Lost' badge need investigation. Orange 'Maintenance' tools are out of service. Green 'Available' tools are ready for checkout.")
                     ]
                 )
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
             }
         }
         .onChange(of: searchText) { Task { await loadData() } }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolsDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolsDashboardPage.swift
@@ -47,6 +47,8 @@ struct IOSToolsDashboardPage: View {
                         ("Tips", "Pull down anywhere on the page to refresh the data. If you see a high number of tools in maintenance, check the Maintenance tab for details.")
                     ]
                 )
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
             }
             .refreshable { await loadData() }
             .task { await loadData() }


### PR DESCRIPTION
## Summary
- Adds explicit presentation detents and visible drag indicators to the 7 tools iOS page sheet presenters from GitHub #268 / WEI-398.
- Uses medium+large detents for short PageHelpSheet help content and large detents for scanner/detail/print-label workflows.

## Verification
- Python regression scan confirmed all seven tools page .sheet blocks include presentationDetents and presentationDragIndicator.
- xcodebuild -workspace 'Wierd Parts.xcworkspace' -scheme 'WiredPart-iOS' -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build

Closes #268