### PR TITLE
fix(ios): allow simulator database startup without keychain

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -516,6 +516,12 @@ final class AppCore: ObservableObject {
 
     // MARK: - SQLCipher Device Bootstrap Key
 
+    /// Stable simulator-only fallback used when ad-hoc/no-codesign QA builds cannot
+    /// access the Keychain (`errSecMissingEntitlement`, -34018). Production devices
+    /// still require the Keychain-backed random bootstrap key below.
+    nonisolated private static let simulatorKeychainFallbackKeyHex =
+        "8f1df32f4be04d5fcde1e8e6ddf9187f53a4b68370d5aafc56f0d43f2e9732a1"
+
     /// Return the device-bound SQLCipher bootstrap key (hex-encoded 64 chars).
     ///
     /// This key is used exclusively to encrypt the database file. It is a random
@@ -541,6 +547,12 @@ final class AppCore: ObservableObject {
         if readStatus == errSecSuccess, let data = result as? Data, data.count == 32 {
             return data.map { String(format: "%02x", $0) }.joined()
         }
+
+        #if targetEnvironment(simulator)
+        if readStatus == errSecMissingEntitlement {
+            return simulatorKeychainFallbackKeyHex
+        }
+        #endif
 
         // Generate 32 fresh random bytes.
         var keyBytes = [UInt8](repeating: 0, count: 32)
@@ -568,6 +580,11 @@ final class AppCore: ObservableObject {
             }
             throw CipherKeyError.keychainAccessFailed(rereadStatus)
         } else if addStatus != errSecSuccess {
+            #if targetEnvironment(simulator)
+            if addStatus == errSecMissingEntitlement {
+                return simulatorKeychainFallbackKeyHex
+            }
+            #endif
             throw CipherKeyError.keychainAccessFailed(addStatus)
         }
         return keyData.map { String(format: "%02x", $0) }.joined()


### PR DESCRIPTION
## Summary
- Fixes the iOS simulator database startup blocker seen in WEI-1509 / GH#486 QA.
- Adds a simulator-only SQLCipher bootstrap-key fallback for ad-hoc/no-codesign QA builds where Keychain calls return errSecMissingEntitlement (-34018).
- Leaves production/device builds on the existing Keychain-backed random device bootstrap key.

## Root cause
- The QA build command uses CODE_SIGNING_ALLOWED=NO for iOS Simulator.
- Fresh simulator launches attempted to create the SQLCipher bootstrap key in Keychain before opening the database.
- On the QA simulator this returns -34018, causing AppCore bootstrap to fail and show "Failed to load database".

## Test Plan
- [x] xcodebuild build -workspace "Wierd Parts.xcworkspace" -scheme WiredPart-iOS -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/wei1509-derived-fixed CODE_SIGNING_ALLOWED=NO
- [x] Fresh uninstall/install/launch on WEI-899 iPhone 13 mini 375pt (98CEE4F6-D8F5-49C3-A1B3-0F4CD6C11EA8): passed database init into WiredPart onboarding; screenshot /tmp/wei1509-phone-fixed-launch.png
- [x] Fresh uninstall/install/launch on WEI-899 iPad 9th gen 768pt (8D1472B2-D136-4ECF-9B2A-F16D62C21984): passed database init into WiredPart onboarding; screenshot /tmp/wei1509-ipad-fixed-launch.png
- [x] swift test --package-path core --filter WarehouseAuditTests (64 tests passed)