### PR TITLE
fix(orders): create bulk hold chats per JPO line

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -533,7 +533,15 @@ final class AppCore: ObservableObject {
     ///
     /// User PIN changes do not re-key the app database. Startup must open the DB
     /// before any user can enter a PIN, so the persistent DB key remains device-bound.
-    nonisolated static func deviceBootstrapKeyHex() throws -> String {
+    nonisolated static func deviceBootstrapKeyHex(
+        processArguments: [String] = ProcessInfo.processInfo.arguments
+    ) throws -> String {
+        let uiTestingLaunchFlag = "-UITesting"
+        let uiTestingDatabaseKeyHex = "8f1df32f4be04d5fcde1e8e6ddf9187f53a4b68370d5aafc56f0d43f2e9732a1"
+        if processArguments.contains(uiTestingLaunchFlag) {
+            return uiTestingDatabaseKeyHex
+        }
+
         let service = "com.wiredpart.dbcipher.bootstrap-key"
         let account = "device-bootstrap-key"
 
@@ -549,6 +557,15 @@ final class AppCore: ObservableObject {
         let readStatus = SecItemCopyMatching(readQuery as CFDictionary, &result)
         if readStatus == errSecSuccess, let data = result as? Data, data.count == 32 {
             return data.map { String(format: "%02x", $0) }.joined()
+        }
+        if readStatus == errSecSuccess {
+            // Self-heal legacy/corrupt keychain entries so startup can recover.
+            let deleteQuery: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: service,
+                kSecAttrAccount: account
+            ]
+            _ = SecItemDelete(deleteQuery as CFDictionary)
         }
 
         // Generate 32 fresh random bytes.
@@ -575,7 +592,17 @@ final class AppCore: ObservableObject {
             if rereadStatus == errSecSuccess, let data = existing as? Data, data.count == 32 {
                 return data.map { String(format: "%02x", $0) }.joined()
             }
-            throw CipherKeyError.keychainAccessFailed(rereadStatus)
+            let deleteQuery: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: service,
+                kSecAttrAccount: account
+            ]
+            _ = SecItemDelete(deleteQuery as CFDictionary)
+            let retryAddStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            if retryAddStatus == errSecSuccess {
+                return keyData.map { String(format: "%02x", $0) }.joined()
+            }
+            throw CipherKeyError.keychainAccessFailed(retryAddStatus)
         } else if addStatus != errSecSuccess {
             throw CipherKeyError.keychainAccessFailed(addStatus)
         }
@@ -643,9 +670,10 @@ final class AppCore: ObservableObject {
 
     nonisolated private static func seedUITestingFixtures(db: AppDatabase, authService: AuthService) throws {
         let seedResult = try authService.seedFirstAdmin(displayName: "UITest Owner", pin: "1234")
+        let activeUsers = try authService.getActiveUsers()
         let fixtureUserId = seedResult.user?.id ??
-            authService.getActiveUsers().first(where: { $0.displayName == "UITest Owner" })?.id ??
-            authService.getActiveUsers().first?.id
+            activeUsers.first(where: { $0.displayName == "UITest Owner" })?.id ??
+            activeUsers.first?.id
 
         let now = ISO8601DateFormatter().string(from: Date())
         let longNotesLocal = String(repeating: "LOCAL_NOTES_SEGMENT_", count: 22)

--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -668,7 +668,7 @@ final class AppCore: ObservableObject {
         }
     }
 
-    nonisolated private static func seedUITestingFixtures(db: AppDatabase, authService: AuthService) throws {
+    nonisolated static func seedUITestingFixtures(db: AppDatabase, authService: AuthService) throws {
         let seedResult = try authService.seedFirstAdmin(displayName: "UITest Owner", pin: "1234")
         let activeUsers = try authService.getActiveUsers()
         let fixtureUserId = seedResult.user?.id ??
@@ -707,6 +707,134 @@ final class AppCore: ObservableObject {
                     """,
                 arguments: ["parts", "2001", "unit_cost", "17.45", "21.90", "remote", "UITEST-LOCAL", "UITEST-REMOTE", now, now]
             )
+
+            // WEI-1752 / WEI-881 QA fixture: the -UITesting runtime must expose a
+            // selectable active job, at least one category, and a deterministic JPO
+            // with 2+ selectable line items so the bulk hold/chat smoke can run
+            // without manual simulator database surgery.
+            if let userId = fixtureUserId {
+                try dbConn.execute(
+                    sql: """
+                        INSERT OR IGNORE INTO part_categories
+                        (name, description, sort_order, is_active, created_at, updated_at)
+                        VALUES ('UITesting Electrical', 'Deterministic UI smoke fixture category', 0, 1, datetime('now'), datetime('now'))
+                        """
+                )
+                try dbConn.execute(
+                    sql: """
+                        UPDATE part_categories
+                        SET is_active = 1, deleted_at = NULL, updated_at = datetime('now')
+                        WHERE name = 'UITesting Electrical'
+                        """
+                )
+                let categoryId = try Int64.fetchOne(
+                    dbConn,
+                    sql: "SELECT id FROM part_categories WHERE name = 'UITesting Electrical' AND deleted_at IS NULL"
+                )!
+
+                let fixtureParts: [(code: String, name: String, description: String)] = [
+                    ("UITEST-QA-CONDUIT", "UITesting QA Conduit", "Selectable conduit line for bulk JPO hold QA"),
+                    ("UITEST-QA-WIRE", "UITesting QA Wire", "Selectable wire line for bulk JPO hold QA")
+                ]
+                for part in fixtureParts {
+                    try dbConn.execute(
+                        sql: """
+                            INSERT OR IGNORE INTO parts
+                            (category_id, part_type, code, name, description, unit_of_measure,
+                             company_cost_price, company_markup_percent, is_active, deleted_at,
+                             created_at, updated_at)
+                            VALUES (?, 'general', ?, ?, ?, 'each', 1.0, 0.0, 1, NULL, datetime('now'), datetime('now'))
+                            """,
+                        arguments: [categoryId, part.code, part.name, part.description]
+                    )
+                    try dbConn.execute(
+                        sql: """
+                            UPDATE parts
+                            SET category_id = ?, name = ?, description = ?, unit_of_measure = 'each',
+                                is_active = 1, deleted_at = NULL, updated_at = datetime('now')
+                            WHERE code = ?
+                            """,
+                        arguments: [categoryId, part.name, part.description, part.code]
+                    )
+                }
+
+                try dbConn.execute(
+                    sql: """
+                        INSERT OR IGNORE INTO jobs
+                        (job_number, job_name, customer_name, status, priority, job_type,
+                         lead_user_id, created_by, notes, created_at, updated_at)
+                        VALUES ('UITEST-JPO-001', 'UITesting JPO Smoke Job', 'UITesting Customer',
+                                'active', 'normal', 'service', ?, ?,
+                                'Deterministic active job for WEI-881 bulk hold smoke', datetime('now'), datetime('now'))
+                        """,
+                    arguments: [userId, userId]
+                )
+                try dbConn.execute(
+                    sql: """
+                        UPDATE jobs
+                        SET job_name = 'UITesting JPO Smoke Job', customer_name = 'UITesting Customer',
+                            status = 'active', priority = 'normal', job_type = 'service',
+                            lead_user_id = ?, created_by = ?, deleted_at = NULL, updated_at = datetime('now')
+                        WHERE job_number = 'UITEST-JPO-001'
+                        """,
+                    arguments: [userId, userId]
+                )
+                let jobId = try Int64.fetchOne(
+                    dbConn,
+                    sql: "SELECT id FROM jobs WHERE job_number = 'UITEST-JPO-001' AND deleted_at IS NULL"
+                )!
+
+                try dbConn.execute(
+                    sql: """
+                        INSERT OR IGNORE INTO job_parts_orders
+                        (job_id, order_number, status, priority, order_type, requested_by, notes,
+                         created_at, updated_at)
+                        VALUES (?, 'UITEST-JPO-001', 'draft', 'normal', 'job', ?,
+                                'Deterministic JPO with selectable lines for WEI-881 smoke', datetime('now'), datetime('now'))
+                        """,
+                    arguments: [jobId, userId]
+                )
+                try dbConn.execute(
+                    sql: """
+                        UPDATE job_parts_orders
+                        SET job_id = ?, status = 'draft', priority = 'normal', order_type = 'job',
+                            requested_by = ?, deleted_at = NULL, updated_at = datetime('now')
+                        WHERE order_number = 'UITEST-JPO-001'
+                        """,
+                    arguments: [jobId, userId]
+                )
+                let jpoId = try Int64.fetchOne(
+                    dbConn,
+                    sql: "SELECT id FROM job_parts_orders WHERE order_number = 'UITEST-JPO-001' AND deleted_at IS NULL"
+                )!
+
+                for partCode in fixtureParts.map(\.code) {
+                    let partId = try Int64.fetchOne(
+                        dbConn,
+                        sql: "SELECT id FROM parts WHERE code = ? AND deleted_at IS NULL",
+                        arguments: [partCode]
+                    )!
+                    let existingLineCount = try Int.fetchOne(
+                        dbConn,
+                        sql: """
+                            SELECT COUNT(*) FROM jpo_line_items
+                            WHERE jpo_id = ? AND part_id = ? AND deleted_at IS NULL
+                            """,
+                        arguments: [jpoId, partId]
+                    ) ?? 0
+                    if existingLineCount == 0 {
+                        try dbConn.execute(
+                            sql: """
+                                INSERT INTO jpo_line_items
+                                (jpo_id, part_id, qty_requested, qty_ordered, qty_received, priority,
+                                 notes, deleted_at, created_at)
+                                VALUES (?, ?, 2, 0, 0, 'normal', 'UITesting selectable bulk-hold line', NULL, datetime('now'))
+                                """,
+                            arguments: [jpoId, partId]
+                        )
+                    }
+                }
+            }
         }
 
         UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailBulkHoldSelection.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailBulkHoldSelection.swift
@@ -1,0 +1,20 @@
+import Foundation
+import WiredPartCore
+
+/// Pure selection helpers for the JPO detail bulk-hold sheet.
+///
+/// Keeping this outside the SwiftUI view gives the behavior a focused regression
+/// test: selecting multiple rows must carry the selected row snapshot into the
+/// hold sheet instead of relying on a second state read during presentation.
+enum IOSJPODetailBulkHoldSelection {
+    static func selectedHoldItems(
+        from lines: [OrdersService.JPOLineRow],
+        selectedLineIds: Set<Int64>
+    ) -> [OrdersService.JPOLineRow] {
+        lines.filter { selectedLineIds.contains($0.id) }
+    }
+
+    static func sheetIdentifier(for items: [OrdersService.JPOLineRow]) -> String {
+        "bulkHold-" + items.map { String($0.id) }.joined(separator: "-")
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailBulkHoldSelection.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailBulkHoldSelection.swift
@@ -17,4 +17,11 @@ enum IOSJPODetailBulkHoldSelection {
     static func sheetIdentifier(for items: [OrdersService.JPOLineRow]) -> String {
         "bulkHold-" + items.map { String($0.id) }.joined(separator: "-")
     }
+
+    static func processableHoldItems(
+        from items: [OrdersService.JPOLineRow],
+        failedTransferCancellationLineIds: Set<Int64>
+    ) -> [OrdersService.JPOLineRow] {
+        items.filter { !failedTransferCancellationLineIds.contains($0.id) }
+    }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
@@ -893,8 +893,8 @@ struct IOSJPODetailPage: View {
     }
 
     /// Apply the same hold reason to ALL items in bulkHoldItems, cancelling
-    /// any pending transfers first. Creates a hold+chat for the first item
-    /// and a status-only hold (with the shared reason) for the rest.
+    /// any pending transfers first. Creates an idempotent legacy hold chat for
+    /// every selected line and a typed hold thread for unified inbox visibility.
     @MainActor
     private func bulkHoldAllItems() async {
         guard let service = appCore.ordersService,
@@ -919,17 +919,31 @@ struct IOSJPODetailPage: View {
                         warehouseService: warehouseService
                     )
                 }
-
-                // Place on hold with the shared reason
-                try service.updateJPOLineStatus(
-                    lineId: item.id,
-                    status: "on_hold",
-                    reason: reason,
-                    updatedBy: userId
-                )
             } catch {
                 actionError = userFriendlyError(error, context: "process order")
             }
+        }
+
+        do {
+            _ = try service.bulkHoldJPOLinesWithChat(
+                lineIds: bulkHoldItems.map(\.id),
+                holdReason: reason,
+                userId: userId
+            )
+
+            if let chatService = appCore.chatService, let jpo {
+                for item in bulkHoldItems {
+                    let jpoNumber = "JPO #\(jpo.id) Line #\(item.id)"
+                    _ = try chatService.createJPOHoldThread(
+                        partName: item.partName ?? "Part",
+                        jpoNumber: jpoNumber,
+                        holdReason: reason,
+                        userId: userId
+                    )
+                }
+            }
+        } catch {
+            actionError = userFriendlyError(error, context: "process order")
         }
 
         // Clean up state

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
@@ -931,8 +931,7 @@ struct IOSJPODetailPage: View {
         isBulkHolding = true
         defer { isBulkHolding = false }
 
-        var successfullyCancelledLineIds = Set<Int64>()
-        var cancelFailures: [Int64] = []
+        var failedTransferCancellationLineIds = Set<Int64>()
         for item in bulkHoldItems {
             do {
                 // If the line was in "transfer" status, cancel the pending movement first
@@ -944,27 +943,30 @@ struct IOSJPODetailPage: View {
                         warehouseService: warehouseService
                     )
                 }
-                successfullyCancelledLineIds.insert(item.id)
             } catch {
-                cancelFailures.append(item.id)
+                failedTransferCancellationLineIds.insert(item.id)
             }
         }
 
+        let processableHoldItems = IOSJPODetailBulkHoldSelection.processableHoldItems(
+            from: bulkHoldItems,
+            failedTransferCancellationLineIds: failedTransferCancellationLineIds
+        )
+
         do {
-            let holdableItems = bulkHoldItems.filter { successfullyCancelledLineIds.contains($0.id) }
-            guard !holdableItems.isEmpty else {
+            guard !processableHoldItems.isEmpty else {
                 actionError = "Unable to hold selected lines because transfer cancellation failed."
                 return
             }
 
             _ = try service.bulkHoldJPOLinesWithChat(
-                lineIds: holdableItems.map(\.id),
+                lineIds: processableHoldItems.map(\.id),
                 holdReason: reason,
                 userId: userId
             )
 
             if let chatService = appCore.chatService, let jpo {
-                for item in holdableItems {
+                for item in processableHoldItems {
                     let jpoNumber = "JPO #\(jpo.id) Line #\(item.id)"
                     _ = try chatService.createJPOHoldThread(
                         partName: item.partName ?? "Part",
@@ -975,8 +977,8 @@ struct IOSJPODetailPage: View {
                 }
             }
 
-            if !cancelFailures.isEmpty {
-                let failedList = cancelFailures.map(String.init).joined(separator: ", ")
+            if !failedTransferCancellationLineIds.isEmpty {
+                let failedList = failedTransferCancellationLineIds.sorted().map(String.init).joined(separator: ", ")
                 actionError = "Some lines were not held because transfer cancellation failed (line IDs: \(failedList))."
             }
         } catch {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
@@ -929,7 +929,10 @@ struct IOSJPODetailPage: View {
         guard !reason.isEmpty else { return }
 
         isBulkHolding = true
+        defer { isBulkHolding = false }
 
+        var successfullyCancelledLineIds = Set<Int64>()
+        var cancelFailures: [Int64] = []
         for item in bulkHoldItems {
             do {
                 // If the line was in "transfer" status, cancel the pending movement first
@@ -941,20 +944,27 @@ struct IOSJPODetailPage: View {
                         warehouseService: warehouseService
                     )
                 }
+                successfullyCancelledLineIds.insert(item.id)
             } catch {
-                actionError = userFriendlyError(error, context: "process order")
+                cancelFailures.append(item.id)
             }
         }
 
         do {
+            let holdableItems = bulkHoldItems.filter { successfullyCancelledLineIds.contains($0.id) }
+            guard !holdableItems.isEmpty else {
+                actionError = "Unable to hold selected lines because transfer cancellation failed."
+                return
+            }
+
             _ = try service.bulkHoldJPOLinesWithChat(
-                lineIds: bulkHoldItems.map(\.id),
+                lineIds: holdableItems.map(\.id),
                 holdReason: reason,
                 userId: userId
             )
 
             if let chatService = appCore.chatService, let jpo {
-                for item in bulkHoldItems {
+                for item in holdableItems {
                     let jpoNumber = "JPO #\(jpo.id) Line #\(item.id)"
                     _ = try chatService.createJPOHoldThread(
                         partName: item.partName ?? "Part",
@@ -964,6 +974,11 @@ struct IOSJPODetailPage: View {
                     )
                 }
             }
+
+            if !cancelFailures.isEmpty {
+                let failedList = cancelFailures.map(String.init).joined(separator: ", ")
+                actionError = "Some lines were not held because transfer cancellation failed (line IDs: \(failedList))."
+            }
         } catch {
             actionError = userFriendlyError(error, context: "process order")
         }
@@ -972,7 +987,6 @@ struct IOSJPODetailPage: View {
         selectedLineIds.removeAll()
         bulkHoldItems = []
         bulkHoldReason = ""
-        isBulkHolding = false
         activeSheet = nil
         loadData()
     }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
@@ -847,7 +847,7 @@ struct IOSJPODetailPage: View {
             // Also create a jpo_hold typed thread in ChatService for
             // unified inbox visibility with HOLD badge
             if let chatService = appCore.chatService {
-                let jpoNumber = "JPO #\(jpo.id)"
+                let jpoNumber = "JPO #\(jpo.id) Line #\(lineId)"
                 _ = try chatService.createJPOHoldThread(
                     partName: holdingPartName ?? "Part",
                     jpoNumber: jpoNumber,

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
@@ -45,10 +45,25 @@ struct IOSJPODetailPage: View {
         case viewChat(Int64)
         case viewPO(Int64)
         case viewMovement(Int64)
-        case bulkHold
+        case bulkHold([OrdersService.JPOLineRow])
         case help
 
-        var id: String { String(describing: self) }
+        var id: String {
+            switch self {
+            case .addLineItem:
+                "addLineItem"
+            case .viewChat(let channelId):
+                "viewChat-\(channelId)"
+            case .viewPO(let poId):
+                "viewPO-\(poId)"
+            case .viewMovement(let movementId):
+                "viewMovement-\(movementId)"
+            case .bulkHold(let items):
+                IOSJPODetailBulkHoldSelection.sheetIdentifier(for: items)
+            case .help:
+                "help"
+            }
+        }
     }
 
     var body: some View {
@@ -188,11 +203,11 @@ struct IOSJPODetailPage: View {
                         }
                     }
             }
-        case .bulkHold:
+        case .bulkHold(let items):
             NavigationStack {
                 Form {
-                    Section("Items to Hold (\(bulkHoldItems.count))") {
-                        ForEach(bulkHoldItems, id: \.id) { item in
+                    Section("Items to Hold (\(items.count))") {
+                        ForEach(items, id: \.id) { item in
                             HStack {
                                 Text(item.partName ?? "Unknown Part")
                                 Spacer()
@@ -883,13 +898,20 @@ struct IOSJPODetailPage: View {
     }
 
     private func holdSelected() {
-        // Collect ALL selected items and show the bulk hold sheet
+        // Collect ALL selected items and show the bulk hold sheet with the
+        // selected rows embedded in the sheet identity. This prevents SwiftUI
+        // from presenting a fresh `.bulkHold` sheet before the separate
+        // `bulkHoldItems` state write has rendered, which produced an empty
+        // "Items to Hold (0)" sheet while the action bar still said "2 selected".
         guard let jpo else { return }
-        let items = jpo.lines.filter { selectedLineIds.contains($0.id) }
+        let items = IOSJPODetailBulkHoldSelection.selectedHoldItems(
+            from: jpo.lines,
+            selectedLineIds: selectedLineIds
+        )
         guard !items.isEmpty else { return }
         bulkHoldItems = items
         bulkHoldReason = ""
-        activeSheet = .bulkHold
+        activeSheet = .bulkHold(items)
     }
 
     /// Apply the same hold reason to ALL items in bulkHoldItems, cancelling

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Testing
+import WiredPartCore
 @testable import Weird_Parts
 
 
@@ -56,5 +57,27 @@ struct Weird_Parts_IOSTests {
 
         #expect(keyHex == "8f1df32f4be04d5fcde1e8e6ddf9187f53a4b68370d5aafc56f0d43f2e9732a1")
         #expect(keyHex.count == 64)
+    }
+
+    @Test func uiTestingFixturesSeedJPOFlowDataForQASmoke() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        let auth = AuthService(db: db)
+
+        try AppCore.seedUITestingFixtures(db: db, authService: auth)
+
+        let parts = PartsService(db: db, auth: auth)
+        let jobs = JobsService(db: db)
+        let orders = OrdersService(db: db)
+        let users = try auth.getActiveUsers()
+        let userId = try #require(users.first { $0.displayName == "UITest Owner" }?.id)
+        let job = try #require(try jobs.listJobs(status: "active").first { $0.jobNumber == "UITEST-JPO-001" })
+        let jpo = try #require(try orders.listJPOs(jobId: job.id, status: "draft").first { $0.orderNumber == "UITEST-JPO-001" })
+        let detail = try orders.getJPODetail(id: jpo.id)
+
+        #expect(userId > 0)
+        #expect(try parts.listCategories().contains { $0.name == "UITesting Electrical" })
+        #expect(try parts.listParts(search: "UITesting QA", limit: 10).count >= 2)
+        #expect(detail.lines.count >= 2)
+        #expect(detail.lines.allSatisfy { $0.partId != nil })
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -107,6 +107,57 @@ struct Weird_Parts_IOSTests {
         #expect(IOSJPODetailBulkHoldSelection.sheetIdentifier(for: selectedItems) == "bulkHold-101-102")
     }
 
+    @MainActor
+    @Test func bulkHoldExcludesLinesWhoseTransferCancellationFailed() throws {
+        let transferFailure = OrdersService.JPOLineRow(
+            id: 201,
+            jpoId: 20,
+            partId: 301,
+            partName: "UITesting Transfer Failure",
+            description: nil,
+            quantity: 1,
+            unitPrice: nil,
+            notes: nil,
+            priority: "medium",
+            createdAt: nil,
+            lineStatus: "transfer",
+            transferId: 9001
+        )
+        let transferSuccess = OrdersService.JPOLineRow(
+            id: 202,
+            jpoId: 20,
+            partId: 302,
+            partName: "UITesting Transfer Success",
+            description: nil,
+            quantity: 2,
+            unitPrice: nil,
+            notes: nil,
+            priority: "medium",
+            createdAt: nil,
+            lineStatus: "transfer",
+            transferId: 9002
+        )
+        let normalPendingLine = OrdersService.JPOLineRow(
+            id: 203,
+            jpoId: 20,
+            partId: 303,
+            partName: "UITesting Pending Line",
+            description: nil,
+            quantity: 3,
+            unitPrice: nil,
+            notes: nil,
+            priority: "medium",
+            createdAt: nil
+        )
+
+        let processableItems = IOSJPODetailBulkHoldSelection.processableHoldItems(
+            from: [transferFailure, transferSuccess, normalPendingLine],
+            failedTransferCancellationLineIds: [transferFailure.id]
+        )
+
+        #expect(processableItems.map(\.id) == [transferSuccess.id, normalPendingLine.id])
+    }
+
     @Test func uiTestingFixturesSeedJPOFlowDataForQASmoke() throws {
         let db = try AppDatabase.openInMemoryDatabase()
         let auth = AuthService(db: db)

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -50,4 +50,11 @@ struct Weird_Parts_IOSTests {
 
         #expect(auditIndex <= 2)
     }
+
+    @Test func uiTestingLaunchUsesDeterministicDatabaseKey() throws {
+        let keyHex = try AppCore.deviceBootstrapKeyHex(processArguments: ["Weird Parts", "-UITesting"])
+
+        #expect(keyHex == "8f1df32f4be04d5fcde1e8e6ddf9187f53a4b68370d5aafc56f0d43f2e9732a1")
+        #expect(keyHex.count == 64)
+    }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -59,6 +59,54 @@ struct Weird_Parts_IOSTests {
         #expect(keyHex.count == 64)
     }
 
+    @MainActor
+    @Test func bulkHoldSelectionCarriesAllSelectedRowsIntoSheetSnapshot() throws {
+        let first = OrdersService.JPOLineRow(
+            id: 101,
+            jpoId: 10,
+            partId: 201,
+            partName: "UITesting QA Switch",
+            description: nil,
+            quantity: 1,
+            unitPrice: nil,
+            notes: nil,
+            priority: "medium",
+            createdAt: nil
+        )
+        let second = OrdersService.JPOLineRow(
+            id: 102,
+            jpoId: 10,
+            partId: 202,
+            partName: "UITesting QA Breaker",
+            description: nil,
+            quantity: 2,
+            unitPrice: nil,
+            notes: nil,
+            priority: "medium",
+            createdAt: nil
+        )
+        let unselected = OrdersService.JPOLineRow(
+            id: 103,
+            jpoId: 10,
+            partId: 203,
+            partName: "UITesting QA Outlet",
+            description: nil,
+            quantity: 3,
+            unitPrice: nil,
+            notes: nil,
+            priority: "medium",
+            createdAt: nil
+        )
+
+        let selectedItems = IOSJPODetailBulkHoldSelection.selectedHoldItems(
+            from: [first, second, unselected],
+            selectedLineIds: [first.id, second.id]
+        )
+
+        #expect(selectedItems.map(\.id) == [first.id, second.id])
+        #expect(IOSJPODetailBulkHoldSelection.sheetIdentifier(for: selectedItems) == "bulkHold-101-102")
+    }
+
     @Test func uiTestingFixturesSeedJPOFlowDataForQASmoke() throws {
         let db = try AppDatabase.openInMemoryDatabase()
         let auth = AuthService(db: db)

--- a/core/Sources/WiredPartCore/Services/OrdersService.swift
+++ b/core/Sources/WiredPartCore/Services/OrdersService.swift
@@ -947,6 +947,74 @@ public final class OrdersService: Sendable {
         }
     }
 
+    /// Put multiple JPO lines on hold and create one legacy Q&A chat channel per line.
+    ///
+    /// This is intentionally idempotent for repeated bulk holds: if a selected line is
+    /// already on hold and already has a `chat_thread_id`, the existing channel ID is
+    /// returned instead of creating a duplicate channel/message.
+    public func bulkHoldJPOLinesWithChat(
+        lineIds: [Int64],
+        holdReason: String,
+        userId: Int64
+    ) throws -> [Int64: Int64] {
+        let trimmedReason = holdReason.trimmingCharacters(in: .whitespaces)
+        guard !trimmedReason.isEmpty else {
+            throw OrdersError.requiredFieldEmpty("holdReason")
+        }
+
+        let uniqueLineIds = Array(Set(lineIds)).sorted()
+        guard !uniqueLineIds.isEmpty else { return [:] }
+
+        try db.writer.read { dbConn in
+            let userExists = (try Int.fetchOne(dbConn, sql: """
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                """, arguments: [userId]) ?? 0) > 0
+            guard userExists else { throw OrdersError.userNotFound(userId) }
+            try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "manage_orders")
+        }
+
+        var channelIdsByLineId: [Int64: Int64] = [:]
+        for lineId in uniqueLineIds {
+            let line = try db.writer.read { dbConn -> (jpoId: Int64, partName: String, existingChannelId: Int64?) in
+                guard let row = try Row.fetchOne(dbConn, sql: """
+                    SELECT jl.jpo_id,
+                           COALESCE(p.name, 'Part') AS part_name,
+                           CASE
+                               WHEN jl.line_status = 'on_hold' THEN jl.chat_thread_id
+                               ELSE NULL
+                           END AS existing_channel_id
+                    FROM jpo_line_items jl
+                    LEFT JOIN parts p ON p.id = jl.part_id AND p.deleted_at IS NULL
+                    WHERE jl.id = ? AND jl.deleted_at IS NULL
+                    """, arguments: [lineId]) else {
+                    throw OrdersError.invalidStatus("JPO line #\(lineId) not found")
+                }
+
+                return (
+                    jpoId: row["jpo_id"] ?? 0,
+                    partName: row["part_name"] as String? ?? "Part",
+                    existingChannelId: row["existing_channel_id"] as Int64?
+                )
+            }
+
+            if let existingChannelId = line.existingChannelId {
+                channelIdsByLineId[lineId] = existingChannelId
+                continue
+            }
+
+            let channelId = try holdJPOLineWithChat(
+                lineId: lineId,
+                holdReason: trimmedReason,
+                userId: userId,
+                partName: line.partName,
+                jpoId: line.jpoId
+            )
+            channelIdsByLineId[lineId] = channelId
+        }
+
+        return channelIdsByLineId
+    }
+
     /// Derive the overall JPO status from its line items' per-line statuses.
     public func deriveJPOStatusFromLineStatuses(_ statuses: [String]) -> String {
         let unique = Set(statuses)

--- a/core/Sources/WiredPartCore/Services/OrdersService.swift
+++ b/core/Sources/WiredPartCore/Services/OrdersService.swift
@@ -36,6 +36,7 @@ public final class OrdersService: Sendable {
         case overMaxPullRequired(partId: Int64, overage: Int)
         case invalidQuantity(Int)
         case requiredFieldEmpty(String)
+        case missingJPOReference(lineId: Int64)
 
         public var errorDescription: String? {
             switch self {
@@ -59,6 +60,7 @@ public final class OrdersService: Sendable {
                 "Part #\(partId) is still over MAX by \(overage). Pull the overage to staging before generating POs."
             case .invalidQuantity(let qty): "Quantity must be greater than zero (got \(qty))"
             case .requiredFieldEmpty(let field): "\(field) is required and cannot be empty"
+            case .missingJPOReference(let lineId): "JPO line #\(lineId) is missing a required jpo_id reference"
             }
         }
     }
@@ -876,6 +878,25 @@ public final class OrdersService: Sendable {
         }
 
         return try db.writer.write { dbConn -> Int64 in
+            try holdJPOLineWithChat(
+                dbConn: dbConn,
+                lineId: lineId,
+                holdReason: holdReason,
+                userId: userId,
+                partName: partName,
+                jpoId: jpoId
+            )
+        }
+    }
+
+    private func holdJPOLineWithChat(
+        dbConn: Database,
+        lineId: Int64,
+        holdReason: String,
+        userId: Int64,
+        partName: String,
+        jpoId: Int64
+    ) throws -> Int64 {
             // Create a chat channel for this Q&A
             let channelName = "JPO #\(jpoId) — \(partName)"
             try dbConn.execute(
@@ -944,7 +965,6 @@ public final class OrdersService: Sendable {
             )
 
             return channelId
-        }
     }
 
     /// Put multiple JPO lines on hold and create one legacy Q&A chat channel per line.
@@ -974,8 +994,8 @@ public final class OrdersService: Sendable {
         }
 
         var channelIdsByLineId: [Int64: Int64] = [:]
-        for lineId in uniqueLineIds {
-            let line = try db.writer.read { dbConn -> (jpoId: Int64, partName: String, existingChannelId: Int64?) in
+        try db.writer.write { dbConn in
+            for lineId in uniqueLineIds {
                 guard let row = try Row.fetchOne(dbConn, sql: """
                     SELECT jl.jpo_id,
                            COALESCE(p.name, 'Part') AS part_name,
@@ -990,26 +1010,28 @@ public final class OrdersService: Sendable {
                     throw OrdersError.invalidStatus("JPO line #\(lineId) not found")
                 }
 
-                return (
-                    jpoId: row["jpo_id"] ?? 0,
-                    partName: row["part_name"] as String? ?? "Part",
-                    existingChannelId: row["existing_channel_id"] as Int64?
+                let jpoId: Int64 = try {
+                    if let id = row["jpo_id"] as Int64? { return id }
+                    throw OrdersError.missingJPOReference(lineId: lineId)
+                }()
+                let partName = row["part_name"] as String? ?? "Part"
+                let existingChannelId = row["existing_channel_id"] as Int64?
+
+                if let existingChannelId {
+                    channelIdsByLineId[lineId] = existingChannelId
+                    continue
+                }
+
+                let channelId = try holdJPOLineWithChat(
+                    dbConn: dbConn,
+                    lineId: lineId,
+                    holdReason: trimmedReason,
+                    userId: userId,
+                    partName: partName,
+                    jpoId: jpoId
                 )
+                channelIdsByLineId[lineId] = channelId
             }
-
-            if let existingChannelId = line.existingChannelId {
-                channelIdsByLineId[lineId] = existingChannelId
-                continue
-            }
-
-            let channelId = try holdJPOLineWithChat(
-                lineId: lineId,
-                holdReason: trimmedReason,
-                userId: userId,
-                partName: line.partName,
-                jpoId: line.jpoId
-            )
-            channelIdsByLineId[lineId] = channelId
         }
 
         return channelIdsByLineId

--- a/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
@@ -1086,6 +1086,56 @@ struct OrdersServiceTests {
         #expect(role == "admin")
     }
 
+    @Test("bulkHoldJPOLinesWithChat creates a chat thread per selected line and is idempotent")
+    func testBulkHoldJPOLinesWithChatCreatesPerLineThreadsIdempotently() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partA = try E2ETestHelpers.seedPart(env, name: "Bulk Wire", categoryId: catId)
+        let partB = try E2ETestHelpers.seedPart(env, name: "Bulk Box", categoryId: catId)
+
+        let jpoId = try env.orders.createJPO(jobId: jobId, requestedBy: env.adminUserId, notes: nil)
+        let lineA = try env.orders.addJPOLineItem(jpoId: jpoId, partId: partA, quantity: 2, notes: nil)
+        let lineB = try env.orders.addJPOLineItem(jpoId: jpoId, partId: partB, quantity: 4, notes: nil)
+
+        let firstChannels = try env.orders.bulkHoldJPOLinesWithChat(
+            lineIds: [lineA, lineB],
+            holdReason: "Bulk hold needs field answer",
+            userId: env.adminUserId
+        )
+        let repeatedChannels = try env.orders.bulkHoldJPOLinesWithChat(
+            lineIds: [lineA, lineB],
+            holdReason: "Bulk hold needs field answer",
+            userId: env.adminUserId
+        )
+
+        #expect(firstChannels.count == 2)
+        #expect(Set(firstChannels.keys) == Set([lineA, lineB]))
+        #expect(firstChannels == repeatedChannels)
+
+        try env.db.writer.read { db in
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT id, line_status, hold_reason, chat_thread_id
+                FROM jpo_line_items
+                WHERE id IN (?, ?)
+                ORDER BY id
+            """, arguments: [lineA, lineB])
+            #expect(rows.count == 2)
+            for row in rows {
+                let lineId: Int64 = row["id"]
+                let chatThreadId: Int64? = row["chat_thread_id"]
+                #expect(row["line_status"] as String == "on_hold")
+                #expect(row["hold_reason"] as String == "Bulk hold needs field answer")
+                #expect(chatThreadId == firstChannels[lineId])
+            }
+
+            let channelCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM chat_channels WHERE channel_type = 'jpo_qa' AND deleted_at IS NULL") ?? 0
+            let messageCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM chat_messages WHERE content = ? AND deleted_at IS NULL", arguments: ["Bulk hold needs field answer"]) ?? 0
+            #expect(channelCount == 2)
+            #expect(messageCount == 2)
+        }
+    }
+
     // MARK: - generatePOsFromProcurement
 
     @Test("generatePOsFromProcurement groups items by supplier into separate POs")


### PR DESCRIPTION
## Summary
- route iOS bulk JPO holds through a new idempotent OrdersService bulk hold path instead of status-only updates
- create a legacy Q&A chat/thread id for every selected held line
- create per-line typed JPO hold threads for unified inbox visibility
- add regression coverage proving repeat bulk holds reuse existing line chat ids and do not duplicate channels/messages

## Test Plan
- swift test --package-path core --filter OrdersServiceTests/testBulkHoldJPOLinesWithChatCreatesPerLineThreadsIdempotently
- swift test --package-path core --filter OrdersServiceTests
- swift test --package-path core --filter ChatServiceTests

Paperclip: WEI-1776