### PR TITLE
WEI-1112 recover fleet page-context slice

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
+++ b/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
@@ -87,7 +87,9 @@ struct IOSAIAssistantPanel: View {
     @State private var fleetFuelContext: String?
     @State private var fleetInspectionsContext: String?
     @State private var fleetTrackingContext: String?
+    @State private var fleetTelematicsContext: String?
     @State private var fleetMyTruckContext: String?
+    @State private var officeApprovalsContext: String?
     @State private var toolRegistryContext: String?
     @State private var notebooksListContext: String?
     @State private var settingsContext: String?
@@ -317,7 +319,11 @@ struct IOSAIAssistantPanel: View {
             fleetFuelContext: $fleetFuelContext,
             fleetInspectionsContext: $fleetInspectionsContext,
             fleetTrackingContext: $fleetTrackingContext,
+            fleetTelematicsContext: $fleetTelematicsContext,
             fleetMyTruckContext: $fleetMyTruckContext
+        ))
+        .modifier(OfficePageContextObservers(
+            officeApprovalsContext: $officeApprovalsContext
         ))
         .modifier(ActivePageIdTracker(activePageId: $activePageId))
     }
@@ -694,6 +700,36 @@ struct IOSAIAssistantPanel: View {
             }
             if let ctx = vehiclesContext {
                 navContext += "\n\nVehicles Context: \(ctx)"
+            }
+            if let ctx = fleetDashboardContext {
+                navContext += "\n\nFleet Dashboard Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = fleetMaintenanceContext {
+                navContext += "\n\nFleet Maintenance Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = fleetMileageContext {
+                navContext += "\n\nFleet Mileage Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = fleetFuelContext {
+                navContext += "\n\nFleet Fuel Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = fleetTrailersContext {
+                navContext += "\n\nFleet Trailers Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = fleetInspectionsContext {
+                navContext += "\n\nFleet Inspections Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = fleetTrackingContext {
+                navContext += "\n\nFleet Tracking Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = fleetTelematicsContext {
+                navContext += "\n\nFleet Telematics Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = fleetMyTruckContext {
+                navContext += "\n\nMy Truck Context (READ-ONLY): \(ctx)"
+            }
+            if let ctx = officeApprovalsContext {
+                navContext += "\n\nOffice Approvals Context (READ-ONLY): \(ctx)"
             }
             if let ctx = toolRegistryContext {
                 navContext += "\n\nTool Registry Context: \(ctx)"
@@ -1513,6 +1549,7 @@ private struct FleetPageContextObservers: ViewModifier {
     @Binding var fleetFuelContext: String?
     @Binding var fleetInspectionsContext: String?
     @Binding var fleetTrackingContext: String?
+    @Binding var fleetTelematicsContext: String?
     @Binding var fleetMyTruckContext: String?
 
     func body(content: Content) -> some View {
@@ -1520,50 +1557,52 @@ private struct FleetPageContextObservers: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .fleetDashboardPageActive)) { notification in
                 if let ctx = notification.userInfo?["context"] as? String { fleetDashboardContext = ctx }
             }
-            .onReceive(NotificationCenter.default.publisher(for: .fleetDashboardPageInactive)) { _ in
-                fleetDashboardContext = nil
-            }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetDashboardPageInactive)) { _ in fleetDashboardContext = nil }
             .onReceive(NotificationCenter.default.publisher(for: .fleetTrailersPageActive)) { notification in
                 if let ctx = notification.userInfo?["context"] as? String { fleetTrailersContext = ctx }
             }
-            .onReceive(NotificationCenter.default.publisher(for: .fleetTrailersPageInactive)) { _ in
-                fleetTrailersContext = nil
-            }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetTrailersPageInactive)) { _ in fleetTrailersContext = nil }
             .onReceive(NotificationCenter.default.publisher(for: .fleetMaintenancePageActive)) { notification in
                 if let ctx = notification.userInfo?["context"] as? String { fleetMaintenanceContext = ctx }
             }
-            .onReceive(NotificationCenter.default.publisher(for: .fleetMaintenancePageInactive)) { _ in
-                fleetMaintenanceContext = nil
-            }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetMaintenancePageInactive)) { _ in fleetMaintenanceContext = nil }
             .onReceive(NotificationCenter.default.publisher(for: .fleetMileagePageActive)) { notification in
                 if let ctx = notification.userInfo?["context"] as? String { fleetMileageContext = ctx }
             }
