### PR TITLE
[WEI-1725] Standardize Scheduling empty states

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSDispatchTemplatesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSDispatchTemplatesPage.swift
@@ -55,11 +55,11 @@ struct IOSDispatchTemplatesPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredTemplates.isEmpty {
-            ContentUnavailableView {
-                Label("No Templates", systemImage: "doc.on.doc")
-            } description: {
-                Text("No dispatch templates found.")
-            }
+            EmptyStateView(
+                icon: "doc.on.doc",
+                title: "No Templates",
+                message: "No dispatch templates found."
+            )
         } else {
             List(filteredTemplates, id: \.id) { template in
                 templateRow(template)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSSubSchedulePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSSubSchedulePage.swift
@@ -104,11 +104,11 @@ struct IOSSubSchedulePage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if rows.isEmpty {
-            ContentUnavailableView {
-                Label("No Subs Scheduled", systemImage: "person.badge.clock")
-            } description: {
-                Text("No subcontractors scheduled for \(displayDate).")
-            }
+            EmptyStateView(
+                icon: "person.badge.clock",
+                title: "No Subs Scheduled",
+                message: "No subcontractors scheduled for \(displayDate)."
+            )
         } else {
             List(rows) { row in
                 subRow(row)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSTimeOffPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSTimeOffPage.swift
@@ -137,11 +137,11 @@ struct IOSTimeOffPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredRequests.isEmpty {
-            ContentUnavailableView {
-                Label("No Requests", systemImage: "calendar.badge.clock")
-            } description: {
-                Text("No time-off requests found.")
-            }
+            EmptyStateView(
+                icon: "calendar.badge.clock",
+                title: "No Requests",
+                message: "No time-off requests found."
+            )
         } else {
             List(filteredRequests, id: \.id) { request in
                 requestRow(request)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSWeeklyAvailabilityPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSWeeklyAvailabilityPage.swift
@@ -123,11 +123,11 @@ struct IOSWeeklyAvailabilityPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if rows.isEmpty {
-            ContentUnavailableView {
-                Label("No Data", systemImage: "calendar.badge.exclamationmark")
-            } description: {
-                Text("No availability data for this week.")
-            }
+            EmptyStateView(
+                icon: "calendar.badge.exclamationmark",
+                title: "No Data",
+                message: "No availability data for this week."
+            )
         } else {
             List {
                 // Day header row


### PR DESCRIPTION
## Summary
- Replaced the four scoped Scheduling raw `ContentUnavailableView` empty states with shared `EmptyStateView` calls.
- Preserved existing icons, titles, messages, loading/error branches, filtering, navigation, and data semantics.

## Validation
- `rg -n "ContentUnavailableView" "Weird Parts IOS/Weird Parts IOS/Features/Scheduling" -g "*.swift"` → no matches
- `rg --pcre2 -n "ContentUnavailableView(?!\.search)" "Weird Parts IOS/Weird Parts IOS/Features/Scheduling" -g "*.swift"` → no matches
- `git diff --check` → passed
- `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination "generic/platform=iOS" -derivedDataPath .tmp/DerivedData-WEI1725 CODE_SIGNING_ALLOWED=NO build` → failed on existing `AppCore.swift` throwing-call errors at lines 646-648; no Scheduling compile errors reported before the failure.

## Notes
- No remaining Scheduling `ContentUnavailableView.search` states were found in the scoped directory.

Paperclip: WEI-1725