### PR TITLE
Bound tools dashboard checkout loading

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolsDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolsDashboardPage.swift
@@ -17,6 +17,8 @@ struct IOSToolsDashboardPage: View {
     @State private var loadError: String?
     @State private var activeSheet: ActiveSheet?
 
+    private let recentActivityLimit = 10
+
     private enum ActiveSheet: Identifiable {
         case help
         var id: String { "help" }
@@ -214,7 +216,7 @@ struct IOSToolsDashboardPage: View {
         isLoading = stats == nil
         do {
             stats = try service.getToolsStats()
-            recentCheckouts = try service.listCheckouts(active: false)
+            recentCheckouts = try service.listCheckouts(active: false, limit: recentActivityLimit)
         } catch {
             loadError = userFriendlyError(error, context: "load tools dashboard")
         }

--- a/core/Sources/WiredPartCore/Services/ToolsService.swift
+++ b/core/Sources/WiredPartCore/Services/ToolsService.swift
@@ -293,8 +293,11 @@ public final class ToolsService: Sendable {
     /// - Parameters:
     ///   - toolId: Optional tool ID to filter by.
     ///   - active: When true, only return currently active (unreturned) checkouts.
+    ///   - limit: Optional maximum number of rows to return. Leave nil for full history callers.
     /// - Returns: An array of `CheckoutRow` rows.
-    public func listCheckouts(toolId: Int64? = nil, active: Bool = false) throws -> [CheckoutRow] {
+    public func listCheckouts(toolId: Int64? = nil, active: Bool = false, limit: Int? = nil) throws -> [CheckoutRow] {
+        if let limit, limit <= 0 { return [] }
+
         do {
             return try db.writer.read { dbConn -> [CheckoutRow] in
                 var whereClauses = ["tm.deleted_at IS NULL"]
@@ -307,7 +310,11 @@ public final class ToolsService: Sendable {
                 if active {
                     whereClauses.append("tm.movement_type = 'checkout'")
                 }
+                if let limit {
+                    args.append(limit)
+                }
 
+                let limitClause = limit == nil ? "" : " LIMIT ?"
                 let sql = """
                     SELECT tm.id, tm.created_at AS checked_out_at,
                            NULL AS expected_return, NULL AS returned_at,
@@ -317,7 +324,7 @@ public final class ToolsService: Sendable {
                     LEFT JOIN tools t ON t.id = tm.tool_id AND t.deleted_at IS NULL
                     LEFT JOIN users u ON u.id = tm.performed_by AND u.deleted_at IS NULL
                     WHERE \(whereClauses.joined(separator: " AND "))
-                    ORDER BY tm.created_at DESC
+                    ORDER BY tm.created_at DESC, tm.id DESC\(limitClause)
                     """
 
                 let rows = try Row.fetchAll(dbConn, sql: sql, arguments: StatementArguments(args))

--- a/core/Tests/WiredPartCoreTests/ToolsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ToolsServiceTests.swift
@@ -585,6 +585,33 @@ struct ToolsServiceTests {
         #expect(active[0].toolName == "Active Tool")
     }
 
+    @Test("listCheckouts limit bounds results without changing full history default")
+    func testListCheckoutsLimit() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        let tool1 = try insertTool(env, toolNumber: "T-LIM-1", name: "Old Checkout Tool")
+        let tool2 = try insertTool(env, toolNumber: "T-LIM-2", name: "Middle Checkout Tool")
+        let tool3 = try insertTool(env, toolNumber: "T-LIM-3", name: "Newest Checkout Tool")
+
+        let movement1 = try insertToolMovement(env, toolId: tool1, movementType: "checkout", performedBy: env.adminUserId)
+        let movement2 = try insertToolMovement(env, toolId: tool2, movementType: "return", performedBy: env.adminUserId)
+        let movement3 = try insertToolMovement(env, toolId: tool3, movementType: "checkout", performedBy: env.adminUserId)
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE tool_movements SET created_at = '2026-01-01 09:00:00' WHERE id = ?", arguments: [movement1])
+            try db.execute(sql: "UPDATE tool_movements SET created_at = '2026-01-02 09:00:00' WHERE id = ?", arguments: [movement2])
+            try db.execute(sql: "UPDATE tool_movements SET created_at = '2026-01-03 09:00:00' WHERE id = ?", arguments: [movement3])
+        }
+
+        let fullHistory = try env.tools.listCheckouts()
+        let limited = try env.tools.listCheckouts(limit: 2)
+        let zeroLimit = try env.tools.listCheckouts(limit: 0)
+
+        #expect(fullHistory.map(\.toolName) == ["Newest Checkout Tool", "Middle Checkout Tool", "Old Checkout Tool"])
+        #expect(limited.map(\.toolName) == ["Newest Checkout Tool", "Middle Checkout Tool"])
+        #expect(zeroLimit.isEmpty)
+    }
+
     // =========================================================================
     // MARK: - 9. Tools Stats
     // =========================================================================


### PR DESCRIPTION
## Summary
- add optional limit support to ToolsService.listCheckouts while preserving full-history default callers
- bound IOSToolsDashboardPage recent activity loading to 10 rows instead of all historical tool movements
- add regression coverage for limited checkout results and zero-limit behavior

## Validation
- swift test --filter ToolsServiceTests/testListCheckouts
- xcodebuild -workspace 'Wierd Parts.xcworkspace' -scheme 'WiredPart-iOS' -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build

Fixes WEI-396
Closes #274