### PR TITLE
fix(ios): restore UI testing database bootstrap

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -533,7 +533,15 @@ final class AppCore: ObservableObject {
     ///
     /// User PIN changes do not re-key the app database. Startup must open the DB
     /// before any user can enter a PIN, so the persistent DB key remains device-bound.
-    nonisolated static func deviceBootstrapKeyHex() throws -> String {
+    nonisolated static func deviceBootstrapKeyHex(
+        processArguments: [String] = ProcessInfo.processInfo.arguments
+    ) throws -> String {
+        let uiTestingLaunchFlag = "-UITesting"
+        let uiTestingDatabaseKeyHex = "8f1df32f4be04d5fcde1e8e6ddf9187f53a4b68370d5aafc56f0d43f2e9732a1"
+        if processArguments.contains(uiTestingLaunchFlag) {
+            return uiTestingDatabaseKeyHex
+        }
+
         let service = "com.wiredpart.dbcipher.bootstrap-key"
         let account = "device-bootstrap-key"
 
@@ -549,6 +557,15 @@ final class AppCore: ObservableObject {
         let readStatus = SecItemCopyMatching(readQuery as CFDictionary, &result)
         if readStatus == errSecSuccess, let data = result as? Data, data.count == 32 {
             return data.map { String(format: "%02x", $0) }.joined()
+        }
+        if readStatus == errSecSuccess {
+            // Self-heal legacy/corrupt keychain entries so startup can recover.
+            let deleteQuery: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: service,
+                kSecAttrAccount: account
+            ]
+            _ = SecItemDelete(deleteQuery as CFDictionary)
         }
 
         // Generate 32 fresh random bytes.
@@ -575,7 +592,17 @@ final class AppCore: ObservableObject {
             if rereadStatus == errSecSuccess, let data = existing as? Data, data.count == 32 {
                 return data.map { String(format: "%02x", $0) }.joined()
             }
-            throw CipherKeyError.keychainAccessFailed(rereadStatus)
+            let deleteQuery: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: service,
+                kSecAttrAccount: account
+            ]
+            _ = SecItemDelete(deleteQuery as CFDictionary)
+            let retryAddStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            if retryAddStatus == errSecSuccess {
+                return keyData.map { String(format: "%02x", $0) }.joined()
+            }
+            throw CipherKeyError.keychainAccessFailed(retryAddStatus)
         } else if addStatus != errSecSuccess {
             throw CipherKeyError.keychainAccessFailed(addStatus)
         }
@@ -643,9 +670,10 @@ final class AppCore: ObservableObject {
 
     nonisolated private static func seedUITestingFixtures(db: AppDatabase, authService: AuthService) throws {
         let seedResult = try authService.seedFirstAdmin(displayName: "UITest Owner", pin: "1234")
+        let activeUsers = try authService.getActiveUsers()
         let fixtureUserId = seedResult.user?.id ??
-            authService.getActiveUsers().first(where: { $0.displayName == "UITest Owner" })?.id ??
-            authService.getActiveUsers().first?.id
+            activeUsers.first(where: { $0.displayName == "UITest Owner" })?.id ??
+            activeUsers.first?.id
 
         let now = ISO8601DateFormatter().string(from: Date())
         let longNotesLocal = String(repeating: "LOCAL_NOTES_SEGMENT_", count: 22)

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -50,4 +50,11 @@ struct Weird_Parts_IOSTests {
 
         #expect(auditIndex <= 2)
     }
+
+    @Test func uiTestingLaunchUsesDeterministicDatabaseKey() throws {
+        let keyHex = try AppCore.deviceBootstrapKeyHex(processArguments: ["Weird Parts", "-UITesting"])
+
+        #expect(keyHex == "8f1df32f4be04d5fcde1e8e6ddf9187f53a4b68370d5aafc56f0d43f2e9732a1")
+        #expect(keyHex.count == 64)
+    }
 }


### PR DESCRIPTION
## Summary
- Restores deterministic SQLCipher bootstrap key selection whenever the app launches with `-UITesting`.
- Restores keychain self-heal behavior for corrupt/legacy bootstrap keychain entries.
- Adds regression coverage for the UI-testing deterministic database key path.
- Keeps UI-testing fixture user lookup compile-safe by reading active users once.

## Test Plan
- [x] `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`
- [x] Direct simulator launch on WEI-899 iPhone 13 mini 375pt (`98CEE4F6-D8F5-49C3-A1B3-0F4CD6C11EA8`) with `-UITesting` reached the WiredPart login screen with seeded `UITest Owner` instead of `Failed to load database`.
- [x] Verified `Documents/WiredPart/wiredpart-uitesting.sqlite` plus WAL/SHM were created in the simulator data container.
- [x] `swift test --package-path core --filter OrdersServiceTests` passed: 105 tests.
- [x] `swift test --package-path core --filter ChatServiceTests` passed: 52 tests.

## Notes
- Unblocks WEI-881 runtime smoke by clearing GH #489's database-startup blocker.
- Full app unit-test target still has pre-existing unrelated compile failures in `FormSheetStateTests.swift` / `CreationFormActionsTests.swift` for missing `StandardFormSheetState` and `CreationFormActionPolicy`; app build and focused service suites pass.

Fixes #489
