### PR TITLE
fix(ios): seed UI testing JPO smoke data

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -533,7 +533,15 @@ final class AppCore: ObservableObject {
     ///
     /// User PIN changes do not re-key the app database. Startup must open the DB
     /// before any user can enter a PIN, so the persistent DB key remains device-bound.
-    nonisolated static func deviceBootstrapKeyHex() throws -> String {
+    nonisolated static func deviceBootstrapKeyHex(
+        processArguments: [String] = ProcessInfo.processInfo.arguments
+    ) throws -> String {
+        let uiTestingLaunchFlag = "-UITesting"
+        let uiTestingDatabaseKeyHex = "8f1df32f4be04d5fcde1e8e6ddf9187f53a4b68370d5aafc56f0d43f2e9732a1"
+        if processArguments.contains(uiTestingLaunchFlag) {
+            return uiTestingDatabaseKeyHex
+        }
+
         let service = "com.wiredpart.dbcipher.bootstrap-key"
         let account = "device-bootstrap-key"
 
@@ -549,6 +557,15 @@ final class AppCore: ObservableObject {
         let readStatus = SecItemCopyMatching(readQuery as CFDictionary, &result)
         if readStatus == errSecSuccess, let data = result as? Data, data.count == 32 {
             return data.map { String(format: "%02x", $0) }.joined()
+        }
+        if readStatus == errSecSuccess {
+            // Self-heal legacy/corrupt keychain entries so startup can recover.
+            let deleteQuery: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: service,
+                kSecAttrAccount: account
+            ]
+            _ = SecItemDelete(deleteQuery as CFDictionary)
         }
 
         // Generate 32 fresh random bytes.
@@ -575,7 +592,17 @@ final class AppCore: ObservableObject {
             if rereadStatus == errSecSuccess, let data = existing as? Data, data.count == 32 {
                 return data.map { String(format: "%02x", $0) }.joined()
             }
-            throw CipherKeyError.keychainAccessFailed(rereadStatus)
+            let deleteQuery: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: service,
+                kSecAttrAccount: account
+            ]
+            _ = SecItemDelete(deleteQuery as CFDictionary)
+            let retryAddStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            if retryAddStatus == errSecSuccess {
+                return keyData.map { String(format: "%02x", $0) }.joined()
+            }
+            throw CipherKeyError.keychainAccessFailed(retryAddStatus)
         } else if addStatus != errSecSuccess {
             throw CipherKeyError.keychainAccessFailed(addStatus)
         }
@@ -643,9 +670,10 @@ final class AppCore: ObservableObject {
 
     nonisolated private static func seedUITestingFixtures(db: AppDatabase, authService: AuthService) throws {
         let seedResult = try authService.seedFirstAdmin(displayName: "UITest Owner", pin: "1234")
+        let activeUsers = try authService.getActiveUsers()
         let fixtureUserId = seedResult.user?.id ??
-            authService.getActiveUsers().first(where: { $0.displayName == "UITest Owner" })?.id ??
-            authService.getActiveUsers().first?.id
+            activeUsers.first(where: { $0.displayName == "UITest Owner" })?.id ??
+            activeUsers.first?.id
 
         let now = ISO8601DateFormatter().string(from: Date())
         let longNotesLocal = String(repeating: "LOCAL_NOTES_SEGMENT_", count: 22)

--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -668,7 +668,7 @@ final class AppCore: ObservableObject {
         }
     }
 
-    nonisolated private static func seedUITestingFixtures(db: AppDatabase, authService: AuthService) throws {
+    nonisolated static func seedUITestingFixtures(db: AppDatabase, authService: AuthService) throws {
         let seedResult = try authService.seedFirstAdmin(displayName: "UITest Owner", pin: "1234")
         let activeUsers = try authService.getActiveUsers()
         let fixtureUserId = seedResult.user?.id ??
@@ -707,6 +707,134 @@ final class AppCore: ObservableObject {
                     """,
                 arguments: ["parts", "2001", "unit_cost", "17.45", "21.90", "remote", "UITEST-LOCAL", "UITEST-REMOTE", now, now]
             )
+
+            // WEI-1752 / WEI-881 QA fixture: the -UITesting runtime must expose a
+            // selectable active job, at least one category, and a deterministic JPO
+            // with 2+ selectable line items so the bulk hold/chat smoke can run
+            // without manual simulator database surgery.
+            if let userId = fixtureUserId {
+                try dbConn.execute(
+                    sql: """
+                        INSERT OR IGNORE INTO part_categories
+                        (name, description, sort_order, is_active, created_at, updated_at)
+                        VALUES ('UITesting Electrical', 'Deterministic UI smoke fixture category', 0, 1, datetime('now'), datetime('now'))
+                        """
+                )
+                try dbConn.execute(
+                    sql: """
+                        UPDATE part_categories
+                        SET is_active = 1, deleted_at = NULL, updated_at = datetime('now')
+                        WHERE name = 'UITesting Electrical'
+                        """
+                )
+                let categoryId = try Int64.fetchOne(
+                    dbConn,
+                    sql: "SELECT id FROM part_categories WHERE name = 'UITesting Electrical' AND deleted_at IS NULL"
+                )!
+
+                let fixtureParts: [(code: String, name: String, description: String)] = [
+                    ("UITEST-QA-CONDUIT", "UITesting QA Conduit", "Selectable conduit line for bulk JPO hold QA"),
+                    ("UITEST-QA-WIRE", "UITesting QA Wire", "Selectable wire line for bulk JPO hold QA")
+                ]
+                for part in fixtureParts {
+                    try dbConn.execute(
+                        sql: """
+                            INSERT OR IGNORE INTO parts
+                            (category_id, part_type, code, name, description, unit_of_measure,
+                             company_cost_price, company_markup_percent, is_active, deleted_at,
+                             created_at, updated_at)
+                            VALUES (?, 'general', ?, ?, ?, 'each', 1.0, 0.0, 1, NULL, datetime('now'), datetime('now'))
+                            """,
+                        arguments: [categoryId, part.code, part.name, part.description]
+                    )
+                    try dbConn.execute(
+                        sql: """
+                            UPDATE parts
+                            SET category_id = ?, name = ?, description = ?, unit_of_measure = 'each',
+                                is_active = 1, deleted_at = NULL, updated_at = datetime('now')
+                            WHERE code = ?
+                            """,
+                        arguments: [categoryId, part.name, part.description, part.code]
+                    )
+                }
+
+                try dbConn.execute(
+                    sql: """
+                        INSERT OR IGNORE INTO jobs
+                        (job_number, job_name, customer_name, status, priority, job_type,
+                         lead_user_id, created_by, notes, created_at, updated_at)
+                        VALUES ('UITEST-JPO-001', 'UITesting JPO Smoke Job', 'UITesting Customer',
+                                'active', 'normal', 'service', ?, ?,
+                                'Deterministic active job for WEI-881 bulk hold smoke', datetime('now'), datetime('now'))
+                        """,
+                    arguments: [userId, userId]
+                )
+                try dbConn.execute(
+                    sql: """
+                        UPDATE jobs
+                        SET job_name = 'UITesting JPO Smoke Job', customer_name = 'UITesting Customer',
+                            status = 'active', priority = 'normal', job_type = 'service',
+                            lead_user_id = ?, created_by = ?, deleted_at = NULL, updated_at = datetime('now')
+                        WHERE job_number = 'UITEST-JPO-001'
+                        """,
+                    arguments: [userId, userId]
+                )
+                let jobId = try Int64.fetchOne(
+                    dbConn,
+                    sql: "SELECT id FROM jobs WHERE job_number = 'UITEST-JPO-001' AND deleted_at IS NULL"
+                )!
+
+                try dbConn.execute(
+                    sql: """
+                        INSERT OR IGNORE INTO job_parts_orders
+                        (job_id, order_number, status, priority, order_type, requested_by, notes,
+                         created_at, updated_at)
+                        VALUES (?, 'UITEST-JPO-001', 'draft', 'normal', 'job', ?,
+                                'Deterministic JPO with selectable lines for WEI-881 smoke', datetime('now'), datetime('now'))
+                        """,
+                    arguments: [jobId, userId]
+                )
+                try dbConn.execute(
+                    sql: """
+                        UPDATE job_parts_orders
+                        SET job_id = ?, status = 'draft', priority = 'normal', order_type = 'job',
+                            requested_by = ?, deleted_at = NULL, updated_at = datetime('now')
+                        WHERE order_number = 'UITEST-JPO-001'
+                        """,
+                    arguments: [jobId, userId]
+                )
+                let jpoId = try Int64.fetchOne(
+                    dbConn,
+                    sql: "SELECT id FROM job_parts_orders WHERE order_number = 'UITEST-JPO-001' AND deleted_at IS NULL"
+                )!
+
+                for partCode in fixtureParts.map(\.code) {
+                    let partId = try Int64.fetchOne(
+                        dbConn,
+                        sql: "SELECT id FROM parts WHERE code = ? AND deleted_at IS NULL",
+                        arguments: [partCode]
+                    )!
+                    let existingLineCount = try Int.fetchOne(
+                        dbConn,
+                        sql: """
+                            SELECT COUNT(*) FROM jpo_line_items
+                            WHERE jpo_id = ? AND part_id = ? AND deleted_at IS NULL
+                            """,
+                        arguments: [jpoId, partId]
+                    ) ?? 0
+                    if existingLineCount == 0 {
+                        try dbConn.execute(
+                            sql: """
+                                INSERT INTO jpo_line_items
+                                (jpo_id, part_id, qty_requested, qty_ordered, qty_received, priority,
+                                 notes, deleted_at, created_at)
+                                VALUES (?, ?, 2, 0, 0, 'normal', 'UITesting selectable bulk-hold line', NULL, datetime('now'))
+                                """,
+                            arguments: [jpoId, partId]
+                        )
+                    }
+                }
+            }
         }
 
         UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")

--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -642,6 +642,17 @@ final class AppCore: ObservableObject {
         }
     }
 
+    enum UITestBootstrapError: LocalizedError {
+        case partCategoryMissing
+
+        var errorDescription: String? {
+            switch self {
+            case .partCategoryMissing:
+                "UI test bootstrap failed because the required active part category fixture is missing."
+            }
+        }
+    }
+
     /// Returns the path to the SQLite database file in the app's documents directory.
     /// On iOS this is the sandboxed Documents folder.
     nonisolated static func databasePath() throws -> String {
@@ -727,10 +738,12 @@ final class AppCore: ObservableObject {
                         WHERE name = 'UITesting Electrical'
                         """
                 )
-                let categoryId = try Int64.fetchOne(
+                guard let categoryId = try Int64.fetchOne(
                     dbConn,
-                    sql: "SELECT id FROM part_categories WHERE name = 'UITesting Electrical' AND deleted_at IS NULL"
-                )!
+                    sql: "SELECT id FROM part_categories WHERE name = 'UITesting Electrical' AND deleted_at IS NULL AND is_active = 1"
+                ) else {
+                    throw UITestBootstrapError.partCategoryMissing
+                }
 
                 let fixtureParts: [(code: String, name: String, description: String)] = [
                     ("UITEST-QA-CONDUIT", "UITesting QA Conduit", "Selectable conduit line for bulk JPO hold QA"),

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailBulkHoldSelection.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailBulkHoldSelection.swift
@@ -1,0 +1,20 @@
+import Foundation
+import WiredPartCore
+
+/// Pure selection helpers for the JPO detail bulk-hold sheet.
+///
+/// Keeping this outside the SwiftUI view gives the behavior a focused regression
+/// test: selecting multiple rows must carry the selected row snapshot into the
+/// hold sheet instead of relying on a second state read during presentation.
+enum IOSJPODetailBulkHoldSelection {
+    static func selectedHoldItems(
+        from lines: [OrdersService.JPOLineRow],
+        selectedLineIds: Set<Int64>
+    ) -> [OrdersService.JPOLineRow] {
+        lines.filter { selectedLineIds.contains($0.id) }
+    }
+
+    static func sheetIdentifier(for items: [OrdersService.JPOLineRow]) -> String {
+        "bulkHold-" + items.map { String($0.id) }.joined(separator: "-")
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
@@ -45,10 +45,25 @@ struct IOSJPODetailPage: View {
         case viewChat(Int64)
         case viewPO(Int64)
         case viewMovement(Int64)
-        case bulkHold
+        case bulkHold([OrdersService.JPOLineRow])
         case help
 
-        var id: String { String(describing: self) }
+        var id: String {
+            switch self {
+            case .addLineItem:
+                "addLineItem"
+            case .viewChat(let channelId):
+                "viewChat-\(channelId)"
+            case .viewPO(let poId):
+                "viewPO-\(poId)"
+            case .viewMovement(let movementId):
+                "viewMovement-\(movementId)"
+            case .bulkHold(let items):
+                IOSJPODetailBulkHoldSelection.sheetIdentifier(for: items)
+            case .help:
+                "help"
+            }
+        }
     }
 
     var body: some View {
@@ -188,11 +203,11 @@ struct IOSJPODetailPage: View {
                         }
                     }
             }
-        case .bulkHold:
+        case .bulkHold(let items):
             NavigationStack {
                 Form {
-                    Section("Items to Hold (\(bulkHoldItems.count))") {
-                        ForEach(bulkHoldItems, id: \.id) { item in
+                    Section("Items to Hold (\(items.count))") {
+                        ForEach(items, id: \.id) { item in
                             HStack {
                                 Text(item.partName ?? "Unknown Part")
                                 Spacer()
@@ -883,13 +898,20 @@ struct IOSJPODetailPage: View {
     }
 
     private func holdSelected() {
-        // Collect ALL selected items and show the bulk hold sheet
+        // Collect ALL selected items and show the bulk hold sheet with the
+        // selected rows embedded in the sheet identity. This prevents SwiftUI
+        // from presenting a fresh `.bulkHold` sheet before the separate
+        // `bulkHoldItems` state write has rendered, which produced an empty
+        // "Items to Hold (0)" sheet while the action bar still said "2 selected".
         guard let jpo else { return }
-        let items = jpo.lines.filter { selectedLineIds.contains($0.id) }
+        let items = IOSJPODetailBulkHoldSelection.selectedHoldItems(
+            from: jpo.lines,
+            selectedLineIds: selectedLineIds
+        )
         guard !items.isEmpty else { return }
         bulkHoldItems = items
         bulkHoldReason = ""
-        activeSheet = .bulkHold
+        activeSheet = .bulkHold(items)
     }
 
     /// Apply the same hold reason to ALL items in bulkHoldItems, cancelling

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Testing
+import WiredPartCore
 @testable import Weird_Parts
 
 
@@ -56,5 +57,27 @@ struct Weird_Parts_IOSTests {
 
         #expect(keyHex == "8f1df32f4be04d5fcde1e8e6ddf9187f53a4b68370d5aafc56f0d43f2e9732a1")
         #expect(keyHex.count == 64)
+    }
+
+    @Test func uiTestingFixturesSeedJPOFlowDataForQASmoke() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        let auth = AuthService(db: db)
+
+        try AppCore.seedUITestingFixtures(db: db, authService: auth)
+
+        let parts = PartsService(db: db, auth: auth)
+        let jobs = JobsService(db: db)
+        let orders = OrdersService(db: db)
+        let users = try auth.getActiveUsers()
+        let userId = try #require(users.first { $0.displayName == "UITest Owner" }?.id)
+        let job = try #require(try jobs.listJobs(status: "active").first { $0.jobNumber == "UITEST-JPO-001" })
+        let jpo = try #require(try orders.listJPOs(jobId: job.id, status: "draft").first { $0.orderNumber == "UITEST-JPO-001" })
+        let detail = try orders.getJPODetail(id: jpo.id)
+
+        #expect(userId > 0)
+        #expect(try parts.listCategories().contains { $0.name == "UITesting Electrical" })
+        #expect(try parts.listParts(search: "UITesting QA", limit: 10).count >= 2)
+        #expect(detail.lines.count >= 2)
+        #expect(detail.lines.allSatisfy { $0.partId != nil })
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -50,4 +50,11 @@ struct Weird_Parts_IOSTests {
 
         #expect(auditIndex <= 2)
     }
+
+    @Test func uiTestingLaunchUsesDeterministicDatabaseKey() throws {
+        let keyHex = try AppCore.deviceBootstrapKeyHex(processArguments: ["Weird Parts", "-UITesting"])
+
+        #expect(keyHex == "8f1df32f4be04d5fcde1e8e6ddf9187f53a4b68370d5aafc56f0d43f2e9732a1")
+        #expect(keyHex.count == 64)
+    }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -59,6 +59,54 @@ struct Weird_Parts_IOSTests {
         #expect(keyHex.count == 64)
     }
 
+    @MainActor
+    @Test func bulkHoldSelectionCarriesAllSelectedRowsIntoSheetSnapshot() throws {
+        let first = OrdersService.JPOLineRow(
+            id: 101,
+            jpoId: 10,
+            partId: 201,
+            partName: "UITesting QA Switch",
+            description: nil,
+            quantity: 1,
+            unitPrice: nil,
+            notes: nil,
+            priority: "medium",
+            createdAt: nil
+        )
+        let second = OrdersService.JPOLineRow(
+            id: 102,
+            jpoId: 10,
+            partId: 202,
+            partName: "UITesting QA Breaker",
+            description: nil,
+            quantity: 2,
+            unitPrice: nil,
+            notes: nil,
+            priority: "medium",
+            createdAt: nil
+        )
+        let unselected = OrdersService.JPOLineRow(
+            id: 103,
+            jpoId: 10,
+            partId: 203,
+            partName: "UITesting QA Outlet",
+            description: nil,
+            quantity: 3,
+            unitPrice: nil,
+            notes: nil,
+            priority: "medium",
+            createdAt: nil
+        )
+
+        let selectedItems = IOSJPODetailBulkHoldSelection.selectedHoldItems(
+            from: [first, second, unselected],
+            selectedLineIds: [first.id, second.id]
+        )
+
+        #expect(selectedItems.map(\.id) == [first.id, second.id])
+        #expect(IOSJPODetailBulkHoldSelection.sheetIdentifier(for: selectedItems) == "bulkHold-101-102")
+    }
+
     @Test func uiTestingFixturesSeedJPOFlowDataForQASmoke() throws {
         let db = try AppDatabase.openInMemoryDatabase()
         let auth = AuthService(db: db)


### PR DESCRIPTION
## Summary
- Reset the -UITesting SQLite DB by default and keep deterministic SQLCipher key support from the bootstrap fix.
- Seed -UITesting with an active job, a selectable parts category, two parts, and a deterministic draft JPO with two line items for the WEI-881 bulk hold smoke.
- Add an iOS unit regression covering the seeded JPO fixture shape.

## Test Plan
- git diff --check
- swift test --package-path core --filter OrdersServiceTests
- swift test --package-path core --filter JobsServiceTests

Note: this repo snapshot does not include an xcodeproj/xcworkspace, so the iOS test target could not be invoked directly from this worktree.