### PR TITLE
perf(fleet): index inspection dashboard lookup

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -124,6 +124,7 @@ extension AppDatabase {
         registerMigration085AuditSessionEvents(&migrator)
         registerMigration086PartAutoWishlistOptIn(&migrator)
         registerMigration087ServicePermissionGateBackfill(&migrator)
+        registerMigration088FleetInspectionDashboardLookupIndex(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -5167,6 +5168,15 @@ extension AppDatabase {
                         """, arguments: [grant.key, hatName])
                 }
             }
+        }
+    }
+
+    private static func registerMigration088FleetInspectionDashboardLookupIndex(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("088_fleet_inspection_dashboard_index") { db in
+            try db.execute(sql: """
+                CREATE INDEX IF NOT EXISTS idx_ir_vehicle_performed_at
+                ON inspection_records(vehicle_id, performed_at)
+                """)
         }
     }
 

--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -8,8 +8,8 @@ public final class AppDatabase: Sendable {
     public let writer: any DatabaseWriter
 
     /// The total number of registered migrations. Update when adding new migrations.
-    /// Migrations are 000-087.
-    public static let schemaVersion = 87
+    /// Migrations are 000-088.
+    public static let schemaVersion = 88
 
     /// Initialize with an existing database writer and run all migrations.
     public init(_ writer: any DatabaseWriter) throws {

--- a/core/Tests/WiredPartCoreTests/DatabaseTests.swift
+++ b/core/Tests/WiredPartCoreTests/DatabaseTests.swift
@@ -96,9 +96,23 @@ struct DatabaseTests {
         }
     }
 
-    @Test("Schema version is 83")
+    @Test("Schema version is 88")
     func testSchemaVersion() throws {
-        #expect(AppDatabase.schemaVersion == 83)
+        #expect(AppDatabase.schemaVersion == 88)
+    }
+
+    @Test("Migration 088 adds fleet inspection dashboard lookup index")
+    func testMigration088FleetInspectionDashboardLookupIndex() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+
+        let indexRows = try db.writer.read { db in
+            try Row.fetchAll(db, sql: "PRAGMA index_info('idx_ir_vehicle_performed_at')")
+        }
+
+        let indexedColumns = indexRows.map { row -> String in
+            row["name"]
+        }
+        #expect(indexedColumns == ["vehicle_id", "performed_at"])
     }
 
     @Test("Migration 082 adds structured estimation review columns")


### PR DESCRIPTION
## Summary
- Adds migration 088 to create idx_ir_vehicle_performed_at on inspection_records(vehicle_id, performed_at)
- Bumps AppDatabase schemaVersion to 88
- Adds DatabaseTests coverage for the new compound index and current schema version

Fixes #313

## Verification
- swift test --filter DatabaseTests/testMigration088FleetInspectionDashboardLookupIndex --filter DatabaseTests/testSchemaVersion
- swift test --filter DatabaseTests