### PR TITLE
ci(codeql): exclude SwiftPM dependency checkouts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: "WiredPart CodeQL config"
+
+# Swift Package Manager checks dependencies out under core/.build by default.
+# Those generated dependency sources are not application code and previously
+# produced alerts against GRDB internals. Keep CodeQL focused on tracked source.
+paths-ignore:
+  - "**/.build/**"
+  - "**/DerivedData/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,10 +67,13 @@ jobs:
           # security-and-quality is the broader query pack — catches
           # both vulnerabilities and code-smell patterns.
           queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
-      - name: Build Swift package
+      - name: Build Swift package outside repository
         if: github.event_name != 'pull_request'
-        run: swift build --package-path core
+        # Keep SwiftPM dependency checkouts out of $GITHUB_WORKSPACE so CodeQL
+        # does not report third-party package internals as application alerts.
+        run: swift build --package-path core --scratch-path "$RUNNER_TEMP/wiredpart-swiftpm-build"
 
       - name: Perform CodeQL Analysis
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
- Adds a CodeQL config that ignores generated SwiftPM and DerivedData directories.
- Builds the Swift package with a scratch path under RUNNER_TEMP so GRDB dependency sources are not checked out under core/.build in the repository workspace.
- Preserves the existing PR recovery gate while keeping full Swift CodeQL on push and schedule events.

## Verification
- ruby YAML parse succeeded for .github/workflows/codeql.yml and .github/codeql/codeql-config.yml.
- swift build --package-path core --scratch-path /tmp/wei384-swiftpm-build passed.
- Verified core/.build was not created by the scratch-path build.

Closes #309