-            .onReceive(NotificationCenter.default.publisher(for: .fleetMileagePageInactive)) { _ in
-                fleetMileageContext = nil
-            }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetMileagePageInactive)) { _ in fleetMileageContext = nil }
             .onReceive(NotificationCenter.default.publisher(for: .fleetFuelPageActive)) { notification in
                 if let ctx = notification.userInfo?["context"] as? String { fleetFuelContext = ctx }
             }
-            .onReceive(NotificationCenter.default.publisher(for: .fleetFuelPageInactive)) { _ in
-                fleetFuelContext = nil
-            }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetFuelPageInactive)) { _ in fleetFuelContext = nil }
             .onReceive(NotificationCenter.default.publisher(for: .fleetInspectionsPageActive)) { notification in
                 if let ctx = notification.userInfo?["context"] as? String { fleetInspectionsContext = ctx }
             }
-            .onReceive(NotificationCenter.default.publisher(for: .fleetInspectionsPageInactive)) { _ in
-                fleetInspectionsContext = nil
-            }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetInspectionsPageInactive)) { _ in fleetInspectionsContext = nil }
             .onReceive(NotificationCenter.default.publisher(for: .fleetTrackingPageActive)) { notification in
                 if let ctx = notification.userInfo?["context"] as? String { fleetTrackingContext = ctx }
             }
-            .onReceive(NotificationCenter.default.publisher(for: .fleetTrackingPageInactive)) { _ in
-                fleetTrackingContext = nil
+            .onReceive(NotificationCenter.default.publisher(for: .fleetTrackingPageInactive)) { _ in fleetTrackingContext = nil }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetTelematicsPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { fleetTelematicsContext = ctx }
             }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetTelematicsPageInactive)) { _ in fleetTelematicsContext = nil }
             .onReceive(NotificationCenter.default.publisher(for: .fleetMyTruckPageActive)) { notification in
                 if let ctx = notification.userInfo?["context"] as? String { fleetMyTruckContext = ctx }
             }
-            .onReceive(NotificationCenter.default.publisher(for: .fleetMyTruckPageInactive)) { _ in
-                fleetMyTruckContext = nil
+            .onReceive(NotificationCenter.default.publisher(for: .fleetMyTruckPageInactive)) { _ in fleetMyTruckContext = nil }
+    }
+}
+
+private struct OfficePageContextObservers: ViewModifier {
+    @Binding var officeApprovalsContext: String?
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .officeApprovalsPageActive)) { notification in
+                if let ctx = notification.userInfo?["context"] as? String { officeApprovalsContext = ctx }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .officeApprovalsPageInactive)) { _ in
+                officeApprovalsContext = nil
             }
     }
 }
@@ -1778,6 +1817,38 @@ private struct ActivePageIdTrackerFleetToolsNotebooks: ViewModifier {
         content
             .onReceive(NotificationCenter.default.publisher(for: .vehiclesPageActive)) { _ in activePageId = "fleet-vehicles" }
             .onReceive(NotificationCenter.default.publisher(for: .vehiclesPageInactive)) { _ in if activePageId == "fleet-vehicles" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetDashboardPageActive)) { _ in activePageId = "fleet-dashboard" }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetDashboardPageInactive)) { _ in if activePageId == "fleet-dashboard" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetMaintenancePageActive)) { _ in activePageId = "fleet-maintenance" }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetMaintenancePageInactive)) { _ in if activePageId == "fleet-maintenance" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetMileagePageActive)) { _ in activePageId = "fleet-mileage" }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetMileagePageInactive)) { _ in if activePageId == "fleet-mileage" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetFuelPageActive)) { _ in activePageId = "fleet-fuel" }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetFuelPageInactive)) { _ in if activePageId == "fleet-fuel" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetTrailersPageActive)) { _ in activePageId = "fleet-trailers" }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetTrailersPageInactive)) { _ in if activePageId == "fleet-trailers" { activePageId = nil } }
