### PR TITLE
feat(ai): resume latest assistant conversation

### DIFF
--- a/core/Sources/WiredPartCore/AI/FoundationModelsService.swift
+++ b/core/Sources/WiredPartCore/AI/FoundationModelsService.swift
@@ -519,6 +519,24 @@ public actor FoundationModelsService {
         }
     }
 
+    /// Return the most recently active conversation ID, if any persisted chat exists.
+    ///
+    /// The AI assistant panel uses this to resume the last conversation across app launches
+    /// instead of generating a new UUID every time the panel is rebuilt.
+    public static func latestConversationId(from db: AppDatabase) async throws -> String? {
+        try await db.writer.read { dbConn in
+            try String.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT conversation_id
+                    FROM ai_conversation_messages
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """
+            )
+        }
+    }
+
     // MARK: - Private Generation
 
     /// Core generation method that handles the FoundationModels API call.

--- a/core/Tests/WiredPartCoreTests/FoundationModelsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/FoundationModelsServiceTests.swift
@@ -217,6 +217,37 @@ struct FoundationModelsServiceTests {
         #expect(list.first?.preview == "Latest reply")
     }
 
+    @Test("latestConversationId returns nil when no messages exist")
+    func testLatestConversationId_emptyDatabase() async throws {
+        let env = try E2ETestHelpers.setUp()
+        let latest = try await FoundationModelsService.latestConversationId(from: env.db)
+        #expect(latest == nil)
+    }
+
+    @Test("latestConversationId returns most recently active conversation")
+    func testLatestConversationId_returnsMostRecentConversation() async throws {
+        let env = try E2ETestHelpers.setUp()
+        let older = AIConversationMessage(
+            id: "latest-old",
+            conversationId: "older-conv",
+            role: "user",
+            content: "Older thread",
+            createdAt: "2026-04-20 07:00:00"
+        )
+        let newer = AIConversationMessage(
+            id: "latest-new",
+            conversationId: "newer-conv",
+            role: "assistant",
+            content: "Newer thread",
+            createdAt: "2026-04-20 08:00:00"
+        )
+        try await FoundationModelsService.saveMessage(older, to: env.db)
+        try await FoundationModelsService.saveMessage(newer, to: env.db)
+
+        let latest = try await FoundationModelsService.latestConversationId(from: env.db)
+        #expect(latest == "newer-conv")
+    }
+
     // MARK: - AIConversationMessage Init
 
     @Test("AIConversationMessage defaults to UUID id and now timestamp")


### PR DESCRIPTION
## Summary
- Adds FoundationModelsService.latestConversationId(from:) to find the most recently active persisted AI conversation.
- Adds regression coverage for empty chat history and newest-conversation selection.

## Scope / exclusions
- This is the WEI-1471 FoundationModels core service/test slice only.
- Excludes unrelated dirty workspace changes in database migrations, Fleet, Jobs, Orders, iOS UI, warehouse evidence artifacts, tracker hashes, and Paperclip runtime paths.

## Validation
- swift test --filter 'WiredPartCoreTests.FoundationModelsServiceTests/testLatestConversationId' — PASS (2 tests)
- swift test --filter latestConversationId — build PASS but SwiftPM filter matched 0 tests; reran with listed fully-qualified test prefix above.
- git diff --check — PASS

Refs WEI-1471
Refs WEI-1026
