### PR TITLE
fix(wei-1932): reconcile retained backend worktrees

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -497,17 +497,18 @@ final class AppCore: ObservableObject {
         badgeCountService = nil
         db = nil
 
-        // 3. Delete the database file
-        try DeviceResetService.deleteDatabaseFile(atPath: dbPath)
+        // 3. Delete the database files and local backups
+        try DeviceResetService.deleteDatabaseStorage(atPath: dbPath)
 
-        // 4. Clear saved session and all onboarding UserDefaults flags so the
-        //    fresh DB is not skipped by stale "already completed" flags.
+        // 4. Clear saved session and app-scoped UserDefaults state so reset
+        //    cannot inherit drafts, sync flags, or onboarding progress.
         currentUser = nil
         currentToken = nil
         permissions = []
-        UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
-        UserDefaults.standard.removeObject(forKey: "hasCompletedCompanySetup")
-        UserDefaults.standard.removeObject(forKey: "hasSeenWelcome")
+        onboardingManager = nil
+        onboardAIRuntimeBootstrap = nil
+        badgeCountManager.setUserId(nil)
+        DeviceResetService.clearSavedAppState()
 
         // 5. Re-bootstrap — will detect no users/profile and set needsOnboarding = true
         isReady = false

--- a/core/Sources/WiredPartCore/Services/DeviceResetService.swift
+++ b/core/Sources/WiredPartCore/Services/DeviceResetService.swift
@@ -140,6 +140,32 @@ public final class DeviceResetService: Sendable {
         }
     }
 
+    /// Delete all database-owned local files, including local database backups.
+    /// Reset is a full local wipe, so leaving backup snapshots behind preserves
+    /// recoverable user data after the app returns to first-run setup.
+    public static func deleteDatabaseStorage(atPath path: String) throws {
+        try deleteDatabaseFile(atPath: path)
+
+        let fm = FileManager.default
+        let backupPath = (path as NSString).deletingLastPathComponent + "/Backups"
+        if fm.fileExists(atPath: backupPath) {
+            try fm.removeItem(atPath: backupPath)
+        }
+    }
+
+    /// Clear app-scoped defaults that survive SQLite deletion.
+    /// Passing a custom suite makes the behavior testable without touching
+    /// process-wide defaults.
+    public static func clearSavedAppState(
+        defaults: UserDefaults = .standard,
+        domainName: String? = Bundle.main.bundleIdentifier
+    ) {
+        if let domainName {
+            defaults.removePersistentDomain(forName: domainName)
+        }
+        defaults.synchronize()
+    }
+
     // MARK: - Admin Verification
 
     /// Verify that a user has admin-level permission to approve a reset.

