### PR TITLE
Fix fleet DateFormatter hot-path allocations

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSFleetDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSFleetDashboardPage.swift
@@ -226,10 +226,12 @@ struct IOSFleetDashboardPage: View {
                 .background(Color(.secondarySystemGroupedBackground))
                 .clipShape(RoundedRectangle(cornerRadius: 12))
             } else {
+                let todayString = Formatters.localDateFormatter.string(from: Date())
+
                 VStack(spacing: 0) {
                     ForEach(Array(vehicles.enumerated()), id: \.element.id) { index, vehicle in
                         NavigationLink(value: vehicle.id) {
-                            vehicleStatusRow(vehicle)
+                            vehicleStatusRow(vehicle, todayString: todayString)
                         }
                         .buttonStyle(.plain)
 
@@ -244,7 +246,7 @@ struct IOSFleetDashboardPage: View {
         }
     }
 
-    private func vehicleStatusRow(_ vehicle: FleetService.VehicleStatusItem) -> some View {
+    private func vehicleStatusRow(_ vehicle: FleetService.VehicleStatusItem, todayString: String) -> some View {
         HStack(spacing: 12) {
             Image(systemName: vehicleIcon(vehicle.vehicleType))
                 .font(.body)
@@ -499,12 +501,6 @@ struct IOSFleetDashboardPage: View {
         case "maintenance": return .orange
         default: return .secondary
         }
-    }
-
-    private var todayString: String {
-        let fmt = DateFormatter()
-        fmt.dateFormat = "yyyy-MM-dd"
-        return fmt.string(from: Date())
     }
 
     // MARK: - Data Loading

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSFuelPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSFuelPage.swift
@@ -153,10 +153,8 @@ struct IOSFuelPage: View {
         isLoading = fuelLogs.isEmpty
         loadError = nil
         do {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd"
-            let startStr = formatter.string(from: effectiveStart)
-            let endStr = formatter.string(from: effectiveEnd)
+            let startStr = Formatters.localDateFormatter.string(from: effectiveStart)
+            let endStr = Formatters.localDateFormatter.string(from: effectiveEnd)
             fuelLogs = try service.listFuelLogs(start: startStr, end: endStr)
         } catch {
             loadError = userFriendlyError(error, context: "load fuel data")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMaintenancePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMaintenancePage.swift
@@ -159,10 +159,8 @@ struct IOSMaintenancePage: View {
         isLoading = records.isEmpty
         loadError = nil
         do {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd"
-            let startStr = formatter.string(from: effectiveStart)
-            let endStr = formatter.string(from: effectiveEnd)
+            let startStr = Formatters.localDateFormatter.string(from: effectiveStart)
+            let endStr = Formatters.localDateFormatter.string(from: effectiveEnd)
             records = try service.listMaintenanceRecords(start: startStr, end: endStr)
         } catch {
             loadError = userFriendlyError(error, context: "load maintenance data")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMileagePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMileagePage.swift
@@ -151,10 +151,8 @@ struct IOSMileagePage: View {
         isLoading = mileageLogs.isEmpty
         loadError = nil
         do {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd"
-            let startStr = formatter.string(from: effectiveStart)
-            let endStr = formatter.string(from: effectiveEnd)
+            let startStr = Formatters.localDateFormatter.string(from: effectiveStart)
+            let endStr = Formatters.localDateFormatter.string(from: effectiveEnd)
             mileageLogs = try service.listMileageLogs(start: startStr, end: endStr)
         } catch {
             loadError = userFriendlyError(error, context: "load mileage data")


### PR DESCRIPTION
## Summary
- Reuses shared `Formatters.localDateFormatter` in Fleet fuel, mileage, and maintenance date-range loads
- Computes Fleet Dashboard today string once per vehicle-list render instead of allocating a formatter per row
- Removes the four Fleet `DateFormatter()` hot-path allocations tracked by GH #315

## Test Plan
- `xcodebuild -workspace 'Wierd Parts.xcworkspace' -scheme 'WiredPart-iOS' -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`

Closes #315

Paperclip: WEI-379