### PR TITLE
Fix remaining silent appCore service guards

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/CategoriesEditorPanel.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/CategoriesEditorPanel.swift
@@ -750,15 +750,19 @@ struct ColorSupplierPartNumbersSection: View {
         isLoading = true
         supplierPartsError = nil
         Task.detached {
-            let results: [(supplierId: Int64, supplierName: String, supplierPartNumber: String?)]
             do {
-                results = try service.getColorSupplierPartNumbers(colorId: colorId)
+                let results = try service.getColorSupplierPartNumbers(colorId: colorId)
+                await MainActor.run {
+                    supplierParts = results
+                    supplierPartsError = nil
+                    isLoading = false
+                }
             } catch {
-                results = [] // Non-critical: supplier part numbers may not be configured
-            }
-            await MainActor.run {
-                supplierParts = results
-                isLoading = false
+                await MainActor.run {
+                    supplierParts = []
+                    supplierPartsError = "Failed to load supplier part numbers"
+                    isLoading = false
+                }
             }
         }
     }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/CategoriesEditorPanel.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/CategoriesEditorPanel.swift
@@ -688,12 +688,18 @@ struct ColorSupplierPartNumbersSection: View {
     @State private var supplierParts: [(supplierId: Int64, supplierName: String, supplierPartNumber: String?)] = []
     @State private var isExpanded = false
     @State private var isLoading = false
+    @State private var supplierPartsError: String?
 
     var body: some View {
         DisclosureGroup("Supplier Part Numbers", isExpanded: $isExpanded) {
             if isLoading {
                 ProgressView()
                     .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, DS.Space.sm)
+            } else if let supplierPartsError {
+                Label(supplierPartsError, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.red)
                     .padding(.vertical, DS.Space.sm)
             } else if supplierParts.isEmpty {
                 Text("No suppliers linked to parts with this color.")
@@ -737,8 +743,12 @@ struct ColorSupplierPartNumbersSection: View {
     }
 
     private func loadSupplierParts() {
-        guard let service = appCore.partsService else { return }
+        guard let service = appCore.partsService else {
+            supplierPartsError = "Parts service unavailable"
+            return
+        }
         isLoading = true
+        supplierPartsError = nil
         Task.detached {
             let results: [(supplierId: Int64, supplierName: String, supplierPartNumber: String?)]
             do {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/CategoriesTreeView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/CategoriesTreeView.swift
@@ -29,6 +29,7 @@ struct CategoriesTreeView: View {
 
     /// Cache of effective cost per colorId, loaded alongside hierarchy.
     @State private var colorPriceCache: [Int64: Double?] = [:]
+    @State private var colorPriceError: String?
 
     // Single active-sheet enum to avoid multiple .sheet conflicts
     enum ActiveSheet: Identifiable {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/CategoriesTreeView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/CategoriesTreeView.swift
@@ -125,6 +125,15 @@ struct CategoriesTreeView: View {
             .padding(.horizontal, DS.Space.lg)
             .padding(.bottom, DS.Space.sm)
 
+            if let colorPriceError {
+                Label(colorPriceError, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, DS.Space.lg)
+                    .padding(.bottom, DS.Space.sm)
+            }
+
             if filteredCategories.isEmpty {
                 if searchText.isEmpty {
                     VStack(spacing: DS.Space.lg) {
@@ -237,7 +246,11 @@ struct CategoriesTreeView: View {
 
     /// Load effective cost for every color in the hierarchy into the cache.
     private func loadColorPrices() {
-        guard let parts = appCore.partsService else { return }
+        guard let parts = appCore.partsService else {
+            colorPriceError = "Parts service unavailable"
+            return
+        }
+        colorPriceError = nil
         var cache: [Int64: Double?] = [:]
         for catNode in hierarchy.categories {
             for styleNode in catNode.styles {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsBrandsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsBrandsPage.swift
@@ -584,7 +584,10 @@ private struct BrandDetailSheet: View {
     }
 
     private func toggleCarryStatus(_ link: PartsService.BrandSupplierRow) {
-        guard let service = appCore.partsService else { return }
+        guard let service = appCore.partsService else {
+            loadError = "Parts service unavailable"
+            return
+        }
         let newStatus = link.carryStatus == "carry_on_shelf" ? "need_to_order" : "carry_on_shelf"
         do {
             try service.updateBrandSupplierCarryStatus(

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
@@ -1177,7 +1177,10 @@ struct PartsCatalogPage: View {
     // MARK: - Cascade Price Cache
 
     private func loadCascadePriceCache() async {
-        guard let service = appCore.partsService else { return }
+        guard let service = appCore.partsService else {
+            await MainActor.run { actionError = "Parts service unavailable" }
+            return
+        }
         var cache: [Int64: PartsService.ResolvedCascadeCost] = [:]
         for part in parts {
             guard let colorId = part.colorId else { continue }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsPricingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsPricingPage.swift
@@ -746,7 +746,10 @@ struct PartsPricingPage: View {
     }
 
     private func loadCascadeData() async {
-        guard let service = appCore.partsService else { return }
+        guard let service = appCore.partsService else {
+            await MainActor.run { loadError = "Parts service unavailable" }
+            return
+        }
         do {
             let allTypes = try service.listTypes()
             let allStyles = try service.listStyles()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
@@ -1085,7 +1085,10 @@ private struct SupplierDetailSheet: View {
     }
 
     private func toggleBrandCarryStatus(_ item: (brandId: Int64, brandName: String, partCount: Int, carryStatus: String)) {
-        guard let service = appCore.partsService else { return }
+        guard let service = appCore.partsService else {
+            loadError = "Parts service unavailable"
+            return
+        }
         let newStatus = item.carryStatus == "carry_on_shelf" ? "need_to_order" : "carry_on_shelf"
         do {
             try service.updateBrandSupplierCarryStatus(

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactDetailPage.swift
@@ -235,7 +235,10 @@ private struct EditContactSheet: View {
     }
 
     private func loadContact() {
-        guard let service = appCore.peopleService else { return }
+        guard let service = appCore.peopleService else {
+            errorMessage = "People service unavailable"
+            return
+        }
         do {
             if let c = try service.getContact(id: contactId) {
                 firstName = c.firstName

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSHatsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSHatsPage.swift
@@ -423,7 +423,10 @@ private struct HatDetailSheet: View {
     }
 
     private func removeMember(at offsets: IndexSet) {
-        guard let service = appCore.peopleService else { return }
+        guard let service = appCore.peopleService else {
+            loadError = "People service unavailable"
+            return
+        }
         for index in offsets {
             let member = members[index]
             do {
@@ -545,7 +548,10 @@ private struct AddEmployeeToHatSheet: View {
     }
 
     private func assignEmployee(_ employeeId: Int64) {
-        guard let service = appCore.peopleService else { return }
+        guard let service = appCore.peopleService else {
+            loadError = "People service unavailable"
+            return
+        }
         do {
             try service.toggleHatAssignment(employeeId: employeeId, hatId: hatId, assign: true)
             dismiss()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleConfigPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleConfigPage.swift
@@ -477,7 +477,11 @@ struct IOSScheduleConfigPage: View {
     // MARK: - Template & Holiday Actions
 
     private func saveShiftTemplate(_ data: ShiftTemplateEditSheet.TemplateData) {
-        guard let svc = appCore.schedulingService else { return }
+        guard let svc = appCore.schedulingService else {
+            saveError = "Scheduling service not available"
+            activeSheet = nil
+            return
+        }
         do {
             try svc.saveShiftTemplate(
                 id: data.existingId, name: data.name, hatId: data.hatId,
@@ -493,7 +497,11 @@ struct IOSScheduleConfigPage: View {
     }
 
     private func deleteShiftTemplate(_ id: Int64) {
-        guard let svc = appCore.schedulingService else { return }
+        guard let svc = appCore.schedulingService else {
+            saveError = "Scheduling service not available"
+            activeSheet = nil
+            return
+        }
         do {
             try svc.deleteShiftTemplate(id: id)
             shiftTemplates = (try? svc.getShiftTemplates()) ?? []
@@ -504,7 +512,11 @@ struct IOSScheduleConfigPage: View {
     }
 
     private func saveHoliday(_ data: HolidayEditSheet.HolidayData) {
-        guard let svc = appCore.schedulingService else { return }
+        guard let svc = appCore.schedulingService else {
+            saveError = "Scheduling service not available"
+            activeSheet = nil
+            return
+        }
         do {
             try svc.saveHoliday(
                 id: data.existingId, name: data.name, date: data.date,
@@ -518,7 +530,11 @@ struct IOSScheduleConfigPage: View {
     }
 
     private func deleteHoliday(_ id: Int64) {
-        guard let svc = appCore.schedulingService else { return }
+        guard let svc = appCore.schedulingService else {
+            saveError = "Scheduling service not available"
+            activeSheet = nil
+            return
+        }
         do {
             try svc.deleteHoliday(id: id)
             holidays = (try? svc.getHolidays()) ?? []

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepPlacement.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepPlacement.swift
@@ -535,7 +535,10 @@ struct WizardStepPlacement: View {
     // MARK: - Cart Mode Actions
 
     private func loadBinsForCartMode() {
-        guard let svc = appCore.warehouseService else { return }
+        guard let svc = appCore.warehouseService else {
+            stepError = "Warehouse service not available"
+            return
+        }
         var loadedBins: [FloorPlanBinInfo] = []
         var loadedAreas: [WarehouseStorageArea] = []
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepWalkingPath.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepWalkingPath.swift
@@ -278,7 +278,10 @@ struct WizardStepWalkingPath: View {
     }
 
     private func suggestPath() {
-        guard let service = appCore.warehouseService else { return }
+        guard let service = appCore.warehouseService else {
+            stepError = "Warehouse service not available"
+            return
+        }
         do {
             previewStops = try service.suggestWalkingPath(floorPlanId: floorPlanId)
         } catch {

--- a/tests/test_silent_service_guards.py
+++ b/tests/test_silent_service_guards.py
@@ -1,0 +1,29 @@
+import re
+import unittest
+from pathlib import Path
+
+
+class SilentServiceGuardTests(unittest.TestCase):
+    def test_no_one_line_appcore_service_guard_silently_returns(self):
+        """appCore service guards must surface an error instead of doing nothing."""
+        repo_root = Path(__file__).resolve().parents[1]
+        ios_root = repo_root / "Weird Parts IOS" / "Weird Parts IOS"
+        pattern = re.compile(
+            r"guard\s+let\s+\w+\s*=\s*appCore\.\w+Service\s+else\s*\{\s*return\s*\}"
+        )
+
+        offenders: list[str] = []
+        for swift_file in ios_root.rglob("*.swift"):
+            text = swift_file.read_text(encoding="utf-8")
+            for match in pattern.finditer(text):
+                line_no = text.count("\n", 0, match.start()) + 1
+                offenders.append(f"{swift_file.relative_to(repo_root)}:{line_no}: {match.group(0)}")
+
+        self.assertFalse(
+            offenders,
+            "Silent appCore service guard returns found:\n" + "\n".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replaces the remaining exact one-line `guard let ... = appCore.*Service else { return }` silent service bails with user-visible error state in Scheduling, People, Parts, and Warehouse UI slices.
- Adds a lightweight Python unittest scanner so this specific silent-guard pattern stays at zero.
- Keeps the fix PR-sized for GH#122/WEI-416 rather than sweeping every broader guard shape in the codebase.

## Validation
- `python3 tests/test_silent_service_guards.py` ✅
- `git diff --check` ✅
- `swift test` from `core/` attempted, but dependency resolution/build did not finish before the 600s timeout after fetching/resolving GRDB.swift.

## Notes
- Branch hygiene warning: repository is currently above the configured hard cap (124 remote branches observed). I finished this already-assigned high-priority slice but did not open additional follow-up branches.

Refs GH#122 / WEI-416
