### PR TITLE
fix: standardize Tools empty states

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolCheckoutsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolCheckoutsPage.swift
@@ -150,13 +150,13 @@ struct IOSToolCheckoutsPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { Task { await loadData() } }
         } else if filteredCheckouts.isEmpty {
-            ContentUnavailableView {
-                Label("No Checkouts", systemImage: "arrow.up.right.circle")
-            } description: {
-                Text(showActiveOnly
+            EmptyStateView(
+                icon: "arrow.up.right.circle",
+                title: "No Checkouts",
+                message: showActiveOnly
                     ? "No tools are currently checked out."
-                    : "No checkout records found.")
-            }
+                    : "No checkout records found."
+            )
         } else {
             List(filteredCheckouts, id: \.id) { checkout in
                 checkoutRow(checkout)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolKitsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolKitsPage.swift
@@ -65,11 +65,11 @@ struct IOSToolKitsPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { Task { await loadData() } }
         } else if filteredKits.isEmpty {
-            ContentUnavailableView {
-                Label("No Kits", systemImage: "bag")
-            } description: {
-                Text("No tool kits found.")
-            }
+            EmptyStateView(
+                icon: "bag",
+                title: "No Kits",
+                message: "No tool kits found."
+            )
         } else {
             List(filteredKits) { kit in
                 kitRow(kit)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolsDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolsDashboardPage.swift
@@ -74,11 +74,11 @@ struct IOSToolsDashboardPage: View {
                 .padding()
             }
         } else {
-            ContentUnavailableView {
-                Label("No Tools", systemImage: "wrench.and.screwdriver")
-            } description: {
-                Text("No tools data available.")
-            }
+            EmptyStateView(
+                icon: "wrench.and.screwdriver",
+                title: "No Tools",
+                message: "No tools data available."
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- Replaced the three remaining non-search `ContentUnavailableView` usages in Tools pages with the shared `EmptyStateView` pattern.
- Preserved the existing icons, titles, messages, loading/error behavior, filtering, and list layouts.
- Kept empty states outside list rows/sections so the full-screen shared empty state remains layout-safe.

## Validation
- `rg -n "ContentUnavailableView" "Weird Parts IOS/Weird Parts IOS/Features/Tools" -g '*.swift'` → no matches
- `rg --pcre2 -n "ContentUnavailableView(?!\\.search)" "Weird Parts IOS/Weird Parts IOS/Features/Tools" -g '*.swift'` → no matches
- `git diff --check` → pass
- `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' -derivedDataPath .tmp/DerivedData-WEI1728 CODE_SIGNING_ALLOWED=NO build` → fails only on known baseline `AppCore.swift:646-648` Swift 6 throwing-operator errors; grep confirmed no Tools file errors/warnings in the build log.

Paperclip: WEI-1728
