### PR TITLE
feat: add warehouse my verifications page

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
@@ -42,6 +42,16 @@ struct WiredPartIOSApp: App {
         ProcessInfo.processInfo.arguments.contains("-UITestingWarehouseSetupWizard")
     }
 
+    private var shouldOpenMyVerificationsForUITest: Bool {
+        let args = ProcessInfo.processInfo.arguments
+        return args.contains("-UITestingMultiUserVerificationFixture") ||
+            args.contains("-UITestingMyVerificationsPopulated") ||
+            args.contains("-UITestingMyVerificationsEmpty") ||
+            args.contains("-UITestingMyVerificationsError") ||
+            args.contains("-UITestingMyVerificationsLoading") ||
+            args.contains("-UITestingMyVerificationsDuplicate")
+    }
+
     /// Resolved color scheme from the user's theme setting.
     private var resolvedColorScheme: ColorScheme? {
         switch appCore.theme.themeMode {
@@ -66,6 +76,14 @@ struct WiredPartIOSApp: App {
                     } else if appCore.needsBootstrap {
                         BootstrapView()
                             .environmentObject(appCore)
+                    } else if shouldOpenWarehouseSetupForUITest {
+                        WarehouseOnboardingWizard()
+                            .environmentObject(appCore)
+                    } else if shouldOpenMyVerificationsForUITest {
+                        NavigationStack {
+                            IOSMyVerificationsPage()
+                                .environmentObject(appCore)
+                        }
                     } else if appCore.currentUser == nil {
                         LoginView()
                             .environmentObject(appCore)
@@ -77,9 +95,6 @@ struct WiredPartIOSApp: App {
                             .environmentObject(appCore)
                     } else if !hasCompletedOnboarding {
                         OnboardingWalkthroughView()
-                            .environmentObject(appCore)
-                    } else if shouldOpenWarehouseSetupForUITest {
-                        WarehouseOnboardingWizard()
                             .environmentObject(appCore)
                     } else {
                         IOSMainView()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMyVerificationsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMyVerificationsPage.swift
@@ -1,0 +1,366 @@
+import SwiftUI
+import WiredPartCore
+
+/// Operator-facing queue for independent warehouse audit counts.
+///
+/// The page intentionally hides the system expected quantity while an operator
+/// submits a count so the verification remains unbiased.
+struct IOSMyVerificationsPage: View {
+    private static let duplicateSubmitMessage = "You've already submitted a count for this part. Each counter can submit once."
+
+    @EnvironmentObject private var appCore: AppCore
+
+    @State private var rows: [VerificationRow] = []
+    @State private var isLoading = true
+    @State private var loadError: String?
+    @State private var selectedRow: VerificationRow?
+    @State private var actionError: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            OnboardingBanner(pageId: "warehouse-my-verifications")
+
+            content
+        }
+        .navigationTitle("My Verifications")
+        .accessibilityIdentifier("IOSMyVerificationsPage")
+        .refreshable { loadData() }
+        .sheet(item: $selectedRow) { row in
+            SubmitVerificationCountSheet(row: row) { quantity, notes in
+                submit(row: row, quantity: quantity, notes: notes)
+            }
+        }
+        .alert("Verification Error", isPresented: Binding(
+            get: { actionError != nil },
+            set: { if !$0 { actionError = nil } }
+        )) {
+            Button("OK") { actionError = nil }
+        } message: {
+            Text(actionError ?? "")
+        }
+        .onAppear {
+            NotificationCenter.default.post(
+                name: .warehouseMyVerificationsPageActive,
+                object: nil,
+                userInfo: ["context": "My Verifications: \(rows.count) pending operator count assignments."]
+            )
+        }
+        .onDisappear {
+            NotificationCenter.default.post(name: .warehouseMyVerificationsPageInactive, object: nil)
+        }
+        .task { loadData() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isLoading {
+            ProgressView("Loading verifications...")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .accessibilityIdentifier("myVerificationsLoadingState")
+        } else if let loadError {
+            ErrorStateView(message: loadError) { loadData() }
+                .accessibilityIdentifier("myVerificationsErrorState")
+        } else if rows.isEmpty {
+            EmptyStateView(
+                icon: "checkmark.seal",
+                title: "No Verifications",
+                message: "You do not have any warehouse counts assigned right now."
+            )
+            .accessibilityIdentifier("myVerificationsEmptyState")
+        } else {
+            List(rows) { row in
+                Button {
+                    selectedRow = row
+                } label: {
+                    VerificationAssignmentRow(row: row)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("myVerificationAssignmentRow_\(row.id)")
+            }
+            .accessibilityIdentifier("myVerificationsPopulatedState")
+        }
+    }
+
+    private func loadData() {
+        isLoading = true
+        loadError = nil
+
+        if let fixtureRows = fixtureRowsIfRequested() {
+            rows = fixtureRows
+            isLoading = ProcessInfo.processInfo.arguments.contains("-UITestingMyVerificationsLoading")
+            if ProcessInfo.processInfo.arguments.contains("-UITestingMyVerificationsError") {
+                loadError = "Unable to load verification assignments."
+                isLoading = false
+            }
+            return
+        }
+
+        guard let service = appCore.warehouseService else {
+            rows = []
+            loadError = "Warehouse service is not available."
+            isLoading = false
+            return
+        }
+
+        guard let userId = appCore.currentUser?.id else {
+            rows = []
+            loadError = "Sign in to view your verification assignments."
+            isLoading = false
+            return
+        }
+
+        do {
+            rows = try service.getMyMultiUserAuditAssignments(userId: userId).compactMap(VerificationRow.init)
+            isLoading = false
+        } catch {
+            rows = []
+            loadError = error.localizedDescription
+            isLoading = false
+        }
+    }
+
+    private func submit(row: VerificationRow, quantity: Int, notes: String?) {
+        if row.isFixtureDuplicate {
+            actionError = Self.duplicateSubmitMessage
+            return
+        }
+
+        guard let service = appCore.warehouseService else {
+            actionError = "Warehouse service is not available."
+            return
+        }
+        guard let userId = appCore.currentUser?.id else {
+            actionError = "Sign in to submit this verification."
+            return
+        }
+        guard let assignmentId = row.assignmentId else {
+            actionError = "This verification assignment is missing an ID."
+            return
+        }
+
+        do {
+            try service.submitMultiUserCount(
+                assignmentId: assignmentId,
+                quantity: quantity,
+                userId: userId,
+                notes: notes
+            )
+            selectedRow = nil
+            loadData()
+        } catch WarehouseService.WarehouseError.sessionAlreadyCompleted {
+            actionError = Self.duplicateSubmitMessage
+        } catch {
+            actionError = error.localizedDescription
+        }
+    }
+
+    private func fixtureRowsIfRequested() -> [VerificationRow]? {
+        let args = ProcessInfo.processInfo.arguments
+        guard args.contains("-UITestingMultiUserVerificationFixture") ||
+              args.contains("-UITestingMyVerificationsPopulated") ||
+              args.contains("-UITestingMyVerificationsEmpty") ||
+              args.contains("-UITestingMyVerificationsError") ||
+              args.contains("-UITestingMyVerificationsLoading") ||
+              args.contains("-UITestingMyVerificationsDuplicate") else {
+            return nil
+        }
+
+        if args.contains("-UITestingMyVerificationsEmpty") {
+            return []
+        }
+
+        return [
+            VerificationRow(
+                id: "fixture-s2",
+                assignmentId: nil,
+                partId: 92001,
+                partName: "S2 Copper Coupling",
+                binLocation: "WH-A-02-S2",
+                assignedUserName: "UITest Owner",
+                auditSessionId: 486,
+                createdAt: "Today, 9:15 AM",
+                isFixtureDuplicate: false
+            ),
+            VerificationRow(
+                id: "fixture-s3",
+                assignmentId: nil,
+                partId: 92002,
+                partName: "S3 Brass Valve",
+                binLocation: "WH-A-03-S3",
+                assignedUserName: "UITest Owner",
+                auditSessionId: 486,
+                createdAt: "Today, 9:30 AM",
+                isFixtureDuplicate: args.contains("-UITestingMyVerificationsDuplicate")
+            )
+        ]
+    }
+}
+
+private struct VerificationRow: Identifiable, Hashable {
+    let id: String
+    let assignmentId: Int64?
+    let partId: Int64
+    let partName: String
+    let binLocation: String?
+    let assignedUserName: String?
+    let auditSessionId: Int64?
+    let createdAt: String?
+    let isFixtureDuplicate: Bool
+
+    init?(_ assignment: MultiUserAuditAssignment) {
+        guard let assignmentId = assignment.id else { return nil }
+        self.id = String(assignmentId)
+        self.assignmentId = assignmentId
+        self.partId = assignment.partId
+        self.partName = assignment.partName
+        self.binLocation = assignment.binLocation
+        self.assignedUserName = assignment.assignedUserName
+        self.auditSessionId = assignment.auditSessionId
+        self.createdAt = assignment.createdAt
+        self.isFixtureDuplicate = false
+    }
+
+    init(
+        id: String,
+        assignmentId: Int64?,
+        partId: Int64,
+        partName: String,
+        binLocation: String?,
+        assignedUserName: String?,
+        auditSessionId: Int64?,
+        createdAt: String?,
+        isFixtureDuplicate: Bool
+    ) {
+        self.id = id
+        self.assignmentId = assignmentId
+        self.partId = partId
+        self.partName = partName
+        self.binLocation = binLocation
+        self.assignedUserName = assignedUserName
+        self.auditSessionId = auditSessionId
+        self.createdAt = createdAt
+        self.isFixtureDuplicate = isFixtureDuplicate
+    }
+
+    var accessibilitySummary: String {
+        [
+            partName,
+            binLocation.map { "Bin \($0)" },
+            auditSessionId.map { "Audit session \($0)" },
+            "Double tap to submit count"
+        ]
+        .compactMap { $0 }
+        .joined(separator: ", ")
+    }
+}
+
+private struct VerificationAssignmentRow: View {
+    let row: VerificationRow
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "checkmark.seal.fill")
+                .foregroundStyle(.blue)
+                .font(.title2)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(row.partName)
+                    .font(.headline)
+                    .accessibilityIdentifier("myVerificationPartName_\(row.id)")
+
+                if let binLocation = row.binLocation, !binLocation.isEmpty {
+                    Label(binLocation, systemImage: "mappin.and.ellipse")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("myVerificationBin_\(row.id)")
+                }
+
+                HStack(spacing: 8) {
+                    if let sessionId = row.auditSessionId {
+                        Text("Session #\(sessionId)")
+                    }
+                    if let createdAt = row.createdAt, !createdAt.isEmpty {
+                        Text(createdAt)
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
+        }
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(row.accessibilitySummary)
+        .accessibilityHint("Opens the submit count sheet. The expected system quantity is hidden.")
+        .accessibilitySortPriority(1)
+    }
+}
+
+private struct SubmitVerificationCountSheet: View {
+    let row: VerificationRow
+    let onSubmit: (Int, String?) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var quantityText = ""
+    @State private var notes = ""
+    @FocusState private var quantityFocused: Bool
+
+    private var quantity: Int? {
+        Int(quantityText.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Part") {
+                    Text(row.partName)
+                        .font(.headline)
+                    if let binLocation = row.binLocation, !binLocation.isEmpty {
+                        Label(binLocation, systemImage: "mappin.and.ellipse")
+                    }
+                    Text("System expected quantity is hidden until the verification is resolved.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("expectedQuantityHiddenMessage")
+                }
+
+                Section("Count") {
+                    TextField("Quantity counted", text: $quantityText)
+                        .keyboardType(.numberPad)
+                        .focused($quantityFocused)
+                        .accessibilityIdentifier("myVerificationQuantityField")
+                        .accessibilityLabel("S3 quantity counted")
+                        .accessibilityHint("Enter the physical quantity counted. The expected quantity is not shown.")
+                        .accessibilitySortPriority(2)
+
+                    TextField("Notes optional", text: $notes, axis: .vertical)
+                        .lineLimit(2...4)
+                        .accessibilityIdentifier("myVerificationNotesField")
+                }
+            }
+            .navigationTitle("Submit Count")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Submit") {
+                        guard let quantity else { return }
+                        onSubmit(quantity, notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : notes)
+                    }
+                    .disabled(quantity == nil)
+                    .accessibilityIdentifier("myVerificationSubmitButton")
+                }
+            }
+            .onAppear { quantityFocused = true }
+        }
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMyVerificationsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMyVerificationsPage.swift
@@ -121,6 +121,7 @@ struct IOSMyVerificationsPage: View {
 
     private func submit(row: VerificationRow, quantity: Int, notes: String?) {
         if row.isFixtureDuplicate {
+            selectedRow = nil
             actionError = Self.duplicateSubmitMessage
             return
         }
@@ -148,6 +149,7 @@ struct IOSMyVerificationsPage: View {
             selectedRow = nil
             loadData()
         } catch WarehouseService.WarehouseError.sessionAlreadyCompleted {
+            selectedRow = nil
             actionError = Self.duplicateSubmitMessage
         } catch {
             actionError = error.localizedDescription

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMyVerificationsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMyVerificationsPage.swift
@@ -38,13 +38,6 @@ struct IOSMyVerificationsPage: View {
         } message: {
             Text(actionError ?? "")
         }
-        .onAppear {
-            NotificationCenter.default.post(
-                name: .warehouseMyVerificationsPageActive,
-                object: nil,
-                userInfo: ["context": "My Verifications: \(rows.count) pending operator count assignments."]
-            )
-        }
         .onDisappear {
             NotificationCenter.default.post(name: .warehouseMyVerificationsPageInactive, object: nil)
         }
@@ -92,6 +85,9 @@ struct IOSMyVerificationsPage: View {
                 loadError = "Unable to load verification assignments."
                 isLoading = false
             }
+            if !isLoading, loadError == nil {
+                postActiveContext()
+            }
             return
         }
 
@@ -112,6 +108,7 @@ struct IOSMyVerificationsPage: View {
         do {
             rows = try service.getMyMultiUserAuditAssignments(userId: userId).compactMap(VerificationRow.init)
             isLoading = false
+            postActiveContext()
         } catch {
             rows = []
             loadError = error.localizedDescription
@@ -120,6 +117,11 @@ struct IOSMyVerificationsPage: View {
     }
 
     private func submit(row: VerificationRow, quantity: Int, notes: String?) {
+        guard quantity >= 0 else {
+            actionError = "Quantity counted must be 0 or greater."
+            return
+        }
+
         if row.isFixtureDuplicate {
             selectedRow = nil
             actionError = Self.duplicateSubmitMessage
@@ -151,9 +153,19 @@ struct IOSMyVerificationsPage: View {
         } catch WarehouseService.WarehouseError.sessionAlreadyCompleted {
             selectedRow = nil
             actionError = Self.duplicateSubmitMessage
+        } catch WarehouseService.WarehouseError.invalidQuantity {
+            actionError = "Quantity counted must be 0 or greater."
         } catch {
             actionError = error.localizedDescription
         }
+    }
+
+    private func postActiveContext() {
+        NotificationCenter.default.post(
+            name: .warehouseMyVerificationsPageActive,
+            object: nil,
+            userInfo: ["context": "My Verifications: \(rows.count) pending operator count assignments."]
+        )
     }
 
     private func fixtureRowsIfRequested() -> [VerificationRow]? {
@@ -318,6 +330,16 @@ private struct SubmitVerificationCountSheet: View {
         Int(quantityText.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
+    private var isQuantityValid: Bool {
+        guard let quantity else { return false }
+        return quantity >= 0
+    }
+
+    private var quantityValidationMessage: String? {
+        guard let quantity else { return nil }
+        return quantity < 0 ? "Quantity counted must be 0 or greater." : nil
+    }
+
     var body: some View {
         NavigationStack {
             Form {
@@ -338,9 +360,16 @@ private struct SubmitVerificationCountSheet: View {
                         .keyboardType(.numberPad)
                         .focused($quantityFocused)
                         .accessibilityIdentifier("myVerificationQuantityField")
-                        .accessibilityLabel("S3 quantity counted")
+                        .accessibilityLabel("\(row.partName) quantity counted")
                         .accessibilityHint("Enter the physical quantity counted. The expected quantity is not shown.")
                         .accessibilitySortPriority(2)
+
+                    if let quantityValidationMessage {
+                        Text(quantityValidationMessage)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                            .accessibilityIdentifier("myVerificationQuantityValidation")
+                    }
 
                     TextField("Notes optional", text: $notes, axis: .vertical)
                         .lineLimit(2...4)
@@ -358,7 +387,7 @@ private struct SubmitVerificationCountSheet: View {
                         guard let quantity else { return }
                         onSubmit(quantity, notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : notes)
                     }
-                    .disabled(quantity == nil)
+                    .disabled(!isQuantityValid)
                     .accessibilityIdentifier("myVerificationSubmitButton")
                 }
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
@@ -669,6 +669,7 @@ struct WarehouseDashboardPage: View {
                 subPageLink(title: "Inventory", icon: "square.grid.3x3.fill", color: .purple, tabId: "warehouse-inventory")
                 subPageLink(title: "Locations", icon: "map.fill", color: .mint, tabId: "warehouse-locations")
                 subPageLink(title: "Audit", icon: "checkmark.shield.fill", color: .orange, tabId: "warehouse-audit")
+                subPageLink(title: "My Verifications", icon: "checkmark.seal.fill", color: .blue, tabId: "warehouse-my-verifications")
                 subPageLink(title: "Returns", icon: "arrow.uturn.left", color: .indigo, tabId: "warehouse-returns")
                 subPageLink(title: "Tools", icon: "wrench.and.screwdriver.fill", color: .brown, tabId: "warehouse-tools")
                 subPageLink(title: "Leaderboard", icon: "trophy.fill", color: .yellow, tabId: "warehouse-leaderboard")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseRouter.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseRouter.swift
@@ -31,6 +31,8 @@ struct WarehouseRouter: View {
             IOSWarehouseReturnsPage()
         case "warehouse-audit":
             IOSAuditPage()
+        case "warehouse-my-verifications":
+            IOSMyVerificationsPage()
         case "warehouse-inventory":
             IOSInventoryGridPage()
         case "warehouse-tools":

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/IOSContentRouter.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/IOSContentRouter.swift
@@ -139,6 +139,8 @@ struct IOSContentRouter: View {
             WarehouseRouter(tabId: "warehouse-returns")
         case "/warehouse/audit":
             WarehouseRouter(tabId: "warehouse-audit")
+        case "/warehouse/my-verifications":
+            WarehouseRouter(tabId: "warehouse-my-verifications")
         case "/warehouse/inventory":
             WarehouseRouter(tabId: "warehouse-inventory")
         case "/warehouse/tools":

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
@@ -100,13 +100,14 @@ let appModules: [AppModule] = [
     // 5. Warehouse — movements, receiving, staging
     AppModule(id: "warehouse", label: "Warehouse", icon: "building.fill", tabs: [
         AppTab(id: "warehouse-dashboard", label: "Dashboard", icon: "chart.bar.fill", path: "/warehouse/dashboard"),
+        // Keep Audit near the front so 375pt iPhone QA can tap it without first scrolling the horizontal tab bar.
+        AppTab(id: "warehouse-audit", label: "Audit", icon: "checkmark.shield.fill", path: "/warehouse/audit", permission: "perform_audit"),
+        AppTab(id: "warehouse-my-verifications", label: "My Verifications", icon: "checkmark.seal.fill", path: "/warehouse/my-verifications", permission: "perform_audit"),
         AppTab(id: "warehouse-receiving", label: "Sorting", icon: "shippingbox.fill", path: "/warehouse/receiving"),
         AppTab(id: "warehouse-staging", label: "Staging", icon: "tray.2.fill", path: "/warehouse/staging"),
         AppTab(id: "warehouse-movements", label: "Movements", icon: "arrow.left.arrow.right", path: "/warehouse/movements"),
         AppTab(id: "warehouse-inventory", label: "Inventory", icon: "square.grid.3x3.fill", path: "/warehouse/inventory"),
         AppTab(id: "warehouse-locations", label: "Locations", icon: "map.fill", path: "/warehouse/locations"),
-        AppTab(id: "warehouse-audit", label: "Audit", icon: "checkmark.shield.fill", path: "/warehouse/audit", permission: "perform_audit"),
-        AppTab(id: "warehouse-my-verifications", label: "My Verifications", icon: "checkmark.seal.fill", path: "/warehouse/my-verifications", permission: "perform_audit"),
         AppTab(id: "warehouse-returns", label: "Returns", icon: "arrow.uturn.left", path: "/warehouse/returns"),
         AppTab(id: "warehouse-tools", label: "Tools", icon: "wrench.and.screwdriver.fill", path: "/warehouse/tools"),
         AppTab(id: "warehouse-organization", label: "Org Audit", icon: "tag.fill", path: "/warehouse/organization", permission: "manage_warehouse"),

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
@@ -106,6 +106,7 @@ let appModules: [AppModule] = [
         AppTab(id: "warehouse-inventory", label: "Inventory", icon: "square.grid.3x3.fill", path: "/warehouse/inventory"),
         AppTab(id: "warehouse-locations", label: "Locations", icon: "map.fill", path: "/warehouse/locations"),
         AppTab(id: "warehouse-audit", label: "Audit", icon: "checkmark.shield.fill", path: "/warehouse/audit", permission: "perform_audit"),
+        AppTab(id: "warehouse-my-verifications", label: "My Verifications", icon: "checkmark.seal.fill", path: "/warehouse/my-verifications", permission: "perform_audit"),
         AppTab(id: "warehouse-returns", label: "Returns", icon: "arrow.uturn.left", path: "/warehouse/returns"),
         AppTab(id: "warehouse-tools", label: "Tools", icon: "wrench.and.screwdriver.fill", path: "/warehouse/tools"),
         AppTab(id: "warehouse-organization", label: "Org Audit", icon: "tag.fill", path: "/warehouse/organization", permission: "manage_warehouse"),
@@ -420,6 +421,12 @@ extension Notification.Name {
 
     /// Posted when the warehouse audit page disappears.
     static let warehouseAuditPageInactive = Notification.Name("WiredPart.warehouseAuditPageInactive")
+
+    /// Posted when the operator My Verifications page appears, with read-only assignment context for AI.
+    static let warehouseMyVerificationsPageActive = Notification.Name("WiredPart.warehouseMyVerificationsPageActive")
+
+    /// Posted when the operator My Verifications page disappears.
+    static let warehouseMyVerificationsPageInactive = Notification.Name("WiredPart.warehouseMyVerificationsPageInactive")
 
     /// Posted when the warehouse returns page appears, with read-only return status context for AI.
     static let warehouseReturnsPageActive = Notification.Name("WiredPart.warehouseReturnsPageActive")

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -23,4 +23,12 @@ struct Weird_Parts_IOSTests {
         #expect(!QAThreadStatusBuckets.isResolved("open"))
         #expect(!QAThreadStatusBuckets.isResolved("escalated"))
     }
+
+    @MainActor
+    @Test func warehouseAuditTabStaysWithinInitialPhoneToolbarViewport() async throws {
+        let warehouseTabs = appModules.first { $0.id == "warehouse" }?.tabs ?? []
+        let auditIndex = try #require(warehouseTabs.firstIndex { $0.id == "warehouse-audit" })
+
+        #expect(auditIndex <= 2)
+    }
 }


### PR DESCRIPTION
## Summary
- Adds the operator-facing Warehouse > My Verifications page for pending multi-user audit assignments.
- Adds loading, empty, error, populated, duplicate-submit, and fixture states for WEI-1343/GH#486 evidence capture.
- Adds the route, navigation tab, dashboard shortcut, hidden expected quantity submit sheet, and accessibility identifiers/labels for the S2/S3 acceptance surfaces.

## Test Plan
- [x] xcodebuild -workspace \"Wierd Parts.xcworkspace\" -scheme \"WiredPart-iOS\" -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO
- [x] git diff --cached --check

## Notes
- Build initially hit a stale/missing GRDB checkout after clearing DerivedData for disk space; resolving package dependencies and rerunning succeeded.
- Closes GH #486 acceptance gap tracked by Paperclip WEI-1512.