### PR TITLE
Fix JobsList job estimate summary fields

### DIFF
--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -420,27 +420,51 @@ public final class JobsService: Sendable {
                 args.append(offset)
 
                 let sql = """
+                    WITH team_counts AS (
+                        SELECT jtm.job_id, COUNT(*) AS team_count
+                        FROM job_team_members jtm
+                        WHERE jtm.deleted_at IS NULL
+                        GROUP BY jtm.job_id
+                    ),
+                    labor_totals AS (
+                        SELECT le.job_id,
+                               SUM(le.regular_hours + le.overtime_hours) AS labor_hours,
+                               SUM(
+                                   le.regular_hours * COALESCE(u.pay_rate, 0)
+                                   + le.overtime_hours * COALESCE(u.pay_rate, 0) * 1.5
+                               ) AS labor_cost
+                        FROM labor_entries le
+                        LEFT JOIN users u ON u.id = le.user_id AND u.deleted_at IS NULL
+                        WHERE le.deleted_at IS NULL
+                          AND le.status = 'completed'
+                        GROUP BY le.job_id
+                    ),
+                    po_costs AS (
+                        SELECT jpo.job_id,
+                               SUM(
+                                   pli.qty_ordered * COALESCE(pli.received_unit_cost, pli.unit_cost, 0)
+                               ) AS po_cost
+                        FROM po_line_items pli
+                        JOIN purchase_orders po ON po.id = pli.po_id
+                        JOIN jpo_line_items jli ON jli.id = pli.jpo_line_id
+                        JOIN job_parts_orders jpo ON jpo.id = jli.jpo_id
+                        WHERE pli.deleted_at IS NULL
+                          AND jli.deleted_at IS NULL
+                          AND jpo.deleted_at IS NULL
+                          AND po.deleted_at IS NULL
+                          AND po.status NOT IN ('cancelled')
+                        GROUP BY jpo.job_id
+                    )
                     SELECT j.id, j.job_number, j.job_name, j.customer_name,
                            j.status, j.priority, j.job_type, j.start_date, j.due_date,
                            j.current_stage_id, j.estimated_hours, j.budget_limit,
-                           COALESCE((SELECT COUNT(*) FROM job_team_members jtm
-                                     WHERE jtm.job_id = j.id AND jtm.deleted_at IS NULL), 0) AS team_count,
-                           COALESCE((SELECT SUM(le.regular_hours + le.overtime_hours)
-                                     FROM labor_entries le
-                                     WHERE le.job_id = j.id AND le.deleted_at IS NULL), 0) AS labor_hours,
-                           COALESCE((SELECT SUM(le.regular_hours * COALESCE(u.pay_rate, 0))
-                                     FROM labor_entries le
-                                     LEFT JOIN users u ON u.id = le.user_id AND u.deleted_at IS NULL
-                                     WHERE le.job_id = j.id AND le.deleted_at IS NULL), 0)
-                           +
-                           COALESCE((SELECT SUM(po.total_cost)
-                                     FROM purchase_orders po
-                                     JOIN po_jpo_links pjl ON pjl.po_id = po.id
-                                     JOIN job_parts_orders jpo ON jpo.id = pjl.jpo_id
-                                     WHERE jpo.job_id = j.id
-                                       AND po.status NOT IN ('cancelled')
-                                       AND po.deleted_at IS NULL), 0) AS actual_cost
+                           COALESCE(tc.team_count, 0) AS team_count,
+                           COALESCE(lt.labor_hours, 0) AS labor_hours,
+                           COALESCE(lt.labor_cost, 0) + COALESCE(pc.po_cost, 0) AS actual_cost
                     FROM jobs j
+                    LEFT JOIN team_counts tc ON tc.job_id = j.id
+                    LEFT JOIN labor_totals lt ON lt.job_id = j.id
+                    LEFT JOIN po_costs pc ON pc.job_id = j.id
                     WHERE \(whereClauses.joined(separator: " AND "))
                     ORDER BY j.created_at DESC
                     LIMIT ? OFFSET ?

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -52,12 +52,20 @@ public final class JobsService: Sendable {
         public let startDate: String?
         public let dueDate: String?
         public let currentStageId: Int64?
+        public let estimatedHours: Double?
+        public let budgetLimit: Double?
+        public let laborHours: Double
+        public let actualCost: Double
 
         public init(
             id: Int64, jobNumber: String, jobName: String, customerName: String?,
             status: String, priority: String, jobType: String = "service",
             teamCount: Int, startDate: String?, dueDate: String?,
-            currentStageId: Int64? = nil
+            currentStageId: Int64? = nil,
+            estimatedHours: Double? = nil,
+            budgetLimit: Double? = nil,
+            laborHours: Double = 0,
+            actualCost: Double = 0
         ) {
             self.id = id
             self.jobNumber = jobNumber
@@ -70,6 +78,10 @@ public final class JobsService: Sendable {
             self.startDate = startDate
             self.dueDate = dueDate
             self.currentStageId = currentStageId
+            self.estimatedHours = estimatedHours
+            self.budgetLimit = budgetLimit
+            self.laborHours = laborHours
+            self.actualCost = actualCost
         }
     }
 
@@ -410,9 +422,24 @@ public final class JobsService: Sendable {
                 let sql = """
                     SELECT j.id, j.job_number, j.job_name, j.customer_name,
                            j.status, j.priority, j.job_type, j.start_date, j.due_date,
-                           j.current_stage_id,
+                           j.current_stage_id, j.estimated_hours, j.budget_limit,
                            COALESCE((SELECT COUNT(*) FROM job_team_members jtm
-                                     WHERE jtm.job_id = j.id AND jtm.deleted_at IS NULL), 0) AS team_count
+                                     WHERE jtm.job_id = j.id AND jtm.deleted_at IS NULL), 0) AS team_count,
+                           COALESCE((SELECT SUM(le.regular_hours + le.overtime_hours)
+                                     FROM labor_entries le
+                                     WHERE le.job_id = j.id AND le.deleted_at IS NULL), 0) AS labor_hours,
+                           COALESCE((SELECT SUM(le.regular_hours * COALESCE(u.pay_rate, 0))
+                                     FROM labor_entries le
+                                     LEFT JOIN users u ON u.id = le.user_id AND u.deleted_at IS NULL
+                                     WHERE le.job_id = j.id AND le.deleted_at IS NULL), 0)
+                           +
+                           COALESCE((SELECT SUM(po.total_cost)
+                                     FROM purchase_orders po
+                                     JOIN po_jpo_links pjl ON pjl.po_id = po.id
+                                     JOIN job_parts_orders jpo ON jpo.id = pjl.jpo_id
+                                     WHERE jpo.job_id = j.id
+                                       AND po.status NOT IN ('cancelled')
+                                       AND po.deleted_at IS NULL), 0) AS actual_cost
                     FROM jobs j
                     WHERE \(whereClauses.joined(separator: " AND "))
                     ORDER BY j.created_at DESC
