### PR TITLE
feat(warehouse): dashboard and movements UX for GH-74

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
@@ -258,6 +258,9 @@ struct WarehouseDashboardPage: View {
                 // Smart Card Filters
                 smartCardFilters
 
+                // Alerts / Warnings
+                alertsBanner
+
                 // KPI Summary
                 kpiRow
 
@@ -348,6 +351,44 @@ struct WarehouseDashboardPage: View {
         .accessibilityLabel("\(filter.rawValue): \(count)")
     }
 
+    // MARK: - Alerts
+
+    @ViewBuilder
+    private var alertsBanner: some View {
+        let auditDueCount = max(0, auditSummary.map { $0.totalParts - $0.countedParts } ?? 0)
+        let lowConfidenceCount = auditSummary?.discrepancies ?? 0
+        let shortfalls = dashKPIs?.kpis.shortfallCount ?? 0
+
+        if auditDueCount > 0 || lowConfidenceCount > 0 || shortfalls > 0 {
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Warehouse Alerts", systemImage: "exclamationmark.triangle.fill")
+                    .font(.headline)
+                    .foregroundStyle(.orange)
+
+                if auditDueCount > 0 {
+                    alertLine("\(auditDueCount) part\(auditDueCount == 1 ? "" : "s") still need audit coverage", icon: "clipboard")
+                }
+                if lowConfidenceCount > 0 {
+                    alertLine("\(lowConfidenceCount) low-confidence/variance area\(lowConfidenceCount == 1 ? "" : "s") need review", icon: "chart.bar.doc.horizontal")
+                }
+                if shortfalls > 0 {
+                    alertLine("\(shortfalls) stocked part\(shortfalls == 1 ? "" : "s") below minimum", icon: "shippingbox")
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(Color.orange.opacity(0.10))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.orange.opacity(0.25), lineWidth: 1))
+        }
+    }
+
+    private func alertLine(_ text: String, icon: String) -> some View {
+        Label(text, systemImage: icon)
+            .font(.caption)
+            .foregroundStyle(.primary)
+    }
+
     // MARK: - KPI Row
 
     private var kpiRow: some View {
@@ -407,35 +448,35 @@ struct WarehouseDashboardPage: View {
                 .padding(.horizontal, 4)
 
             HStack(spacing: 12) {
-                Button { activeSheet = .newMovement } label: {
+                Button { navigate(to: "warehouse-movements") } label: {
                     quickActionButton(
-                        title: "New Movement",
+                        title: "Movements",
                         icon: "arrow.left.arrow.right.circle.fill",
                         color: .blue
                     )
                 }
                 .buttonStyle(.plain)
-                .accessibilityIdentifier("whAction_newMovement")
+                .accessibilityIdentifier("whAction_movements")
 
-                Button { activeSheet = .qrScanner } label: {
+                Button { navigate(to: "warehouse-receiving") } label: {
                     quickActionButton(
-                        title: "Scan QR",
-                        icon: "qrcode.viewfinder",
-                        color: .orange
-                    )
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("whAction_scanQR")
-
-                Button { activeSheet = .onboardingWizard } label: {
-                    quickActionButton(
-                        title: "Setup Wizard",
-                        icon: "wand.and.stars",
+                        title: "Receiving",
+                        icon: "arrow.down.circle",
                         color: .green
                     )
                 }
                 .buttonStyle(.plain)
-                .accessibilityIdentifier("whAction_setupWizard")
+                .accessibilityIdentifier("whAction_receiving")
+
+                Button { navigate(to: "warehouse-audit") } label: {
+                    quickActionButton(
+                        title: "Audit",
+                        icon: "clipboard.fill",
+                        color: .orange
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("whAction_audit")
             }
         }
     }
@@ -469,21 +510,25 @@ struct WarehouseDashboardPage: View {
                 GridItem(.flexible(), spacing: 10),
                 GridItem(.flexible(), spacing: 10),
             ], spacing: 10) {
-                subPageLink(title: "Audit", icon: "clipboard", color: .orange, moduleId: "warehouse-audit")
-                subPageLink(title: "Staging", icon: "shippingbox.and.arrow.backward", color: .blue, moduleId: "warehouse-staging")
+                subPageLink(title: "Movements", icon: "arrow.left.arrow.right", color: .blue, moduleId: "warehouse-movements")
                 subPageLink(title: "Receiving", icon: "arrow.down.circle", color: .green, moduleId: "warehouse-receiving")
+                subPageLink(title: "Staging", icon: "shippingbox.and.arrow.backward", color: .blue, moduleId: "warehouse-staging")
+                subPageLink(title: "Returns", icon: "arrow.uturn.left", color: .purple, moduleId: "warehouse-returns")
+                subPageLink(title: "Audit", icon: "clipboard", color: .orange, moduleId: "warehouse-audit")
                 subPageLink(title: "Inventory", icon: "square.grid.3x3", color: .purple, moduleId: "warehouse-inventory")
+                subPageLink(title: "Locations", icon: "mappin.and.ellipse", color: .teal, moduleId: "warehouse-locations")
+                subPageLink(title: "Floor Plan", icon: "map", color: .indigo, moduleId: "warehouse-locations")
+                subPageLink(title: "Tools", icon: "wrench.and.screwdriver", color: .brown, moduleId: "warehouse-tools")
+                subPageLink(title: "Network", icon: "point.3.connected.trianglepath.dotted", color: .cyan, moduleId: "warehouse-network")
+                subPageLink(title: "Leaderboard", icon: "trophy", color: .yellow, moduleId: "warehouse-leaderboard")
+                subPageLink(title: "Settings", icon: "gearshape", color: .gray, moduleId: "warehouse-settings")
             }
         }
     }
 
     private func subPageLink(title: String, icon: String, color: Color, moduleId: String) -> some View {
         Button {
-            NotificationCenter.default.post(
-                name: .navigateToModule,
-                object: nil,
-                userInfo: ["moduleId": moduleId]
-            )
+            navigate(to: moduleId)
         } label: {
             HStack(spacing: 8) {
                 Image(systemName: icon)
@@ -506,6 +551,14 @@ struct WarehouseDashboardPage: View {
             .clipShape(RoundedRectangle(cornerRadius: 10))
         }
         .buttonStyle(.plain)
+    }
+
+    private func navigate(to moduleId: String) {
+        NotificationCenter.default.post(
+            name: .navigateToModule,
+            object: nil,
+            userInfo: ["moduleId": moduleId]
+        )
     }
 
     // MARK: - Recent Activity
@@ -624,7 +677,7 @@ struct WarehouseDashboardPage: View {
         do {
             dashKPIs = try service.getDashboardKPIs()
             auditSummary = try service.getAuditSummary()
-            recentMovements = try service.listMovements(limit: 10)
+            recentMovements = try service.listMovements(limit: 10, sortOrder: .newestFirst)
             postAIContext()
         } catch {
             loadError = userFriendlyError(error, context: "load warehouse dashboard")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
@@ -15,6 +15,7 @@ struct WarehouseMovementsPage: View {
     @State private var selectedFilter: MovementFilter?
     @State private var loadError: String?
     @State private var activeSheet: ActiveSheet?
+    @State private var completedHistoryExpanded = false
 
     // Date filter
     @State private var dateRange: ReportDateRange = .thisWeek
@@ -25,15 +26,19 @@ struct WarehouseMovementsPage: View {
     private var effectiveEnd: Date { dateRange.dateInterval?.end ?? customEnd }
 
     private enum MovementFilter: String, CaseIterable {
-        case transfers = "Transfers"
-        case receives = "Receives"
-        case returns = "Returns"
-        case adjustments = "Adjustments"
+        case all = "All"
+        case transfers = "Transfer"
+        case receives = "Received"
+        case consumed = "Consumed"
+        case returns = "Return"
+        case adjustments = "Adjustment"
 
-        var movementType: String {
+        var movementType: String? {
             switch self {
+            case .all: nil
             case .transfers: "transfer"
             case .receives: "receive"
+            case .consumed: "consume"
             case .returns: "return_to_supplier"
             case .adjustments: "adjustment"
             }
@@ -43,6 +48,7 @@ struct WarehouseMovementsPage: View {
     private enum ActiveSheet: Identifiable {
         case movementDetail(WarehouseService.MovementRow)
         case newMovement
+        case quickLog
         case qrScanner
         case help
 
@@ -50,6 +56,7 @@ struct WarehouseMovementsPage: View {
             switch self {
             case .movementDetail(let m): "detail-\(m.id)"
             case .newMovement: "newMovement"
+            case .quickLog: "quickLog"
             case .qrScanner: "qrScanner"
             case .help: "help"
             }
@@ -81,6 +88,10 @@ struct WarehouseMovementsPage: View {
                     Image(systemName: "qrcode.viewfinder")
                 }
                 .accessibilityLabel("Scan QR code")
+                Button { activeSheet = .quickLog } label: {
+                    Image(systemName: "square.and.pencil")
+                }
+                .accessibilityLabel("Quick log movement")
                 Button { activeSheet = .newMovement } label: {
                     Image(systemName: "plus")
                 }
@@ -119,6 +130,10 @@ struct WarehouseMovementsPage: View {
         case .newMovement:
             IOSMovementWizard(onComplete: { loadData() })
                 .environmentObject(appCore)
+        case .quickLog:
+            QuickLogMovementSheet(openFullMovementWizard: {
+                activeSheet = .newMovement
+            })
         case .qrScanner:
             QRScanSheet(expectedType: .part) { result in
                 activeSheet = nil
@@ -128,9 +143,10 @@ struct WarehouseMovementsPage: View {
             PageHelpSheet(
                 title: "Movements Help",
                 sections: [
-                    ("Overview", "Track all stock movements: transfers between locations, receiving from suppliers, returns, and adjustments."),
-                    ("Creating Movements", "Tap + to start a new guided movement. The wizard walks you through selecting parts, quantities, and locations."),
-                    ("Filtering", "Use the smart card chips to filter by movement type. Search by part name. Tap any movement for details.")
+                    ("Overview", "Track all stock movements: transfers, receiving, consumed-on-job, supplier returns, and inventory adjustments."),
+                    ("Creating Movements", "Tap + to start a guided movement. Use Quick Log for an informal already-happened event that should be documented before entering exact stock details."),
+                    ("Filtering", "Use the six smart cards to filter by movement type or return to All. Search by part name. Tap any movement for type-specific details."),
+                    ("History", "Active movements are shown first, oldest to newest. Completed history keeps the last 7 days collapsed until you need it.")
                 ]
             )
         }
@@ -139,15 +155,18 @@ struct WarehouseMovementsPage: View {
     // MARK: - Smart Card Filters
 
     private var smartCardFilters: some View {
-        let transferCount = movements.filter { $0.movementType == "transfer" }.count
-        let receiveCount = movements.filter { $0.movementType == "receive" }.count
-        let returnCount = movements.filter { $0.movementType == "return_to_supplier" }.count
-        let adjustCount = movements.filter { $0.movementType == "adjustment" }.count
+        let transferCount = dateFilteredMovements.filter { $0.movementType == "transfer" }.count
+        let receiveCount = dateFilteredMovements.filter { $0.movementType == "receive" }.count
+        let consumedCount = dateFilteredMovements.filter { $0.movementType == "consume" }.count
+        let returnCount = dateFilteredMovements.filter { $0.movementType == "return_to_supplier" }.count
+        let adjustCount = dateFilteredMovements.filter { $0.movementType == "adjustment" }.count
 
         return ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
+                filterCard(.all, count: dateFilteredMovements.count, icon: "tray.full", color: .accentColor)
                 filterCard(.transfers, count: transferCount, icon: "arrow.left.arrow.right", color: .blue)
                 filterCard(.receives, count: receiveCount, icon: "arrow.down.circle", color: .green)
+                filterCard(.consumed, count: consumedCount, icon: "flame", color: .orange)
                 filterCard(.returns, count: returnCount, icon: "arrow.uturn.left", color: .purple)
                 filterCard(.adjustments, count: adjustCount, icon: "plus.forwardslash.minus", color: .gray)
             }
@@ -161,7 +180,7 @@ struct WarehouseMovementsPage: View {
         let isSelected = selectedFilter == filter
 
         return Button {
-            selectedFilter = isSelected ? nil : filter
+            selectedFilter = filter == .all || isSelected ? nil : filter
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: icon)
@@ -186,39 +205,81 @@ struct WarehouseMovementsPage: View {
     // MARK: - Filtered Movements
 
     private var filteredMovements: [WarehouseService.MovementRow] {
-        var result = movements
-        if let filter = selectedFilter {
-            result = result.filter { $0.movementType == filter.movementType }
+        var result = dateFilteredMovements
+        if let filter = selectedFilter, let movementType = filter.movementType {
+            result = result.filter { $0.movementType == movementType }
         }
         if !searchText.isEmpty {
             let query = searchText.lowercased()
             result = result.filter { $0.partName.lowercased().contains(query) }
         }
-        return result
+        return result.sorted { ($0.createdAt ?? "") < ($1.createdAt ?? "") }
+    }
+
+    private var dateFilteredMovements: [WarehouseService.MovementRow] {
+        movements.filter { movement in
+            guard let date = movementDate(movement) else { return true }
+            return date >= effectiveStart && date <= effectiveEnd
+        }
     }
 
     // MARK: - Movements List
+
+    private var activeMovements: [WarehouseService.MovementRow] {
+        let cutoff = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
+        return filteredMovements.filter { movementDate($0) ?? Date.distantFuture >= cutoff }
+    }
+
+    private var completedHistoryMovements: [WarehouseService.MovementRow] {
+        let cutoff = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
+        return filteredMovements.filter { movementDate($0) ?? Date.distantFuture < cutoff }
+    }
 
     @ViewBuilder
     private var movementsList: some View {
         List {
             Section {
-                Text("\(filteredMovements.count) movement\(filteredMovements.count == 1 ? "" : "s")")
+                Text("\(filteredMovements.count) movement\(filteredMovements.count == 1 ? "" : "s") • oldest to newest")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
-            ForEach(filteredMovements, id: \.id) { movement in
-                Button {
-                    activeSheet = .movementDetail(movement)
-                } label: {
-                    movementRow(movement)
+            Section("Active") {
+                if activeMovements.isEmpty {
+                    Text("No active movements in the selected range.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(activeMovements, id: \.id) { movementButton($0) }
                 }
-                .buttonStyle(.plain)
+            }
+
+            Section {
+                DisclosureGroup(isExpanded: $completedHistoryExpanded) {
+                    if completedHistoryMovements.isEmpty {
+                        Text("No completed movements older than 7 days for this filter.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(completedHistoryMovements, id: \.id) { movementButton($0) }
+                    }
+                } label: {
+                    Label("Completed History (7+ days)", systemImage: "clock.arrow.circlepath")
+                        .font(.subheadline)
+                }
             }
         }
         .listStyle(.insetGrouped)
         .scrollDismissesKeyboard(.interactively)
+    }
+
+    private func movementButton(_ movement: WarehouseService.MovementRow) -> some View {
+        Button {
+            activeSheet = .movementDetail(movement)
+        } label: {
+            movementRow(movement)
+        }
+        .buttonStyle(.plain)
     }
 
     @ViewBuilder
@@ -301,7 +362,7 @@ struct WarehouseMovementsPage: View {
         isLoading = movements.isEmpty
         loadError = nil
         do {
-            movements = try service.listMovements(limit: 200)
+            movements = try service.listMovements(limit: 200, sortOrder: .oldestFirst)
             postAIContext()
         } catch {
             loadError = userFriendlyError(error, context: "load movements")
@@ -365,6 +426,80 @@ struct WarehouseMovementsPage: View {
     private func formatDate(_ dateStr: String?) -> String {
         guard let dateStr else { return "" }
         return dateStr.count >= 10 ? String(dateStr.prefix(10)) : dateStr
+    }
+
+    private func movementDate(_ movement: WarehouseService.MovementRow) -> Date? {
+        guard let raw = movement.createdAt else { return nil }
+        return Self.sqliteDateFormatter.date(from: raw)
+            ?? ISO8601DateFormatter().date(from: raw)
+    }
+
+    private static let sqliteDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter
+    }()
+}
+
+// MARK: - Quick Log Sheet
+
+private struct QuickLogMovementSheet: View {
+    let openFullMovementWizard: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    Label("Quick Log", systemImage: "square.and.pencil")
+                        .font(.headline)
+                    Text("Use this for already-happened warehouse events that need a fast note before exact stock details are entered. The full movement wizard still records inventory-safe quantities and locations.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("Common informal events") {
+                    quickLogHint("Transfer", icon: "arrow.left.arrow.right", note: "Moved between warehouse locations")
+                    quickLogHint("Received", icon: "arrow.down.circle", note: "Supplier or PO items arrived")
+                    quickLogHint("Consumed", icon: "flame", note: "Used on a job or delivery")
+                    quickLogHint("Return", icon: "arrow.uturn.left", note: "Return to supplier, manager approval required")
+                    quickLogHint("Adjustment", icon: "plus.forwardslash.minus", note: "Inventory correction, audit trail required")
+                }
+
+                Section {
+                    Button {
+                        dismiss()
+                        openFullMovementWizard()
+                    } label: {
+                        Label("Open full movement wizard", systemImage: "plus.circle.fill")
+                    }
+                }
+            }
+            .navigationTitle("Quick Log")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func quickLogHint(_ title: String, icon: String, note: String) -> some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Text(note)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: icon)
+                .foregroundStyle(Color.accentColor)
+        }
     }
 }
 

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -134,7 +134,7 @@ public final class WarehouseService: Sendable {
         let pendingReturns = try safeCount(
             sql: """
                 SELECT COUNT(*) FROM stock_movements
-                WHERE movement_type = 'return'
+                WHERE movement_type IN ('return', 'return_to_supplier')
                   AND date(created_at) = date('now')
                   AND deleted_at IS NULL
                 """
@@ -360,6 +360,19 @@ public final class WarehouseService: Sendable {
         }
     }
 
+    /// Sort order for movement list queries.
+    public enum MovementSortOrder: Sendable {
+        case newestFirst
+        case oldestFirst
+
+        fileprivate var sql: String {
+            switch self {
+            case .newestFirst: "DESC"
+            case .oldestFirst: "ASC"
+            }
+        }
+    }
+
     /// Movement validation result.
     public struct ValidationResult: Sendable {
         public let isValid: Bool
@@ -452,7 +465,8 @@ public final class WarehouseService: Sendable {
         search: String? = nil,
         movementType: String? = nil,
         limit: Int = 100,
-        offset: Int = 0
+        offset: Int = 0,
+        sortOrder: MovementSortOrder = .newestFirst
     ) throws -> [MovementRow] {
         do {
             return try db.writer.read { dbConn -> [MovementRow] in
@@ -481,7 +495,7 @@ public final class WarehouseService: Sendable {
                     LEFT JOIN parts p ON p.id = sm.part_id AND p.deleted_at IS NULL
                     LEFT JOIN users u ON u.id = sm.performed_by AND u.deleted_at IS NULL
                     WHERE \(whereClauses.joined(separator: " AND "))
-                    ORDER BY sm.created_at DESC
+                    ORDER BY sm.created_at \(sortOrder.sql)
                     LIMIT ? OFFSET ?
                     """
 


### PR DESCRIPTION
## Summary\n- Keeps Warehouse Dashboard and Movements UI files free of direct GRDB imports and routes data through WarehouseService.\n- Adds dashboard alerts plus 10+ warehouse sub-page quick links and distinct quick navigation actions.\n- Expands Movements to six smart filters, oldest-first ordering, active/completed history grouping, detail sheets, and a Quick Log entry point.\n- Adds WarehouseService movement sort-order support and includes return_to_supplier in dashboard return counts.\n\n## Test Plan\n- xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO\n- swift test --filter 'Warehouse|E2E: Warehouse' (build completed; command timed out after 600s while waiting on test runner output)\n\nCloses #74