+            .modifier(ActivePageIdTrackerFleetToolsNotebooksFleetTail(activePageId: $activePageId))
+    }
+}
+
+private struct ActivePageIdTrackerFleetToolsNotebooksFleetTail: ViewModifier {
+    @Binding var activePageId: String?
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .fleetInspectionsPageActive)) { _ in activePageId = "fleet-inspections" }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetInspectionsPageInactive)) { _ in if activePageId == "fleet-inspections" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetTelematicsPageActive)) { _ in activePageId = "fleet-tracking" }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetTelematicsPageInactive)) { _ in if activePageId == "fleet-tracking" { activePageId = nil } }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetMyTruckPageActive)) { _ in activePageId = "fleet-my-truck" }
+            .onReceive(NotificationCenter.default.publisher(for: .fleetMyTruckPageInactive)) { _ in if activePageId == "fleet-my-truck" { activePageId = nil } }
+            .modifier(ActivePageIdTrackerFleetToolsNotebooksTail(activePageId: $activePageId))
+    }
+}
+
+private struct ActivePageIdTrackerFleetToolsNotebooksTail: ViewModifier {
+    @Binding var activePageId: String?
+    func body(content: Content) -> some View {
+        content
             .onReceive(NotificationCenter.default.publisher(for: .toolRegistryPageActive)) { _ in activePageId = "tools-registry" }
             .onReceive(NotificationCenter.default.publisher(for: .toolRegistryPageInactive)) { _ in if activePageId == "tools-registry" { activePageId = nil } }
             .onReceive(NotificationCenter.default.publisher(for: .notebooksListPageActive)) { _ in activePageId = "notebooks-all" }

--- a/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
+++ b/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
@@ -311,13 +311,17 @@ struct IOSAIAssistantPanel: View {
             notebooksListContext: $notebooksListContext,
             settingsContext: $settingsContext
         ))
-        .modifier(FleetPageContextObservers(
+        .modifier(FleetPageContextObserversPrimary(
             fleetDashboardContext: $fleetDashboardContext,
             fleetTrailersContext: $fleetTrailersContext,
-            fleetMaintenanceContext: $fleetMaintenanceContext,
+            fleetMaintenanceContext: $fleetMaintenanceContext
+        ))
+        .modifier(FleetPageContextObserversOps(
             fleetMileageContext: $fleetMileageContext,
             fleetFuelContext: $fleetFuelContext,
-            fleetInspectionsContext: $fleetInspectionsContext,
+            fleetInspectionsContext: $fleetInspectionsContext
+        ))
+        .modifier(FleetPageContextObserversTracking(
             fleetTrackingContext: $fleetTrackingContext,
             fleetTelematicsContext: $fleetTelematicsContext,
             fleetMyTruckContext: $fleetMyTruckContext
@@ -1541,16 +1545,11 @@ private struct FeaturePageContextObserversGroupB: ViewModifier {
 
 
 /// Fleet page observers added for WEI-1112 coverage slices beyond Vehicles.
-private struct FleetPageContextObservers: ViewModifier {
+/// Split into smaller modifiers to keep SwiftUI type-checking bounded.
+private struct FleetPageContextObserversPrimary: ViewModifier {
     @Binding var fleetDashboardContext: String?
     @Binding var fleetTrailersContext: String?
     @Binding var fleetMaintenanceContext: String?
-    @Binding var fleetMileageContext: String?
-    @Binding var fleetFuelContext: String?
-    @Binding var fleetInspectionsContext: String?
-    @Binding var fleetTrackingContext: String?
-    @Binding var fleetTelematicsContext: String?
-    @Binding var fleetMyTruckContext: String?
 
     func body(content: Content) -> some View {
         content
@@ -1566,6 +1565,16 @@ private struct FleetPageContextObservers: ViewModifier {
                 if let ctx = notification.userInfo?["context"] as? String { fleetMaintenanceContext = ctx }
             }
             .onReceive(NotificationCenter.default.publisher(for: .fleetMaintenancePageInactive)) { _ in fleetMaintenanceContext = nil }
+    }
+}
+
+private struct FleetPageContextObserversOps: ViewModifier {
+    @Binding var fleetMileageContext: String?
+    @Binding var fleetFuelContext: String?
+    @Binding var fleetInspectionsContext: String?
+
+    func body(content: Content) -> some View {
+        content
             .onReceive(NotificationCenter.default.publisher(for: .fleetMileagePageActive)) { notification in
                 if let ctx = notification.userInfo?["context"] as? String { fleetMileageContext = ctx }
             }
@@ -1578,6 +1587,16 @@ private struct FleetPageContextObservers: ViewModifier {
                 if let ctx = notification.userInfo?["context"] as? String { fleetInspectionsContext = ctx }
             }
             .onReceive(NotificationCenter.default.publisher(for: .fleetInspectionsPageInactive)) { _ in fleetInspectionsContext = nil }
+    }
+}
+
+private struct FleetPageContextObserversTracking: ViewModifier {
+    @Binding var fleetTrackingContext: String?
+    @Binding var fleetTelematicsContext: String?
+    @Binding var fleetMyTruckContext: String?
+
+    func body(content: Content) -> some View {
+        content
             .onReceive(NotificationCenter.default.publisher(for: .fleetTrackingPageActive)) { notification in
                 if let ctx = notification.userInfo?["context"] as? String { fleetTrackingContext = ctx }
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSFleetDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSFleetDashboardPage.swift
@@ -44,6 +44,16 @@ struct IOSFleetDashboardPage: View {
             loadData()
             appCore.onboardingManager?.markCompleted("fleet-dashboard-view")
         }
+        .onAppear {
+            NotificationCenter.default.post(
+                name: .fleetDashboardPageActive,
+                object: nil,
+                userInfo: ["context": fleetDashboardContext]
+            )
+        }
+        .onDisappear {
+            NotificationCenter.default.post(name: .fleetDashboardPageInactive, object: nil)
+        }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .help } label: {
@@ -68,6 +78,13 @@ struct IOSFleetDashboardPage: View {
     }
 
     // MARK: - Dashboard Content
+
+    private var fleetDashboardContext: String {
+        let stats = dashStats
+        return """
+        page=Fleet Dashboard; vehicles=\(vehicles.count); active_vehicles=\(stats?.activeVehicles ?? 0); maintenance_due=\(stats?.maintenanceDue ?? 0); overdue_inspections=\(stats?.overdueInspections ?? 0); trailers=\(stats?.totalTrailers ?? 0); upcoming_maintenance=\(upcomingMaintenance.count); recent_maintenance=\(recentMaintenance.count)
+        """
+    }
 
     @ViewBuilder
     private var dashboardContent: some View {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSFuelPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSFuelPage.swift
@@ -46,6 +46,16 @@ struct IOSFuelPage: View {
             .onChange(of: dateRange) { loadData() }
             .onChange(of: customStart) { loadData() }
             .onChange(of: customEnd) { loadData() }
+            .onAppear {
+                NotificationCenter.default.post(
+                    name: .fleetFuelPageActive,
+                    object: nil,
+                    userInfo: ["context": fleetFuelContext]
+                )
+            }
+            .onDisappear {
+                NotificationCenter.default.post(name: .fleetFuelPageInactive, object: nil)
+            }
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button { activeSheet = .help } label: {
@@ -68,6 +78,11 @@ struct IOSFuelPage: View {
     }
 
     // MARK: - Fuel List
+
+    private var fleetFuelContext: String {
+        let searchState = searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "none" : "active"
+        return "page=Fleet Fuel; total_logs=\(fuelLogs.count); visible_logs=\(filteredLogs.count); date_range=\(dateRange.rawValue); search=\(searchState)"
+    }
 
     @ViewBuilder
     private var fuelList: some View {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSInspectionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSInspectionsPage.swift
@@ -32,6 +32,16 @@ struct IOSInspectionsPage: View {
             .onChange(of: scenePhase) { _, phase in
                 if phase == .active { loadData() }
             }
+            .onAppear {
+                NotificationCenter.default.post(
+                    name: .fleetInspectionsPageActive,
+                    object: nil,
+                    userInfo: ["context": fleetInspectionsContext]
+                )
+            }
+            .onDisappear {
+                NotificationCenter.default.post(name: .fleetInspectionsPageInactive, object: nil)
+            }
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button { activeSheet = .help } label: {
@@ -54,6 +64,11 @@ struct IOSInspectionsPage: View {
     }
 
     // MARK: - Inspection List
+
+    private var fleetInspectionsContext: String {
+        let searchState = searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "none" : "active"
+        return "page=Fleet Inspections; total_inspections=\(inspections.count); visible_inspections=\(filteredInspections.count); search=\(searchState)"
+    }
 
     @ViewBuilder
     private var inspectionList: some View {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMaintenancePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMaintenancePage.swift
@@ -48,6 +48,16 @@ struct IOSMaintenancePage: View {
             .onChange(of: dateRange) { loadData() }
             .onChange(of: customStart) { loadData() }
             .onChange(of: customEnd) { loadData() }
+            .onAppear {
+                NotificationCenter.default.post(
+                    name: .fleetMaintenancePageActive,
+                    object: nil,
+                    userInfo: ["context": fleetMaintenanceContext]
+                )
+            }
+            .onDisappear {
+                NotificationCenter.default.post(name: .fleetMaintenancePageInactive, object: nil)
+            }
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button { activeSheet = .help } label: {
@@ -70,6 +80,11 @@ struct IOSMaintenancePage: View {
     }
 
     // MARK: - Maintenance List
+
+    private var fleetMaintenanceContext: String {
+        let searchState = searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "none" : "active"
+        return "page=Fleet Maintenance; total_records=\(records.count); visible_records=\(filteredRecords.count); date_range=\(dateRange.rawValue); search=\(searchState)"
+    }
 
     @ViewBuilder
     private var maintenanceList: some View {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMileagePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMileagePage.swift
@@ -46,6 +46,16 @@ struct IOSMileagePage: View {
             .onChange(of: dateRange) { loadData() }
             .onChange(of: customStart) { loadData() }
             .onChange(of: customEnd) { loadData() }
+            .onAppear {
+                NotificationCenter.default.post(
+                    name: .fleetMileagePageActive,
+                    object: nil,
+                    userInfo: ["context": fleetMileageContext]
+                )
+            }
+            .onDisappear {
+                NotificationCenter.default.post(name: .fleetMileagePageInactive, object: nil)
+            }
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button { activeSheet = .help } label: {
@@ -68,6 +78,11 @@ struct IOSMileagePage: View {
     }
 
     // MARK: - Mileage List
+
+    private var fleetMileageContext: String {
+        let searchState = searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "none" : "active"
+        return "page=Fleet Mileage; total_logs=\(mileageLogs.count); visible_logs=\(filteredLogs.count); date_range=\(dateRange.rawValue); search=\(searchState)"
+    }
 
     @ViewBuilder
     private var mileageList: some View {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMyTruckPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMyTruckPage.swift
@@ -66,6 +66,16 @@ struct IOSMyTruckPage: View {
             loadData()
             appCore.onboardingManager?.markCompleted("fleet-my-truck")
         }
+        .onAppear {
+            NotificationCenter.default.post(
+                name: .fleetMyTruckPageActive,
+                object: nil,
+                userInfo: ["context": fleetMyTruckContext]
+            )
+        }
+        .onDisappear {
+            NotificationCenter.default.post(name: .fleetMyTruckPageInactive, object: nil)
+        }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .help } label: {
@@ -80,6 +90,13 @@ struct IOSMyTruckPage: View {
     }
 
     // MARK: - No Vehicle
+
+    private var fleetMyTruckContext: String {
+        let vehicleName = vehicle?.vehicleName ?? "unassigned"
+        return """
+        page=My Truck; vehicle=\(vehicleName); inventory_tab=\(inventoryTab.rawValue); truck_stock=\(truckStock.count); transfer_items=\(transferItems.count); recent_mileage_logs=\(recentMileage.count); recent_fuel_logs=\(recentFuel.count)
+        """
+    }
 
     private var noVehicleView: some View {
         EmptyStateView(

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTelematicsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTelematicsPage.swift
@@ -29,6 +29,16 @@ struct IOSTelematicsPage: View {
             .searchable(text: $searchText, prompt: "Search vehicles...")
             .refreshable { loadData() }
             .task { loadData() }
+            .onAppear {
+                NotificationCenter.default.post(
+                    name: .fleetTelematicsPageActive,
+                    object: nil,
+                    userInfo: ["context": fleetTelematicsContext]
+                )
+            }
+            .onDisappear {
+                NotificationCenter.default.post(name: .fleetTelematicsPageInactive, object: nil)
+            }
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button { activeSheet = .help } label: {
@@ -51,6 +61,11 @@ struct IOSTelematicsPage: View {
     }
 
     // MARK: - Location List
+
+    private var fleetTelematicsContext: String {
+        let searchState = searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "none" : "active"
+        return "page=Fleet Telematics; total_locations=\(locations.count); visible_locations=\(filteredLocations.count); search=\(searchState)"
+    }
 
     @ViewBuilder
     private var locationList: some View {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTrailersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTrailersPage.swift
@@ -38,6 +38,16 @@ struct IOSTrailersPage: View {
             .onChange(of: scenePhase) { _, phase in
                 if phase == .active { loadData() }
             }
+            .onAppear {
+                NotificationCenter.default.post(
+                    name: .fleetTrailersPageActive,
+                    object: nil,
+                    userInfo: ["context": fleetTrailersContext]
+                )
+            }
+            .onDisappear {
+                NotificationCenter.default.post(name: .fleetTrailersPageInactive, object: nil)
+            }
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button {
@@ -75,6 +85,11 @@ struct IOSTrailersPage: View {
     }
 
     // MARK: - Trailer List
+
+    private var fleetTrailersContext: String {
+        let searchState = searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "none" : "active"
+        return "page=Fleet Trailers; total_trailers=\(trailers.count); visible_trailers=\(filteredTrailers.count); search=\(searchState)"
+    }
 
     @ViewBuilder
     private var trailerList: some View {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSUnifiedApprovalsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSUnifiedApprovalsPage.swift
@@ -199,6 +199,16 @@ struct IOSUnifiedApprovalsPage: View {
             loadData()
             appCore.onboardingManager?.markCompleted("approvals-view")
         }
+        .onAppear {
+            NotificationCenter.default.post(
+                name: .officeApprovalsPageActive,
+                object: nil,
+                userInfo: ["context": approvalsPageContext]
+            )
+        }
+        .onDisappear {
+            NotificationCenter.default.post(name: .officeApprovalsPageInactive, object: nil)
+        }
         .alert("Error", isPresented: Binding(
             get: { actionError != nil },
             set: { if !$0 { actionError = nil } }
@@ -245,6 +255,17 @@ struct IOSUnifiedApprovalsPage: View {
     }
 
     private var totalCount: Int { allItems.count }
+
+    private var approvalsPageContext: String {
+        let pendingSummary = ApprovalType.allCases
+            .map { "\($0.label): \(count(for: $0))" }
+            .joined(separator: ", ")
+        let selectedFilter = activeFilter?.label ?? "All"
+        let searchState = searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "none" : "active"
+        return """
+        page=Office Approvals; total_pending=\(totalCount); visible_pending=\(filteredItems.count); selected_filter=\(selectedFilter); search=\(searchState); pending_by_type=[\(pendingSummary)]
+        """
+    }
 
     private func count(for type: ApprovalType) -> Int {
         switch type {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/SettingsRouter.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/SettingsRouter.swift
@@ -19,6 +19,16 @@ struct SettingsRouter: View {
                     .padding(.horizontal)
                     .padding(.vertical, 6)
             }
+            .onAppear {
+                NotificationCenter.default.post(
+                    name: .settingsPageActive,
+                    object: nil,
+                    userInfo: ["context": settingsPageContext]
+                )
+            }
+            .onDisappear {
+                NotificationCenter.default.post(name: .settingsPageInactive, object: nil)
+            }
     }
 
     @ViewBuilder
@@ -108,5 +118,10 @@ struct SettingsRouter: View {
     private func comingSoonPage(_ title: String, icon: String) -> some View {
         EmptyStateView(icon: icon, title: title, message: "This page is being built.")
             .navigationTitle(title)
+    }
+
+    private var settingsPageContext: String {
+        let scope = SyncScope.scope(for: tabId)
+        return "page=Settings; tab_id=\(tabId); sync_scope=\(scope.rawValue)"
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
@@ -535,6 +535,12 @@ extension Notification.Name {
     /// Posted when the My Truck page disappears.
     static let fleetMyTruckPageInactive = Notification.Name("WiredPart.fleetMyTruckPageInactive")
 
+    /// Posted when the Fleet Telematics page appears, with read-only telematics context for AI.
+    static let fleetTelematicsPageActive = Notification.Name("WiredPart.fleetTelematicsPageActive")
+
+    /// Posted when the Fleet Telematics page disappears.
+    static let fleetTelematicsPageInactive = Notification.Name("WiredPart.fleetTelematicsPageInactive")
+
     // MARK: - Tools
 
     /// Posted when the Tool Registry page appears, with tool count context for AI.
@@ -550,6 +556,14 @@ extension Notification.Name {
 
     /// Posted when the Notebooks List page disappears.
     static let notebooksListPageInactive = Notification.Name("WiredPart.notebooksListPageInactive")
+
+    // MARK: - Office
+
+    /// Posted when the Office Approvals page appears, with read-only approval context for AI.
+    static let officeApprovalsPageActive = Notification.Name("WiredPart.officeApprovalsPageActive")
+
+    /// Posted when the Office Approvals page disappears.
+    static let officeApprovalsPageInactive = Notification.Name("WiredPart.officeApprovalsPageInactive")
 
     // MARK: - Settings
 

--- a/Weird Parts IOS/Weird Parts IOS/Shared/HelpContentRegistry.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/HelpContentRegistry.swift
@@ -132,6 +132,7 @@ struct HelpContentRegistry {
         "WiredPart.fleetInspectionsPageActive": "fleet-inspections",
         "WiredPart.fleetTrackingPageActive": "fleet-tracking",
         "WiredPart.fleetMyTruckPageActive": "fleet-my-truck",
+        "WiredPart.officeApprovalsPageActive": "office-approvals",
         "WiredPart.toolRegistryPageActive": "tools-registry",
         "WiredPart.notebooksListPageActive": "notebooks-all",
     ]

--- a/docs/testing/ai-page-context-coverage.md
+++ b/docs/testing/ai-page-context-coverage.md
@@ -9,9 +9,9 @@ Complete the 87-page page-context coverage set by adding read-only page-active/p
 
 ## Current Coverage
 
-Implemented page-context notifications observed by `IOSAIAssistantPanel`: 55 page contexts.
+Implemented page-context notifications observed by `IOSAIAssistantPanel`: 57 page contexts.
 
-Help registry mappings with matching help entries: 46 page contexts; 8 fleet router-tab mappings were added for active page ID alignment and are pending dedicated help-entry extraction.
+Help registry mappings with matching help entries: 49 page contexts. Fleet tab contexts are observed by the AI panel; dedicated help-entry extraction remains for Fleet tabs beyond Dashboard and Maintenance.
 
 Known gap: `settingsPageActive` is observed by the AI panel and active-page tracker, but `HelpContentRegistry` does not yet contain a `settings-app-config` entry. That should be handled in the settings slice rather than mapped to a missing help entry.
 
@@ -132,24 +132,37 @@ Added the jobs completion page-context slice:
 
 All payloads are read-only summaries of visible state, selected filters, lifecycle state, and available entry points. They do not expose mutating commands, action IDs, or write intents.
 
+## WEI-1112 Productivity Restart Slice
 
-## WEI-1112 Fleet Router-Tab Slice
+Added the two missing active/inactive context posts required to bring declared page-active notifications to full feature-page emission coverage:
 
-Added the next fleet coverage slice at the router-tab level so high-traffic fleet pages expose read-only AI context without touching unrelated page internals:
+- `IOSUnifiedApprovalsPage`: `officeApprovalsPageActive` / `officeApprovalsPageInactive` with read-only summary of total/visible pending approvals, selected filter, search state, and pending counts by approval type.
+- `SettingsRouter`: `settingsPageActive` / `settingsPageInactive` with read-only summary of selected settings tab and sync scope classification.
 
-- `FleetRouter` now posts read-only page contexts for Fleet Dashboard, Trailers, Maintenance, Mileage, Fuel, Inspections, Tracking/Telematics, and My Truck.
-- `NavigationConfig.swift` declares active/inactive notification pairs for each newly covered fleet tab.
-- `IOSAIAssistantPanel` observes those notifications and appends the active tab context into `navigationContext` with explicit READ-ONLY labels.
-- `ActivePageIdTracker` maps the same notifications to Fleet tab IDs so the assistant can identify the current fleet page.
-- `HelpContentRegistry.notificationToPageId` maps the new notifications to their Fleet tab IDs; dedicated help-entry extraction remains for a later help-content slice.
+All payloads remain read-only summaries and avoid mutating commands, IDs for write actions, or workflow state changes.
 
-The payloads are intentionally concise and non-mutating: page name, workflow summary, visible/read-only interpretation, and available navigation/review entry points only.
+## WEI-1112 Fleet Primary Tabs Slice
+
+Added the next high-traffic Fleet coverage slice across the primary Fleet tabs:
+
+- `IOSFleetDashboardPage`: `fleetDashboardPageActive` / `fleetDashboardPageInactive` with read-only KPI, maintenance, and trailer summary counts.
+- `IOSMaintenancePage`: `fleetMaintenancePageActive` / `fleetMaintenancePageInactive` with total/visible records, date range, and search state.
+- `IOSMileagePage`: `fleetMileagePageActive` / `fleetMileagePageInactive` with total/visible logs, date range, and search state.
+- `IOSFuelPage`: `fleetFuelPageActive` / `fleetFuelPageInactive` with total/visible logs, date range, and search state.
+- `IOSTrailersPage`: `fleetTrailersPageActive` / `fleetTrailersPageInactive` with total/visible trailers and search state.
+- `IOSInspectionsPage`: `fleetInspectionsPageActive` / `fleetInspectionsPageInactive` with total/visible inspections and search state.
+- `IOSTelematicsPage`: `fleetTelematicsPageActive` / `fleetTelematicsPageInactive` with total/visible locations and search state.
+- `IOSMyTruckPage`: `fleetMyTruckPageActive` / `fleetMyTruckPageInactive` with assigned vehicle, selected inventory tab, and read-only count summaries.
+
+Also wired these notifications through `IOSAIAssistantPanel` context observers/navigation-context prompt assembly and active page tracker IDs. Existing `fleetTrackingPageActive` router-tab context remains supported for the FleetRouter tracking tab.
+
+All payloads remain read-only summaries and avoid mutating commands, write action IDs, or workflow state changes.
 
 ## Next Highest-Traffic Remaining Slices
 
-1. People/Office/Reports: Contacts, customers, contractors, teams, office dashboard, approvals, spending, warehouse exec, all report pages.
-2. Remaining Fleet auxiliary routes: trailer locations and truck tools if promoted into visible `appModules` tabs.
-3. Settings: add missing help entries and page context for the high-use settings pages before mapping them to help content.
+1. Fleet secondary pages and deep links: trailer locations, truck tools, and detail-heavy flows still need explicit inventory decisions (context post vs N/A).
+2. People area long-tail pages: contractors, teams, hats, permissions, and detail flows require the same explicit inventory/mapping treatment.
+3. Settings help parity: add missing `settings-app-config` help entry before mapping settings context to help content.
 
 ## Validation
 
@@ -178,10 +191,19 @@ Validated jobs completion slice in the shared workspace on 2026-05-14:
 - Help registry mapping check returned no missing mapped page IDs.
 - `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` passed. Remaining output was warnings only.
 
-Validated fleet router-tab slice in an isolated worktree on 2026-05-17:
+Validated WEI-1112 productivity restart slice in the shared workspace on 2026-05-17:
 
-- Fleet notification names are declared, posted by `FleetRouter`, observed by `IOSAIAssistantPanel`, tracked for active page selection, and mapped in `HelpContentRegistry.notificationToPageId`.
-- Build command: `xcodebuild -workspace 'Wierd Parts.xcworkspace' -scheme 'WiredPart-iOS' -destination 'generic/platform=iOS' -derivedDataPath .paperclip/DerivedData-WEI1112-fleet CODE_SIGNING_ALLOWED=NO build`.
+- Static inventory check confirms parity: declared page-active notifications = 60, pages posting page-active notifications = 60, missing = 0.
+- `rg` confirmation shows new posts in `IOSUnifiedApprovalsPage` and `SettingsRouter`.
+- `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` passed. Remaining output was warnings only.
+
+Validated WEI-1112 Fleet primary tabs slice in the shared workspace on 2026-05-17:
+
+- Static parity checks on the recovered main-based branch reported declared page-active notifications = 57 and AI panel observers = 57, with no undeclared references or missing observers. One router-tab notification (`fleetTrackingPageActive`) is emitted through `FleetRouter` indirection rather than a literal `post(name: .fleetTrackingPageActive)` call.
+- Fleet notification names are declared, posted by their pages, observed by `IOSAIAssistantPanel`, and tracked for active page selection.
+- Help mapping is limited to help entries that currently exist; dedicated help-entry extraction remains for Fleet tabs beyond Dashboard and Maintenance.
+- First build attempt hit Swift type-checker complexity in `IOSAIAssistantPanel` active-page tracker; resolved by splitting/consolidating Fleet tracker observers.
+- `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` passed after the split. Remaining output was warnings only.
 
 Static validation:
 


### PR DESCRIPTION
## Summary
- recovers WEI-1112 fleet/office/settings page-context work onto current main
- merges latest main and resolves SwiftUI type-checker pressure by splitting fleet context observers into smaller modifiers
- adds read-only AI context posts for Fleet primary pages plus Office Approvals and Settings routing context
- updates docs/testing/ai-page-context-coverage.md with current recovered coverage counts

## Validation
- git diff --check
- conflict-marker scan
- xcodebuild build -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "generic/platform=iOS Simulator" -derivedDataPath /tmp/wei1903-pr564-derived-2 CODE_SIGNING_ALLOWED=NO ONLY_ACTIVE_ARCH=YES ARCHS=arm64: SUCCEEDED

Refs WEI-1112 / WEI-1903 branch drain.