### PR TITLE
fix(people): standardize empty states

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactDetailPage.swift
@@ -28,10 +28,10 @@ struct IOSContactDetailPage: View {
             } else if let contact {
                 contactDetail(contact)
             } else {
-                ContentUnavailableView(
-                    "Contact Not Found",
-                    systemImage: "person.crop.circle.badge.questionmark",
-                    description: Text("This contact may have been deleted.")
+                EmptyStateView(
+                    icon: "person.crop.circle.badge.questionmark",
+                    title: "Contact Not Found",
+                    message: "This contact may have been deleted."
                 )
             }
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactsPage.swift
@@ -155,11 +155,11 @@ struct IOSContactsPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredActive.isEmpty && filteredInactive.isEmpty {
-            ContentUnavailableView {
-                Label("No Contacts", systemImage: "person.crop.rectangle.stack")
-            } description: {
-                Text("No contacts match your criteria.")
-            }
+            EmptyStateView(
+                icon: "person.crop.rectangle.stack",
+                title: "No Contacts",
+                message: "No contacts match your criteria."
+            )
         } else {
             List {
                 // Active contacts

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeeDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeeDetailPage.swift
@@ -502,10 +502,10 @@ struct IOSEmployeeDetailPage: View {
                 }
             } else if activity.isEmpty {
                 Section {
-                    ContentUnavailableView(
-                        "No recent activity",
-                        systemImage: "clock.badge.questionmark",
-                        description: Text("Recent job sessions will appear here after this employee clocks in.")
+                    EmptyStateView(
+                        icon: "clock.badge.questionmark",
+                        title: "No recent activity",
+                        message: "Recent job sessions will appear here after this employee clocks in."
                     )
                 }
             } else {

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSHatsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSHatsPage.swift
@@ -108,11 +108,11 @@ struct IOSHatsPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredHats.isEmpty {
-            ContentUnavailableView {
-                Label("No Hats", systemImage: "graduationcap")
-            } description: {
-                Text("No roles have been created yet.")
-            }
+            EmptyStateView(
+                icon: "graduationcap",
+                title: "No Hats",
+                message: "No roles have been created yet."
+            )
         } else {
             List(filteredHats, id: \.id) { hat in
                 Button {
@@ -481,11 +481,11 @@ private struct AddEmployeeToHatSheet: View {
                 if let error = loadError {
                     ErrorStateView(message: error) { loadEmployees() }
                 } else if availableEmployees.isEmpty {
-                    ContentUnavailableView {
-                        Label("No Employees Available", systemImage: "person.slash")
-                    } description: {
-                        Text("All employees are already assigned to this hat.")
-                    }
+                    EmptyStateView(
+                        icon: "person.slash",
+                        title: "No Employees Available",
+                        message: "All employees are already assigned to this hat."
+                    )
                 } else {
                     List(availableEmployees) { emp in
                         Button {

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamDetailPage.swift
@@ -41,8 +41,11 @@ struct IOSTeamDetailPage: View {
             } else if let team = team {
                 teamContent(team)
             } else {
-                ContentUnavailableView("Team Not Found", systemImage: "person.3.fill",
-                                       description: Text("This team may have been deleted."))
+                EmptyStateView(
+                    icon: "person.3.fill",
+                    title: "Team Not Found",
+                    message: "This team may have been deleted."
+                )
             }
         }
         .navigationTitle(team?.name ?? "Team")
@@ -394,10 +397,10 @@ private struct AddMemberSheet: View {
                 if isLoading {
                     ProgressView("Loading employees...")
                 } else if filteredEmployees.isEmpty {
-                    ContentUnavailableView(
-                        "No Available Employees",
-                        systemImage: "person.badge.plus",
-                        description: Text("All employees are already members of this team.")
+                    EmptyStateView(
+                        icon: "person.badge.plus",
+                        title: "No Available Employees",
+                        message: "All employees are already members of this team."
                     )
                 } else {
                     List(filteredEmployees) { employee in

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamsPage.swift
@@ -15,6 +15,7 @@ struct IOSTeamsPage: View {
     @State private var searchText = ""
     @State private var loadError: String?
     @State private var filter: TeamFilter = .all
+    @State private var showEmployeesPage = false
 
     private enum TeamFilter {
         case all, active, mine
@@ -46,6 +47,10 @@ struct IOSTeamsPage: View {
                     }
                     .accessibilityLabel("Help")
                 }
+            }
+            .navigationDestination(isPresented: $showEmployeesPage) {
+                IOSEmployeesPage()
+                    .environmentObject(appCore)
             }
             .sheet(item: $activeSheet) { sheet in
                 switch sheet {
@@ -154,15 +159,13 @@ struct IOSTeamsPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if teams.isEmpty {
-            ContentUnavailableView {
-                Label("No Teams Yet", systemImage: "person.3.fill")
-            } description: {
-                Text("Teams are built from employees. Create your employees first, then organize them into teams here.")
-            } actions: {
-                NavigationLink(destination: IOSEmployeesPage().environmentObject(appCore)) {
-                    Label("Go to Employees", systemImage: "person.badge.plus")
-                }
-                .buttonStyle(.borderedProminent)
+            EmptyStateView(
+                icon: "person.3.fill",
+                title: "No Teams Yet",
+                message: "Teams are built from employees. Create your employees first, then organize them into teams here.",
+                actionLabel: "Go to Employees"
+            ) {
+                showEmployeesPage = true
             }
         } else if filteredTeams.isEmpty {
             ContentUnavailableView.search(text: searchText)


### PR DESCRIPTION
## Summary
- Replaced scoped non-search People `ContentUnavailableView` usages with the shared `EmptyStateView` pattern.
- Preserved existing titles, SF Symbols, and copy for contact/team not-found, contacts, hats, recent activity, add-member/add-hat employee availability, and teams empty states.
- Preserved the existing Teams empty-state action by routing the `EmptyStateView` button to the Employees page; left `ContentUnavailableView.search(text:)` untouched.

## Validation
- `rg -n "ContentUnavailableView" <scoped People files>` → only `IOSTeamsPage.swift:171: ContentUnavailableView.search(text: searchText)` remains.
- `rg --pcre2 -n "ContentUnavailableView(?!\\.search)" <scoped People files>` → no output.
- `git diff --check` → passed.
- `swift build` in `core/` → passed.
- `xcodebuild -quiet -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` → failed in pre-existing/untouched `App/AppCore.swift` throwing-call errors at lines 646-648; touched People files emitted no errors before that failure.

Paperclip: WEI-1722