@@ -432,7 +459,11 @@ public final class JobsService: Sendable {
                         teamCount: row["team_count"] ?? 0,
                         startDate: row["start_date"] as String?,
                         dueDate: row["due_date"] as String?,
-                        currentStageId: row["current_stage_id"] as Int64?
+                        currentStageId: row["current_stage_id"] as Int64?,
+                        estimatedHours: row["estimated_hours"] as Double?,
+                        budgetLimit: row["budget_limit"] as Double?,
+                        laborHours: row["labor_hours"] ?? 0,
+                        actualCost: row["actual_cost"] ?? 0
                     )
                 }
             }

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -24,6 +24,115 @@ struct JobsServiceTests {
         #expect(jobs.contains(where: { $0.jobNumber == "J-TEST" }))
     }
 
+    @Test("listJobs aggregates completed labor and job-linked PO line costs without duplication")
+    func testListJobsAggregatesCompletedLaborAndPOLineCosts() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LIST-1", name: "Aggregate Job")
+        let secondJpoJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LIST-2", name: "Other Job")
+        let supplierId = try E2ETestHelpers.seedSupplier(env)
+        let categoryId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, name: "Primary Part", categoryId: categoryId)
+        let secondPartId = try E2ETestHelpers.seedPart(env, name: "Secondary Part", categoryId: categoryId)
+
+        try env.db.writer.write { db in
+            try db.execute(
+                sql: "UPDATE users SET pay_rate = ?, deleted_at = NULL, is_active = 1 WHERE id = ?",
+                arguments: [20.0, env.adminUserId]
+            )
+            try db.execute(
+                sql: "UPDATE jobs SET estimated_hours = ?, budget_limit = ? WHERE id = ?",
+                arguments: [12.5, 500.0, jobId]
+            )
+
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, datetime('now', '-8 hours'), datetime('now', '-2 hours'), 4.0, 2.0, 'completed', datetime('now'))
+                """, arguments: [env.adminUserId, jobId])
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, datetime('now', '-1 hours'), 10.0, 5.0, 'clocked_in', datetime('now'))
+                """, arguments: [env.adminUserId, jobId])
+
+            try db.execute(sql: """
+                INSERT INTO job_parts_orders (job_id, order_number, status, requested_by, created_at, updated_at)
+                VALUES (?, 'JPO-LIST-1', 'submitted', ?, datetime('now'), datetime('now'))
+                """, arguments: [jobId, env.adminUserId])
+            let firstJpoId = db.lastInsertedRowID
+
+            try db.execute(sql: """
+                INSERT INTO job_parts_orders (job_id, order_number, status, requested_by, created_at, updated_at)
+                VALUES (?, 'JPO-LIST-2', 'submitted', ?, datetime('now'), datetime('now'))
+                """, arguments: [jobId, env.adminUserId])
+            let secondJpoId = db.lastInsertedRowID
+
+            try db.execute(sql: """
+                INSERT INTO job_parts_orders (job_id, order_number, status, requested_by, created_at, updated_at)
+                VALUES (?, 'JPO-LIST-3', 'submitted', ?, datetime('now'), datetime('now'))
+                """, arguments: [secondJpoJobId, env.adminUserId])
+            let otherJobJpoId = db.lastInsertedRowID
+
+            try db.execute(sql: """
+                INSERT INTO jpo_line_items (jpo_id, part_id, qty_requested, qty_ordered, created_at)
+                VALUES (?, ?, 3, 3, datetime('now'))
+                """, arguments: [firstJpoId, partId])
+            let firstJpoLineId = db.lastInsertedRowID
+
+            try db.execute(sql: """
+                INSERT INTO jpo_line_items (jpo_id, part_id, qty_requested, qty_ordered, created_at)
+                VALUES (?, ?, 1, 1, datetime('now'))
+                """, arguments: [secondJpoId, secondPartId])
+            let secondJpoLineId = db.lastInsertedRowID
+
+            try db.execute(sql: """
+                INSERT INTO jpo_line_items (jpo_id, part_id, qty_requested, qty_ordered, created_at)
+                VALUES (?, ?, 2, 2, datetime('now'))
+                """, arguments: [otherJobJpoId, secondPartId])
+            let otherJobLineId = db.lastInsertedRowID
+
+            try db.execute(sql: """
+                INSERT INTO purchase_orders
+                    (po_number, supplier_id, status, total_cost, submitted_by, created_at, updated_at)
+                VALUES ('PO-LIST-1', ?, 'submitted', 999.0, ?, datetime('now'), datetime('now'))
+                """, arguments: [supplierId, env.adminUserId])
+            let firstPoId = db.lastInsertedRowID
+
+            try db.execute(sql: """
+                INSERT INTO purchase_orders
+                    (po_number, supplier_id, status, total_cost, submitted_by, created_at, updated_at)
+                VALUES ('PO-LIST-2', ?, 'cancelled', 1000.0, ?, datetime('now'), datetime('now'))
+                """, arguments: [supplierId, env.adminUserId])
+            let cancelledPoId = db.lastInsertedRowID
+
+            try db.execute(sql: "INSERT INTO po_jpo_links (po_id, jpo_id, created_at) VALUES (?, ?, datetime('now'))", arguments: [firstPoId, firstJpoId])
+            try db.execute(sql: "INSERT INTO po_jpo_links (po_id, jpo_id, created_at) VALUES (?, ?, datetime('now'))", arguments: [firstPoId, secondJpoId])
+            try db.execute(sql: "INSERT INTO po_jpo_links (po_id, jpo_id, created_at) VALUES (?, ?, datetime('now'))", arguments: [firstPoId, otherJobJpoId])
+
+            try db.execute(sql: """
+                INSERT INTO po_line_items (po_id, jpo_line_id, part_id, qty_ordered, unit_cost, created_at)
+                VALUES (?, ?, ?, 3, 15.0, datetime('now'))
+                """, arguments: [firstPoId, firstJpoLineId, partId])
+            try db.execute(sql: """
+                INSERT INTO po_line_items (po_id, jpo_line_id, part_id, qty_ordered, unit_cost, received_unit_cost, created_at)
+                VALUES (?, ?, ?, 1, 35.0, 40.0, datetime('now'))
+                """, arguments: [firstPoId, secondJpoLineId, secondPartId])
+            try db.execute(sql: """
+                INSERT INTO po_line_items (po_id, jpo_line_id, part_id, qty_ordered, unit_cost, created_at)
+                VALUES (?, ?, ?, 2, 50.0, datetime('now'))
+                """, arguments: [cancelledPoId, otherJobLineId, secondPartId])
+        }
+
+        let jobs = try env.jobs.listJobs()
+        let job = try #require(jobs.first(where: { $0.id == jobId }))
+        let otherJob = try #require(jobs.first(where: { $0.id == secondJpoJobId }))
+        #expect(job.estimatedHours == 12.5)
+        #expect(job.budgetLimit == 500.0)
+        #expect(abs(job.laborHours - 6.0) < 0.0001)
+        #expect(abs(job.actualCost - 225.0) < 0.0001)
+        #expect(abs(otherJob.actualCost) < 0.0001)
+    }
+
     @Test("Get job detail")
     func testGetJobDetail() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary\n- Restores JobsService.JobListItem fields consumed by JobsListPage for hour and budget progress.\n- Populates estimated hours, budget limit, labor hours, and actual cost directly in the jobs list query instead of hiding the UI semantics.\n\n## Verification\n- xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/wei1572-dd-after build CODE_SIGNING_ALLOWED=NO\n\nRefs GH#562. Refs WEI-1572.