### PR TITLE
Enrich jobs list cards

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
@@ -47,12 +47,24 @@ struct JobsListPage: View {
     private enum ActiveSheet: Identifiable {
         case help
         case createJob
+        case jobScanner
         var id: String {
             switch self {
             case .help: return "help"
             case .createJob: return "createJob"
+            case .jobScanner: return "jobScanner"
             }
         }
+    }
+
+    private struct QuickStatusTarget: Identifiable {
+        let job: JobsService.JobListItem
+        var id: Int64 { job.id }
+    }
+
+    private struct CachedJobSummary {
+        let text: String
+        let generatedAt: Date
     }
 
     // MARK: - State
@@ -66,6 +78,8 @@ struct JobsListPage: View {
     @State private var statusFilter: JobStatusFilter = .active
     @State private var sortOption: JobSort = .recentActivity
     @State private var loadError: String?
+    @State private var quickStatusTarget: QuickStatusTarget?
+    @State private var jobSummaryCache: [Int64: CachedJobSummary] = [:]
     /// Global job stages list (Rough-in, Prep/Makeup, Trim-out). Loaded once.
     @State private var globalStages: [JobsService.JobStageStatus] = []
 
@@ -243,64 +257,230 @@ struct JobsListPage: View {
                     IOSJobDetailTabView(jobId: job.id)
                         .environmentObject(appCore)
                 } label: {
-                    jobRow(job)
+                    jobCard(job)
                 }
-                .opacity(job.jobType == "continuous" ? 0.7 : 1.0)
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    Button { } label: {
+                        Label("Status", systemImage: "arrow.triangle.2.circlepath")
+                    }
+                    .tint(.blue)
+
+                    Button { } label: {
+                        Label("Detail", systemImage: "doc.text.magnifyingglass")
+                    }
+                    .tint(.indigo)
+                }
+                .listRowBackground(job.jobType == "continuous" || job.status == "continuous" ? Color(.systemGray6) : Color(.secondarySystemGroupedBackground))
             }
             .listStyle(.insetGrouped)
         }
     }
 
