### PR TITLE
fix(notebooks): standardize empty states

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSJobNotebooksPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSJobNotebooksPage.swift
@@ -98,11 +98,11 @@ struct IOSJobNotebooksPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredNotebooks.isEmpty {
-            ContentUnavailableView {
-                Label("No Job Notebooks", systemImage: "hammer.circle")
-            } description: {
-                Text("No job-linked notebooks match your criteria.")
-            }
+            EmptyStateView(
+                icon: "hammer.circle",
+                title: "No Job Notebooks",
+                message: "No job-linked notebooks match your criteria."
+            )
         } else {
             List(filteredNotebooks, id: \.id) { notebook in
                 NavigationLink(destination: IOSNotebookDetailPage(notebookId: notebook.id).environmentObject(appCore)) {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookTemplatesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookTemplatesPage.swift
@@ -32,11 +32,11 @@ struct IOSNotebookTemplatesPage: View {
             } else if let error = loadError {
                 ErrorStateView(message: error) { loadData() }
             } else if filteredTemplates.isEmpty {
-                ContentUnavailableView {
-                    Label("No Templates", systemImage: "doc.text")
-                } description: {
-                    Text("No notebook templates found.")
-                }
+                EmptyStateView(
+                    icon: "doc.text",
+                    title: "No Templates",
+                    message: "No notebook templates found."
+                )
             } else {
                 templateList
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebooksListPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebooksListPage.swift
@@ -137,11 +137,11 @@ struct IOSNotebooksListPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredNotebooks.isEmpty {
-            ContentUnavailableView {
-                Label("No Notebooks", systemImage: "book.closed")
-            } description: {
-                Text("No notebooks match your criteria.")
-            }
+            EmptyStateView(
+                icon: "book.closed",
+                title: "No Notebooks",
+                message: "No notebooks match your criteria."
+            )
         } else {
             List(filteredNotebooks, id: \.id) { notebook in
                 NavigationLink(destination: IOSNotebookDetailPage(notebookId: notebook.id).environmentObject(appCore)) {


### PR DESCRIPTION
## Summary
- Replaced the remaining raw Notebooks `ContentUnavailableView` empty states with shared `EmptyStateView` usage.
- Preserved the existing SF Symbols, titles, descriptions, filtering, navigation, loading, and error semantics.
- Kept the empty states outside `List` rows/sections, matching the existing layout-safe full-page branches.

## Validation
- `rg -n "ContentUnavailableView" "Weird Parts IOS/Weird Parts IOS/Features/Notebooks" -g '*.swift'` -> no matches\n- `rg --pcre2 -n "ContentUnavailableView(?!\\.search)" "Weird Parts IOS/Weird Parts IOS/Features/Notebooks" -g '*.swift'` -> no matches\n- `git diff --check` -> passed\n- `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination generic/platform=iOS -derivedDataPath .tmp/DerivedData-WEI1727 CODE_SIGNING_ALLOWED=NO build` -> failed on pre-existing unrelated AppCore.swift Swift 6 throwing-call errors at lines 646-648; touched Notebooks files reached SwiftDriver job discovery and emitted no diagnostics before the failure.\n\n## Notes\n- Notebooks is clear of raw `ContentUnavailableView` matches after this slice.\n\nPaperclip: WEI-1727