### PR TITLE
docs: add local-to-cloud Git sync runbook

### DIFF
--- a/docs/local-to-cloud-git-sync.md
+++ b/docs/local-to-cloud-git-sync.md
@@ -1,0 +1,37 @@
+# Local-to-Cloud Git Sync Runbook
+
+This repo uses local Paperclip worktrees plus GitHub as the cloud source of truth. Before closing a sync task, verify the exact local branch state and push only the branch/commits that belong to the active issue.
+
+## Audit
+
+Run the sync audit from the active worktree:
+
+```bash
+scripts/git-cloud-sync-audit.sh
+```
+
+The audit fetches `origin`, reports dirty worktree state, shows whether the current branch has an upstream, lists local branches that are ahead/behind or lack upstreams, and compares local/remote tag counts.
+
+## Push the Active Issue Branch
+
+If the worktree is clean and the current branch is the intended issue branch:
+
+```bash
+git push -u origin HEAD
+git ls-remote --heads origin "$(git branch --show-current)"
+git rev-parse HEAD
+```
+
+The `git ls-remote` SHA must match `git rev-parse HEAD`. If the current branch already tracks `origin/<branch>`, use `git push` and verify the same way.
+
+## Guardrails
+
+- Do not force-push `main`.
+- Do not commit or push unrelated dirty/untracked files just to clear status.
+- Treat local branches with no upstream as separate decisions unless the current issue explicitly owns them.
+- Treat divergent `main` as a reconciliation task, not as part of a feature-branch sync.
+- Fetch before reporting branch state so ahead/behind counts use fresh remote refs.
+
+## Current Baseline from WEI-1033
+
+On 2026-05-13, the task worktree was clean, had no tags, and branch `WEI-1032-get-github-synced-from-this-computer-to-the-cloud` initially had no upstream. Other local branches had separate divergence/no-upstream state and were not pushed under this issue because their ownership was ambiguous.

--- a/scripts/git-cloud-sync-audit.sh
+++ b/scripts/git-cloud-sync-audit.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+remote="${1:-origin}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: run from inside the Git worktree" >&2
+  exit 1
+fi
+
+branch="$(git branch --show-current)"
+head_sha="$(git rev-parse HEAD)"
+
+echo "Git cloud sync audit"
+echo "remote: ${remote}"
+echo "branch: ${branch:-detached}"
+echo "head: ${head_sha}"
+echo
+
+echo "Remote URLs"
+git remote -v | awk -v remote="$remote" '$1 == remote { print }'
+echo
+
+echo "Fetching remote refs and tags..."
+git fetch --prune --tags "$remote" >/dev/null
+echo
+
+echo "Worktree status"
+if git diff --quiet && git diff --cached --quiet && [ -z "$(git status --porcelain --untracked-files=all)" ]; then
+  echo "clean"
+else
+  git status --short --untracked-files=all
+fi
+echo
+
+echo "Current branch tracking"
+if [ -n "$branch" ] && upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)"; then
+  read -r behind ahead < <(git rev-list --left-right --count "$upstream...HEAD")
+  echo "${branch} tracks ${upstream}: ahead ${ahead}, behind ${behind}"
+else
+  echo "${branch:-detached HEAD} has no upstream"
+fi
+echo
+
+echo "Local branches with tracking divergence or no upstream"
+while read -r refname shortname upstream; do
+  if [ -z "$upstream" ]; then
+    echo "${shortname}: no upstream"
+    continue
+  fi
+
+  if ! git rev-parse --verify --quiet "$upstream" >/dev/null; then
+    echo "${shortname}: upstream ${upstream} is gone"
+    continue
+  fi
+
+  read -r behind ahead < <(git rev-list --left-right --count "$upstream...$refname")
+  if [ "$ahead" != "0" ] || [ "$behind" != "0" ]; then
+    echo "${shortname}: tracks ${upstream}, ahead ${ahead}, behind ${behind}"
+  fi
+done < <(git for-each-ref --format='%(refname) %(refname:short) %(upstream:short)' refs/heads)
+echo
+
+echo "Tag sync"
+local_tags="$(git tag --list | wc -l | tr -d ' ')"
+remote_tags="$(git ls-remote --refs --tags "$remote" | wc -l | tr -d ' ')"
+echo "local tags: ${local_tags}; remote tags: ${remote_tags}"


### PR DESCRIPTION
## Summary
- Rewrites the old contaminated reconstruction branch onto current main.
- Preserves only the still-useful local-to-cloud Git sync runbook and audit script from commit e7eb4d15.
- Drops the stale shared onboarding/conflict stack that is already superseded by main/closed PRs.

## Validation
- git diff --check
- bash -n scripts/git-cloud-sync-audit.sh
- scripts/git-cloud-sync-audit.sh origin smoke run

Part of WEI-1903 branch drain.