### PR TITLE
fix: add service permission gates

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -123,6 +123,7 @@ extension AppDatabase {
         registerMigration084WarehouseOnboardingCompletedSteps(&migrator)
         registerMigration085AuditSessionEvents(&migrator)
         registerMigration086PartAutoWishlistOptIn(&migrator)
+        registerMigration087ServicePermissionGateBackfill(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -5127,6 +5128,45 @@ extension AppDatabase {
                 type: .integer,
                 defaultValue: 0
             )
+        }
+    }
+
+    private static func registerMigration087ServicePermissionGateBackfill(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("087_service_permission_gate_backfill") { db in
+            let permissionGrants: [(key: String, hats: [String])] = [
+                ("manage_chat", ["Admin", "Manager"]),
+                ("moderate_chat", ["Admin", "Manager", "Office"]),
+                ("send_rfi", ["Admin", "Manager", "Lead", "Office"]),
+                ("manage_orders", ["Admin", "Manager", "Office"]),
+                ("manage_notebooks", ["Admin", "Manager", "Lead", "Office"]),
+                ("manage_templates", ["Admin", "Manager", "Office"]),
+                ("view_job_reports", ["Admin", "Manager", "Lead", "Office"]),
+                ("view_jobs", ["Admin", "Manager", "Lead", "Office", "Worker"]),
+                ("manage_fleet", ["Admin", "Manager"]),
+                ("manage_people", ["Admin", "Manager", "Office"]),
+                ("view_reports", ["Admin", "Manager", "Office"]),
+                ("approve_time_off", ["Admin", "Manager", "Office"]),
+                ("move_stock_warehouse", ["Admin", "Manager", "Lead", "Worker"]),
+                ("perform_audit", ["Admin", "Manager", "Lead", "Worker"]),
+                ("manage_warehouse", ["Admin", "Manager", "Lead"]),
+                ("manage_tools", ["Admin", "Manager"]),
+                ("checkout_tools", ["Admin", "Manager", "Lead", "Worker"]),
+                ("maintain_tools", ["Admin", "Manager", "Lead"]),
+                ("create_jobs", ["Admin", "Manager", "Lead", "Office"]),
+                ("forecasting.approve_recommendation", ["Admin", "Manager"]),
+                ("forecasting.dismiss_recommendation", ["Admin", "Manager"]),
+                ("parts.manage_company_costs", ["Admin", "Manager"]),
+                ("parts.approve_scheduled_deletion", ["Admin", "Manager"]),
+            ]
+
+            for grant in permissionGrants {
+                for hatName in grant.hats {
+                    try db.execute(sql: """
+                        INSERT OR IGNORE INTO hat_permissions (hat_id, permission_key)
+                        SELECT id, ? FROM hats WHERE name = ?
+                        """, arguments: [grant.key, hatName])
+                }
+            }
         }
     }
 

