### PR TITLE
fix(fleet): add vehicle location log migration

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -125,6 +125,7 @@ extension AppDatabase {
         registerMigration086PartAutoWishlistOptIn(&migrator)
         registerMigration087ServicePermissionGateBackfill(&migrator)
         registerMigration088FleetInspectionDashboardLookupIndex(&migrator)
+        registerMigration089VehicleLocationLogs(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -5176,6 +5177,38 @@ extension AppDatabase {
             try db.execute(sql: """
                 CREATE INDEX IF NOT EXISTS idx_ir_vehicle_performed_at
                 ON inspection_records(vehicle_id, performed_at)
+                """)
+        }
+    }
+
+    private static func registerMigration089VehicleLocationLogs(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("089_vehicle_location_logs") { db in
+            try db.create(table: "vehicle_location_logs", ifNotExists: true) { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("vehicle_id", .integer).notNull()
+                    .references("vehicles", onDelete: .cascade)
+                t.column("user_id", .integer)
+                    .references("users")
+                t.column("latitude", .double)
+                t.column("longitude", .double)
+                t.column("speed", .double)
+                t.column("status", .text).notNull().defaults(to: "unknown")
+                t.column("recorded_at", .text).notNull().defaults(sql: "(datetime('now'))")
+                t.column("deleted_at", .text)
+            }
+
+            try db.execute(sql: """
+                CREATE INDEX IF NOT EXISTS idx_vll_vehicle
+                ON vehicle_location_logs(vehicle_id)
+                """)
+            try db.execute(sql: """
+                CREATE INDEX IF NOT EXISTS idx_vll_latest_active
+                ON vehicle_location_logs(vehicle_id, id)
+                WHERE deleted_at IS NULL
+                """)
+            try db.execute(sql: """
+                CREATE INDEX IF NOT EXISTS idx_vll_recorded_at
+                ON vehicle_location_logs(recorded_at)
                 """)
         }
     }

--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -8,8 +8,8 @@ public final class AppDatabase: Sendable {
     public let writer: any DatabaseWriter
 
     /// The total number of registered migrations. Update when adding new migrations.
-    /// Migrations are 000-088.
-    public static let schemaVersion = 88
+    /// Migrations are 000-089.
+    public static let schemaVersion = 89
 
     /// Initialize with an existing database writer and run all migrations.
     public init(_ writer: any DatabaseWriter) throws {

--- a/core/Tests/WiredPartCoreTests/DatabaseTests.swift
+++ b/core/Tests/WiredPartCoreTests/DatabaseTests.swift
@@ -85,6 +85,7 @@ struct DatabaseTests {
             // Wishlist & background tasks (057-058)
             "wishlist_items",    // 057
             "background_task_log", // 058
+            "vehicle_location_logs", // 089
             // Audit assignments & permissions (059-060)
         ]
 
@@ -96,9 +97,33 @@ struct DatabaseTests {
         }
     }
 
-    @Test("Schema version is 88")
+    @Test("Schema version is 89")
     func testSchemaVersion() throws {
-        #expect(AppDatabase.schemaVersion == 88)
+        #expect(AppDatabase.schemaVersion == 89)
+    }
+
+    @Test("Migration 089 creates vehicle location logs table and latest-location indexes")
+    func testMigration089VehicleLocationLogsIndexes() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+
+        let result = try db.writer.read { db -> (tableExists: Bool, columns: [String], indexes: [String]) in
+            let tableExists = try db.tableExists("vehicle_location_logs")
+            let columns = tableExists ? try db.columns(in: "vehicle_location_logs").map(\.name) : []
+            let indexes = try Row.fetchAll(db, sql: "PRAGMA index_list('vehicle_location_logs')")
+                .map { row in row["name"] as String }
+            return (tableExists, columns, indexes)
+        }
+
+        #expect(result.tableExists, "vehicle_location_logs should be managed by migrations")
+        #expect(result.columns.contains("vehicle_id"))
+        #expect(result.columns.contains("user_id"))
+        #expect(result.columns.contains("latitude"))
+        #expect(result.columns.contains("longitude"))
+        #expect(result.columns.contains("recorded_at"))
+        #expect(result.columns.contains("deleted_at"))
+        #expect(result.indexes.contains("idx_vll_vehicle"))
+        #expect(result.indexes.contains("idx_vll_latest_active"))
+        #expect(result.indexes.contains("idx_vll_recorded_at"))
     }
 
     @Test("Migration 088 adds fleet inspection dashboard lookup index")


### PR DESCRIPTION
## Summary
- Adds migration 089 to create `vehicle_location_logs`, matching existing FleetService telematics queries.
- Adds indexes for per-vehicle history, latest active location lookups, and recorded-at sorting.
- Bumps schemaVersion to 89 and covers the migration in DatabaseTests.

## Test Plan
- RED verified before implementation: `swift test --filter DatabaseTests/testMigration089VehicleLocationLogsIndexes --filter DatabaseTests/testSchemaVersion` failed with missing table/schema 88.
- GREEN: `swift test --filter DatabaseTests/testMigration089VehicleLocationLogsIndexes --filter DatabaseTests/testSchemaVersion --filter FleetServiceTests/testVehicleStatusCounts` passed.
- `git diff --check` passed.

Paperclip: WEI-1471
Parent: WEI-1026