### PR TITLE
fix(orders): group procurement demand in SQL

### DIFF
--- a/core/Sources/WiredPartCore/Services/OrdersService.swift
+++ b/core/Sources/WiredPartCore/Services/OrdersService.swift
@@ -1141,12 +1141,15 @@ public final class OrdersService: Sendable {
                 let hour = calendar.component(.hour, from: Date())
                 let isPre2PM = hour < 14
 
-                // 1. Get approved JPO lines not yet in procurement/ordered
-                let jpoLines = try Row.fetchAll(dbConn, sql: """
+                // 1. Get approved JPO demand grouped in SQL by part + JPO.
+                // GROUP_CONCAT preserves contributing line IDs without fetching every
+                // raw JPO line into Swift and folding dictionaries there.
+                let jpoDemandRows = try Row.fetchAll(dbConn, sql: """
                     SELECT jl.part_id, p.name AS part_name, p.code AS part_code,
                            b.name AS brand_name,
                            CASE WHEN b.name IS NULL OR b.name = 'General' THEN 1 ELSE 0 END AS is_generic,
-                           jl.qty_requested AS quantity, jl.id AS line_id,
+                           SUM(jl.qty_requested) AS quantity,
+                           GROUP_CONCAT(jl.id) AS line_ids_csv,
                            jpo.id AS jpo_id, j.job_name
                     FROM jpo_line_items jl
                     JOIN job_parts_orders jpo ON jpo.id = jl.jpo_id
@@ -1156,28 +1159,26 @@ public final class OrdersService: Sendable {
                     WHERE jl.line_status = 'approved'
                       AND jl.deleted_at IS NULL
                       AND jpo.deleted_at IS NULL
+                    GROUP BY jl.part_id, p.name, p.code, b.name, jpo.id, j.job_name
                     """)
 
-                // Group by part_id, tracking JPO line IDs per source
                 var partDemand: [Int64: (partRow: Row, sources: [DemandSource], totalQty: Int)] = [:]
-                // Track line IDs per (partId, jpoId) for merging lines from same JPO
-                var lineIdTracker: [Int64: [Int64: [Int64]]] = [:]  // [partId: [jpoId: [lineIds]]]
 
-                for row in jpoLines {
+                for row in jpoDemandRows {
                     guard let partId: Int64 = row["part_id"] else { continue }
                     let jpoId: Int64 = row["jpo_id"] ?? 0
                     let jobName: String = row["job_name"] ?? ""
                     let qty: Int = row["quantity"] ?? 0
-                    let lineId: Int64 = row["line_id"] ?? 0
-
-                    lineIdTracker[partId, default: [:]][jpoId, default: []].append(lineId)
+                    let lineIds = (row["line_ids_csv"] as String? ?? "")
+                        .split(separator: ",")
+                        .compactMap { Int64($0) }
 
                     let source = DemandSource(
                         sourceType: "jpo",
                         sourceId: jpoId,
                         sourceName: "JPO #\(jpoId) (\(jobName))",
                         quantity: qty,
-                        lineIds: [lineId]
+                        lineIds: lineIds
                     )
 
                     if partDemand[partId] != nil {

--- a/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
@@ -175,6 +175,60 @@ struct OrdersServiceTests {
         #expect(demand.count >= 0)
     }
 
+    @Test("Procurement demand SQL grouping preserves combined JPO quantity and line ids")
+    func testProcurementDemandSQLGroupingPreservesQuantityAndLineIds() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, name: "Grouped Generic Clamp", categoryId: catId)
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-GROUP-1", name: "Grouped Job")
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "Grouped Supplier")
+        _ = try env.parts.addPartSupplierLink(partId: partId, supplierId: supplierId, costPrice: 2.75)
+
+        let jpoId: Int64 = try env.db.writer.write { db in
+            let orderNumber = "JPO-GROUP-\(UUID().uuidString)"
+            try db.execute(
+                sql: """
+                    INSERT INTO job_parts_orders
+                    (job_id, order_number, requested_by, status, priority, notes, created_at, updated_at)
+                    VALUES (?, ?, ?, 'approved', 'normal', NULL, datetime('now'), datetime('now'))
+                    """,
+                arguments: [jobId, orderNumber, env.adminUserId]
+            )
+            return db.lastInsertedRowID
+        }
+
+        let lineA: Int64 = try env.db.writer.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO jpo_line_items
+                    (jpo_id, part_id, qty_requested, line_status, created_at)
+                    VALUES (?, ?, 2, 'approved', datetime('now'))
+                    """,
+                arguments: [jpoId, partId]
+            )
+            return db.lastInsertedRowID
+        }
+        let lineB: Int64 = try env.db.writer.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO jpo_line_items
+                    (jpo_id, part_id, qty_requested, line_status, created_at)
+                    VALUES (?, ?, 3, 'approved', datetime('now'))
+                    """,
+                arguments: [jpoId, partId]
+            )
+            return db.lastInsertedRowID
+        }
+
+        let demand = try env.orders.getProcurementDemand()
+        let item = try #require(demand.filter { $0.id == partId }.first)
+        let source = try #require(item.sources.filter { $0.sourceType == "jpo" && $0.sourceId == jpoId }.first)
+
+        #expect(item.totalDemand == 5)
+        #expect(source.quantity == 5)
+        #expect(Set(source.lineIds) == Set([lineA, lineB]))
+    }
+
     // MARK: - Returns
 
     @Test("List returns empty on fresh DB")


### PR DESCRIPTION
## Summary
- Move approved JPO procurement demand aggregation from Swift row folding to SQL SUM/GROUP_CONCAT grouped by part and JPO.
- Parse grouped line IDs once per JPO source while preserving the existing ProcurementItem/DemandSource contract.
- Add regression coverage for repeated approved JPO lines on the same part/JPO.

## Test Plan
- swift test --filter OrdersServiceTests/testProcurementDemandSQLGroupingPreservesQuantityAndLineIds
- swift test --filter OrdersServiceTests/testProcurementDemand
- swift build

Closes #330