### PR TITLE
Fix warehouse clock-in/out flow

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
@@ -1153,8 +1153,8 @@ struct IOSClockPage: View {
                 logger.info("Calling service.clockIn(userId: \(userId), jobId: \(jobId ?? 0))")
 
                 if isShop {
-                    // Clock in to Shop/Warehouse (jobId = 0 or a special "shop" job)
-                    try service.clockIn(userId: userId, jobId: jobId ?? 0, gpsLat: lat, gpsLng: lng)
+                    // Clock in to Shop/Warehouse through the internal warehouse time bucket.
+                    try service.clockInToWarehouse(userId: userId, gpsLat: lat, gpsLng: lng)
                     isShopClockIn = true
                     geofenceManager.stopMonitoring()
                 } else if let jid = jobId {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSQuestionnairePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSQuestionnairePage.swift
@@ -73,12 +73,6 @@ struct IOSQuestionnairePage: View {
         if isLoading {
             ProgressView("Loading questions...")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if questions.isEmpty && companionPolls.isEmpty {
-            EmptyStateView(
-                icon: "questionmark.circle",
-                title: "No Questions",
-                message: "No clock-out questions are configured. You can close this screen."
-            )
         } else {
             List {
                 // Error banner
@@ -92,9 +86,15 @@ struct IOSQuestionnairePage: View {
 
                 // Instructions
                 Section {
-                    Text("Please answer the following questions before clocking out.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    if questions.isEmpty && companionPolls.isEmpty {
+                        Label("No configured questions today. Submit after confirming your breaks.", systemImage: "questionmark.circle")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("Please answer the following questions before clocking out.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
 
                 // Question list

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -11,6 +11,8 @@ import GRDB
 /// Ported from: Jobs & Labor feature area (Phases 4, 4.5, 15)
 public final class JobsService: Sendable {
     private let db: AppDatabase
+    private static let warehouseClockJobNumber = "__SHOP_WAREHOUSE__"
+    private static let warehouseClockJobName = "Shop / Warehouse"
 
     public init(db: AppDatabase) {
         self.db = db
@@ -970,6 +972,45 @@ public final class JobsService: Sendable {
                     VALUES (?, ?, datetime('now'), ?, ?, 'clocked_in', datetime('now'))
                     """,
                 arguments: [userId, jobId, gpsLat, gpsLng]
+            )
+            return dbConn.lastInsertedRowID
+        }
+    }
+
+    /// Clock a user into the internal Shop / Warehouse time bucket.
+    ///
+    /// The labor_entries schema requires a job_id, while the iOS clock page
+    /// exposes Shop / Warehouse as a pinned non-job option. This method bridges
+    /// that gap by creating/reusing a hidden active job row that is not shown in
+    /// the normal clock job picker, then creating the labor entry against it.
+    @discardableResult
+    public func clockInToWarehouse(
+        userId: Int64,
+        gpsLat: Double? = nil,
+        gpsLng: Double? = nil
+    ) throws -> Int64 {
+        try db.writer.write { dbConn in
+            let existing = try Int.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT COUNT(*) FROM labor_entries
+                    WHERE user_id = ? AND status = 'clocked_in' AND deleted_at IS NULL
+                    """,
+                arguments: [userId]
+            ) ?? 0
+
+            if existing > 0 {
+                throw JobsError.alreadyClockedIn(userId: userId, jobId: 0)
+            }
+
+            let warehouseJobId = try Self.ensureWarehouseClockJob(dbConn: dbConn, createdBy: userId)
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_in_gps_lat, clock_in_gps_lng, status, created_at)
+                    VALUES (?, ?, datetime('now'), ?, ?, 'clocked_in', datetime('now'))
+                    """,
+                arguments: [userId, warehouseJobId, gpsLat, gpsLng]
             )
             return dbConn.lastInsertedRowID
         }
@@ -2021,9 +2062,11 @@ public final class JobsService: Sendable {
                                     THEN ', ' || city ELSE '' END AS full_address,
                            gps_lat, gps_lng, status
                     FROM jobs
-                    WHERE status IN ('active', 'in_progress') AND deleted_at IS NULL
+                    WHERE status IN ('active', 'in_progress')
+                      AND deleted_at IS NULL
+                      AND job_number != ?
                     ORDER BY job_name ASC
-                    """)
+                    """, arguments: [Self.warehouseClockJobNumber])
                 return rows.map { row in
                     ClockJobRow(
                         id: row["id"] ?? 0,
@@ -2070,6 +2113,33 @@ public final class JobsService: Sendable {
             if isTableNotFoundError(error) { return 0.0 }
             throw error
         }
+    }
+
+    private static func ensureWarehouseClockJob(dbConn: Database, createdBy: Int64?) throws -> Int64 {
+        if let id = try Int64.fetchOne(
+            dbConn,
+            sql: "SELECT id FROM jobs WHERE job_number = ? AND deleted_at IS NULL LIMIT 1",
+            arguments: [warehouseClockJobNumber]
+        ) {
+            return id
+        }
+
+        try dbConn.execute(
+            sql: """
+                INSERT INTO jobs
+                (job_number, job_name, customer_name, status, priority, job_type,
+                 created_by, notes, job_classification, created_at, updated_at)
+                VALUES (?, ?, ?, 'active', 'normal', 'internal', ?, ?, 'internal', datetime('now'), datetime('now'))
+                """,
+            arguments: [
+                warehouseClockJobNumber,
+                warehouseClockJobName,
+                "Internal",
+                createdBy,
+                "Internal time bucket for Shop / Warehouse clock entries."
+            ]
+        )
+        return dbConn.lastInsertedRowID
     }
 
     /// List active/in-progress jobs, optionally excluding a specific job ID.

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -177,6 +177,18 @@ struct JobsServiceTests {
         #expect(afterClockOut.first?.clockOut != nil)
     }
 
+    @Test("Warehouse clock in creates current shop entry")
+    func testWarehouseClockInCreatesCurrentShopEntry() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        let laborEntryId = try env.jobs.clockInToWarehouse(userId: env.adminUserId)
+        let active = try env.jobs.getActiveClockEntry(userId: env.adminUserId)
+
+        #expect(laborEntryId > 0)
+        #expect(active?.id == laborEntryId)
+        #expect(active?.jobName == "Shop / Warehouse")
+    }
+
     @Test("Labor summary after clock in/out")
     func testLaborSummary() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Add a dedicated JobsService warehouse clock-in path that creates/reuses an internal Shop / Warehouse job instead of trying to clock into job id 0.
- Update the iOS clock page to use that warehouse path, preserving current-job transparency after clock-in.
- Keep the clock-out questionnaire visible even when there are no configured custom questions so break/end-of-day verification still appears.
- Add regression coverage for warehouse clock-in creating the active Shop / Warehouse entry.

Fixes #599

## Verification
- swift test --filter JobsServiceTests/testWarehouseClockInCreatesCurrentShopEntry
- swift test --filter JobsServiceTests