--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -8,8 +8,8 @@ public final class AppDatabase: Sendable {
     public let writer: any DatabaseWriter
 
     /// The total number of registered migrations. Update when adding new migrations.
-    /// Migrations are 000-084, so count = 85.
-    public static let schemaVersion = 84
+    /// Migrations are 000-087.
+    public static let schemaVersion = 87
 
     /// Initialize with an existing database writer and run all migrations.
     public init(_ writer: any DatabaseWriter) throws {

--- a/core/Sources/WiredPartCore/Services/ChatService.swift
+++ b/core/Sources/WiredPartCore/Services/ChatService.swift
@@ -356,6 +356,10 @@ public final class ChatService: Sendable {
         jobId: Int64? = nil,
         createdBy: Int64
     ) throws -> Int64 {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_chat")
+        }
+
         guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw ChatError.requiredFieldEmpty
         }
@@ -653,7 +657,11 @@ public final class ChatService: Sendable {
         holdReason: String?,
         userId: Int64
     ) throws -> Int64 {
-        try db.writer.write { dbConn in
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "manage_orders")
+        }
+
+        return try db.writer.write { dbConn in
             let channelName = "Hold: \(partName) (\(jpoNumber))"
 
             // Check if a thread already exists for this part + JPO
@@ -915,6 +923,10 @@ public final class ChatService: Sendable {
     /// `userId` must flow from the session; no default to prevent hardcoded user 1
     /// attribution on auto-created notebooks (documented in memory/feedback_hardcoded_user_ids.md).
     public func autoSaveToJobNotebook(channelId: Int64, attachment: MessageAttachment, userId: Int64) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "manage_notebooks")
+        }
+
         try db.writer.write { dbConn in
             // Get job ID from channel
             guard let row = try Row.fetchOne(dbConn, sql: """
@@ -1218,6 +1230,10 @@ public final class ChatService: Sendable {
 
     /// Escalate a Q&A thread to the next level.
     public func escalateThread(threadId: Int64, escalatedBy: Int64, notes: String?) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: escalatedBy, permissionKey: "moderate_chat")
+        }
+
         try db.writer.write { dbConn in
             guard let row = try Row.fetchOne(dbConn, sql: """
                 SELECT current_level FROM qa_threads WHERE id = ? AND deleted_at IS NULL
@@ -1320,7 +1336,11 @@ public final class ChatService: Sendable {
         createdBy: Int64,
         jobId: Int64? = nil
     ) throws -> Int64 {
-        try db.writer.write { dbConn in
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_chat")
+        }
+
+        return try db.writer.write { dbConn in
             // Create the channel with type "supplier" and optional job link
             try dbConn.execute(sql: """
                 INSERT INTO chat_channels (channel_type, job_id, name, created_by, is_active, created_at)

--- a/core/Sources/WiredPartCore/Services/DashboardService.swift
+++ b/core/Sources/WiredPartCore/Services/DashboardService.swift
@@ -1394,7 +1394,11 @@ public final class DashboardService: Sendable {
         issues: String,
         tomorrowNotes: String
     ) throws -> Int64 {
-        try db.writer.write { conn in
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "view_job_reports")
+        }
+
+        return try db.writer.write { conn in
             // Find or create a "Daily Reports" notebook for this user
             var notebookId = try Int64.fetchOne(conn, sql: """
                 SELECT id FROM notebooks
@@ -1465,7 +1469,11 @@ public final class DashboardService: Sendable {
         jobId: Int64?,
         description: String
     ) throws -> Int64 {
-        try db.writer.write { conn in
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "view_jobs")
+        }
+
+        return try db.writer.write { conn in
             // Find or create a "Problem Reports" notebook
             var notebookId = try Int64.fetchOne(conn, sql: """
                 SELECT id FROM notebooks

--- a/core/Sources/WiredPartCore/Services/FleetService.swift
+++ b/core/Sources/WiredPartCore/Services/FleetService.swift
@@ -1755,6 +1755,10 @@ public final class FleetService: Sendable {
         trailerId: Int64, locationType: String, locationLabel: String?,
         jobId: Int64? = nil, recordedBy: Int64
     ) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: recordedBy, permissionKey: "manage_fleet")
+        }
+
         try db.writer.write { dbConn in
             // Guard: trailer must be active and not tombstoned — inserting history
             // against a soft-deleted trailer creates an orphan audit row and leaves

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -539,6 +539,11 @@ public final class JobsService: Sendable {
     ) throws -> Int64 {
         guard !jobName.trimmingCharacters(in: .whitespaces).isEmpty else { throw JobsError.requiredFieldEmpty }
         guard !jobNumber.trimmingCharacters(in: .whitespaces).isEmpty else { throw JobsError.requiredFieldEmpty }
+        if let createdBy {
+            try db.writer.read { dbConn in
+                try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "create_jobs")
+            }
+        }
         return try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
@@ -1504,6 +1509,10 @@ public final class JobsService: Sendable {
         createdBy: Int64,
         targetUserId: Int64? = nil
     ) throws -> Int64 {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "create_jobs")
+        }
+
         guard !text.trimmingCharacters(in: .whitespaces).isEmpty else { throw JobsError.requiredFieldEmpty }
         return try db.writer.write { dbConn in
             try dbConn.execute(
@@ -1700,6 +1709,10 @@ public final class JobsService: Sendable {
 
     /// Mark a daily report as reviewed.
     public func markReportReviewed(reportId: Int64, reviewedBy: Int64) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: reviewedBy, permissionKey: "view_job_reports")
+        }
+
         try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """

--- a/core/Sources/WiredPartCore/Services/NotebooksService.swift
+++ b/core/Sources/WiredPartCore/Services/NotebooksService.swift
@@ -345,6 +345,10 @@ public final class NotebooksService: Sendable {
         jobId: Int64? = nil,
         createdBy: Int64
     ) throws -> Int64 {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_notebooks")
+        }
+
         guard !title.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw NotebooksError.requiredFieldEmpty
         }
@@ -375,6 +379,10 @@ public final class NotebooksService: Sendable {
         entryType: String = "note",
         createdBy: Int64
     ) throws -> Int64 {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_notebooks")
+        }
+
         guard !title.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw NotebooksError.requiredFieldEmpty
         }
@@ -484,6 +492,10 @@ public final class NotebooksService: Sendable {
 
     /// Classify a to-do as regular or warranty work.
     public func classifyTodoWork(entryId: Int64, classification: String, classifiedBy: Int64) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: classifiedBy, permissionKey: "manage_notebooks")
+        }
+
         try db.writer.write { dbConn in
             // Get current classification for history
             let current = try String.fetchOne(dbConn, sql: """
@@ -512,6 +524,10 @@ public final class NotebooksService: Sendable {
 
     /// Manager reviews/approves a classification.
     public func reviewClassification(entryId: Int64, reviewedBy: Int64, approved: Bool, newClassification: String?) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: reviewedBy, permissionKey: "manage_notebooks")
+        }
+
         try db.writer.write { dbConn in
             if approved {
                 // Approve current classification
@@ -591,6 +607,10 @@ public final class NotebooksService: Sendable {
 
     /// Reclassify a to-do with reason tracking. Resets the review flag.
     public func reclassifyTodoWork(entryId: Int64, newClassification: String, changedBy: Int64, reason: String?) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: changedBy, permissionKey: "manage_notebooks")
+        }
+
         try db.writer.write { dbConn in
             let current = try String.fetchOne(dbConn, sql: """
                 SELECT work_classification FROM notebook_entries WHERE id = ?
@@ -883,7 +903,11 @@ public final class NotebooksService: Sendable {
         createdBy: Int64,
         sortOrder: Int? = nil
     ) throws -> Int64 {
-        try db.writer.write { dbConn in
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_notebooks")
+        }
+
+        return try db.writer.write { dbConn in
             let order: Int
             if let so = sortOrder {
                 order = so
@@ -1177,6 +1201,10 @@ public final class NotebooksService: Sendable {
         templateData: NotebookTemplateData,
         createdBy: Int64
     ) throws -> Int64 {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_templates")
+        }
+
         guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw NotebooksError.requiredFieldEmpty
         }
@@ -1193,6 +1221,10 @@ public final class NotebooksService: Sendable {
 
     /// Apply a job template to a notebook — creates groups, sections, and entries.
     public func applyJobTemplate(templateId: Int64, notebookId: Int64, createdBy: Int64) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_templates")
+        }
+
         let templateRow = try db.writer.read { dbConn in
             try Row.fetchOne(dbConn, sql: "SELECT template_data FROM notebook_templates WHERE id = ?", arguments: [templateId])
         }
@@ -1248,6 +1280,10 @@ public final class NotebooksService: Sendable {
 
     /// Apply a page template to a section — creates entries.
     public func applyPageTemplate(templateId: Int64, sectionId: Int64, createdBy: Int64) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_templates")
+        }
+
         let templateRow = try db.writer.read { dbConn in
             try Row.fetchOne(dbConn, sql: "SELECT template_data FROM notebook_templates WHERE id = ?", arguments: [templateId])
         }
@@ -1290,6 +1326,10 @@ public final class NotebooksService: Sendable {
 
     /// Seed default templates if none exist.
     public func seedDefaultTemplates(createdBy: Int64) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_templates")
+        }
+
         let count = try db.writer.read { dbConn -> Int in
             try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM notebook_templates WHERE is_default = 1") ?? 0
         }

--- a/core/Sources/WiredPartCore/Services/OrdersService.swift
+++ b/core/Sources/WiredPartCore/Services/OrdersService.swift
@@ -825,6 +825,10 @@ public final class OrdersService: Sendable {
         partName: String,
         jpoId: Int64
     ) throws -> Int64 {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "manage_orders")
+        }
+
         guard !holdReason.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw OrdersError.requiredFieldEmpty("holdReason")
         }
@@ -2001,6 +2005,10 @@ public final class OrdersService: Sendable {
     /// Update the status of a purchase order.
     /// Fixes #195: fetch old status BEFORE update. Fixes #204: accept userId instead of hardcoding 1.
     public func updatePOStatus(id: Int64, status: String, userId: Int64) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "manage_orders")
+        }
+
         try db.writer.write { dbConn in
             // 1. Fetch old status BEFORE the update (fixes #195)
             guard let row = try Row.fetchOne(

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -2886,6 +2886,12 @@ public final class PartsService: Sendable {
 
     /// Update a company cost setting.
     public func updateCompanyCostSetting(key: String, value: String, updatedBy: Int64? = nil) throws {
+        if let updatedBy {
+            try db.writer.read { dbConn in
+                try ServicePermissionGate.requirePermission(dbConn, userId: updatedBy, permissionKey: "parts.manage_company_costs")
+            }
+        }
+
         try db.writer.write { dbConn in
             try dbConn.execute(sql: """
                 INSERT INTO company_cost_settings (setting_key, setting_value, updated_by, updated_at)
@@ -5892,6 +5898,12 @@ public final class PartsService: Sendable {
 
     /// Approve a scheduled deletion — performs the actual soft delete.
     public func approveScheduledDeletion(id: Int64, approvedBy: Int64?) throws {
+        if let approvedBy {
+            try db.writer.read { dbConn in
+                try ServicePermissionGate.requirePermission(dbConn, userId: approvedBy, permissionKey: "parts.approve_scheduled_deletion")
+            }
+        }
+
         try db.writer.write { db in
             let row = try Row.fetchOne(db, sql: "SELECT * FROM scheduled_deletions WHERE id = ?", arguments: [id])
             guard let row else { return }

--- a/core/Sources/WiredPartCore/Services/PeopleService.swift
+++ b/core/Sources/WiredPartCore/Services/PeopleService.swift
@@ -1793,6 +1793,10 @@ public final class PeopleService: Sendable {
     /// Add a communication entry for a customer.
     @discardableResult
     public func addCommunicationEntry(customerId: Int64, commType: String, content: String, createdBy: Int64) throws -> Int64 {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_people")
+        }
+
         guard !commType.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw PeopleError.requiredFieldEmpty("commType")
         }
@@ -1920,6 +1924,10 @@ public final class PeopleService: Sendable {
     /// Add a note to a contractor.
     @discardableResult
     public func addContractorNote(contractorId: Int64, content: String, createdBy: Int64) throws -> Int64 {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_people")
+        }
+
         guard !content.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw PeopleError.requiredFieldEmpty("content")
         }
@@ -2241,6 +2249,10 @@ public final class PeopleService: Sendable {
         customerId: Int64, jobId: Int64?, amount: Double, dueDate: String,
         invoiceNumber: String?, createdBy: Int64
     ) throws -> Int64 {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_people")
+        }
+
         guard amount > 0 else { throw PeopleError.invalidAmount(amount) }
         guard !dueDate.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw PeopleError.requiredFieldEmpty("dueDate")

--- a/core/Sources/WiredPartCore/Services/ReportsService.swift
+++ b/core/Sources/WiredPartCore/Services/ReportsService.swift
@@ -634,6 +634,10 @@ public final class ReportsService: Sendable {
         name: String, type: String, columns: [String],
         filters: [String: String], userId: Int64, isShared: Bool
     ) throws -> Int64 {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "view_reports")
+        }
+
         let columnsData = try JSONSerialization.data(withJSONObject: columns)
         let filtersData = try JSONSerialization.data(withJSONObject: filters)
         let columnsJson = String(data: columnsData, encoding: .utf8) ?? "[]"
@@ -648,6 +652,7 @@ public final class ReportsService: Sendable {
     }
 
     /// Get saved reports for a user (own + shared).
+    // SCANNER-IGNORE: system-only read-only listing; does not write audit fields.
     public func getSavedReports(userId: Int64) throws -> [SavedReport] {
         do {
             return try db.writer.read { dbConn -> [SavedReport] in

--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -502,6 +502,12 @@ public final class SchedulingService: Sendable {
         status: String,
         approvedBy: Int64? = nil
     ) throws {
+        if let approvedBy {
+            try db.writer.read { dbConn in
+                try ServicePermissionGate.requirePermission(dbConn, userId: approvedBy, permissionKey: "approve_time_off")
+            }
+        }
+
         let validStatuses = ["pending", "approved", "denied", "cancelled"]
         guard validStatuses.contains(status) else {
             throw SchedulingError.invalidStatus(status)

--- a/core/Sources/WiredPartCore/Services/ServicePermissionGate.swift
+++ b/core/Sources/WiredPartCore/Services/ServicePermissionGate.swift
@@ -1,0 +1,54 @@
+import Foundation
+import GRDB
+
+/// Shared authorization gate for service-layer mutation methods.
+///
+/// UI permission checks are defense-in-breadth only. Service methods that accept an
+/// actor user id and write audit fields must verify that actor against the local
+/// hat permission tables before performing the write.
+public enum ServicePermissionGate {
+    public enum GateError: Error, Sendable, Equatable, LocalizedError {
+        case insufficientPermissions(required: String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .insufficientPermissions(let required):
+                return "You don't have permission to perform this action (required: \(required))"
+            }
+        }
+    }
+
+    public static func hasPermission(_ dbConn: Database, userId: Int64, permissionKey: String) throws -> Bool {
+        let count = try Int.fetchOne(
+            dbConn,
+            sql: """
+                SELECT COUNT(*)
+                FROM user_hats uh
+                JOIN hat_permissions hp ON hp.hat_id = uh.hat_id
+                JOIN users u ON u.id = uh.user_id
+                WHERE uh.user_id = ?
+                  AND uh.is_active = 1
+                  AND uh.deleted_at IS NULL
+                  AND u.is_active = 1
+                  AND u.deleted_at IS NULL
+                  AND hp.permission_key = ?
+                LIMIT 1
+                """,
+            arguments: [userId, permissionKey]
+        ) ?? 0
+        return count > 0
+    }
+
+    public static func requirePermission(_ dbConn: Database, userId: Int64, permissionKey: String) throws {
+        guard try hasPermission(dbConn, userId: userId, permissionKey: permissionKey) else {
+            throw GateError.insufficientPermissions(required: permissionKey)
+        }
+    }
+
+    public static func requirePermission(_ dbConn: Database, userId: Int64?, permissionKey: String) throws {
+        guard let userId else {
+            throw GateError.insufficientPermissions(required: permissionKey)
+        }
+        try requirePermission(dbConn, userId: userId, permissionKey: permissionKey)
+    }
+}

--- a/core/Sources/WiredPartCore/Services/ToolsService.swift
+++ b/core/Sources/WiredPartCore/Services/ToolsService.swift
@@ -411,6 +411,10 @@ public final class ToolsService: Sendable {
     /// Logs the status change in `tool_change_log` with `performedBy` for
     /// audit traceability (#272).
     public func markToolMaintenance(toolId: Int64, performedBy: Int64) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: performedBy, permissionKey: "maintain_tools")
+        }
+
         try db.writer.write { dbConn in
             // FK-orphan guards mirror the pattern in other write methods.
             let toolExists = (try Int.fetchOne(dbConn, sql: """
@@ -773,6 +777,10 @@ public final class ToolsService: Sendable {
     public func checkoutToolWithCondition(
         toolId: Int64, userId: Int64, condition: String, notes: String? = nil
     ) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "checkout_tools")
+        }
+
         guard !condition.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw ToolsError.requiredFieldEmpty("condition")
         }
@@ -818,6 +826,10 @@ public final class ToolsService: Sendable {
     public func returnToolWithCondition(
         toolId: Int64, userId: Int64, condition: String, notes: String? = nil
     ) throws {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "checkout_tools")
+        }
+
         guard !condition.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw ToolsError.requiredFieldEmpty("condition")
         }
@@ -1477,7 +1489,11 @@ public final class ToolsService: Sendable {
         performedBy: Int64, conditionBefore: String?, conditionAfter: String?,
         notes: String?, cost: Double?
     ) throws -> Int64 {
-        try db.writer.write { dbConn in
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: performedBy, permissionKey: "maintain_tools")
+        }
+
+        return try db.writer.write { dbConn in
             // Guard: tool must exist and not be tombstoned — otherwise the
             // INSERT INTO tool_maintenance_records below would create an orphan record.
             let exists = (try Int.fetchOne(dbConn, sql: """

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -566,6 +566,10 @@ public final class WarehouseService: Sendable {
         unitCostAtMove: Double? = nil,
         unitSellAtMove: Double? = nil
     ) throws -> Int64 {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: performedBy, permissionKey: "move_stock_warehouse")
+        }
+
         // qty must be positive. Movement direction (pull vs. add) is determined by
         // which of fromLocationType/toLocationType is non-nil, not by sign. A
         // negative qty inverts the stock delta: `qty = qty - (-3)` = qty + 3.
@@ -705,6 +709,10 @@ public final class WarehouseService: Sendable {
     /// the entire batch rolls back — no partial state is committed.
     @discardableResult
     public func createBatchMovements(movements: [MovementInput], performedBy: Int64) throws -> [Int64] {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: performedBy, permissionKey: "move_stock_warehouse")
+        }
+
         guard !movements.isEmpty else { return [] }
         for m in movements {
             guard m.qty > 0 else { throw WarehouseError.invalidQuantity }
@@ -1601,6 +1609,10 @@ public final class WarehouseService: Sendable {
         notes: String?,
         userId: Int64
     ) throws -> Int64 {
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "perform_audit")
+        }
+
         guard !scope.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw WarehouseError.requiredFieldEmpty
         }
@@ -1647,6 +1659,12 @@ public final class WarehouseService: Sendable {
         reason: String?,
         performedBy: Int64?
     ) throws {
+        if let performedBy {
+            try db.writer.read { dbConn in
+                try ServicePermissionGate.requirePermission(dbConn, userId: performedBy, permissionKey: "perform_audit")
+            }
+        }
+
         guard newQty >= 0 else { throw WarehouseError.invalidQuantity }
         try db.writer.write { dbConn in
             if let uid = performedBy {
@@ -1840,7 +1858,11 @@ public final class WarehouseService: Sendable {
         recordedBy: Int64,
         notes: String? = nil
     ) throws -> Int64 {
-        try db.writer.write { dbConn in
+        try db.writer.read { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: recordedBy, permissionKey: "manage_warehouse")
+        }
+
+        return try db.writer.write { dbConn in
             // Guard: trailer must exist and not be tombstoned — otherwise the
             // INSERT creates an orphan trailer_location_events row against a
             // decommissioned trailer (the FK constraint accepts the write).
@@ -3019,6 +3041,8 @@ public final class WarehouseService: Sendable {
                 WHERE id = ? AND deleted_at IS NULL
                 """, arguments: [sessionId]) ?? 0) > 0
             guard sessionExists else { throw WarehouseError.sessionNotFound(sessionId) }
+
+            try ServicePermissionGate.requirePermission(dbConn, userId: recordedBy, permissionKey: "perform_audit")
 
             try dbConn.execute(sql: """
                 INSERT INTO audit_session_events
@@ -4448,12 +4472,18 @@ public final class WarehouseService: Sendable {
                 try conf.update(dbConn)
             }
 
-            // Update audit session if active
+            // Update the latest active audit session if one exists. Use a subquery
+            // instead of UPDATE ... ORDER BY ... LIMIT because the bundled SQLite
+            // build used by tests does not enable UPDATE_LIMIT syntax.
             try dbConn.execute(sql: """
                 UPDATE audit_sessions_v2
                 SET misplaced_found = misplaced_found + 1
-                WHERE status = 'active' AND started_by = ?
-                ORDER BY started_at DESC LIMIT 1
+                WHERE id = (
+                    SELECT id FROM audit_sessions_v2
+                    WHERE status = 'active' AND started_by = ?
+                    ORDER BY started_at DESC
+                    LIMIT 1
+                )
                 """, arguments: [foundBy])
 
             return log


### PR DESCRIPTION
## Summary
- Add shared ServicePermissionGate helper for service-layer mutation authorization.
- Apply permission gates/backfill permission keys across scanner-reported service methods.
- Keep read-only saved reports listing scanner-ignored with the accepted system-only marker.
- Gate audit-session event writes and fix the audit-session misplaced-count update to use SQLite-compatible subquery syntax.

## Verification
- python3 ~/.claude/scheduled-tasks/service-permission-gate-scanner/scanner.py core/Sources/WiredPartCore/Services
- swift build --build-path .build-wei356-final-verify
- swift test --build-path .build-wei356-final-verify --filter WarehouseAuditTests
- swift test --build-path .build-wei356-final-verify --filter ReportsServiceTests

Closes #368