### PR TITLE
fix(reports): standardize report metric empty states

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/FleetFuelCostReport.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/FleetFuelCostReport.swift
@@ -30,9 +30,11 @@ struct FleetFuelCostReport: View {
                 Section { ProgressView("Loading...") }
             } else if fuelData.isEmpty {
                 Section {
-                    ContentUnavailableView("No Fuel Data",
-                        systemImage: "fuelpump",
-                        description: Text("No fuel logs found for this period."))
+                    EmptyStateView(
+                        icon: "fuelpump",
+                        title: "No Fuel Data",
+                        message: "No fuel logs found for this period."
+                    )
                 }
             } else {
                 // Summary

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/FleetMaintenanceTrendsReport.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/FleetMaintenanceTrendsReport.swift
@@ -30,9 +30,11 @@ struct FleetMaintenanceTrendsReport: View {
                 Section { ProgressView("Loading...") }
             } else if trendData.isEmpty {
                 Section {
-                    ContentUnavailableView("No Maintenance Data",
-                        systemImage: "wrench.and.screwdriver",
-                        description: Text("No maintenance records found for this period."))
+                    EmptyStateView(
+                        icon: "wrench.and.screwdriver",
+                        title: "No Maintenance Data",
+                        message: "No maintenance records found for this period."
+                    )
                 }
             } else {
                 Section("Summary") {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/FleetMileageSummaryReport.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/FleetMileageSummaryReport.swift
@@ -30,9 +30,11 @@ struct FleetMileageSummaryReport: View {
                 Section { ProgressView("Loading...") }
             } else if mileageData.isEmpty {
                 Section {
-                    ContentUnavailableView("No Mileage Data",
-                        systemImage: "speedometer",
-                        description: Text("No mileage logs found for this period."))
+                    EmptyStateView(
+                        icon: "speedometer",
+                        title: "No Mileage Data",
+                        message: "No mileage logs found for this period."
+                    )
                 }
             } else {
                 Section("Summary") {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/FleetUtilizationReport.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/FleetUtilizationReport.swift
@@ -31,9 +31,11 @@ struct FleetUtilizationReport: View {
                 Section { ProgressView("Loading...") }
             } else if utilizationData.isEmpty {
                 Section {
-                    ContentUnavailableView("No Utilization Data",
-                        systemImage: "car.fill",
-                        description: Text("No vehicle activity found for this period."))
+                    EmptyStateView(
+                        icon: "car.fill",
+                        title: "No Utilization Data",
+                        message: "No vehicle activity found for this period."
+                    )
                 }
             } else {
                 Section("Summary") {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/SchedulingCrewUtilizationReport.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/SchedulingCrewUtilizationReport.swift
@@ -30,9 +30,11 @@ struct SchedulingCrewUtilizationReport: View {
                 Section { ProgressView("Loading...") }
             } else if utilizationData.isEmpty {
                 Section {
-                    ContentUnavailableView("No Scheduling Data",
-                        systemImage: "person.3",
-                        description: Text("No dispatch entries found for this period."))
+                    EmptyStateView(
+                        icon: "person.3",
+                        title: "No Scheduling Data",
+                        message: "No dispatch entries found for this period."
+                    )
                 }
             } else {
                 Section("Summary") {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/SchedulingDispatchEfficiencyReport.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/SchedulingDispatchEfficiencyReport.swift
@@ -30,9 +30,11 @@ struct SchedulingDispatchEfficiencyReport: View {
                 Section { ProgressView("Loading...") }
             } else if efficiencyData.isEmpty {
                 Section {
-                    ContentUnavailableView("No Dispatch Data",
-                        systemImage: "paperplane",
-                        description: Text("No dispatch entries found for this period."))
+                    EmptyStateView(
+                        icon: "paperplane",
+                        title: "No Dispatch Data",
+                        message: "No dispatch entries found for this period."
+                    )
                 }
             } else {
                 Section("Summary") {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/SchedulingPipelineReport.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/SchedulingPipelineReport.swift
@@ -23,9 +23,11 @@ struct SchedulingPipelineReport: View {
                 Section { ProgressView("Loading...") }
             } else if pipelineData.isEmpty {
                 Section {
-                    ContentUnavailableView("No Pipeline Data",
-                        systemImage: "rectangle.stack",
-                        description: Text("No jobs found in the system."))
+                    EmptyStateView(
+                        icon: "rectangle.stack",
+                        title: "No Pipeline Data",
+                        message: "No jobs found in the system."
+                    )
                 }
             } else {
                 Section("Overview") {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/WarehouseBackorderReport.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/WarehouseBackorderReport.swift
@@ -23,9 +23,11 @@ struct WarehouseBackorderReport: View {
                 Section { ProgressView("Loading...") }
             } else if backorderData.isEmpty {
                 Section {
-                    ContentUnavailableView("No Backorders",
-                        systemImage: "checkmark.circle",
-                        description: Text("All PO items are fully received."))
+                    EmptyStateView(
+                        icon: "checkmark.circle",
+                        title: "No Backorders",
+                        message: "All PO items are fully received."
+                    )
                 }
             } else {
                 Section("Summary") {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/WarehouseInventoryValueReport.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/WarehouseInventoryValueReport.swift
@@ -23,9 +23,11 @@ struct WarehouseInventoryValueReport: View {
                 Section { ProgressView("Loading...") }
             } else if valueData.isEmpty {
                 Section {
-                    ContentUnavailableView("No Inventory Data",
-                        systemImage: "shippingbox",
-                        description: Text("No inventory categories found."))
+                    EmptyStateView(
+                        icon: "shippingbox",
+                        title: "No Inventory Data",
+                        message: "No inventory categories found."
+                    )
                 }
             } else {
                 Section("Total Value") {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/WarehouseTurnoverReport.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/WarehouseTurnoverReport.swift
@@ -30,9 +30,11 @@ struct WarehouseTurnoverReport: View {
                 Section { ProgressView("Loading...") }
             } else if turnoverData.isEmpty {
                 Section {
-                    ContentUnavailableView("No Movement Data",
-                        systemImage: "arrow.left.arrow.right",
-                        description: Text("No stock movements found for this period."))
+                    EmptyStateView(
+                        icon: "arrow.left.arrow.right",
+                        title: "No Movement Data",
+                        message: "No stock movements found for this period."
+                    )
                 }
             } else {
                 Section("Summary") {


### PR DESCRIPTION
## Summary
- Replaced raw ContentUnavailableView empty states with EmptyStateView in the ten WEI-1714 scoped report metric/chart files.
- Preserved existing titles, SF Symbol names, messages, loading branches, error branches, filter handling, export rows, and navigation/help behavior.

## Validation
- PASS: rg -n "ContentUnavailableView" <10 scoped report files> returned no matches.
- PASS: git diff --check.
- FAIL (unrelated trunk issue): xcodebuild build -quiet -scheme WiredPart-iOS -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO fails in SettingsPrivacyPage.swift because OnboardingTelemetryService is not in scope. No errors were reported in the ten touched report files.

Closes WEI-1714