### PR TITLE
test(security): avoid keychain access in cipher salt tests

### DIFF
--- a/core/Sources/WiredPartCore/Security/CipherKeyManager.swift
+++ b/core/Sources/WiredPartCore/Security/CipherKeyManager.swift
@@ -103,6 +103,11 @@ public final class CipherKeyManager: Sendable {
 
     /// Delete the persisted salt (use only during device wipe / factory reset).
     public func deleteSalt() {
+        if Self.isRunningUnderTestBundle {
+            Self.clearProcessLocalTestSalt()
+            return
+        }
+
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: Self.keychainService,
@@ -129,6 +134,12 @@ public final class CipherKeyManager: Sendable {
         let salt = try generateSalt()
         testSalt = salt
         return salt
+    }
+
+    private static func clearProcessLocalTestSalt() {
+        testSaltLock.lock()
+        defer { testSaltLock.unlock() }
+        testSalt = nil
     }
 
     private static func generateSalt() throws -> Data {

--- a/core/Sources/WiredPartCore/Security/CipherKeyManager.swift
+++ b/core/Sources/WiredPartCore/Security/CipherKeyManager.swift
@@ -33,6 +33,8 @@ public final class CipherKeyManager: Sendable {
     private static let keychainAccount = "wp.dbcipher.salt"
     private static let keychainService = "com.wiredpart.dbcipher"
     private static let logger = Logger(subsystem: "com.wiredpart.core", category: "CipherKeyManager")
+    nonisolated(unsafe) private static var testSalt: Data?
+    private static let testSaltLock = NSLock()
 
     private init() {}
 
@@ -64,18 +66,20 @@ public final class CipherKeyManager: Sendable {
     /// - Returns: 32-byte `Data` value.
     /// - Throws: `CipherKeyError.keychainAccessFailed` on a hard Keychain failure.
     public func loadOrCreateSalt() throws -> Data {
+        // SwiftPM's command-line test runner can block indefinitely on macOS Keychain
+        // access when no GUI authorization session is available. Production app code
+        // still uses the Keychain path below; tests use a process-local stable salt so
+        // key derivation behavior remains deterministic without touching user Keychains.
+        if Self.isRunningUnderTestBundle {
+            return try Self.loadOrCreateProcessLocalTestSalt()
+        }
+
         // Attempt read first.
         if let existing = readSaltFromKeychain() {
             return existing
         }
 
-        // Generate 32 cryptographically-random bytes.
-        var bytes = [UInt8](repeating: 0, count: 32)
-        let rc = SecRandomCopyBytes(kSecRandomDefault, 32, &bytes)
-        guard rc == errSecSuccess else {
-            throw CipherKeyError.saltGenerationFailed(rc)
-        }
-        let salt = Data(bytes)
+        let salt = try Self.generateSalt()
 
         do {
             try writeSaltToKeychain(salt)
@@ -108,6 +112,33 @@ public final class CipherKeyManager: Sendable {
         if status != errSecSuccess && status != errSecItemNotFound {
             Self.logger.warning("CipherKeyManager: SecItemDelete returned \(status) — salt may persist")
         }
+    }
+
+    // MARK: - Private Test Helpers
+
+    private static var isRunningUnderTestBundle: Bool {
+        let executablePath = Bundle.main.executablePath ?? ""
+        return executablePath.contains(".xctest") ||
+            ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
+    private static func loadOrCreateProcessLocalTestSalt() throws -> Data {
+        testSaltLock.lock()
+        defer { testSaltLock.unlock() }
+        if let existing = testSalt { return existing }
+        let salt = try generateSalt()
+        testSalt = salt
+        return salt
+    }
+
+    private static func generateSalt() throws -> Data {
+        // Generate 32 cryptographically-random bytes.
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let rc = SecRandomCopyBytes(kSecRandomDefault, 32, &bytes)
+        guard rc == errSecSuccess else {
+            throw CipherKeyError.saltGenerationFailed(rc)
+        }
+        return Data(bytes)
     }
 
     // MARK: - Private Keychain Helpers

--- a/core/Tests/WiredPartCoreTests/AppDatabaseCipherTests.swift
+++ b/core/Tests/WiredPartCoreTests/AppDatabaseCipherTests.swift
@@ -64,10 +64,28 @@ struct AppDatabaseCipherTests {
     @Test("testSaltLoadOrCreate — generates 32-byte salt and is idempotent")
     func testSaltLoadOrCreate() throws {
         let manager = CipherKeyManager.shared
+        manager.deleteSalt()
+        defer { manager.deleteSalt() }
+
         let salt1 = try manager.loadOrCreateSalt()
         let salt2 = try manager.loadOrCreateSalt()
         #expect(salt1.count == 32)
         #expect(salt1 == salt2)  // idempotent — same salt on second call
+    }
+
+    @Test("testDeleteSaltClearsTestSalt — test runner salt reset avoids Keychain access")
+    func testDeleteSaltClearsTestSalt() throws {
+        let manager = CipherKeyManager.shared
+        manager.deleteSalt()
+        let salt1 = try manager.loadOrCreateSalt()
+
+        manager.deleteSalt()
+        let salt2 = try manager.loadOrCreateSalt()
+
+        #expect(salt1.count == 32)
+        #expect(salt2.count == 32)
+        #expect(salt1 != salt2, "deleteSalt should clear the process-local test salt")
+        manager.deleteSalt()
     }
 
     // MARK: - Option B Migration Tests


### PR DESCRIPTION
## Summary
- Keeps production CipherKeyManager on the Keychain-backed SQLCipher salt path
- Adds a process-local salt path only when running inside the Swift test bundle
- Prevents SwiftPM/macOS CLI tests from hanging on GUI Keychain authorization while preserving deterministic salt behavior in tests

## Verification
- swiftc -typecheck core/Sources/WiredPartCore/Security/CipherKeyManager.swift
- git diff --check origin/main...HEAD

## Notes
- Full swift test is currently blocked in this environment by existing FoundationModels macro plugin errors in core/Sources/WiredPartCore/AI/AITools.swift, unrelated to this change.

Refs #292