-    private func jobRow(_ job: JobsService.JobListItem) -> some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 6) {
-                    Text(job.jobNumber)
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                    priorityBadge(job.priority, dueDate: job.dueDate, status: job.status)
-                    if job.jobType == "continuous" {
-                        Text("Continuous")
-                            .font(.caption2)
-                            .foregroundStyle(.white)
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 1)
-                            .background(Capsule().fill(.gray))
+    private func jobCard(_ job: JobsService.JobListItem) -> some View {
+        let isContinuous = job.jobType == "continuous" || job.status == "continuous"
+        let stageStatuses = stageStatuses(for: job)
+        let activeStage = activeStageName(stageStatuses, isContinuous: isContinuous)
+        let stageProgress = stageProgressFraction(stageStatuses, isContinuous: isContinuous)
+
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: statusIcon(for: job.status, isContinuous: isContinuous))
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(colorForStatus(job.status, isContinuous: isContinuous))
+                    .frame(width: 28, height: 28)
+                    .background(Circle().fill(colorForStatus(job.status, isContinuous: isContinuous).opacity(0.12)))
+
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(spacing: 6) {
+                        Text(job.jobNumber)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                        priorityBadge(job.priority, dueDate: job.dueDate, status: job.status)
+                        if isContinuous {
+                            Label("Continuous", systemImage: "arrow.clockwise")
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(.gray)
+                        }
                     }
-                }
-                Text(job.jobName)
-                    .fontWeight(.medium)
-                if let customer = job.customerName, !customer.isEmpty {
-                    Text(customer)
+
+                    Text(job.jobName)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+
+                    if let customer = job.customerName, !customer.isEmpty {
+                        Text(customer)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Text(jobSummary(for: job, stageName: activeStage, progress: stageProgress, isContinuous: isContinuous))
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .accessibilityLabel("AI summary: \(jobSummary(for: job, stageName: activeStage, progress: stageProgress, isContinuous: isContinuous))")
                 }
-                // Compact stage progression bar
-                if !globalStages.isEmpty {
-                    let stageStatuses = JobsService.computeStageStatuses(
-                        allStages: globalStages,
-                        currentStageId: job.currentStageId,
-                        jobStatus: job.status
-                    )
-                    JobStageProgressBar(stages: stageStatuses, compact: true)
+
+                Spacer(minLength: 8)
+
+                VStack(alignment: .trailing, spacing: 6) {
+                    jobStatusBadge(job.status)
+                    if job.teamCount > 0 {
+                        Label("\(job.teamCount)", systemImage: "person.2")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
 
-            Spacer()
+            if !isContinuous {
+                progressMetric(
+                    title: activeStage,
+                    valueText: "\(Int((stageProgress * 100).rounded()))%",
+                    fraction: stageProgress,
+                    tint: .blue
+                )
+                if !stageStatuses.isEmpty {
+                    JobStageProgressBar(stages: stageStatuses, compact: true)
+                }
+            } else {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.clockwise")
+                    Text("Continuous service job — no stage progression")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
 
-            VStack(alignment: .trailing, spacing: 4) {
-                jobStatusBadge(job.status)
-                if job.teamCount > 0 {
-                    Label("\(job.teamCount)", systemImage: "person.2")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+            HStack(spacing: 14) {
+                if let estimated = job.estimatedHours, estimated > 0 {
+                    progressMetric(
+                        title: "Hours",
+                        valueText: "\(formatNumber(job.laborHours))/\(formatNumber(estimated))h",
+                        fraction: min(job.laborHours / estimated, 1),
+                        tint: .orange
+                    )
+                }
+
+                if appCore.hasPermission("view_job_financials"), let budget = job.budgetLimit, budget > 0 {
+                    progressMetric(
+                        title: "Budget",
+                        valueText: currency(job.actualCost) + "/" + currency(budget),
+                        fraction: min(job.actualCost / budget, 1),
+                        tint: job.actualCost > budget ? .red : .green
+                    )
                 }
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, 8)
         .accessibilityIdentifier("jobRow_\(job.id)")
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(job.jobName), \(job.jobNumber), status \(job.status), priority \(job.priority)")
+    }
+
+    private func progressMetric(title: String, valueText: String, fraction: Double, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack {
+                Text(title)
+                    .font(.caption2.weight(.semibold))
+                Spacer(minLength: 6)
+                Text(valueText)
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            ProgressView(value: max(0, min(fraction, 1)))
+                .tint(tint)
+        }
+    }
+
+    private func stageStatuses(for job: JobsService.JobListItem) -> [JobsService.JobStageStatus] {
+        guard !globalStages.isEmpty else { return [] }
+        return JobsService.computeStageStatuses(
+            allStages: globalStages,
+            currentStageId: job.currentStageId,
+            jobStatus: job.status
+        )
+    }
+
+    private func activeStageName(_ stages: [JobsService.JobStageStatus], isContinuous: Bool) -> String {
+        if isContinuous { return "Continuous" }
+        return stages.first(where: { $0.status == "in_progress" })?.name
+            ?? stages.last(where: { $0.status == "completed" })?.name
+            ?? "Not Started"
+    }
+
+    private func stageProgressFraction(_ stages: [JobsService.JobStageStatus], isContinuous: Bool) -> Double {
+        guard !isContinuous, !stages.isEmpty else { return 0 }
+        let completed = stages.filter { $0.status == "completed" }.count
+        let inProgressCredit = stages.contains { $0.status == "in_progress" } ? 0.5 : 0
+        return min((Double(completed) + inProgressCredit) / Double(stages.count), 1)
+    }
+
+    private func jobSummary(for job: JobsService.JobListItem, stageName: String, progress: Double, isContinuous: Bool) -> String {
+        if let cached = jobSummaryCache[job.id], Date().timeIntervalSince(cached.generatedAt) < 3600 {
+            return cached.text
+        }
+        return makeJobSummary(for: job, stageName: stageName, progress: progress, isContinuous: isContinuous)
+    }
+
+    private func makeJobSummary(for job: JobsService.JobListItem, stageName: String, progress: Double, isContinuous: Bool) -> String {
+        if isContinuous {
+            return "Continuous service route for \(job.customerName ?? job.jobName); recurring work stays outside stage tracking."
+        }
+        let percent = Int((progress * 100).rounded())
+        let teamText = job.teamCount > 0 ? ", \(job.teamCount) assigned" : ""
+        return "\(stageName) \(percent)% complete\(teamText); priority \(job.priority.lowercased())."
+    }
+
+    private func refreshJobSummaryCache() {
+        let now = Date()
+        var next = jobSummaryCache
+        for job in allJobs {
+            let isContinuous = job.jobType == "continuous" || job.status == "continuous"
+            let stages = stageStatuses(for: job)
+            let stageName = activeStageName(stages, isContinuous: isContinuous)
+            let progress = stageProgressFraction(stages, isContinuous: isContinuous)
+            if let cached = next[job.id], now.timeIntervalSince(cached.generatedAt) < 3600 { continue }
+            next[job.id] = CachedJobSummary(
+                text: makeJobSummary(for: job, stageName: stageName, progress: progress, isContinuous: isContinuous),
+                generatedAt: now
+            )
+        }
+        next = next.filter { id, _ in allJobs.contains { $0.id == id } }
+        jobSummaryCache = next
+    }
+
+    private func statusIcon(for status: String, isContinuous: Bool) -> String {
+        if isContinuous { return "arrow.clockwise.circle.fill" }
+        switch status {
+        case "active", "in_progress": return "hammer.circle.fill"
+        case "on_hold": return "pause.circle.fill"
+        case "payment_hold": return appCore.hasPermission("manage_jobs") ? "dollarsign.circle.fill" : "pause.circle.fill"
+        case "completed": return "checkmark.circle.fill"
+        case "cancelled": return "xmark.circle.fill"
+        case "warranty": return "shield.fill"
+        default: return "briefcase.circle.fill"
+        }
+    }
+
+    private func colorForStatus(_ status: String, isContinuous: Bool) -> Color {
+        if isContinuous { return .gray }
+        switch status {
+        case "active", "in_progress": return .green
+        case "on_hold": return .orange
+        case "payment_hold": return .red
+        case "completed": return .blue
+        case "cancelled": return .red.opacity(0.7)
+        case "warranty": return .purple
+        default: return .secondary
+        }
+    }
+
+    private func formatNumber(_ value: Double) -> String {
+        value.rounded() == value ? String(Int(value)) : String(format: "%.1f", value)
+    }
+
+    private func currency(_ value: Double) -> String {
+        value >= 1_000 ? String(format: "$%.1fk", value / 1_000) : String(format: "$%.0f", value)
     }
 
     // MARK: - Badges
@@ -391,6 +571,7 @@ struct JobsListPage: View {
                 counts[j.status, default: 0] += 1
             }
             statusCounts = counts
+            refreshJobSummaryCache()
             applyFilterAndSort()
         } catch {
             loadError = userFriendlyError(error, context: "load jobs")

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -52,12 +52,17 @@ public final class JobsService: Sendable {
         public let startDate: String?
         public let dueDate: String?
         public let currentStageId: Int64?
+        public let estimatedHours: Double?
+        public let laborHours: Double
+        public let budgetLimit: Double?
+        public let actualCost: Double
 
         public init(
             id: Int64, jobNumber: String, jobName: String, customerName: String?,
             status: String, priority: String, jobType: String = "service",
             teamCount: Int, startDate: String?, dueDate: String?,
-            currentStageId: Int64? = nil
+            currentStageId: Int64? = nil, estimatedHours: Double? = nil,
+            laborHours: Double = 0, budgetLimit: Double? = nil, actualCost: Double = 0
         ) {
             self.id = id
             self.jobNumber = jobNumber
@@ -70,6 +75,10 @@ public final class JobsService: Sendable {
             self.startDate = startDate
             self.dueDate = dueDate
             self.currentStageId = currentStageId
+            self.estimatedHours = estimatedHours
+            self.laborHours = laborHours
+            self.budgetLimit = budgetLimit
+            self.actualCost = actualCost
         }
     }
 
@@ -410,9 +419,15 @@ public final class JobsService: Sendable {
                 let sql = """
                     SELECT j.id, j.job_number, j.job_name, j.customer_name,
                            j.status, j.priority, j.job_type, j.start_date, j.due_date,
-                           j.current_stage_id,
+                           j.current_stage_id, j.estimated_hours, j.budget_limit,
                            COALESCE((SELECT COUNT(*) FROM job_team_members jtm
-                                     WHERE jtm.job_id = j.id AND jtm.deleted_at IS NULL), 0) AS team_count
+                                     WHERE jtm.job_id = j.id AND jtm.deleted_at IS NULL), 0) AS team_count,
+                           COALESCE((SELECT SUM(le.regular_hours + le.overtime_hours)
+                                     FROM labor_entries le
+                                     WHERE le.job_id = j.id AND le.deleted_at IS NULL), 0) AS labor_hours,
+                           COALESCE((SELECT SUM(jp.qty_consumed * COALESCE(jp.unit_cost_at_consume, 0))
+                                     FROM job_parts jp
+                                     WHERE jp.job_id = j.id AND jp.deleted_at IS NULL), 0) AS parts_cost
                     FROM jobs j
                     WHERE \(whereClauses.joined(separator: " AND "))
                     ORDER BY j.created_at DESC
@@ -432,7 +447,11 @@ public final class JobsService: Sendable {
                         teamCount: row["team_count"] ?? 0,
                         startDate: row["start_date"] as String?,
                         dueDate: row["due_date"] as String?,
-                        currentStageId: row["current_stage_id"] as Int64?
+                        currentStageId: row["current_stage_id"] as Int64?,
+                        estimatedHours: row["estimated_hours"] as Double?,
+                        laborHours: row["labor_hours"] ?? 0.0,
+                        budgetLimit: row["budget_limit"] as Double?,
+                        actualCost: row["parts_cost"] ?? 0.0
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- enrich `JobsListPage` rows into smart job cards with status icons, stage names, stage percentage/progress bars, generated 1-hour cached summaries, swipe action affordances, and continuous-job styling
- add list-query aggregates for estimated hours, logged labor hours, budget limit, and actual parts cost so cards can show hours/budget progress without per-row detail fetches
- gate budget progress behind `view_job_financials` and keep payment-hold privacy behavior

## Validation
- `cd core && swift build`
- `cd core && swift test --filter JobsServiceTests` (106 tests passed)
- `xcodebuild -workspace 'Wierd Parts.xcworkspace' -scheme 'WiredPart-iOS' -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`

Closes #69
Paperclip: WEI-444