### PR TITLE
fix(jobs): carry daily overtime across entries

### DIFF
--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -978,13 +978,15 @@ public final class JobsService: Sendable {
     ) throws -> Int64 {
         try db.writer.write { dbConn in
             // Verify the entry exists and is clocked in
-            guard let _ = try Row.fetchOne(
+            guard let entry = try Row.fetchOne(
                 dbConn,
-                sql: "SELECT id, clock_in FROM labor_entries WHERE id = ? AND status = 'clocked_in' AND deleted_at IS NULL",
+                sql: "SELECT id, user_id, clock_in FROM labor_entries WHERE id = ? AND status = 'clocked_in' AND deleted_at IS NULL",
                 arguments: [laborEntryId]
             ) else {
                 throw JobsError.laborEntryNotFound(laborEntryId)
             }
+            let userId: Int64 = entry["user_id"] ?? 0
+            let clockIn: String = entry["clock_in"] ?? ""
 
             // Calculate raw elapsed hours
             let rawHours = try Double.fetchOne(dbConn, sql: """
@@ -999,9 +1001,22 @@ public final class JobsService: Sendable {
                 """, arguments: [laborEntryId]) ?? 0
             let totalHours = max(0, rawHours - (breakMinutes / 60.0))
 
-            // Split into regular/overtime at 8-hour daily threshold
-            let regularHours = min(totalHours, 8.0)
-            let overtimeHours = max(0, totalHours - 8.0)
+            // Split into regular/overtime at the per-user, per-day threshold. Count earlier
+            // completed entries for the same worker/day so switching jobs does not restart
+            // the daily regular-hours allowance.
+            let priorWorkedHours = try Double.fetchOne(dbConn, sql: """
+                SELECT COALESCE(SUM(regular_hours + overtime_hours), 0)
+                FROM labor_entries
+                WHERE user_id = ?
+                  AND id != ?
+                  AND status = 'completed'
+                  AND deleted_at IS NULL
+                  AND date(clock_in) = date(?)
+                  AND clock_in < ?
+                """, arguments: [userId, laborEntryId, clockIn, clockIn]) ?? 0
+            let remainingRegularHours = max(0, 8.0 - priorWorkedHours)
+            let regularHours = min(totalHours, remainingRegularHours)
+            let overtimeHours = max(0, totalHours - regularHours)
 
             try dbConn.execute(
                 sql: """

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -128,6 +128,52 @@ struct JobsServiceTests {
         #expect(summary.totalEntries >= 1)
     }
 
+    @Test("Daily overtime threshold spans multiple labor entries")
+    func testDailyOvertimeThresholdSpansMultipleLaborEntries() throws {
+        let env = try E2ETestHelpers.setUp()
+        let firstJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-OT-1", name: "First OT Job")
+        let secondJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-OT-2", name: "Second OT Job")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES
+                    (
+                        ?,
+                        ?,
+                        date(datetime('now', '-4 hours')) || ' 00:00:00',
+                        date(datetime('now', '-4 hours')) || ' 06:00:00',
+                        6.0,
+                        0.0,
+                        'completed',
+                        datetime('now')
+                    )
+                """, arguments: [env.adminUserId, firstJobId])
+        }
+
+        let secondLaborEntryId = try env.jobs.clockIn(userId: env.adminUserId, jobId: secondJobId)
+        try env.db.writer.write { db in
+            try db.execute(
+                sql: "UPDATE labor_entries SET clock_in = datetime('now', '-4 hours') WHERE id = ?",
+                arguments: [secondLaborEntryId]
+            )
+        }
+
+        try env.jobs.clockOut(laborEntryId: secondLaborEntryId)
+
+        let secondEntry = try env.db.writer.read { db in
+            try Row.fetchOne(
+                db,
+                sql: "SELECT regular_hours, overtime_hours FROM labor_entries WHERE id = ?",
+                arguments: [secondLaborEntryId]
+            )
+        }
+
+        #expect(secondEntry?["regular_hours"] as Double? == 2.0)
+        #expect(secondEntry?["overtime_hours"] as Double? == 2.0)
+    }
+
     // MARK: - Team Members
 
     @Test("Add and remove team member from job")


### PR DESCRIPTION
## Summary
- Fixes JobsService clock-out regular/overtime split so daily regular-hour allowance is shared across prior completed entries for the same user/day.
- Adds a Swift Testing regression covering a worker who switches jobs after 6 completed hours and then clocks out after 4 more hours.

## Scope / exclusions
- Bounded WEI-1471 slice from the dirty core workspace: JobsService + JobsServiceTests only.
- Excludes the unrelated dirty core slices for FoundationModels, database/fleet migrations, FleetService, and OrdersService.
- Excludes all unrelated iOS UI, warehouse evidence, Paperclip runtime, tracker/hash, and generated/private state.

## Tests
- `cd core && swift test --filter JobsServiceTests/testDailyOvertimeThresholdSpansMultipleLaborEntries` — passed (1 Swift Testing test).
- `cd core && swift test --filter JobsServiceTests` — passed (107 Swift Testing tests).

## Branch hygiene
- Branch-cap blocker WEI-1469 is done; remote branch count was 99 immediately before this push and is now 100 after creating this bounded PR branch. Do not create additional branches until more branch drain/merge cleanup happens.

Paperclip: WEI-1471
Parent: WEI-1026
