### PR TITLE
fix(warehouse): standardize empty states

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/CartManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/CartManager.swift
@@ -74,11 +74,11 @@ struct CartSheetView: View {
         NavigationStack {
             VStack(spacing: 0) {
                 if cartManager.isEmpty {
-                    ContentUnavailableView {
-                        Label("Cart is Empty", systemImage: "cart")
-                    } description: {
-                        Text("Add parts or bins from any list to move them in bulk.")
-                    }
+                    EmptyStateView(
+                        icon: "cart",
+                        title: "Cart is Empty",
+                        message: "Add parts or bins from any list to move them in bulk."
+                    )
                 } else {
                     cartList
                     placeAllButton

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
@@ -689,11 +689,11 @@ struct IOSAuditPage: View {
 
                 if stopItems.isEmpty {
                     Section {
-                        ContentUnavailableView {
-                            Label("No parts here", systemImage: "tray")
-                        } description: {
-                            Text("Confirm empty or report count.")
-                        }
+                        EmptyStateView(
+                            icon: "tray",
+                            title: "No parts here",
+                            message: "Confirm empty or report count."
+                        )
 
                         Button {
                             recordWalkingPathEvent(type: "empty_confirmed", notes: "Confirmed empty walking-path stop")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseOnboardingWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseOnboardingWizard.swift
@@ -159,11 +159,11 @@ struct WarehouseOnboardingWizard: View {
 
     @ViewBuilder
     private var incompleteStepView: some View {
-        ContentUnavailableView {
-            Label("Complete Step 1 First", systemImage: "1.circle")
-        } description: {
-            Text("Create a floor plan before setting up storage units.")
-        }
+        EmptyStateView(
+            icon: "1.circle",
+            title: "Complete Step 1 First",
+            message: "Create a floor plan before setting up storage units."
+        )
     }
 
     @ViewBuilder

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep2.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep2.swift
@@ -74,11 +74,11 @@ struct WarehouseWizardStep2: View {
                     Text("This storage unit will be permanently removed from the floor plan.")
                 }
             } else {
-                ContentUnavailableView {
-                    Label("No Storage Units", systemImage: "cabinet.fill")
-                } description: {
-                    Text("Tap the button above to add your first shelf, rack, or storage area.")
-                }
+                EmptyStateView(
+                    icon: "cabinet.fill",
+                    title: "No Storage Units",
+                    message: "Tap the button above to add your first shelf, rack, or storage area."
+                )
             }
         }
         .task { loadUnits() }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep3.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep3.swift
@@ -46,11 +46,11 @@ struct WarehouseWizardStep3: View {
             .padding(.horizontal)
 
             if allAreas.isEmpty {
-                ContentUnavailableView {
-                    Label("No Areas Yet", systemImage: "tag.fill")
-                } description: {
-                    Text("Add storage units in Step 2 first.")
-                }
+                EmptyStateView(
+                    icon: "tag.fill",
+                    title: "No Areas Yet",
+                    message: "Add storage units in Step 2 first."
+                )
             } else {
                 List {
                     ForEach(stickerGroups, id: \.unitName) { group in

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep4.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep4.swift
@@ -25,11 +25,11 @@ struct WarehouseWizardStep4: View {
     var body: some View {
         VStack(spacing: 0) {
             if allAreas.isEmpty {
-                ContentUnavailableView {
-                    Label("No Areas Yet", systemImage: "figure.walk")
-                } description: {
-                    Text("Add storage units in Step 2 first.")
-                }
+                EmptyStateView(
+                    icon: "figure.walk",
+                    title: "No Areas Yet",
+                    message: "Add storage units in Step 2 first."
+                )
             } else if let area = currentArea {
                 areaContent(area)
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep5.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep5.swift
@@ -25,11 +25,11 @@ struct WarehouseWizardStep5: View {
     var body: some View {
         VStack(spacing: 0) {
             if allAreas.isEmpty {
-                ContentUnavailableView {
-                    Label("No Areas Yet", systemImage: "number.circle.fill")
-                } description: {
-                    Text("Add storage units in Step 2 and assign parts in Step 4 first.")
-                }
+                EmptyStateView(
+                    icon: "number.circle.fill",
+                    title: "No Areas Yet",
+                    message: "Add storage units in Step 2 and assign parts in Step 4 first."
+                )
             } else if let area = currentArea {
                 areaContent(area)
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep6.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep6.swift
@@ -59,11 +59,11 @@ struct WarehouseWizardStep6: View {
             .background(Color.blue.opacity(0.05))
 
             if assignedParts.isEmpty {
-                ContentUnavailableView {
-                    Label("No Parts to Configure", systemImage: "target")
-                } description: {
-                    Text("Assign parts to locations in Step 4 first.")
-                }
+                EmptyStateView(
+                    icon: "target",
+                    title: "No Parts to Configure",
+                    message: "Assign parts to locations in Step 4 first."
+                )
             } else {
                 partsList
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepAreas.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepAreas.swift
@@ -30,11 +30,11 @@ struct WizardStepAreas: View {
             .padding()
 
             if units.isEmpty {
-                ContentUnavailableView {
-                    Label("No Storage Units", systemImage: "cabinet.fill")
-                } description: {
-                    Text("Add storage units in Step 3 first.")
-                }
+                EmptyStateView(
+                    icon: "cabinet.fill",
+                    title: "No Storage Units",
+                    message: "Add storage units in Step 3 first."
+                )
             } else {
                 List {
                     ForEach(units, id: \.id) { unit in

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepBins.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepBins.swift
@@ -36,11 +36,11 @@ struct WizardStepBins: View {
             .padding()
 
             if allAreas.isEmpty {
-                ContentUnavailableView {
-                    Label("No Areas Yet", systemImage: "tray.fill")
-                } description: {
-                    Text("Create storage units with levels and areas in earlier steps first.")
-                }
+                EmptyStateView(
+                    icon: "tray.fill",
+                    title: "No Areas Yet",
+                    message: "Create storage units with levels and areas in earlier steps first."
+                )
             } else {
                 List {
                     ForEach(allAreas) { area in

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepPlacement.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepPlacement.swift
@@ -400,10 +400,10 @@ struct WizardStepPlacement: View {
     private var cartBinBrowser: some View {
         Group {
             if allBins.isEmpty {
-                ContentUnavailableView(
-                    "No Bins",
-                    systemImage: "tray",
-                    description: Text("Create bins in storage areas first.")
+                EmptyStateView(
+                    icon: "tray",
+                    title: "No Bins",
+                    message: "Create bins in storage areas first."
                 )
             } else {
                 List {
@@ -456,10 +456,10 @@ struct WizardStepPlacement: View {
                     .font(.headline)
 
                 if allAreas.isEmpty {
-                    ContentUnavailableView(
-                        "No Areas",
-                        systemImage: "square.dashed",
-                        description: Text("Create storage areas first.")
+                    EmptyStateView(
+                        icon: "square.dashed",
+                        title: "No Areas",
+                        message: "Create storage areas first."
                     )
                 } else {
                     List(allAreas, id: \.id, selection: $selectedAreaId) { area in

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepShelves.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepShelves.swift
@@ -34,11 +34,11 @@ struct WizardStepShelves: View {
             .padding()
 
             if units.isEmpty {
-                ContentUnavailableView {
-                    Label("No Storage Units", systemImage: "cabinet.fill")
-                } description: {
-                    Text("Add storage units in Step 3 first.")
-                }
+                EmptyStateView(
+                    icon: "cabinet.fill",
+                    title: "No Storage Units",
+                    message: "Add storage units in Step 3 first."
+                )
             } else {
                 List {
                     ForEach(units, id: \.id) { unit in

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepWalkingPath.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepWalkingPath.swift
@@ -65,11 +65,11 @@ struct WizardStepWalkingPath: View {
         List {
             Section {
                 if displayedStops.isEmpty {
-                    ContentUnavailableView {
-                        Label("No Walking Path", systemImage: "figure.walk")
-                    } description: {
-                        Text("Add stops or preview a suggested path before saving.")
-                    }
+                    EmptyStateView(
+                        icon: "figure.walk",
+                        title: "No Walking Path",
+                        message: "Add stops or preview a suggested path before saving."
+                    )
                 } else {
                     ForEach(Array(displayedStops.enumerated()), id: \.element) { index, areaId in
                         stopRow(areaId: areaId, index: index)
@@ -170,7 +170,11 @@ struct WizardStepWalkingPath: View {
             } else if let first = displayedStops.first, let area = areaById[first] {
                 areaPreview(area)
             } else {
-                ContentUnavailableView("Select a Stop", systemImage: "rectangle.dashed", description: Text("Tap a stop to preview its location."))
+                EmptyStateView(
+                    icon: "rectangle.dashed",
+                    title: "Select a Stop",
+                    message: "Tap a stop to preview its location."
+                )
             }
             Spacer()
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepZones.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepZones.swift
@@ -196,10 +196,10 @@ struct WizardStepZones: View {
                 }
 
                 if zones.isEmpty {
-                    ContentUnavailableView(
-                        "No Zones",
-                        systemImage: "rectangle.3.group",
-                        description: Text("Drag a zone type onto the grid.")
+                    EmptyStateView(
+                        icon: "rectangle.3.group",
+                        title: "No Zones",
+                        message: "Drag a zone type onto the grid."
                     )
                     .padding(.top, 24)
                 }
@@ -283,10 +283,10 @@ struct WizardStepZones: View {
                     .buttonStyle(.bordered)
                 }
             } else {
-                ContentUnavailableView(
-                    "Select a Zone",
-                    systemImage: "cursorarrow.click.2",
-                    description: Text("Tap a placed zone to edit or delete it.")
+                EmptyStateView(
+                    icon: "cursorarrow.click.2",
+                    title: "Select a Zone",
+                    message: "Tap a placed zone to edit or delete it."
                 )
             }
 


### PR DESCRIPTION
## Summary
- Replaced raw non-search `ContentUnavailableView` placeholders with shared `EmptyStateView` across the scoped Warehouse cart, audit, onboarding, wizard, and placement surfaces.
- Preserved existing SF Symbols, titles, messages, buttons, wizard flow, cart behavior, audit actions, and validation/data-loading semantics.
- Left global search empty states untouched.

## Validation
- RED/pre-change scoped grep found 17 raw `ContentUnavailableView` matches in the WEI-1716 Warehouse file set.
- Post-change scoped grep across all 14 requested Warehouse files found 0 `ContentUnavailableView` matches.
- `git diff --check` passed.
- `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` currently fails on an unrelated trunk issue in `SettingsPrivacyPage.swift`:
  - `cannot find type 'OnboardingTelemetryService' in scope`
  - No errors were reported in the touched Warehouse files before the build stopped.

Paperclip: WEI-1716
