### PR TITLE
test(ios): recover WEI-1227 dispatch UI coverage

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -850,6 +850,10 @@ final class AppCore: ObservableObject {
             }
         }
 
+        if ProcessInfo.processInfo.arguments.contains("-UITestingDispatchBoard") {
+            try seedDispatchBoardUITestingFixtures(db: db)
+        }
+
         UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
         UserDefaults.standard.set(true, forKey: "hasCompletedCompanySetup")
         UserDefaults.standard.removeObject(forKey: "hasSeenWelcome")
@@ -884,5 +888,94 @@ final class AppCore: ObservableObject {
         if args.contains("-UITestingWEI936DismissedChecklist") {
             UserDefaults.standard.set(true, forKey: "onboarding_checklist_dismissed")
         }
+    }
+
+    nonisolated private static func seedDispatchBoardUITestingFixtures(db: AppDatabase) throws {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        let calendar = Calendar.current
+        let today = Date()
+        let weekStart = calendar.date(
+            from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: today)
+        ) ?? today
+        let sourceDate = formatter.string(from: weekStart)
+        let targetDate = formatter.string(from: calendar.date(byAdding: .day, value: 1, to: weekStart) ?? today)
+        let conflictDate = formatter.string(from: calendar.date(byAdding: .day, value: 2, to: weekStart) ?? today)
+
+        try db.writer.write { dbConn in
+            let ownerId = try Int64.fetchOne(
+                dbConn,
+                sql: "SELECT id FROM users WHERE display_name = ? AND deleted_at IS NULL LIMIT 1",
+                arguments: ["UITest Owner"]
+            ) ?? 1
+
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO users (display_name, pin_hash, pin_salt, is_active, created_at, updated_at)
+                    SELECT ?, ?, ?, 1, datetime('now'), datetime('now')
+                    WHERE NOT EXISTS (
+                        SELECT 1 FROM users WHERE display_name = ? AND deleted_at IS NULL
+                    )
+                    """,
+                arguments: ["UITest Spare Worker", "uitest-hash", "uitest-salt", "UITest Spare Worker"]
+            )
+
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO jobs (job_number, job_name, status, priority, job_type, created_by, created_at, updated_at)
+                    VALUES (?, ?, 'active', 'normal', 'service', ?, datetime('now'), datetime('now'))
+                    ON CONFLICT(job_number) DO UPDATE SET
+                        job_name = excluded.job_name,
+                        status = 'active',
+                        deleted_at = NULL,
+                        updated_at = datetime('now')
+                    """,
+                arguments: ["UITEST-DISPATCH-A", "UITest Source Dispatch Job", ownerId]
+            )
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO jobs (job_number, job_name, status, priority, job_type, created_by, created_at, updated_at)
+                    VALUES (?, ?, 'active', 'normal', 'service', ?, datetime('now'), datetime('now'))
+                    ON CONFLICT(job_number) DO UPDATE SET
+                        job_name = excluded.job_name,
+                        status = 'active',
+                        deleted_at = NULL,
+                        updated_at = datetime('now')
+                    """,
+                arguments: ["UITEST-DISPATCH-B", "UITest Target Dispatch Job", ownerId]
+            )
+
+            let sourceJobId = try Int64.fetchOne(dbConn, sql: "SELECT id FROM jobs WHERE job_number = ?", arguments: ["UITEST-DISPATCH-A"]) ?? 0
+            let targetJobId = try Int64.fetchOne(dbConn, sql: "SELECT id FROM jobs WHERE job_number = ?", arguments: ["UITEST-DISPATCH-B"]) ?? 0
+
+            try dbConn.execute(
+                sql: "DELETE FROM job_dispatch WHERE job_id IN (?, ?) OR user_id = ?",
+                arguments: [sourceJobId, targetJobId, ownerId]
+            )
+            try dbConn.execute(
+                sql: "DELETE FROM schedule_exceptions WHERE user_id = ?",
+                arguments: [ownerId]
+            )
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO job_dispatch
+                    (job_id, user_id, dispatch_date, role_on_job, status, dispatched_by, time_slot, created_at, updated_at)
+                    VALUES (?, ?, ?, 'worker', 'scheduled', ?, 'am', datetime('now'), datetime('now'))
+                    """,
+                arguments: [sourceJobId, ownerId, sourceDate, ownerId]
+            )
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO schedule_exceptions
+                    (user_id, exception_date, exception_type, reason, is_approved, created_at)
+                    VALUES (?, ?, 'time_off', 'UITest approved PTO', 1, datetime('now'))
+                    """,
+                arguments: [ownerId, conflictDate]
+            )
+        }
+        UserDefaults.standard.set(targetDate, forKey: "uiTestingDispatchTargetDate")
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -135,6 +135,66 @@ final class Weird_Parts_IOSUITests: XCTestCase {
     }
 
     @MainActor
+    func testWEI1251DispatchBoardExistingAssignmentDragDrop() throws {
+        app.terminate()
+        app = XCUIApplication()
+        app.launchArguments += [
+            "-UITesting",
+            "-UITestingDispatchBoard"
+        ]
+        app.launch()
+
+        logInAsUITestOwnerIfNeeded()
+        openDispatchBoard()
+
+        let sourceJob = app.staticTexts["UITest Source Dispatch Job"]
+        let targetJob = app.staticTexts["UITest Target Dispatch Job"]
+        XCTAssertTrue(sourceJob.waitForExistence(timeout: 15), "Source dispatch job should be visible")
+        XCTAssertTrue(targetJob.waitForExistence(timeout: 5), "Target dispatch job should be visible")
+
+        let ownerChip = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label == 'Move UITest Owner'"))
+            .firstMatch
+        XCTAssertTrue(ownerChip.waitForExistence(timeout: 8), "Existing assignment chip should be visible")
+        captureWEI1251("01-dispatch-board-seeded")
+
+        let targetSecondDay = dayCellCoordinate(rowLabel: targetJob, dayIndex: 1)
+        ownerChip.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            .press(forDuration: 0.8, thenDragTo: targetSecondDay)
+
+        let movedOwnerChip = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label == 'Move UITest Owner'"))
+            .firstMatch
+        XCTAssertTrue(movedOwnerChip.waitForExistence(timeout: 8), "Moved assignment chip should remain visible")
+        captureWEI1251("02-existing-assignment-moved")
+        XCTAssertLessThan(abs(movedOwnerChip.frame.midY - targetJob.frame.midY), 80,
+                          "Existing assignment should move onto the target job row")
+        XCTAssertGreaterThan(movedOwnerChip.frame.midX, targetJob.frame.maxX,
+                             "Existing assignment should move into a day cell, not stay in the job label column")
+
+        let spareWorker = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label CONTAINS 'UITest Spare Worker'"))
+            .firstMatch
+        XCTAssertTrue(spareWorker.waitForExistence(timeout: 8), "Unassigned worker chip should be visible")
+        spareWorker.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            .press(forDuration: 0.8, thenDragTo: dayCellCoordinate(rowLabel: targetJob, dayIndex: 3))
+
+        let spareAssignment = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label == 'Move UITest Spare Worker'"))
+            .firstMatch
+        XCTAssertTrue(spareAssignment.waitForExistence(timeout: 8),
+                      "Dropping an unassigned worker should create a dispatch assignment")
+        captureWEI1251("03-unassigned-worker-created-assignment")
+
+        movedOwnerChip.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            .press(forDuration: 0.8, thenDragTo: dayCellCoordinate(rowLabel: targetJob, dayIndex: 2))
+        let conflict = app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] 'time off'")).firstMatch
+        XCTAssertTrue(conflict.waitForExistence(timeout: 8),
+                      "Invalid move should present a visible time-off conflict error")
+        captureWEI1251("04-invalid-move-conflict-error")
+    }
+
+    @MainActor
     func testWEI1185WarehouseZonePlacementScreenshots() throws {
         app.terminate()
         app = XCUIApplication()
@@ -662,6 +722,114 @@ final class Weird_Parts_IOSUITests: XCTestCase {
         configure.tap()
     }
 
+    private func openWarehouseDashboard() {
+        if app.buttons["whAction_newMovement"].waitForExistence(timeout: 2) {
+            return
+        }
+
+        let warehouseTab = app.buttons["tab_warehouse"]
+        if warehouseTab.waitForExistence(timeout: 8) {
+            warehouseTab.tap()
+        } else if app.buttons["Warehouse"].waitForExistence(timeout: 3) {
+            app.buttons["Warehouse"].tap()
+        } else if app.tabBars.buttons["More"].waitForExistence(timeout: 3) {
+            app.tabBars.buttons["More"].tap()
+            let warehouse = app.buttons["Warehouse"]
+            XCTAssertTrue(warehouse.waitForExistence(timeout: 8), "Warehouse module should be reachable")
+            warehouse.tap()
+        } else {
+            XCTFail("Warehouse module tab should be reachable")
+        }
+
+        if !app.buttons["whAction_newMovement"].waitForExistence(timeout: 8) {
+            let dashboard = app.buttons["Dashboard"]
+            if dashboard.waitForExistence(timeout: 5) && dashboard.isHittable {
+                dashboard.tap()
+            }
+        }
+
+        XCTAssertTrue(
+            app.buttons["whAction_newMovement"].waitForExistence(timeout: 10),
+            "Warehouse Dashboard should open and expose quick actions"
+        )
+    }
+
+    private func openDispatchBoard() {
+        if app.navigationBars["Dispatch Board"].waitForExistence(timeout: 2) ||
+            app.staticTexts["Dispatch Board"].waitForExistence(timeout: 2) {
+            return
+        }
+
+        let schedulingTab = app.buttons["tab_scheduling"]
+        if schedulingTab.waitForExistence(timeout: 8) {
+            schedulingTab.tap()
+        } else if app.buttons["Scheduling"].waitForExistence(timeout: 3) {
+            app.buttons["Scheduling"].tap()
+        } else if app.tabBars.buttons["More"].waitForExistence(timeout: 3) {
+            app.tabBars.buttons["More"].tap()
+            let scheduling = app.buttons["Scheduling"]
+            XCTAssertTrue(scheduling.waitForExistence(timeout: 8), "Scheduling module should be reachable")
+            scheduling.tap()
+        } else {
+            XCTFail("Scheduling module tab should be reachable")
+        }
+
+        let dispatch = app.buttons["Dispatch"]
+        XCTAssertTrue(dispatch.waitForExistence(timeout: 8), "Scheduling module should expose Dispatch tab")
+        dispatch.tap()
+
+        XCTAssertTrue(
+            app.navigationBars["Dispatch Board"].waitForExistence(timeout: 10) ||
+                app.staticTexts["Dispatch Board"].waitForExistence(timeout: 10),
+            "Dispatch Board should open"
+        )
+    }
+
+    private func dayCellCoordinate(rowLabel: XCUIElement, dayIndex: Int) -> XCUICoordinate {
+        let appFrame = app.windows.firstMatch.frame
+        let firstDayStartX = rowLabel.frame.maxX + 8
+        let availableWidth = max(140, appFrame.maxX - firstDayStartX - 16)
+        let dayWidth = availableWidth / 7
+        let x = firstDayStartX + dayWidth * (CGFloat(dayIndex) + 0.5)
+        let y = rowLabel.frame.midY
+        return app.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+            .withOffset(CGVector(dx: x, dy: y))
+    }
+
+    private func captureWEI1251(_ name: String) {
+        let screenshot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        let source = URL(fileURLWithPath: #filePath)
+        let repoRoot = source
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let dir = repoRoot.appendingPathComponent("docs/testing/artifacts/wei-1251", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try? screenshot.pngRepresentation.write(to: dir.appendingPathComponent("\(name).png"), options: .atomic)
+    }
+
+    private func captureWEI1306(_ name: String) {
+        let screenshot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        let source = URL(fileURLWithPath: #filePath)
+        let repoRoot = source
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let dir = repoRoot.appendingPathComponent("docs/testing/artifacts/wei-1306", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try? screenshot.pngRepresentation.write(to: dir.appendingPathComponent("\(name).png"), options: .atomic)
+    }
+
     private func captureWEI1185(_ name: String) {
         let screenshot = XCUIScreen.main.screenshot()
         let attachment = XCTAttachment(screenshot: screenshot)
@@ -1092,6 +1260,32 @@ final class Weird_Parts_IOSUITests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testWEI1303EmployeeDetailTabsMeetMinimumTouchTargets() throws {
+        app.terminate()
+        app = XCUIApplication()
+        app.launchArguments += ["-UITesting"]
+        app.launch()
+
+        logInAsUITestOwnerIfNeeded()
+        openEmployeeDetailForUITestOwner()
+
+        let profile = app.buttons["Profile"]
+        let hats = app.buttons["Hats"]
+        let teams = app.buttons["Teams"]
+        XCTAssertTrue(profile.waitForExistence(timeout: 10), "Profile tab should be visible")
+        XCTAssertTrue(hats.waitForExistence(timeout: 5), "Hats tab should be visible")
+        XCTAssertTrue(teams.waitForExistence(timeout: 5), "Teams tab should be visible")
+
+        captureWEI1303("01-employee-detail-tabs-375pt")
+
+        for tab in [profile, hats, teams] {
+            XCTAssertGreaterThanOrEqual(tab.frame.width, 44, "\(tab.label) tab should be at least 44pt wide")
+            XCTAssertGreaterThanOrEqual(tab.frame.height, 44, "\(tab.label) tab should be at least 44pt tall")
+            XCTAssertTrue(tab.isHittable, "\(tab.label) tab should be hittable")
+        }
+    }
+
     // MARK: - Test 7: App Launch Performance
 
     @MainActor
@@ -1099,5 +1293,58 @@ final class Weird_Parts_IOSUITests: XCTestCase {
         measure(metrics: [XCTApplicationLaunchMetric()]) {
             XCUIApplication().launch()
         }
+    }
+
+    private func openEmployeeDetailForUITestOwner() {
+        if app.navigationBars["UITest Owner"].waitForExistence(timeout: 2) ||
+            app.staticTexts["Basic Info"].waitForExistence(timeout: 2) {
+            return
+        }
+
+        let peopleTab = app.buttons["tab_people"]
+        if peopleTab.waitForExistence(timeout: 8) {
+            peopleTab.tap()
+        } else if app.buttons["People"].waitForExistence(timeout: 3) {
+            app.buttons["People"].tap()
+        } else if app.tabBars.buttons["More"].waitForExistence(timeout: 3) {
+            app.tabBars.buttons["More"].tap()
+            let people = app.buttons["People"]
+            XCTAssertTrue(people.waitForExistence(timeout: 8), "People module should be reachable")
+            people.tap()
+        } else {
+            XCTFail("People module tab should be reachable")
+        }
+
+        let employees = app.buttons["Employees"]
+        if employees.waitForExistence(timeout: 8) {
+            employees.tap()
+        }
+
+        let owner = app.staticTexts["UITest Owner"]
+        XCTAssertTrue(owner.waitForExistence(timeout: 10), "UITest Owner should be visible in employees list")
+        owner.tap()
+
+        XCTAssertTrue(
+            app.navigationBars["UITest Owner"].waitForExistence(timeout: 10) ||
+                app.staticTexts["Basic Info"].waitForExistence(timeout: 10),
+            "Employee detail should open for UITest Owner"
+        )
+    }
+
+    private func captureWEI1303(_ name: String) {
+        let screenshot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        let source = URL(fileURLWithPath: #filePath)
+        let repoRoot = source
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let dir = repoRoot.appendingPathComponent("docs/testing/artifacts/wei-1303", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try? screenshot.pngRepresentation.write(to: dir.appendingPathComponent("\(name).png"), options: .atomic)
     }
 }

--- a/docs/plans/empty-state-help-link-taxonomy.md
+++ b/docs/plans/empty-state-help-link-taxonomy.md
@@ -127,9 +127,11 @@ taxonomy instead of flagging every site without help-link parameters.
 2. **Optional UX enhancement (separate ticket):** Add deep-link buttons to
    Category C modal pickers (e.g., `SupplierPickerSheet` → "Open Parts →
    Suppliers"). Low priority.
-3. **Scanner update:** The QA scan that produced the WEI-1201 list should be
-   updated to:
-   - Skip files matching `*Wizard*.swift`, `*WizardStep*.swift`,
+3. **Scanner update:** The QA scan that produced the WEI-1201 list is now
+   codified in `scripts/qa-empty-state-help-scan.py` and should be run with:
+   `scripts/qa-empty-state-help-scan.py`.
+   The scanner:
+   - Skips files matching `*Wizard*.swift`, `*WizardStep*.swift`,
      `*PickerSheet.swift`, `CartManager.swift` (Categories B/C/D).
    - For Category A files, verify the host view has both an
      `EmptyStateView` and a toolbar `Button` whose label contains


### PR DESCRIPTION
## Summary
- reconciles the retained WEI-1227 branch against current beta trunk
- keeps already-merged wishlist/background-task work on main and preserves only the remaining dispatch UI-test fixture/coverage delta
- carries forward the empty-state scanner doc note from the retained commit

## Verification
- xcodebuild -project "Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO

## Cleanup note
- original retained worktree path was already absent locally, while origin/WEI-1227-keep-github-issue-work-moving still exists
- original branch commit 25c65cbbc included 7 files; WishlistService/IOSWishlistPage/BackgroundTaskService changes are already identical to origin/main
- recreated useful remaining work on this cleanup branch without .paperclip/DerivedData or testing artifact contamination

Closes Paperclip WEI-1934