### PR TITLE
fix(fleet): restore vehicle status counts API

### DIFF
--- a/core/Sources/WiredPartCore/Services/FleetService.swift
+++ b/core/Sources/WiredPartCore/Services/FleetService.swift
@@ -335,6 +335,23 @@ public final class FleetService: Sendable {
         }
     }
 
+    /// Counts for the vehicle status filter cards.
+    public struct VehicleStatusCounts: Sendable, Equatable {
+        public let countsByStatus: [String: Int]
+
+        public init(countsByStatus: [String: Int] = [:]) {
+            self.countsByStatus = countsByStatus
+        }
+
+        public var total: Int {
+            countsByStatus.values.reduce(0, +)
+        }
+
+        public func count(for status: String) -> Int {
+            status == "all" ? total : countsByStatus[status, default: 0]
+        }
+    }
+
     /// Count active, non-deleted vehicles grouped by status.
     ///
     /// `IOSVehiclesPage` uses these pre-aggregated counts for its status cards so
@@ -357,6 +374,11 @@ public final class FleetService: Sendable {
             if isTableNotFoundError(error) { return [:] }
             throw error
         }
+    }
+
+    /// Return strongly typed status counts for UI filter cards.
+    public func getVehicleStatusCounts() throws -> VehicleStatusCounts {
+        VehicleStatusCounts(countsByStatus: try countVehiclesByStatus())
     }
 
     /// Get a single vehicle by ID with full detail and active assignments.

--- a/core/Tests/WiredPartCoreTests/FleetServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/FleetServiceTests.swift
@@ -73,6 +73,12 @@ struct FleetServiceTests {
         #expect(counts["active", default: 0] >= 1)
         #expect(counts["maintenance", default: 0] == 1)
 
+        let statusCounts = try env.fleet.getVehicleStatusCounts()
+        #expect(statusCounts.count(for: "all") >= 2)
+        #expect(statusCounts.count(for: "active") >= 1)
+        #expect(statusCounts.count(for: "maintenance") == 1)
+        #expect(statusCounts.count(for: "retired") == 0)
+
         let activeVehicles = try env.fleet.listVehicles(status: "active")
         #expect(activeVehicles.contains(where: { $0.id == activeId }))
         #expect(!activeVehicles.contains(where: { $0.id == maintenanceId }))


### PR DESCRIPTION
## Summary
- Restores FleetService.VehicleStatusCounts compatibility API used by IOSVehiclesPage.
- Adds getVehicleStatusCounts() backed by existing countVehiclesByStatus() aggregation.
- Adds focused FleetServiceTests coverage for status count lookup behavior.

## Evidence
- cd core && swift test --filter FleetServiceTests/testCountVehiclesByStatus passed locally in prior WEI-1539 run.
- xcodebuild progressed past the GH#559 FleetService.VehicleStatusCounts missing-symbol blocker in prior WEI-1539 run, then exposed a separate pre-existing GH#561 telemetry symbol blocker.

Fixes/advances GH#559. Paperclip: WEI-1539 / WEI-1541 branch-cap unblock.