### PR TITLE
[WEI-1694] Recover scoped empty-state slice

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSDailyReportsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSDailyReportsPage.swift
@@ -118,13 +118,13 @@ struct IOSDailyReportsPage: View {
             ProgressView("Loading reports...")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let error = loadError {
-            ContentUnavailableView("Error", systemImage: "exclamationmark.triangle", description: Text(error))
+            ErrorStateView(message: error) { loadData() }
         } else if reports.isEmpty {
-            ContentUnavailableView {
-                Label("No Activity", systemImage: "doc.plaintext")
-            } description: {
-                Text("No job activity was recorded for \(formattedDate(selectedDate)).")
-            }
+            EmptyStateView(
+                icon: "doc.plaintext",
+                title: "No Activity",
+                message: "No job activity was recorded for \(formattedDate(selectedDate))."
+            )
         } else {
             List {
                 // Summary header

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
@@ -224,11 +224,11 @@ struct IOSJobDetailPage: View {
             }
             .listStyle(.insetGrouped)
         } else {
-            ContentUnavailableView {
-                Label("Job Not Found", systemImage: "hammer")
-            } description: {
-                Text("The requested job could not be loaded.")
-            }
+            EmptyStateView(
+                icon: "hammer",
+                title: "Job Not Found",
+                message: "The requested job could not be loaded."
+            )
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSBookkeeperExportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSBookkeeperExportPage.swift
@@ -99,11 +99,11 @@ struct IOSBookkeeperExportPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if laborRows.isEmpty && materialRows.isEmpty {
-            ContentUnavailableView {
-                Label("No Data", systemImage: "doc.richtext")
-            } description: {
-                Text("No labor or material data for the selected period.")
-            }
+            EmptyStateView(
+                icon: "doc.richtext",
+                title: "No Data",
+                message: "No labor or material data for the selected period."
+            )
         } else {
             List {
                 if !laborRows.isEmpty {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSDailyReportsSummaryPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSDailyReportsSummaryPage.swift
@@ -122,11 +122,11 @@ struct IOSDailyReportsSummaryPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if rows.isEmpty {
-            ContentUnavailableView {
-                Label("No Reports", systemImage: "doc.plaintext")
-            } description: {
-                Text("No daily reports found for \(displayDate).")
-            }
+            EmptyStateView(
+                icon: "doc.plaintext",
+                title: "No Reports",
+                message: "No daily reports found for \(displayDate)."
+            )
         } else {
             List {
                 Section {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSPreBillingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSPreBillingPage.swift
@@ -74,11 +74,11 @@ struct IOSPreBillingPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if rows.isEmpty {
-            ContentUnavailableView {
-                Label("No Billing Data", systemImage: "doc.text")
-            } description: {
-                Text("No labor entries found for the selected period.")
-            }
+            EmptyStateView(
+                icon: "doc.text",
+                title: "No Billing Data",
+                message: "No labor entries found for the selected period."
+            )
         } else {
             List {
                 Section {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSProfitabilityPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSProfitabilityPage.swift
@@ -73,11 +73,11 @@ struct IOSProfitabilityPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredRows.isEmpty {
-            ContentUnavailableView {
-                Label("No Data", systemImage: "chart.line.uptrend.xyaxis")
-            } description: {
-                Text("No profitability data available.")
-            }
+            EmptyStateView(
+                icon: "chart.line.uptrend.xyaxis",
+                title: "No Data",
+                message: "No profitability data available."
+            )
         } else {
             List(filteredRows, id: \.id) { row in
                 profitRow(row)

--- a/Weird Parts IOS/Weird Parts IOS/Sync/SyncConflictReviewPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/SyncConflictReviewPage.swift
@@ -24,10 +24,10 @@ struct SyncConflictReviewPage: View {
                     ProgressView("Loading conflicts...")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else if conflicts.isEmpty {
-                    ContentUnavailableView(
-                        "No Unreviewed Conflicts",
-                        systemImage: "checkmark.circle",
-                        description: Text("All sync conflicts have been reviewed.")
+                    EmptyStateView(
+                        icon: "checkmark.circle",
+                        title: "No Unreviewed Conflicts",
+                        message: "All sync conflicts have been reviewed."
                     )
                 } else {
                     conflictList


### PR DESCRIPTION
## Summary
- Cherry-picked the exact WEI-1040 scoped empty-state conversion from commit `2b065449` onto current `origin/main`.
- Limited the recovery to the seven files named in WEI-1694.
- Replaced the raw non-search `ContentUnavailableView` empty states with the app design-system `EmptyStateView` pattern.

## Validation
- `rg -n "ContentUnavailableView" <7 scoped files>`: no matches.
- `rg -n "ContentUnavailableView\.search" <7 scoped files>`: no matches retained in this bounded slice.
- `git diff --check origin/main...HEAD`: pass.
- `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination "generic/platform=iOS Simulator" build CODE_SIGNING_ALLOWED=NO`: fails in unchanged `App/AppCore.swift:646-648` with throwing-call errors; `AppCore.swift` is not modified by this PR.

Paperclip: WEI-1694.