### PR TITLE
feat(settings): add sync scope filtering

### DIFF
--- a/core/Sources/WiredPartCore/Services/SettingsService.swift
+++ b/core/Sources/WiredPartCore/Services/SettingsService.swift
@@ -8,9 +8,13 @@ import GRDB
 /// with one row per field.
 ///
 /// Ported from: `src/local/services/settings-service.ts`
-// When sync is implemented (Phase 11), filter settings by SyncScope:
-// .company → company-wide sync, .personal → per-user sync, .device → exclude.
-// Tracked: https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/258
+///
+/// Sync scope contract for Phase 11 sync:
+/// - `.company` settings participate in company-wide sync.
+/// - `.personal` settings participate in per-user sync.
+/// - `.device` settings are local-only and excluded from sync payloads.
+///
+/// Tracked: https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/258
 
 public final class SettingsService: Sendable {
     private let db: AppDatabase
@@ -20,6 +24,19 @@ public final class SettingsService: Sendable {
     }
 
     // MARK: - Types
+
+    public enum SyncScope: String, CaseIterable, Sendable {
+        case company
+        case personal
+        case device
+    }
+
+    public struct SettingRow: Sendable, Equatable {
+        public let key: String
+        public let value: String
+        public let category: String
+        public let syncScope: SyncScope
+    }
 
     public struct ThemeSettings: Codable, Sendable {
         public var themeMode: String   // "light", "dark", "system"
@@ -139,6 +156,58 @@ public final class SettingsService: Sendable {
     public func upsertSettingsMap(_ data: [String: String], category: String) throws {
         for (key, value) in data {
             try upsertSetting(key: key, value: value, category: category)
+        }
+    }
+
+    /// Canonical settings sync classifier.
+    ///
+    /// Key-specific rules win over category rules so legacy rows with `general`
+    /// category can still be scoped safely. Unknown settings default to `.company`
+    /// because company-visible configuration is the safer sync default than silently
+    /// dropping operational state.
+    public static func syncScope(for key: String, category: String? = nil) -> SyncScope {
+        let normalizedKey = key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedCategory = (category ?? "general")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        if deviceSettingKeys.contains(normalizedKey) || deviceSettingCategories.contains(normalizedCategory) {
+            return .device
+        }
+        if personalSettingKeys.contains(normalizedKey) || personalSettingCategories.contains(normalizedCategory) {
+            return .personal
+        }
+        return .company
+    }
+
+    /// Return flat setting rows classified for sync payload construction.
+    public func getSettings(scope: SyncScope) throws -> [SettingRow] {
+        try getSettingRows().filter { $0.syncScope == scope }
+    }
+
+    /// Return flat setting rows except the requested scope. Use `.device` to build
+    /// syncable settings while excluding local-only device state.
+    public func getSettings(excludingScope excludedScope: SyncScope) throws -> [SettingRow] {
+        try getSettingRows().filter { $0.syncScope != excludedScope }
+    }
+
+    private func getSettingRows() throws -> [SettingRow] {
+        try db.writer.read { dbConnection in
+            let rows = try Row.fetchAll(
+                dbConnection,
+                sql: "SELECT key, value, category FROM settings ORDER BY category, key"
+            )
+            return rows.map { row in
+                let key: String = row["key"]
+                let value: String = row["value"] ?? ""
+                let category: String = row["category"] ?? "general"
+                return SettingRow(
+                    key: key,
+                    value: value,
+                    category: category,
+                    syncScope: Self.syncScope(for: key, category: category)
+                )
+            }
         }
     }
 
@@ -802,4 +871,48 @@ public final class SettingsService: Sendable {
         let message = String(describing: error)
         return message.contains("no such table") || message.contains("no such column")
     }
+
+    private static let personalSettingCategories: Set<String> = [
+        "notifications",
+        "personal",
+        "theme",
+        "ui",
+        "user_preferences",
+    ]
+
+    private static let personalSettingKeys: Set<String> = [
+        "dashboard_layout",
+        "default_landing_page",
+        "font_family",
+        "notification_preferences",
+        "notifications_enabled",
+        "preferred_language",
+        "primary_color",
+        "reduced_motion",
+        "tab_order",
+        "theme_mode",
+    ]
+
+    private static let deviceSettingCategories: Set<String> = [
+        "backup",
+        "device",
+        "device_keys",
+        "local",
+        "updates",
+    ]
+
+    private static let deviceSettingKeys: Set<String> = [
+        "app_version",
+        "available_version",
+        "backup_count",
+        "bluetooth_enabled",
+        "device_fingerprint",
+        "device_id",
+        "device_name",
+        "device_private_key",
+        "last_backup_time",
+        "last_update_check",
+        "local_database_path",
+        "update_channel",
+    ]
 }

--- a/core/Tests/WiredPartCoreTests/SettingsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SettingsServiceTests.swift
@@ -71,6 +71,52 @@ struct SettingsServiceTests {
         #expect(all["cat_b"]?["b"] == "2")
     }
 
+    @Test("syncScope classifies personal device and company settings")
+    func testSyncScopeClassification() throws {
+        #expect(SettingsService.syncScope(for: "theme_mode", category: "general") == .personal)
+        #expect(SettingsService.syncScope(for: "custom_color", category: "theme") == .personal)
+
+        #expect(SettingsService.syncScope(for: "update_channel", category: "general") == .device)
+        #expect(SettingsService.syncScope(for: "custom_backup_key", category: "backup") == .device)
+
+        #expect(SettingsService.syncScope(for: "payment_terms", category: "pdf") == .company)
+        #expect(SettingsService.syncScope(for: "unknown_future_setting") == .company)
+    }
+
+    @Test("getSettings filters rows by sync scope")
+    func testGetSettingsBySyncScope() throws {
+        let db = try freshDB()
+        let svc = SettingsService(db: db)
+
+        try svc.upsertSetting(key: "payment_terms", value: "Net 30", category: "pdf")
+        try svc.upsertSetting(key: "theme_mode", value: "dark", category: "theme")
+        try svc.upsertSetting(key: "update_channel", value: "beta", category: "updates")
+
+        let company = try svc.getSettings(scope: .company)
+        let personal = try svc.getSettings(scope: .personal)
+        let device = try svc.getSettings(scope: .device)
+
+        #expect(company.contains { $0.key == "payment_terms" && $0.syncScope == .company })
+        #expect(personal.contains { $0.key == "theme_mode" && $0.syncScope == .personal })
+        #expect(device.contains { $0.key == "update_channel" && $0.syncScope == .device })
+    }
+
+    @Test("getSettings excluding device returns syncable rows only")
+    func testGetSettingsExcludingDevice() throws {
+        let db = try freshDB()
+        let svc = SettingsService(db: db)
+
+        try svc.upsertSetting(key: "payment_terms", value: "Net 30", category: "pdf")
+        try svc.upsertSetting(key: "theme_mode", value: "dark", category: "theme")
+        try svc.upsertSetting(key: "last_backup_time", value: "2026-05-17T00:00:00Z", category: "backup")
+
+        let syncable = try svc.getSettings(excludingScope: .device)
+
+        #expect(syncable.contains { $0.key == "payment_terms" })
+        #expect(syncable.contains { $0.key == "theme_mode" })
+        #expect(!syncable.contains { $0.key == "last_backup_time" })
+    }
+
     // MARK: - Theme
 
     @Test("getTheme returns defaults when no settings exist")


### PR DESCRIPTION
## Summary
- Adds a SettingsService.SyncScope contract for company, personal, and device-local settings
- Adds canonical key/category classification plus scope-filtered setting row queries for future sync payloads
- Adds focused SettingsService tests for classification, scope filtering, and device exclusion

## Test Plan
- swift test --filter SettingsServiceTests

Closes #258

Note: remote branch count was already above the configured hard cap (123) before this PR branch was pushed; this PR is intentionally scoped small so it can be reviewed/merged and deleted quickly.