### PR TITLE
fix(jobs): standardize Jobs empty states

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
@@ -1830,10 +1830,10 @@ private struct TodoPickerSheet: View {
         NavigationStack {
             List {
                 if todos.isEmpty {
-                    ContentUnavailableView(
-                        "No To-Dos",
-                        systemImage: "checklist",
-                        description: Text("This job has no active to-dos. Add to-dos in the job's notebook.")
+                    EmptyStateView(
+                        icon: "checklist",
+                        title: "No To-Dos",
+                        message: "This job has no active to-dos. Add to-dos in the job's notebook."
                     )
                 } else {
                     ForEach(todos) { todo in

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailTabView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailTabView.swift
@@ -889,30 +889,18 @@ struct IOSJobDetailTabView: View {
                         ProgressView("Loading job notebook...")
                             .frame(maxWidth: .infinity, alignment: .center)
                     } else {
-                        ContentUnavailableView {
-                            Label("This job does not have a notebook yet", systemImage: "note.text.badge.plus")
-                        } description: {
-                            Text("Create a job notebook for \(job.jobName), or retry loading if it was just created on another device.")
-                        } actions: {
-                            HStack(spacing: 12) {
-                                Button {
-                                    createMissingJobNotebook(for: job)
-                                } label: {
-                                    Label("Create job notebook", systemImage: "plus.circle")
-                                        .frame(minHeight: 44)
-                                }
-                                .buttonStyle(.borderedProminent)
-                                .accessibilityIdentifier("jobNotebookCreateRecovery")
-
-                                Button {
-                                    loadJobNotebook()
-                                } label: {
-                                    Label("Retry", systemImage: "arrow.clockwise")
-                                        .frame(minHeight: 44)
-                                }
-                                .buttonStyle(.bordered)
-                            }
-                        }
+                        EmptyStateView(
+                            icon: "note.text.badge.plus",
+                            title: "This job does not have a notebook yet",
+                            message: "Create a job notebook for \(job.jobName), or retry loading if it was just created on another device.",
+                            actionLabel: "Create job notebook",
+                            actionIcon: "plus.circle",
+                            actionAccessibilityIdentifier: "jobNotebookCreateRecovery",
+                            secondaryActionLabel: "Retry",
+                            secondaryActionIcon: "arrow.clockwise",
+                            secondaryAction: { loadJobNotebook() },
+                            action: { createMissingJobNotebook(for: job) }
+                        )
                     }
                 }
                 .padding()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSQuestionnairePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSQuestionnairePage.swift
@@ -74,11 +74,11 @@ struct IOSQuestionnairePage: View {
             ProgressView("Loading questions...")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if questions.isEmpty && companionPolls.isEmpty {
-            ContentUnavailableView {
-                Label("No Questions", systemImage: "questionmark.circle")
-            } description: {
-                Text("No clock-out questions are configured. You can close this screen.")
-            }
+            EmptyStateView(
+                icon: "questionmark.circle",
+                title: "No Questions",
+                message: "No clock-out questions are configured. You can close this screen."
+            )
         } else {
             List {
                 // Error banner

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSWeeklyReviewSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSWeeklyReviewSheet.swift
@@ -69,11 +69,7 @@ struct IOSWeeklyReviewSheet: View {
                     ProgressView("Loading week data...")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else if let error = loadError {
-                    ContentUnavailableView(
-                        "Error",
-                        systemImage: "exclamationmark.triangle",
-                        description: Text(error)
-                    )
+                    ErrorStateView(message: error)
                 } else {
                     formContent
                 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobReportsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobReportsPage.swift
@@ -81,11 +81,11 @@ struct JobReportsPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadReports() }
         } else if reports.isEmpty {
-            ContentUnavailableView {
-                Label("No Reports", systemImage: "doc.plaintext")
-            } description: {
-                Text("Daily reports will appear here when generated.")
-            }
+            EmptyStateView(
+                icon: "doc.plaintext",
+                title: "No Reports",
+                message: "Daily reports will appear here when generated."
+            )
         } else {
             List(filteredReports, id: \.id) { report in
                 reportRow(report)

--- a/Weird Parts IOS/Weird Parts IOS/Shared/EmptyStateView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/EmptyStateView.swift
@@ -18,7 +18,39 @@ struct EmptyStateView: View {
     let title: String
     let message: String
     var actionLabel: String?
+    var actionIcon: String?
+    var actionAccessibilityIdentifier: String?
+    var secondaryActionLabel: String?
+    var secondaryActionIcon: String?
+    var secondaryActionAccessibilityIdentifier: String?
+    var secondaryAction: (() -> Void)?
     var action: (() -> Void)?
+
+    init(
+        icon: String,
+        title: String,
+        message: String,
+        actionLabel: String? = nil,
+        actionIcon: String? = nil,
+        actionAccessibilityIdentifier: String? = nil,
+        secondaryActionLabel: String? = nil,
+        secondaryActionIcon: String? = nil,
+        secondaryActionAccessibilityIdentifier: String? = nil,
+        secondaryAction: (() -> Void)? = nil,
+        action: (() -> Void)? = nil
+    ) {
+        self.icon = icon
+        self.title = title
+        self.message = message
+        self.actionLabel = actionLabel
+        self.actionIcon = actionIcon
+        self.actionAccessibilityIdentifier = actionAccessibilityIdentifier
+        self.secondaryActionLabel = secondaryActionLabel
+        self.secondaryActionIcon = secondaryActionIcon
+        self.secondaryActionAccessibilityIdentifier = secondaryActionAccessibilityIdentifier
+        self.secondaryAction = secondaryAction
+        self.action = action
+    }
 
     @ScaledMetric(relativeTo: .largeTitle) private var iconSize: CGFloat = 48
 
@@ -40,18 +72,57 @@ struct EmptyStateView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, DS.Space.xxxl)
 
-            if let label = actionLabel, let action = action {
-                Button(action: action) {
-                    Text(label)
-                        .fontWeight(.medium)
+            if actionLabel != nil || secondaryActionLabel != nil {
+                HStack(spacing: DS.Space.md) {
+                    if let label = actionLabel, let action = action {
+                        Button(action: action) {
+                            if let icon = actionIcon {
+                                Label(label, systemImage: icon)
+                                    .fontWeight(.medium)
+                                    .frame(minHeight: 44)
+                            } else {
+                                Text(label)
+                                    .fontWeight(.medium)
+                                    .frame(minHeight: 44)
+                            }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .accessibilityIdentifierIfPresent(actionAccessibilityIdentifier)
+                    }
+
+                    if let label = secondaryActionLabel, let action = secondaryAction {
+                        Button(action: action) {
+                            if let icon = secondaryActionIcon {
+                                Label(label, systemImage: icon)
+                                    .fontWeight(.medium)
+                                    .frame(minHeight: 44)
+                            } else {
+                                Text(label)
+                                    .fontWeight(.medium)
+                                    .frame(minHeight: 44)
+                            }
+                        }
+                        .buttonStyle(.bordered)
+                        .accessibilityIdentifierIfPresent(secondaryActionAccessibilityIdentifier)
+                    }
                 }
-                .buttonStyle(.borderedProminent)
                 .padding(.top, DS.Space.xxs)
             }
 
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func accessibilityIdentifierIfPresent(_ identifier: String?) -> some View {
+        if let identifier {
+            accessibilityIdentifier(identifier)
+        } else {
+            self
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace scoped Jobs raw non-search ContentUnavailableView usages with shared EmptyStateView/ErrorStateView patterns.
- Preserve Jobs empty-state copy, SF Symbols, error handling, and notebook recovery actions.
- Extend EmptyStateView to support optional icon buttons, secondary actions, and optional accessibility identifiers while keeping existing call sites source-compatible.

## Validation
- rg -n "ContentUnavailableView" "Weird Parts IOS/Weird Parts IOS/Features/Jobs" -g '*.swift' => no matches
- rg --pcre2 -n "ContentUnavailableView(?!\.search)" "Weird Parts IOS/Weird Parts IOS/Features/Jobs" -g '*.swift' => no matches
- git diff --check => pass
- xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO => blocked by existing AppCore.swift throwing-call errors at lines 646-648; no touched Jobs/EmptyStateView errors reported before build stopped.

## Notes
- Manual preview/simulator smoke was not completed because the current trunk build is blocked by the unrelated AppCore.swift compile errors above.

Closes WEI-1723