### PR TITLE
perf(fleet): consolidate dashboard stats reads

### DIFF
--- a/core/Sources/WiredPartCore/Services/FleetService.swift
+++ b/core/Sources/WiredPartCore/Services/FleetService.swift
@@ -837,19 +837,6 @@ public final class FleetService: Sendable {
 
     /// Get full fleet dashboard statistics including overdue inspections and cost data.
     public func getFleetDashboardStats() throws -> FleetDashboardStats {
-        let basic = try getFleetStats()
-
-        // Overdue inspections: active vehicles with no inspection today
-        let overdueInspections = try safeCount(sql: """
-            SELECT COUNT(*) FROM vehicles v
-            WHERE v.status = 'active' AND v.deleted_at IS NULL AND v.is_active = 1
-              AND v.id IN (SELECT vehicle_id FROM vehicle_assignments WHERE is_active = 1 AND deleted_at IS NULL)
-              AND v.id NOT IN (
-                  SELECT vehicle_id FROM inspection_records
-                  WHERE deleted_at IS NULL AND date(performed_at) = date('now')
-              )
-            """)
-
         // Month-to-date cost stats
         let fmt = DateFormatter()
         fmt.dateFormat = "yyyy-MM-dd"
@@ -857,58 +844,91 @@ public final class FleetService: Sendable {
         let startOfMonth = cal.date(from: cal.dateComponents([.year, .month], from: Date())) ?? Date()
         let monthStr = fmt.string(from: startOfMonth)
 
-        let fuelCostMTD: Double? = try {
-            do {
-                return try db.writer.read { dbConn in
-                    try Double.fetchOne(dbConn, sql: """
-                        SELECT COALESCE(SUM(total_cost), 0) FROM fuel_logs
-                        WHERE log_date >= ? AND deleted_at IS NULL
-                        """, arguments: [monthStr])
-                }
-            } catch {
-                if isTableNotFoundError(error) { return 0 }
-                throw error
-            }
-        }()
+        do {
+            return try db.writer.read { dbConn -> FleetDashboardStats in
+                let row = try Row.fetchOne(dbConn, sql: """
+                    SELECT
+                        (SELECT COUNT(*)
+                           FROM vehicles
+                          WHERE deleted_at IS NULL
+                            AND is_active = 1) AS total_vehicles,
+                        (SELECT COUNT(*)
+                           FROM vehicles
+                          WHERE status = 'active'
+                            AND deleted_at IS NULL
+                            AND is_active = 1) AS active_vehicles,
+                        (SELECT COUNT(*)
+                           FROM maintenance_schedules ms
+                           JOIN vehicles v ON v.id = ms.vehicle_id
+                                         AND v.deleted_at IS NULL
+                                         AND v.is_active = 1
+                          WHERE ms.deleted_at IS NULL
+                            AND (
+                                (ms.next_due_date IS NOT NULL AND date(ms.next_due_date) <= date('now'))
+                                OR (ms.next_due_miles IS NOT NULL AND v.current_odometer IS NOT NULL
+                                    AND ms.next_due_miles <= v.current_odometer)
+                            )) AS maintenance_due,
+                        (SELECT COUNT(*)
+                           FROM job_trailers
+                          WHERE deleted_at IS NULL
+                            AND is_active = 1) AS total_trailers,
+                        (SELECT COUNT(*)
+                           FROM vehicles v
+                          WHERE v.status = 'active'
+                            AND v.deleted_at IS NULL
+                            AND v.is_active = 1
+                            AND v.id IN (
+                                SELECT vehicle_id
+                                  FROM vehicle_assignments
+                                 WHERE is_active = 1
+                                   AND deleted_at IS NULL
+                            )
+                            AND v.id NOT IN (
+                                SELECT vehicle_id
+                                  FROM inspection_records
+                                 WHERE deleted_at IS NULL
+                                   AND date(performed_at) = date('now')
+                            )) AS overdue_inspections,
+                        (SELECT COALESCE(SUM(total_cost), 0)
+                           FROM fuel_logs
+                          WHERE log_date >= ?
+                            AND deleted_at IS NULL) AS fuel_cost_mtd,
+                        (SELECT COALESCE(CAST(SUM(total_miles) AS INTEGER), 0)
+                           FROM mileage_logs
+                          WHERE log_date >= ?
+                            AND deleted_at IS NULL) AS miles_mtd,
+                        (SELECT COALESCE(SUM(cost), 0)
+                           FROM maintenance_records
+                          WHERE performed_at >= ?
+                            AND deleted_at IS NULL) AS maintenance_cost_mtd
+                    """, arguments: [monthStr, monthStr, monthStr])
 
-        let milesMTD: Int? = try {
-            do {
-                return try db.writer.read { dbConn in
-                    try Int.fetchOne(dbConn, sql: """
-                        SELECT COALESCE(CAST(SUM(total_miles) AS INTEGER), 0) FROM mileage_logs
-                        WHERE log_date >= ? AND deleted_at IS NULL
-                        """, arguments: [monthStr])
-                }
-            } catch {
-                if isTableNotFoundError(error) { return 0 }
-                throw error
+                return FleetDashboardStats(
+                    totalVehicles: row?["total_vehicles"] ?? 0,
+                    activeVehicles: row?["active_vehicles"] ?? 0,
+                    maintenanceDue: row?["maintenance_due"] ?? 0,
+                    overdueInspections: row?["overdue_inspections"] ?? 0,
+                    totalTrailers: row?["total_trailers"] ?? 0,
+                    fuelCostMTD: row?["fuel_cost_mtd"] as Double? ?? 0,
+                    milesMTD: row?["miles_mtd"] as Int? ?? 0,
+                    maintenanceCostMTD: row?["maintenance_cost_mtd"] as Double? ?? 0
+                )
             }
-        }()
-
-        let maintenanceCostMTD: Double? = try {
-            do {
-                return try db.writer.read { dbConn in
-                    try Double.fetchOne(dbConn, sql: """
-                        SELECT COALESCE(SUM(cost), 0) FROM maintenance_records
-                        WHERE performed_at >= ? AND deleted_at IS NULL
-                        """, arguments: [monthStr])
-                }
-            } catch {
-                if isTableNotFoundError(error) { return 0 }
-                throw error
+        } catch {
+            if isTableNotFoundError(error) {
+                return FleetDashboardStats(
+                    totalVehicles: 0,
+                    activeVehicles: 0,
+                    maintenanceDue: 0,
+                    overdueInspections: 0,
+                    totalTrailers: 0,
+                    fuelCostMTD: 0,
+                    milesMTD: 0,
+                    maintenanceCostMTD: 0
+                )
             }
-        }()
-
-        return FleetDashboardStats(
-            totalVehicles: basic.totalVehicles,
-            activeVehicles: basic.activeVehicles,
-            maintenanceDue: basic.maintenanceDue,
-            overdueInspections: overdueInspections,
-            totalTrailers: basic.totalTrailers,
-            fuelCostMTD: fuelCostMTD,
-            milesMTD: milesMTD,
-            maintenanceCostMTD: maintenanceCostMTD
-        )
+            throw error
+        }
     }
 
     /// Get all vehicles with their current assignment and inspection status.

--- a/core/Tests/WiredPartCoreTests/FleetServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/FleetServiceTests.swift
@@ -179,6 +179,56 @@ struct FleetServiceTests {
         #expect(stats.activeVehicles >= 0)
     }
 
+    @Test("Fleet dashboard stats include month-to-date aggregates from consolidated read")
+    func testFleetDashboardStatsMonthToDateAggregates() throws {
+        let env = try E2ETestHelpers.setUp()
+        let before = try env.fleet.getFleetDashboardStats()
+
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        let monthDate = fmt.string(from: Date())
+        let priorMonthDate = "2001-01-15"
+
+        let vehicleId = try env.fleet.createVehicle(
+            actorId: env.adminUserId,
+            vehicleNumber: "V-DASH-MTD", vehicleName: "Dashboard MTD", vehicleType: "truck",
+            make: nil, model: nil, year: nil, color: nil, vin: nil, licensePlate: nil, notes: nil
+        )
+        let userId = try env.auth.createUser(displayName: "Dashboard MTD User", pin: "1234")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO fuel_logs (vehicle_id, user_id, log_date, gallons, total_cost, station)
+                VALUES (?, ?, ?, 10.0, 42.50, 'Current Month Station')
+                """, arguments: [vehicleId, userId, monthDate])
+            try db.execute(sql: """
+                INSERT INTO fuel_logs (vehicle_id, user_id, log_date, gallons, total_cost, station)
+                VALUES (?, ?, ?, 10.0, 99.99, 'Prior Month Station')
+                """, arguments: [vehicleId, userId, priorMonthDate])
+            try db.execute(sql: """
+                INSERT INTO mileage_logs (vehicle_id, user_id, log_date, total_miles, purpose)
+                VALUES (?, ?, ?, 123.0, 'Current month trip')
+                """, arguments: [vehicleId, userId, monthDate])
+            try db.execute(sql: """
+                INSERT INTO mileage_logs (vehicle_id, user_id, log_date, total_miles, purpose)
+                VALUES (?, ?, ?, 456.0, 'Prior month trip')
+                """, arguments: [vehicleId, userId, priorMonthDate])
+            try db.execute(sql: """
+                INSERT INTO maintenance_records (vehicle_id, performed_at, cost, odometer_reading)
+                VALUES (?, ?, 77.25, 1200)
+                """, arguments: [vehicleId, monthDate])
+            try db.execute(sql: """
+                INSERT INTO maintenance_records (vehicle_id, performed_at, cost, odometer_reading)
+                VALUES (?, ?, 88.88, 800)
+                """, arguments: [vehicleId, priorMonthDate])
+        }
+
+        let after = try env.fleet.getFleetDashboardStats()
+        #expect((after.fuelCostMTD ?? 0) == (before.fuelCostMTD ?? 0) + 42.50)
+        #expect((after.milesMTD ?? 0) == (before.milesMTD ?? 0) + 123)
+        #expect((after.maintenanceCostMTD ?? 0) == (before.maintenanceCostMTD ?? 0) + 77.25)
+    }
+
     @Test("Vehicle status list")
     func testVehicleStatusList() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Collapse FleetService.getFleetDashboardStats from 8 separate GRDB read transactions into one db.writer.read using scalar subselect aggregates.
- Preserve the existing missing-table fallback by returning zeroed dashboard stats when the consolidated query hits a table-not-found error.
- Add coverage that current-month fuel, mileage, and maintenance costs are included while older rows are excluded.

## Test Plan
- PASS: `cd core && swift test --filter FleetServiceTests/testFleetDashboardStats`
- NOTE: `cd core && swift test --filter FleetServiceTests` has 2 pre-existing/unrelated failures in updateTrailerLocation userNotFound expectations returning GateError.insufficientPermissions. Dashboard tests passed in that run.

Closes #312

Paperclip: WEI-382