### PR TITLE
fix(fleet): standardize empty states

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSFuelPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSFuelPage.swift
@@ -77,11 +77,11 @@ struct IOSFuelPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredLogs.isEmpty {
-            ContentUnavailableView {
-                Label("No Fuel Logs", systemImage: "fuelpump")
-            } description: {
-                Text("No fuel logs found.")
-            }
+            EmptyStateView(
+                icon: "fuelpump",
+                title: "No Fuel Logs",
+                message: "No fuel logs found."
+            )
         } else {
             List(filteredLogs, id: \.id) { log in
                 fuelRow(log)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSInspectionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSInspectionsPage.swift
@@ -63,11 +63,11 @@ struct IOSInspectionsPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredInspections.isEmpty {
-            ContentUnavailableView {
-                Label("No Inspections", systemImage: "checklist")
-            } description: {
-                Text("No vehicle inspections have been recorded yet.")
-            }
+            EmptyStateView(
+                icon: "checklist",
+                title: "No Inspections",
+                message: "No vehicle inspections have been recorded yet."
+            )
         } else {
             List(filteredInspections, id: \.id) { inspection in
                 inspectionRow(inspection)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMaintenancePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMaintenancePage.swift
@@ -79,11 +79,11 @@ struct IOSMaintenancePage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredRecords.isEmpty {
-            ContentUnavailableView {
-                Label("No Maintenance Records", systemImage: "wrench.and.screwdriver")
-            } description: {
-                Text("No maintenance records found.")
-            }
+            EmptyStateView(
+                icon: "wrench.and.screwdriver",
+                title: "No Maintenance Records",
+                message: "No maintenance records found."
+            )
         } else {
             List(filteredRecords, id: \.id) { record in
                 maintenanceRow(record)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMileagePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMileagePage.swift
@@ -77,11 +77,11 @@ struct IOSMileagePage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredLogs.isEmpty {
-            ContentUnavailableView {
-                Label("No Mileage Logs", systemImage: "road.lanes")
-            } description: {
-                Text("No mileage logs found.")
-            }
+            EmptyStateView(
+                icon: "road.lanes",
+                title: "No Mileage Logs",
+                message: "No mileage logs found."
+            )
         } else {
             List(filteredLogs, id: \.id) { log in
                 mileageRow(log)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMyTruckPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMyTruckPage.swift
@@ -402,7 +402,11 @@ struct IOSMyTruckPage: View {
                 )
                 .environmentObject(appCore)
             } else {
-                ContentUnavailableView("No vehicle assigned", systemImage: "car.2", description: Text("Assign a vehicle before logging fuel."))
+                EmptyStateView(
+                    icon: "car.2",
+                    title: "No vehicle assigned",
+                    message: "Assign a vehicle before logging fuel."
+                )
             }
 
         case .reportIssue:
@@ -417,7 +421,11 @@ struct IOSMyTruckPage: View {
                 )
                 .environmentObject(appCore)
             } else {
-                ContentUnavailableView("No vehicle assigned", systemImage: "car.2", description: Text("Assign a vehicle before reporting an issue."))
+                EmptyStateView(
+                    icon: "car.2",
+                    title: "No vehicle assigned",
+                    message: "Assign a vehicle before reporting an issue."
+                )
             }
 
         case .addTransferItem:
@@ -431,7 +439,11 @@ struct IOSMyTruckPage: View {
                 )
                 .environmentObject(appCore)
             } else {
-                ContentUnavailableView("No vehicle assigned", systemImage: "car.2", description: Text("Assign a vehicle before transferring parts."))
+                EmptyStateView(
+                    icon: "car.2",
+                    title: "No vehicle assigned",
+                    message: "Assign a vehicle before transferring parts."
+                )
             }
 
         case .help:

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTelematicsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTelematicsPage.swift
@@ -60,11 +60,11 @@ struct IOSTelematicsPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredLocations.isEmpty {
-            ContentUnavailableView {
-                Label("No GPS Data", systemImage: "location.slash")
-            } description: {
-                Text("Vehicle location data will appear here once drivers submit GPS updates from their mobile devices.")
-            }
+            EmptyStateView(
+                icon: "location.slash",
+                title: "No GPS Data",
+                message: "Vehicle location data will appear here once drivers submit GPS updates from their mobile devices."
+            )
         } else {
             List(filteredLocations, id: \.id) { location in
                 locationRow(location)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTrailersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTrailersPage.swift
@@ -84,11 +84,11 @@ struct IOSTrailersPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredTrailers.isEmpty {
-            ContentUnavailableView {
-                Label("No Trailers", systemImage: "shippingbox")
-            } description: {
-                Text("No trailers found.")
-            }
+            EmptyStateView(
+                icon: "shippingbox",
+                title: "No Trailers",
+                message: "No trailers found."
+            )
         } else {
             List(filteredTrailers, id: \.id) { trailer in
                 NavigationLink(destination: IOSTrailerDetailPage(trailerId: trailer.id)) {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/PreTripInspectionView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/PreTripInspectionView.swift
@@ -58,8 +58,7 @@ struct PreTripInspectionView: View {
                     ProgressView("Loading checklist...")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else if let error = loadError {
-                    ContentUnavailableView("Error", systemImage: "exclamationmark.triangle",
-                                          description: Text(error))
+                    ErrorStateView(message: error)
                 } else {
                     inspectionForm
                 }


### PR DESCRIPTION
## Summary
- Replace Fleet raw non-search ContentUnavailableView placeholders with EmptyStateView while preserving icons, titles, and messages.
- Replace the PreTripInspectionView load-error placeholder with ErrorStateView(message:).
- Keep sheet gating, data loading, navigation, validation, and assignment behavior unchanged.

## Validation
- rg -n "ContentUnavailableView" "Weird Parts IOS/Weird Parts IOS/Features/Fleet" -g '*.swift' -> no matches
- git diff --check -> pass
- swift build --package-path core -> pass
- xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build -> fails before/away from this slice in AppCore.swift:646-648 with existing throwing-expression errors