### PR TITLE
fix(orders): standardize empty states

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
@@ -1170,7 +1170,11 @@ private struct JPOMovementDetailContent: View {
                 ProgressView("Loading movement...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let error = loadError {
-                ContentUnavailableView("Error", systemImage: "exclamationmark.triangle", description: Text(error))
+                EmptyStateView(
+                    icon: "exclamationmark.triangle",
+                    title: "Error",
+                    message: error
+                )
             } else if let m = movement {
                 List {
                     Section("Movement Info") {
@@ -1214,10 +1218,10 @@ private struct JPOMovementDetailContent: View {
                 }
                 .listStyle(.insetGrouped)
             } else {
-                ContentUnavailableView(
-                    "Movement Not Found",
-                    systemImage: "questionmark.circle",
-                    description: Text("Movement #\(movementId) could not be loaded.")
+                EmptyStateView(
+                    icon: "questionmark.circle",
+                    title: "Movement Not Found",
+                    message: "Movement #\(movementId) could not be loaded."
                 )
             }
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSUnifiedOrderPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSUnifiedOrderPage.swift
@@ -5,11 +5,11 @@ import SwiftUI
 /// Use Job Orders → Create JPO instead.
 struct IOSUnifiedOrderPage: View {
     var body: some View {
-        ContentUnavailableView {
-            Label("Page Replaced", systemImage: "arrow.right.circle")
-        } description: {
-            Text("This page has been replaced. Use Job Orders → Create JPO.")
-        }
+        EmptyStateView(
+            icon: "arrow.right.circle",
+            title: "Page Replaced",
+            message: "This page has been replaced. Use Job Orders → Create JPO."
+        )
         .onAppear {
             NotificationCenter.default.post(
                 name: .unifiedOrderPageActive,

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/SupplierPickerSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/SupplierPickerSheet.swift
@@ -21,11 +21,11 @@ struct SupplierPickerSheet: View {
         NavigationStack {
             VStack(spacing: 0) {
                 if suppliers.isEmpty {
-                    ContentUnavailableView {
-                        Label("No Suppliers", systemImage: "building.2")
-                    } description: {
-                        Text("Add suppliers in the Parts section first.")
-                    }
+                    EmptyStateView(
+                        icon: "building.2",
+                        title: "No Suppliers",
+                        message: "Add suppliers in the Parts section first."
+                    )
                 } else {
                     List(filteredSuppliers, id: \.supplier.id) { item in
                         Button {


### PR DESCRIPTION
## Summary
- Replace the scoped Orders raw ContentUnavailableView usages with shared EmptyStateView
- Preserve existing empty/error titles, SF Symbols, descriptions, and notification behavior
- Leave search-specific empty states untouched

## Validation
- rg -n "ContentUnavailableView" "Weird Parts IOS/Weird Parts IOS/Features/Orders" -g '*.swift' -> no matches
- rg --pcre2 -n "ContentUnavailableView(?!\\.search)" "Weird Parts IOS/Weird Parts IOS/Features/Orders" -g '*.swift' -> no matches
- git diff --check -> pass
- xcodebuild -quiet -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'generic/platform=iOS Simulator' build -> blocked by pre-existing AppCore.swift throwing-expression errors at lines 646-648; no touched Orders-file errors reported before the build stopped

Paperclip: WEI-1724
Parent: GitHub #43