### PR TITLE
fix(ux): standardize final empty states

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSQuestionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSQuestionsPage.swift
@@ -164,11 +164,11 @@ struct IOSQuestionsPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else if filteredThreads.isEmpty {
-            ContentUnavailableView {
-                Label("No Questions", systemImage: "questionmark.circle")
-            } description: {
-                Text("No Q&A threads match your criteria.")
-            }
+            EmptyStateView(
+                icon: "questionmark.circle",
+                title: "No Questions",
+                message: "No Q&A threads match your criteria."
+            )
         } else {
             List(filteredThreads, id: \.id) { thread in
                 NavigationLink {

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/IOSContentRouter.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/IOSContentRouter.swift
@@ -355,14 +355,12 @@ struct IOSContentRouter: View {
             OfficeRouter(tabId: tabId)
         } else {
             let hasOfficeAccess = appCore.hasPermission(officeAccessPermission)
-            ContentUnavailableView(
-                hasOfficeAccess ? "Permission required" : "Office access required",
-                systemImage: "lock.shield",
-                description: Text(
-                    hasOfficeAccess
-                        ? "You do not have the required permission to open this Office page."
-                        : "You do not have Office access."
-                )
+            EmptyStateView(
+                icon: "lock.shield",
+                title: hasOfficeAccess ? "Permission required" : "Office access required",
+                message: hasOfficeAccess
+                    ? "You do not have the required permission to open this Office page."
+                    : "You do not have Office access."
             )
         }
     }


### PR DESCRIPTION
## Summary
- Replaced the final Chat non-search ContentUnavailableView with shared EmptyStateView while preserving icon, title, message, and outside-list placement.
- Replaced the Office route permission denial ContentUnavailableView with shared EmptyStateView while preserving hasOfficeAccess permission branching and copy.
- Left native ContentUnavailableView.search states untouched.

## Validation
- rg -n "ContentUnavailableView" "Weird Parts IOS/Weird Parts IOS" -g '*.swift' -> only native .search usages remain: UserMenuSheet, SearchableList, IOSTeamsPage, CategoriesTreeView.
- rg --pcre2 -n "ContentUnavailableView(?!\.search)" "Weird Parts IOS/Weird Parts IOS" -g '*.swift' -> no matches.
- git diff --check -> pass.
- xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' -derivedDataPath .tmp/DerivedData-WEI1730 CODE_SIGNING_ALLOWED=NO build -> fails only on known baseline AppCore.swift:646-648 Swift 6 throwing-operator errors; touched files compiled with no diagnostics before the baseline failure.

Paperclip: WEI-1730