### PR TITLE
fix(people): expand employee detail tab touch targets

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeeDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeeDetailPage.swift
@@ -166,6 +166,10 @@ struct IOSEmployeeDetailPage: View {
                                 Capsule().fill(selectedTab == tab ? Color.accentColor : Color.secondary.opacity(0.15))
                             )
                             .foregroundStyle(selectedTab == tab ? .white : .primary)
+                            .frame(minWidth: 44, minHeight: 44)
+                            .contentShape(Rectangle())
+                            .accessibilityLabel(Text("\(tab.capitalized) tab"))
+                            .accessibilityAddTraits(selectedTab == tab ? .isSelected : [])
                     }
                     .buttonStyle(.plain)
                 }


### PR DESCRIPTION
## Summary
- Expands Employee Detail horizontal tab chip hit targets to at least 44x44 points.
- Adds an explicit rectangular content shape so the full minimum frame is tappable.
- Adds clearer tab accessibility labels and selected-state traits.

## Verification
- Static checklist: `IOSEmployeeDetailPage.swift` has no `import GRDB`, includes Skills/Certifications/Activity tab code, and now has `frame(minWidth: 44, minHeight: 44)` plus `contentShape(Rectangle())` on tab buttons.
- Attempted: `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -configuration Debug -sdk iphonesimulator -destination "generic/platform=iOS Simulator" -derivedDataPath "/tmp/wei-436-pr465-DerivedData-active" ONLY_ACTIVE_ARCH=YES build`
  - Result: failed on pre-existing/unrelated `JobsListPage.swift` exhaustive switch error for missing `.jobScanner`; Employee Detail changes were not implicated.

Fixes #475
Updates #77