### PR TITLE
fix(parts): standardize remaining Parts empty states

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsImportExportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsImportExportPage.swift
@@ -40,14 +40,15 @@ struct PartsImportExportPage: View {
                         .frame(maxWidth: .infinity)
                         .padding(.top, 40)
                 } else if let error = loadError {
-                    ContentUnavailableView {
-                        Label("Failed to Load", systemImage: "exclamationmark.triangle")
-                    } description: {
-                        Text(error)
-                    } actions: {
-                        Button("Retry") { Task { await loadStats() } }
-                            .buttonStyle(.bordered)
+                    EmptyStateView(
+                        icon: "exclamationmark.triangle",
+                        title: "Failed to Load",
+                        message: error,
+                        actionLabel: "Retry"
+                    ) {
+                        Task { await loadStats() }
                     }
+                    .frame(minHeight: 320)
                 } else {
                     statsSection
                     exportSection

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
@@ -145,11 +145,12 @@ struct PricingBulkEditSheet: View {
         // so the user understands why there's nothing to preview rather than
         // seeing only the "Apply to All" / "Review One at a Time" buttons.
         if previewParts.isEmpty {
-            ContentUnavailableView(
-                "No Parts Match",
-                systemImage: "magnifyingglass",
-                description: Text("No parts match the current bulk-edit filter. Adjust the filter on the previous step or close this sheet.")
+            EmptyStateView(
+                icon: "magnifyingglass",
+                title: "No Parts Match",
+                message: "No parts match the current bulk-edit filter. Adjust the filter on the previous step or close this sheet."
             )
+            .padding()
             .navigationTitle("Preview")
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {


### PR DESCRIPTION
## Summary
- Replaced the remaining non-search `ContentUnavailableView` usages in Parts screens with shared `EmptyStateView`.
- Preserved the existing Parts import/export load-error copy, warning icon, and retry behavior.
- Preserved the Pricing bulk preview no-match copy and kept the empty state outside the `List` so it does not become an oversized row.

## Validation
- `rg -n "ContentUnavailableView" "Weird Parts IOS/Weird Parts IOS/Features/Parts" -g '*.swift'` -> only `CategoriesTreeView.swift` native `ContentUnavailableView.search(text:)` remains.
- `rg --pcre2 -n "ContentUnavailableView(?!\.search)" "Weird Parts IOS/Weird Parts IOS/Features/Parts" -g '*.swift'` -> no matches.
- `git diff --check` -> passed.
- `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'generic/platform=iOS' -derivedDataPath .tmp/DerivedData-WEI1729 CODE_SIGNING_ALLOWED=NO build` -> failed only on known baseline Swift 6 throwing-operator diagnostics in `AppCore.swift:646-648`; touched Parts files emitted no diagnostics.

Closes WEI-1729