--- a/core/Sources/WiredPartCore/Services/DeviceResetService.swift
+++ b/core/Sources/WiredPartCore/Services/DeviceResetService.swift
@@ -145,6 +145,8 @@ public final class DeviceResetService: Sendable {
     /// recoverable user data after the app returns to first-run setup.
     public static func deleteDatabaseStorage(atPath path: String) throws {
         try deleteDatabaseFile(atPath: path)
+        try deleteDatabaseFile(atPath: path + ".unencrypted.bak")
+        try deleteDatabaseFile(atPath: path + ".encrypted-tmp")
 
         let fm = FileManager.default
         let backupPath = (path as NSString).deletingLastPathComponent + "/Backups"
@@ -163,7 +165,6 @@ public final class DeviceResetService: Sendable {
         if let domainName {
             defaults.removePersistentDomain(forName: domainName)
         }
-        defaults.synchronize()
     }
 
     // MARK: - Admin Verification

--- a/core/Sources/WiredPartCore/Services/OrdersService.swift
+++ b/core/Sources/WiredPartCore/Services/OrdersService.swift
@@ -2687,6 +2687,17 @@ public final class OrdersService: Sendable {
                         """,
                     arguments: [poId, jpoLineId, partId, qty]
                 )
+                let poLineId = dbConn.lastInsertedRowID
+                try dbConn.execute(
+                    sql: """
+                        UPDATE jpo_line_items
+                        SET line_status = 'in_procurement',
+                            po_line_id = ?,
+                            status_updated_at = datetime('now')
+                        WHERE id = ? AND deleted_at IS NULL
+                        """,
+                    arguments: [poLineId, jpoLineId]
+                )
             }
 
             // Link PO to JPO (fixes #203: removed try? to propagate errors)

--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -11,9 +11,11 @@ import GRDB
 /// Ported from: Scheduling & Dispatch feature area (Phases 10, 16)
 public final class SchedulingService: Sendable {
     private let db: AppDatabase
+    private let auth: AuthService
 
-    public init(db: AppDatabase) {
+    public init(db: AppDatabase, auth: AuthService? = nil) {
         self.db = db
+        self.auth = auth ?? AuthService(db: db)
     }
 
     // =========================================================================
@@ -35,6 +37,7 @@ public final class SchedulingService: Sendable {
         case requiredFieldEmpty
         case jobNotFound(Int64)
         case userNotFound(Int64)
+        case insufficientPermissions(required: String)
     }
 
     // =========================================================================
@@ -513,6 +516,12 @@ public final class SchedulingService: Sendable {
             throw SchedulingError.invalidStatus(status)
         }
 
+        let requiredPermission = "approve_time_off"
+        guard let approvedBy,
+              try auth.hasPermission(approvedBy, permissionKey: requiredPermission) else {
+            throw SchedulingError.insufficientPermissions(required: requiredPermission)
+        }
+
         try db.writer.write { dbConn in
             // Verify the row exists and retrieve its request_group so we can
             // update every day in the same multi-day request atomically.
@@ -566,7 +575,7 @@ public final class SchedulingService: Sendable {
 
             // Build a WHERE clause that matches all days of the same request:
             // if request_group is set, target the whole group; otherwise just this row.
-            if status == "approved", let approvedBy {
+            if status == "approved" {
                 if let group = requestGroup {
                     try dbConn.execute(
                         sql: """

--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -511,9 +511,11 @@ public final class SchedulingService: Sendable {
         }
 
         let requiredPermission = "approve_time_off"
-        guard let approvedBy,
-              try auth.hasPermission(approvedBy, permissionKey: requiredPermission) else {
-            throw SchedulingError.insufficientPermissions(required: requiredPermission)
+        if status == "approved" || approvedBy != nil {
+            guard let approvedBy,
+                  try auth.hasPermission(approvedBy, permissionKey: requiredPermission) else {
+                throw SchedulingError.insufficientPermissions(required: requiredPermission)
+            }
         }
 
         try db.writer.write { dbConn in

--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -505,12 +505,6 @@ public final class SchedulingService: Sendable {
         status: String,
         approvedBy: Int64? = nil
     ) throws {
-        if let approvedBy {
-            try db.writer.read { dbConn in
-                try ServicePermissionGate.requirePermission(dbConn, userId: approvedBy, permissionKey: "approve_time_off")
-            }
-        }
-
         let validStatuses = ["pending", "approved", "denied", "cancelled"]
         guard validStatuses.contains(status) else {
             throw SchedulingError.invalidStatus(status)

--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -596,7 +596,7 @@ public final class SchedulingService: Sendable {
                     try dbConn.execute(
                         sql: """
                             UPDATE schedule_exceptions
-                            SET is_approved = ?
+                            SET is_approved = ?, approved_by = NULL, approved_at = NULL
                             WHERE request_group = ? AND exception_type = 'time_off' AND deleted_at IS NULL
                             """,
                         arguments: [isApproved, group]
@@ -605,7 +605,7 @@ public final class SchedulingService: Sendable {
                     try dbConn.execute(
                         sql: """
                             UPDATE schedule_exceptions
-                            SET is_approved = ?
+                            SET is_approved = ?, approved_by = NULL, approved_at = NULL
                             WHERE id = ? AND deleted_at IS NULL
                             """,
                         arguments: [isApproved, id]

--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -511,7 +511,8 @@ public final class SchedulingService: Sendable {
         }
 
         let requiredPermission = "approve_time_off"
-        if status == "approved" || approvedBy != nil {
+        let requiresApprovalActor = status == "approved" || status == "denied"
+        if requiresApprovalActor || approvedBy != nil {
             guard let approvedBy,
                   try auth.hasPermission(approvedBy, permissionKey: requiredPermission) else {
                 throw SchedulingError.insufficientPermissions(required: requiredPermission)

--- a/core/Tests/WiredPartCoreTests/DeviceResetServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/DeviceResetServiceTests.swift
@@ -231,6 +231,10 @@ struct DeviceResetServiceTests {
 
         try fm.createDirectory(at: backupDir, withIntermediateDirectories: true)
         fm.createFile(atPath: basePath, contents: Data("db".utf8))
+        fm.createFile(atPath: basePath + ".unencrypted.bak", contents: Data("plaintext backup".utf8))
+        fm.createFile(atPath: basePath + ".unencrypted.bak-wal", contents: Data("plaintext wal".utf8))
+        fm.createFile(atPath: basePath + ".encrypted-tmp", contents: Data("tmp db".utf8))
+        fm.createFile(atPath: basePath + ".encrypted-tmp-shm", contents: Data("tmp shm".utf8))
         fm.createFile(
             atPath: backupDir.appendingPathComponent("manual.sqlite").path,
             contents: Data("backup".utf8)
@@ -239,6 +243,10 @@ struct DeviceResetServiceTests {
         try DeviceResetService.deleteDatabaseStorage(atPath: basePath)
 
         #expect(!fm.fileExists(atPath: basePath))
+        #expect(!fm.fileExists(atPath: basePath + ".unencrypted.bak"))
+        #expect(!fm.fileExists(atPath: basePath + ".unencrypted.bak-wal"))
+        #expect(!fm.fileExists(atPath: basePath + ".encrypted-tmp"))
+        #expect(!fm.fileExists(atPath: basePath + ".encrypted-tmp-shm"))
         #expect(!fm.fileExists(atPath: backupDir.path))
 
         try? fm.removeItem(at: tmpDir)

--- a/core/Tests/WiredPartCoreTests/DeviceResetServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/DeviceResetServiceTests.swift
@@ -221,6 +221,52 @@ struct DeviceResetServiceTests {
         try DeviceResetService.deleteDatabaseFile(atPath: path)
     }
 
+    @Test("deleteDatabaseStorage removes local backups")
+    func testDeleteDatabaseStorageRemovesBackups() throws {
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("test-reset-storage-\(UUID().uuidString)", isDirectory: true)
+        let basePath = tmpDir.appendingPathComponent("wiredpart.sqlite").path
+        let backupDir = tmpDir.appendingPathComponent("Backups", isDirectory: true)
+        let fm = FileManager.default
+
+        try fm.createDirectory(at: backupDir, withIntermediateDirectories: true)
+        fm.createFile(atPath: basePath, contents: Data("db".utf8))
+        fm.createFile(
+            atPath: backupDir.appendingPathComponent("manual.sqlite").path,
+            contents: Data("backup".utf8)
+        )
+
+        try DeviceResetService.deleteDatabaseStorage(atPath: basePath)
+
+        #expect(!fm.fileExists(atPath: basePath))
+        #expect(!fm.fileExists(atPath: backupDir.path))
+
+        try? fm.removeItem(at: tmpDir)
+    }
+
+    @Test("clearSavedAppState removes persisted defaults")
+    func testClearSavedAppStateRemovesDefaults() throws {
+        let suiteName = "DeviceResetServiceTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        defaults.set(true, forKey: "hasCompletedOnboarding")
+        defaults.set(true, forKey: "hasCompletedCompanySetup")
+        defaults.set(Data("draft".utf8), forKey: "partsFlow_counts")
+        defaults.set("device-123", forKey: "com.wiredpart.deviceId")
+        defaults.set(true, forKey: "device_paired")
+
+        DeviceResetService.clearSavedAppState(defaults: defaults, domainName: suiteName)
+
+        #expect(defaults.object(forKey: "hasCompletedOnboarding") == nil)
+        #expect(defaults.object(forKey: "hasCompletedCompanySetup") == nil)
+        #expect(defaults.object(forKey: "partsFlow_counts") == nil)
+        #expect(defaults.object(forKey: "com.wiredpart.deviceId") == nil)
+        #expect(defaults.object(forKey: "device_paired") == nil)
+    }
+
     // MARK: - Admin Verification
 
     @Test("verifyAdminApproval returns true for admin user with correct PIN")

--- a/core/Tests/WiredPartCoreTests/E2ETestHelpers.swift
+++ b/core/Tests/WiredPartCoreTests/E2ETestHelpers.swift
@@ -47,7 +47,7 @@ struct E2ETestHelpers {
         let orders = OrdersService(db: db)
         let fleet = FleetService(db: db, auth: auth)
         let people = PeopleService(db: db)
-        let scheduling = SchedulingService(db: db)
+        let scheduling = SchedulingService(db: db, auth: auth)
         let chat = ChatService(db: db)
         let notebooks = NotebooksService(db: db)
         let reports = ReportsService(db: db)

--- a/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
@@ -458,8 +458,11 @@ struct OrdersServiceTests {
         let partId = try E2ETestHelpers.seedPart(env, name: "Generate PO Part", categoryId: catId)
 
         let jpoId = try env.orders.createJPO(jobId: jobId, requestedBy: env.adminUserId, notes: nil)
-        let lineId = try env.orders.addJPOLineItem(jpoId: jpoId, partId: partId, quantity: 4, notes: nil)
-        try env.orders.updateJPOLineStatus(lineId: lineId, status: "approved", updatedBy: env.adminUserId)
+        let lineId = try env.orders.addJPOLineItem(jpoId: jpoId, partId: partId, quantity: 7, notes: nil)
+        // Follow aggregate-level transitions before procurement generation so this
+        // covers the same approved-JPO workflow users run in the app.
+        try env.orders.updateJPOStatus(id: jpoId, status: "pending")
+        try env.orders.updateJPOStatus(id: jpoId, status: "approved")
 
         let poId = try env.orders.generatePOFromJPO(jpoId: jpoId, supplierId: supplierId)
         #expect(poId > 0)
@@ -470,6 +473,7 @@ struct OrdersServiceTests {
         let poDetail = try env.orders.getPODetail(id: poId)
         #expect(poDetail.lines.count == 1)
         #expect(poDetail.lines.first?.jpoLineId == lineId)
+        #expect(poDetail.lines.first?.quantityOrdered == 7)
 
         let jpoDetail = try env.orders.getJPODetail(id: jpoId)
         let generatedLine = try #require(jpoDetail.lines.first(where: { $0.id == lineId }))

--- a/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
@@ -454,17 +454,27 @@ struct OrdersServiceTests {
         let env = try E2ETestHelpers.setUp()
         let jobId = try E2ETestHelpers.seedJob(env)
         let supplierId = try E2ETestHelpers.seedSupplier(env)
+        let catId = try E2ETestHelpers.seedCategory(env, name: "GeneratePOCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Generate PO Part", categoryId: catId)
 
         let jpoId = try env.orders.createJPO(jobId: jobId, requestedBy: env.adminUserId, notes: nil)
-        // Must follow valid transitions: draft → pending → approved (fixes #205 validation)
-        try env.orders.updateJPOStatus(id: jpoId, status: "pending")
-        try env.orders.updateJPOStatus(id: jpoId, status: "approved")
+        let lineId = try env.orders.addJPOLineItem(jpoId: jpoId, partId: partId, quantity: 4, notes: nil)
+        try env.orders.updateJPOLineStatus(lineId: lineId, status: "approved", updatedBy: env.adminUserId)
 
         let poId = try env.orders.generatePOFromJPO(jpoId: jpoId, supplierId: supplierId)
         #expect(poId > 0)
 
         let pos = try env.orders.listPurchaseOrders()
         #expect(pos.contains(where: { $0.id == poId }))
+
+        let poDetail = try env.orders.getPODetail(id: poId)
+        #expect(poDetail.lines.count == 1)
+        #expect(poDetail.lines.first?.jpoLineId == lineId)
+
+        let jpoDetail = try env.orders.getJPODetail(id: jpoId)
+        let generatedLine = try #require(jpoDetail.lines.first(where: { $0.id == lineId }))
+        #expect(generatedLine.lineStatus == "in_procurement")
+        #expect(generatedLine.poLineId == poDetail.lines.first?.id)
     }
 
     // MARK: - Update Return Status

--- a/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
@@ -186,6 +186,13 @@ struct SchedulingServiceTests {
         let all = try env.scheduling.listTimeOffRequests(userId: env.adminUserId)
         #expect(all.count == 1)
         #expect(all[0].status == "pending") // is_approved = 0 maps to "pending" in the query
+
+        #expect(throws: SchedulingService.SchedulingError.insufficientPermissions(required: "approve_time_off")) {
+            try env.scheduling.updateTimeOffStatus(
+                id: requestId,
+                status: "denied"
+            )
+        }
     }
 
     @Test("updateTimeOffStatus throws for non-existent request")

--- a/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
@@ -2623,12 +2623,13 @@ struct SchedulingServiceTests {
             status: "pending"
         )
 
-        // Verify it's back to pending
+        // Verify it's back to pending and no stale approver is surfaced
         let requests = try env.scheduling.listTimeOffRequests(
             userId: env.adminUserId,
             status: "pending"
         )
         #expect(requests.count == 1)
+        #expect(requests.first?.approvedByName == nil)
     }
 
     // MARK: - Crew Utilization Caps at 1.0

--- a/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
@@ -121,6 +121,47 @@ struct SchedulingServiceTests {
         #expect(requests[0].approvedByName == "TestAdmin")
     }
 
+    @Test("updateTimeOffStatus throws insufficientPermissions when actor lacks approve_time_off")
+    func testUpdateTimeOffStatusRequiresApproveTimeOffPermission() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        let workerId = try env.db.writer.write { db -> Int64 in
+            try db.execute(sql: """
+                INSERT INTO users (display_name, pin_hash, is_active)
+                VALUES ('WorkerUser', 'hash123', 1)
+                """)
+            let userId = db.lastInsertedRowID
+            try db.execute(sql: """
+                INSERT INTO user_hats (user_id, hat_id, is_active)
+                SELECT ?, id, 1 FROM hats WHERE name = 'Worker'
+                """, arguments: [userId])
+            return userId
+        }
+
+        let requestId = try env.scheduling.createTimeOffRequest(
+            userId: env.adminUserId,
+            startDate: "2026-09-02",
+            endDate: "2026-09-02",
+            reason: "Permission gate regression"
+        )
+
+        #expect(throws: SchedulingService.SchedulingError.insufficientPermissions(required: "approve_time_off")) {
+            try env.scheduling.updateTimeOffStatus(
+                id: requestId,
+                status: "approved",
+                approvedBy: workerId
+            )
+        }
+
+        let row = try env.db.writer.read { db in
+            try Row.fetchOne(db, sql: """
+                SELECT is_approved, approved_by FROM schedule_exceptions WHERE id = ?
+                """, arguments: [requestId])
+        }
+        #expect(row?["is_approved"] as Int? == 0)
+        #expect((row?["approved_by"] as Int64?) == nil)
+    }
+
     // MARK: - 4. Reject Time-Off
 
     @Test("updateTimeOffStatus rejects (denies) a pending time-off request")
@@ -136,7 +177,8 @@ struct SchedulingServiceTests {
 
         try env.scheduling.updateTimeOffStatus(
             id: requestId,
-            status: "denied"
+            status: "denied",
+            approvedBy: env.adminUserId
         )
 
         // Denied requests have is_approved = 0, same as pending.
@@ -151,7 +193,7 @@ struct SchedulingServiceTests {
         let env = try E2ETestHelpers.setUp()
 
         #expect(throws: SchedulingService.SchedulingError.self) {
-            try env.scheduling.updateTimeOffStatus(id: 9999, status: "approved")
+            try env.scheduling.updateTimeOffStatus(id: 9999, status: "approved", approvedBy: env.adminUserId)
         }
     }
 
@@ -1273,7 +1315,7 @@ struct SchedulingServiceTests {
         )
 
         // Should not throw — "cancelled" is a valid status
-        try env.scheduling.updateTimeOffStatus(id: requestId, status: "cancelled")
+        try env.scheduling.updateTimeOffStatus(id: requestId, status: "cancelled", approvedBy: env.adminUserId)
 
         // After cancelling, is_approved = 0, which maps to "pending" in the query
         let requests = try env.scheduling.listTimeOffRequests(userId: env.adminUserId)
@@ -1962,7 +2004,8 @@ struct SchedulingServiceTests {
         // Deny the legacy row (hits the else branch at L488)
         try env.scheduling.updateTimeOffStatus(
             id: legacyId,
-            status: "denied"
+            status: "denied",
+            approvedBy: env.adminUserId
         )
 
         // Verify is_approved is still 0


### PR DESCRIPTION
## Summary
- Cherry-picks/preserves useful WEI-353 JPO->PO line status behavior and coverage on top of current main
- Preserves WEI-368 time-off approval permission coverage while keeping non-approval status resets valid
- Preserves WEI-686 reset storage cleanup for app state, local backups, and default-app storage

## Reconciled source branches/worktrees
- WEI-353-fix-jpo-line-status / wei-353-jpo-line-status
- fix/wei-368-dispatch-time-off
- WEI-686-the-app-reset-deletion-of-the-bild-is-not-deleting-the-saved-data-this-neede-s-to-be-fixed

## Test Plan
- swift test --package-path /private/tmp/wei-1932-reconcile/core --filter 'OrdersServiceTests/testGeneratePOFromJPO|SchedulingServiceTests|DeviceResetServiceTests'

Closes Paperclip WEI-1932