### PR TITLE
Optimize fleet vehicle status counts

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSVehiclesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSVehiclesPage.swift
@@ -13,7 +13,7 @@ struct IOSVehiclesPage: View {
     // MARK: - State
 
     @State private var vehicles: [FleetService.VehicleListItem] = []
-    @State private var allVehicles: [FleetService.VehicleListItem] = []
+    @State private var statusCounts = FleetService.VehicleStatusCounts()
     @State private var isLoading = true
     @State private var searchText = ""
     @State private var statusFilter = "all"
@@ -112,8 +112,7 @@ struct IOSVehiclesPage: View {
     // MARK: - Status Picker
 
     private func countForStatus(_ status: String) -> Int {
-        if status == "all" { return allVehicles.count }
-        return allVehicles.filter { $0.status == status }.count
+        statusCounts.count(for: status)
     }
 
     private var statusPicker: some View {
@@ -270,10 +269,8 @@ struct IOSVehiclesPage: View {
         isLoading = vehicles.isEmpty
         loadError = nil
         do {
-            allVehicles = try service.listVehicles(status: nil)
-            vehicles = statusFilter == "all"
-                ? allVehicles
-                : allVehicles.filter { $0.status == statusFilter }
+            statusCounts = try service.getVehicleStatusCounts()
+            vehicles = try service.listVehicles(status: statusFilter == "all" ? nil : statusFilter)
         } catch {
             loadError = userFriendlyError(error, context: "load vehicles")
         }

--- a/core/Sources/WiredPartCore/Services/FleetService.swift
+++ b/core/Sources/WiredPartCore/Services/FleetService.swift
@@ -87,6 +87,40 @@ public final class FleetService: Sendable {
         }
     }
 
+    /// SQL-backed vehicle status counts for fleet filter cards.
+    public struct VehicleStatusCounts: Sendable, Equatable {
+        public let all: Int
+        public let active: Int
+        public let inactive: Int
+        public let maintenance: Int
+        public let retired: Int
+
+        public init(
+            all: Int = 0,
+            active: Int = 0,
+            inactive: Int = 0,
+            maintenance: Int = 0,
+            retired: Int = 0
+        ) {
+            self.all = all
+            self.active = active
+            self.inactive = inactive
+            self.maintenance = maintenance
+            self.retired = retired
+        }
+
+        public func count(for status: String) -> Int {
+            switch status {
+            case "all": return all
+            case "active": return active
+            case "inactive": return inactive
+            case "maintenance": return maintenance
+            case "retired": return retired
+            default: return 0
+            }
+        }
+    }
+
     /// Full vehicle detail including all fields and active assignments.
     public struct VehicleDetail: Sendable {
         public let id: Int64
@@ -331,6 +365,49 @@ public final class FleetService: Sendable {
             }
         } catch {
             if isTableNotFoundError(error) { return [] }
+            throw error
+        }
+    }
+
+    /// Count active, non-deleted vehicles by status without hydrating the full vehicle list.
+    public func getVehicleStatusCounts() throws -> VehicleStatusCounts {
+        do {
+            return try db.writer.read { dbConn -> VehicleStatusCounts in
+                let rows = try Row.fetchAll(dbConn, sql: """
+                    SELECT status, COUNT(*) AS count
+                    FROM vehicles
+                    WHERE deleted_at IS NULL AND is_active = 1
+                    GROUP BY status
+                    """)
+
+                var all = 0
+                var active = 0
+                var inactive = 0
+                var maintenance = 0
+                var retired = 0
+
+                for row in rows {
+                    let count: Int = row["count"] ?? 0
+                    all += count
+                    switch row["status"] as String? {
+                    case "active": active = count
+                    case "inactive": inactive = count
+                    case "maintenance": maintenance = count
+                    case "retired": retired = count
+                    default: break
+                    }
+                }
+
+                return VehicleStatusCounts(
+                    all: all,
+                    active: active,
+                    inactive: inactive,
+                    maintenance: maintenance,
+                    retired: retired
+                )
+            }
+        } catch {
+            if isTableNotFoundError(error) { return VehicleStatusCounts() }
             throw error
         }
     }

--- a/core/Tests/WiredPartCoreTests/FleetServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/FleetServiceTests.swift
@@ -59,6 +59,59 @@ struct FleetServiceTests {
         #expect(active.count >= 1)
     }
 
+    @Test("Vehicle status counts aggregate in SQL and exclude inactive rows")
+    func testVehicleStatusCounts() throws {
+        let env = try E2ETestHelpers.setUp()
+        let before = try env.fleet.getVehicleStatusCounts()
+
+        let activeId = try env.fleet.createVehicle(
+            actorId: env.adminUserId,
+            vehicleNumber: "V-COUNT-ACT", vehicleName: "Count Active", vehicleType: "truck",
+            make: nil, model: nil, year: nil, color: nil, vin: nil, licensePlate: nil, notes: nil
+        )
+        let inactiveId = try env.fleet.createVehicle(
+            actorId: env.adminUserId,
+            vehicleNumber: "V-COUNT-INACT", vehicleName: "Count Inactive", vehicleType: "truck",
+            make: nil, model: nil, year: nil, color: nil, vin: nil, licensePlate: nil, notes: nil
+        )
+        let maintenanceId = try env.fleet.createVehicle(
+            actorId: env.adminUserId,
+            vehicleNumber: "V-COUNT-MAINT", vehicleName: "Count Maintenance", vehicleType: "truck",
+            make: nil, model: nil, year: nil, color: nil, vin: nil, licensePlate: nil, notes: nil
+        )
+        let retiredId = try env.fleet.createVehicle(
+            actorId: env.adminUserId,
+            vehicleNumber: "V-COUNT-RET", vehicleName: "Count Retired", vehicleType: "truck",
+            make: nil, model: nil, year: nil, color: nil, vin: nil, licensePlate: nil, notes: nil
+        )
+        let excludedId = try env.fleet.createVehicle(
+            actorId: env.adminUserId,
+            vehicleNumber: "V-COUNT-EXCL", vehicleName: "Count Excluded", vehicleType: "truck",
+            make: nil, model: nil, year: nil, color: nil, vin: nil, licensePlate: nil, notes: nil
+        )
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE vehicles SET status = 'inactive' WHERE id = ?", arguments: [inactiveId])
+            try db.execute(sql: "UPDATE vehicles SET status = 'maintenance' WHERE id = ?", arguments: [maintenanceId])
+            try db.execute(sql: "UPDATE vehicles SET status = 'retired' WHERE id = ?", arguments: [retiredId])
+            try db.execute(sql: "UPDATE vehicles SET is_active = 0 WHERE id = ?", arguments: [excludedId])
+        }
+
+        let after = try env.fleet.getVehicleStatusCounts()
+        #expect(after.all == before.all + 4)
+        #expect(after.active == before.active + 1)
+        #expect(after.inactive == before.inactive + 1)
+        #expect(after.maintenance == before.maintenance + 1)
+        #expect(after.retired == before.retired + 1)
+        #expect(after.count(for: "all") == after.all)
+        #expect(after.count(for: "active") == after.active)
+        #expect(after.count(for: "unknown") == 0)
+
+        let visibleIds = Set(try env.fleet.listVehicles().map(\.id))
+        #expect(visibleIds.contains(activeId))
+        #expect(!visibleIds.contains(excludedId))
+    }
+
     // MARK: - Trailer CRUD
 
     @Test("Create and list trailers")


### PR DESCRIPTION
## Summary
- add SQL-backed FleetService.getVehicleStatusCounts() aggregation for status badges
- update IOSVehiclesPage to use SQL-backed counts instead of filtering allVehicles during render
- load selected vehicle statuses through listVehicles(status:) so filtering happens in SQL
- add FleetService test coverage for status counts and inactive-row exclusion

## Validation
- swift test --filter FleetServiceTests/testVehicleStatusCounts
- xcodebuild -workspace 'Wierd Parts.xcworkspace' -scheme 'WiredPart-iOS' -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build

Fixes WEI-378
Fixes #316