### PR TITLE
fix(settings): standardize Settings empty states

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/AuditLogPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/AuditLogPage.swift
@@ -36,10 +36,10 @@ struct AuditLogPage: View {
                 ProgressView("Loading audit log...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if entries.isEmpty {
-                ContentUnavailableView(
-                    "No Audit Entries",
-                    systemImage: "doc.text.magnifyingglass",
-                    description: Text("No recent changes have been recorded.")
+                EmptyStateView(
+                    icon: "doc.text.magnifyingglass",
+                    title: "No Audit Entries",
+                    message: "No recent changes have been recorded."
                 )
             } else {
                 List {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSAuditSettingsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSAuditSettingsPage.swift
@@ -51,7 +51,7 @@ struct IOSAuditSettingsPage: View {
                 ProgressView("Loading audit settings...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let loadError {
-                ContentUnavailableView("Unable to Load", systemImage: "exclamationmark.triangle", description: Text(loadError))
+                ErrorStateView(message: loadError)
             } else {
                 settingsForm
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
@@ -33,10 +33,10 @@ struct IOSBackupsPage: View {
             if canManageSettings {
                 backupsForm
             } else {
-                ContentUnavailableView(
-                    "Access Restricted",
-                    systemImage: "lock.shield",
-                    description: Text("You don't have permission to manage backups.")
+                EmptyStateView(
+                    icon: "lock.shield",
+                    title: "Access Restricted",
+                    message: "You don't have permission to manage backups."
                 )
             }
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBootstrapAdminPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBootstrapAdminPage.swift
@@ -24,10 +24,10 @@ struct IOSBootstrapAdminPage: View {
                 ProgressView("Loading devices...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if bootstrapDevices.isEmpty {
-                ContentUnavailableView(
-                    "No Bootstrap Devices",
-                    systemImage: "iphone.and.arrow.forward",
-                    description: Text("No devices have been registered through the bootstrap process yet.")
+                EmptyStateView(
+                    icon: "iphone.and.arrow.forward",
+                    title: "No Bootstrap Devices",
+                    message: "No devices have been registered through the bootstrap process yet."
                 )
             } else {
                 List {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDailyReportTemplatesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDailyReportTemplatesPage.swift
@@ -57,7 +57,7 @@ struct IOSDailyReportTemplatesPage: View {
                 ProgressView("Loading template...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let loadError {
-                ContentUnavailableView("Unable to Load", systemImage: "exclamationmark.triangle", description: Text(loadError))
+                ErrorStateView(message: loadError)
             } else {
                 templateEditor
             }
@@ -181,10 +181,10 @@ struct IOSDailyReportTemplatesPage: View {
         // so the preview doesn't render an empty list with no explanation.
         let enabledSections = sections.filter(\.enabled)
         if enabledSections.isEmpty {
-            ContentUnavailableView(
-                "No Sections Enabled",
-                systemImage: "doc.text.magnifyingglass",
-                description: Text("Enable at least one section in the template editor to preview it here.")
+            EmptyStateView(
+                icon: "doc.text.magnifyingglass",
+                title: "No Sections Enabled",
+                message: "Enable at least one section in the template editor to preview it here."
             )
         } else {
         List {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
@@ -34,10 +34,10 @@ struct IOSDataExportPage: View {
             if canExport {
                 exportForm
             } else {
-                ContentUnavailableView(
-                    "Access Restricted",
-                    systemImage: "lock.shield",
-                    description: Text("You don't have permission to export data.")
+                EmptyStateView(
+                    icon: "lock.shield",
+                    title: "Access Restricted",
+                    message: "You don't have permission to export data."
                 )
             }
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDeviceManagementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDeviceManagementPage.swift
@@ -28,11 +28,11 @@ struct IOSDeviceManagementPage: View {
             }
 
             Section("Paired Devices") {
-                ContentUnavailableView {
-                    Label("No Paired Devices", systemImage: "desktopcomputer")
-                } description: {
-                    Text("Device pairing will be available when sync infrastructure is enabled in a future update.")
-                }
+                EmptyStateView(
+                    icon: "desktopcomputer",
+                    title: "No Paired Devices",
+                    message: "Device pairing will be available when sync infrastructure is enabled in a future update."
+                )
             }
 
             Section("Actions") {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDispatchPreferencesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDispatchPreferencesPage.swift
@@ -49,7 +49,7 @@ struct IOSDispatchPreferencesPage: View {
                 ProgressView("Loading dispatch preferences...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let loadError {
-                ContentUnavailableView("Unable to Load", systemImage: "exclamationmark.triangle", description: Text(loadError))
+                ErrorStateView(message: loadError)
             } else {
                 settingsForm
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSForecastSettingsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSForecastSettingsPage.swift
@@ -54,7 +54,7 @@ struct IOSForecastSettingsPage: View {
                 ProgressView("Loading forecast settings...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let loadError {
-                ContentUnavailableView("Unable to Load", systemImage: "exclamationmark.triangle", description: Text(loadError))
+                ErrorStateView(message: loadError)
             } else {
                 settingsForm
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSIntegrationsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSIntegrationsPage.swift
@@ -26,10 +26,10 @@ struct IOSIntegrationsPage: View {
                 }
             } else if integrations.isEmpty {
                 Section {
-                    ContentUnavailableView(
-                        "No Integrations",
-                        systemImage: "puzzlepiece.extension",
-                        description: Text("No integrations have been configured. Set up integrations from the desktop application.")
+                    EmptyStateView(
+                        icon: "puzzlepiece.extension",
+                        title: "No Integrations",
+                        message: "No integrations have been configured. Set up integrations from the desktop application."
                     )
                 }
             } else {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSOrganizationThresholdsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSOrganizationThresholdsPage.swift
@@ -44,7 +44,7 @@ struct IOSOrganizationThresholdsPage: View {
                 ProgressView("Loading thresholds...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let loadError {
-                ContentUnavailableView("Unable to Load", systemImage: "exclamationmark.triangle", description: Text(loadError))
+                ErrorStateView(message: loadError)
             } else {
                 settingsForm
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSPreTripChecklistPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSPreTripChecklistPage.swift
@@ -81,7 +81,7 @@ struct IOSPreTripChecklistPage: View {
                 ProgressView("Loading checklist...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let loadError {
-                ContentUnavailableView("Unable to Load", systemImage: "exclamationmark.triangle", description: Text(loadError))
+                ErrorStateView(message: loadError)
             } else {
                 checklistEditor
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSReportTemplatesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSReportTemplatesPage.swift
@@ -57,7 +57,7 @@ struct IOSReportTemplatesPage: View {
                 ProgressView("Loading templates...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let loadError {
-                ContentUnavailableView("Unable to Load", systemImage: "exclamationmark.triangle", description: Text(loadError))
+                ErrorStateView(message: loadError)
             } else {
                 templateList
             }
@@ -123,7 +123,7 @@ struct IOSReportTemplatesPage: View {
             }
 
             if templates.isEmpty {
-                ContentUnavailableView("No Templates", systemImage: "doc.on.doc", description: Text("Tap + to create a report template."))
+                EmptyStateView(icon: "doc.on.doc", title: "No Templates", message: "Tap + to create a report template.")
             } else {
                 // My templates
                 let myTemplates = templates.filter { !$0.isShared }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSSharedChannelsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSSharedChannelsPage.swift
@@ -15,11 +15,11 @@ struct IOSSharedChannelsPage: View {
             }
 
             Section("Channels") {
-                ContentUnavailableView {
-                    Label("No Shared Channels", systemImage: "bubble.left.and.bubble.right")
-                } description: {
-                    Text("Shared channels will be configured when multi-device sync is enabled.")
-                }
+                EmptyStateView(
+                    icon: "bubble.left.and.bubble.right",
+                    title: "No Shared Channels",
+                    message: "Shared channels will be configured when multi-device sync is enabled."
+                )
             }
 
             Section {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSSupplierBridgePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSSupplierBridgePage.swift
@@ -24,10 +24,10 @@ struct IOSSupplierBridgePage: View {
                 ProgressView("Loading supplier bridges...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if bridges.isEmpty {
-                ContentUnavailableView(
-                    "No Supplier Bridges",
-                    systemImage: "building.2",
-                    description: Text("No supplier communication bridges have been configured. Set these up from the desktop application.")
+                EmptyStateView(
+                    icon: "building.2",
+                    title: "No Supplier Bridges",
+                    message: "No supplier communication bridges have been configured. Set these up from the desktop application."
                 )
             } else {
                 Form {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSToolPoliciesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSToolPoliciesPage.swift
@@ -44,7 +44,7 @@ struct IOSToolPoliciesPage: View {
                 ProgressView("Loading tool policies...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let loadError {
-                ContentUnavailableView("Unable to Load", systemImage: "exclamationmark.triangle", description: Text(loadError))
+                ErrorStateView(message: loadError)
             } else {
                 settingsForm
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/SettingsRouter.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/SettingsRouter.swift
@@ -106,7 +106,7 @@ struct SettingsRouter: View {
     }
 
     private func comingSoonPage(_ title: String, icon: String) -> some View {
-        ContentUnavailableView(title, systemImage: icon, description: Text("This page is being built."))
+        EmptyStateView(icon: icon, title: title, message: "This page is being built.")
             .navigationTitle(title)
     }
 }


### PR DESCRIPTION
## Summary
- Replaced scoped Settings raw non-search ContentUnavailableView states with EmptyStateView.
- Replaced scoped Settings loadError states with ErrorStateView(message:).
- Preserved existing titles, SF Symbols, and message copy for permission, empty, and coming-soon states.

## Validation
- rg -n "ContentUnavailableView" <17 scoped Settings files> returned no matches.
- git diff --check HEAD^..HEAD passed.
- xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build currently fails in unrelated AppCore.swift lines 646-648 (throwing calls missing try); no touched Settings-file compile errors were reported before the unrelated failure.

## Notes
- Branch hygiene preflight found 90 remote branches (over soft cap, below hard cap); proceeded because WEI-1717 was already assigned/in progress and this PR keeps the work bounded.

Paperclip: WEI-1717