### PR TITLE
feat(warehouse): salvage dashboard UX without artifacts

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
@@ -11,6 +11,8 @@ private let auditLog = Logger(subsystem: "com.wiredpart", category: "warehouse.a
 /// count flow with hidden system counts, speed mode, misplaced part handling.
 struct IOSAuditPage: View {
     @EnvironmentObject private var appCore: AppCore
+    private static let multiUserFixtureFlag = "-UITestingMultiUserVerificationFixture"
+    private static let multiUserFixturePartCode = "UITEST-MUV-001"
 
     // MARK: - State
 
@@ -28,6 +30,7 @@ struct IOSAuditPage: View {
     @State private var recentSessions: [AuditSessionV2] = []
     @State private var warehouseScore: Double = 5.0
     @State private var activeCounts: [AuditCount] = []
+    @State private var selectedItemForVerification: CountingItem?
 
     // Count flow
     @State private var activeSession: AuditSessionV2?
@@ -49,7 +52,7 @@ struct IOSAuditPage: View {
 
     private enum ActiveSheet: Identifiable {
         case auditSetup
-        case misplacedPart
+        case misplacedPart(partId: Int64?, areaId: Int64?)
         case countDetail(CountResult)
         case sessionSummary(AuditSessionV2)
         case help
@@ -57,7 +60,7 @@ struct IOSAuditPage: View {
         var id: String {
             switch self {
             case .auditSetup: "setup"
-            case .misplacedPart: "misplaced"
+            case .misplacedPart(let partId, let areaId): "misplaced-\(partId ?? 0)-\(areaId ?? 0)"
             case .countDetail: "countDetail"
             case .sessionSummary(let s): "summary-\(s.id ?? 0)"
             case .help: "help"
@@ -150,6 +153,13 @@ struct IOSAuditPage: View {
         .sheet(item: $activeSheet) { sheet in
             sheetContent(for: sheet)
         }
+        .sheet(item: $selectedItemForVerification) { item in
+            QueueSendForVerificationSheet(item: item, sessionId: activeSession?.id) {
+                selectedItemForVerification = nil
+                loadData()
+            }
+            .environmentObject(appCore)
+        }
         .alert("Error", isPresented: Binding(
             get: { actionError != nil },
             set: { if !$0 { actionError = nil } }
@@ -178,8 +188,12 @@ struct IOSAuditPage: View {
                 loadData()
             })
             .environmentObject(appCore)
-        case .misplacedPart:
-            MisplacedPartSheet { loadData() }
+        case .misplacedPart(let partId, let areaId):
+            MisplacedPartSheet(
+                candidates: buildQueue(),
+                initialPartId: partId,
+                initialAreaId: areaId
+            ) { loadData() }
                 .environmentObject(appCore)
         case .countDetail(let result):
             CountResultSheet(result: result) {
@@ -338,6 +352,21 @@ struct IOSAuditPage: View {
                                 .onTapGesture {
                                     startCounting(item)
                                 }
+                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                    Button {
+                                        selectedItemForVerification = item
+                                    } label: {
+                                        Label("Verify", systemImage: "person.2.badge.gearshape")
+                                    }
+                                    .tint(.orange)
+                                }
+                                .contextMenu {
+                                    Button {
+                                        selectedItemForVerification = item
+                                    } label: {
+                                        Label("Verify", systemImage: "person.2.badge.gearshape")
+                                    }
+                                }
                         }
 
                         if activeSession != nil {
@@ -371,7 +400,7 @@ struct IOSAuditPage: View {
             if activeSession != nil {
                 Section {
                     Button {
-                        activeSheet = .misplacedPart
+                        activeSheet = .misplacedPart(partId: nil, areaId: nil)
                     } label: {
                         Label("+ Found Misplaced Part", systemImage: "exclamationmark.triangle")
                             .font(.subheadline)
@@ -379,6 +408,38 @@ struct IOSAuditPage: View {
                     }
                     .buttonStyle(.bordered)
                     .tint(.orange)
+                }
+            }
+
+            if isMultiUserVerificationFixtureEnabled {
+                Section("QA Fixture") {
+                    if let fixtureItem = fixtureVerificationItem {
+                        VStack(alignment: .leading, spacing: 10) {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(fixtureItem.partName)
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                Text(fixtureItem.partCode ?? Self.multiUserFixturePartCode)
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundStyle(.secondary)
+                            }
+                            Button {
+                                selectedItemForVerification = fixtureItem
+                            } label: {
+                                Label("Verify Fixture Part", systemImage: "person.2.badge.gearshape")
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(.orange)
+                            .accessibilityIdentifier("qaFixtureVerifyButton")
+                        }
+                        .accessibilityIdentifier("qaFixturePartRow")
+                    } else {
+                        Text("Fixture part \(Self.multiUserFixturePartCode) is not available in this audit queue yet.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .accessibilityIdentifier("qaFixturePartMissingMessage")
+                    }
                 }
             }
 
@@ -653,7 +714,7 @@ struct IOSAuditPage: View {
                     .buttonStyle(.bordered)
 
                     Button {
-                        activeSheet = .misplacedPart
+                        activeSheet = .misplacedPart(partId: item.partId, areaId: item.areaId)
                     } label: {
                         Label("Report Issue", systemImage: "flag")
                             .font(.subheadline)
@@ -705,7 +766,7 @@ struct IOSAuditPage: View {
 
                         Button {
                             recordWalkingPathEvent(type: "count_reported", notes: "Reported count issue at empty walking-path stop")
-                            activeSheet = .misplacedPart
+                            activeSheet = .misplacedPart(partId: nil, areaId: areaId)
                         } label: {
                             Label("Report Count", systemImage: "flag")
                         }
@@ -719,6 +780,21 @@ struct IOSAuditPage: View {
                                 .contentShape(Rectangle())
                                 .onTapGesture {
                                     startCounting(item)
+                                }
+                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                    Button {
+                                        selectedItemForVerification = item
+                                    } label: {
+                                        Label("Verify", systemImage: "person.2.badge.gearshape")
+                                    }
+                                    .tint(.orange)
+                                }
+                                .contextMenu {
+                                    Button {
+                                        selectedItemForVerification = item
+                                    } label: {
+                                        Label("Verify", systemImage: "person.2.badge.gearshape")
+                                    }
                                 }
                         }
                     }
@@ -734,7 +810,7 @@ struct IOSAuditPage: View {
 
                         Button {
                             recordWalkingPathEvent(type: "deviation_reported", notes: "Reported issue during walking-path stop")
-                            activeSheet = .misplacedPart
+                            activeSheet = .misplacedPart(partId: nil, areaId: areaId)
                         } label: {
                             Label("Report Issue", systemImage: "flag")
                         }
@@ -875,6 +951,17 @@ struct IOSAuditPage: View {
         case .soon: return all.filter { $0.confidence >= 80 && $0.confidence < 90 }.count
         case .good: return all.filter { $0.confidence >= 90 }.count
         case .noLocation: return all.filter { $0.locationCode.isEmpty || $0.locationCode == "—" }.count
+        }
+    }
+
+    private var isMultiUserVerificationFixtureEnabled: Bool {
+        ProcessInfo.processInfo.arguments.contains(Self.multiUserFixtureFlag)
+    }
+
+    private var fixtureVerificationItem: CountingItem? {
+        buildQueue().first {
+            $0.partCode == Self.multiUserFixturePartCode ||
+            $0.partName == "UITest Verification Part"
         }
     }
 
@@ -1037,8 +1124,14 @@ struct IOSAuditPage: View {
     }
 
     private func recordWalkingPathEvent(type: String, notes: String? = nil) {
-        guard let service = appCore.warehouseService,
-              let sessionId = activeSession?.id else { return }
+        guard let service = appCore.warehouseService else {
+            auditLog.error("recordAuditSessionEvent skipped: warehouse service unavailable")
+            return
+        }
+        guard let sessionId = activeSession?.id else {
+            auditLog.error("recordAuditSessionEvent skipped: no active audit session")
+            return
+        }
         do {
             try service.recordAuditSessionEvent(
                 sessionId: sessionId,
@@ -1202,6 +1295,11 @@ struct IOSAuditPage: View {
                     partNameCache[conf.partId] = name
                 }
             }
+            if partCodeCache[conf.partId] == nil {
+                if let code = try? service.getPartCode(partId: conf.partId) {
+                    partCodeCache[conf.partId] = code
+                }
+            }
             if locationCodeCache[conf.areaId] == nil {
                 if let code = try? service.generateFullLocationCode(areaId: conf.areaId) {
                     locationCodeCache[conf.areaId] = code
@@ -1244,17 +1342,109 @@ struct IOSAuditPage: View {
     }
 }
 
+private struct QueueSendForVerificationSheet: View {
+    @EnvironmentObject private var appCore: AppCore
+    @Environment(\.dismiss) private var dismiss
+
+    let item: IOSAuditPage.CountingItem
+    let sessionId: Int64?
+    let onSent: () -> Void
+
+    @State private var requiredCounts = 2
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Part") {
+                    LabeledContent("Part", value: item.partName)
+                    if let code = item.partCode, !code.isEmpty {
+                        LabeledContent("Code", value: code)
+                    }
+                    LabeledContent("Location", value: item.locationCode)
+                    LabeledContent("Expected", value: "\(item.systemCount)")
+                }
+
+                Section("Verification") {
+                    Stepper("Required counters: \(requiredCounts)", value: $requiredCounts, in: 2...3)
+                    Text("Counters are assigned automatically from eligible active users.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Send for Verification")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Send") { submit() }
+                            .fontWeight(.semibold)
+                    }
+                }
+            }
+            .interactiveDismissDisabled(isSaving)
+        }
+    }
+
+    private func submit() {
+        guard let service = appCore.warehouseService,
+              let userId = appCore.currentUser?.id else {
+            errorMessage = "Service or user unavailable."
+            return
+        }
+
+        isSaving = true
+        errorMessage = nil
+        do {
+            _ = try service.flagForMultiUserAudit(
+                partId: item.partId,
+                expectedQty: item.systemCount,
+                sessionId: sessionId,
+                flaggedBy: userId,
+                requiredCounts: requiredCounts
+            )
+            onSent()
+            dismiss()
+        } catch WarehouseService.WarehouseError.invalidQuantity {
+            errorMessage = "Expected quantity must be 0 or greater."
+        } catch {
+            errorMessage = userFriendlyError(error, context: "send for multi-user verification")
+        }
+        isSaving = false
+    }
+}
+
 // MARK: - Misplaced Part Sheet
 
 private struct MisplacedPartSheet: View {
     @EnvironmentObject private var appCore: AppCore
     @Environment(\.dismiss) private var dismiss
 
+    let candidates: [IOSAuditPage.CountingItem]
+    let initialPartId: Int64?
+    let initialAreaId: Int64?
     let onSave: () -> Void
 
-    @State private var partName = ""
+    @State private var selectedPartId: Int64?
+    @State private var foundAtAreaId: Int64?
+    @State private var homeAreaId: Int64?
     @State private var qtyFound = 1
-    @State private var resolution: String = "carted"
+    @State private var resolution: String = "sort_later"
     @State private var isSaving = false
     @State private var errorMessage: String?
 
@@ -1262,14 +1452,32 @@ private struct MisplacedPartSheet: View {
         NavigationStack {
             Form {
                 Section("Misplaced Part") {
-                    TextField("Part name or scan", text: $partName)
+                    Picker("Part", selection: $selectedPartId) {
+                        Text("Select Part").tag(Int64?.none)
+                        ForEach(candidates, id: \.partId) { item in
+                            Text(item.partCode.map { "\(item.partName) (\($0))" } ?? item.partName)
+                                .tag(Int64?.some(item.partId))
+                        }
+                    }
+                    Picker("Found At", selection: $foundAtAreaId) {
+                        Text("Select Area").tag(Int64?.none)
+                        ForEach(uniqueAreas, id: \.id) { area in
+                            Text(area.label).tag(Int64?.some(area.id))
+                        }
+                    }
+                    Picker("Correct Location", selection: $homeAreaId) {
+                        Text("Sort Later").tag(Int64?.none)
+                        ForEach(uniqueAreas, id: \.id) { area in
+                            Text(area.label).tag(Int64?.some(area.id))
+                        }
+                    }
                     Stepper("Quantity: \(qtyFound)", value: $qtyFound, in: 1...999)
                 }
 
                 Section("What to do?") {
                     Picker("Resolution", selection: $resolution) {
-                        Text("Cart (sort later)").tag("carted")
-                        Text("Leave here").tag("left_here")
+                        Text("Add to cart / sort later").tag("sort_later")
+                        Text("Quick fix here").tag("quick_fix")
                         Text("Move to home").tag("moved_to_home")
                     }
                     .pickerStyle(.inline)
@@ -1293,30 +1501,60 @@ private struct MisplacedPartSheet: View {
                     } else {
                         Button("Save") { saveMisplaced() }
                             .fontWeight(.semibold)
-                            .disabled(partName.isEmpty)
+                            .disabled(selectedPartId == nil || foundAtAreaId == nil)
                     }
                 }
             }
+            .onAppear(perform: configureInitialSelection)
+        }
+    }
+
+    private var uniqueAreas: [(id: Int64, label: String)] {
+        var seen: Set<Int64> = []
+        return candidates.compactMap { item in
+            guard !seen.contains(item.areaId) else { return nil }
+            seen.insert(item.areaId)
+            return (item.areaId, item.locationCode)
+        }
+    }
+
+    private func configureInitialSelection() {
+        if selectedPartId == nil {
+            selectedPartId = initialPartId ?? candidates.first?.partId
+        }
+        if foundAtAreaId == nil {
+            foundAtAreaId = initialAreaId ?? candidates.first(where: { $0.partId == selectedPartId })?.areaId
+        }
+        if homeAreaId == nil, resolution != "sort_later" {
+            homeAreaId = candidates.first(where: { $0.partId == selectedPartId })?.areaId
         }
     }
 
     private func saveMisplaced() {
         guard let service = appCore.warehouseService,
-              let userId = appCore.currentUser?.id else {
+              let userId = appCore.currentUser?.id,
+              let partId = selectedPartId,
+              let foundAtAreaId else {
             errorMessage = "Service unavailable"
             return
         }
         isSaving = true
         errorMessage = nil
         do {
-            // Log with placeholder IDs — in production would resolve from search
-            try service.logMisplacedPart(
-                partId: 0,
-                foundAtAreaId: 0,
-                homeAreaId: nil,
+            let log = try service.logMisplacedPart(
+                partId: partId,
+                foundAtAreaId: foundAtAreaId,
+                homeAreaId: homeAreaId,
                 qtyFound: qtyFound,
                 foundBy: userId
             )
+            if resolution != "sort_later" {
+                try service.resolveMisplacedPart(
+                    logId: log.id!,
+                    resolution: resolution,
+                    resolvedBy: userId
+                )
+            }
             try service.updateUserRating(userId: userId, action: "misplacement_find")
             dismiss()
             onSave()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
@@ -1420,8 +1420,6 @@ private struct QueueSendForVerificationSheet: View {
             )
             onSent()
             dismiss()
-        } catch WarehouseService.WarehouseError.invalidQuantity {
-            errorMessage = "Expected quantity must be 0 or greater."
         } catch {
             errorMessage = userFriendlyError(error, context: "send for multi-user verification")
         }
@@ -1454,7 +1452,7 @@ private struct MisplacedPartSheet: View {
                 Section("Misplaced Part") {
                     Picker("Part", selection: $selectedPartId) {
                         Text("Select Part").tag(Int64?.none)
-                        ForEach(candidates, id: \.partId) { item in
+                        ForEach(uniqueParts, id: \.partId) { item in
                             Text(item.partCode.map { "\(item.partName) (\($0))" } ?? item.partName)
                                 .tag(Int64?.some(item.partId))
                         }
@@ -1509,6 +1507,15 @@ private struct MisplacedPartSheet: View {
         }
     }
 
+    private var uniqueParts: [IOSAuditPage.CountingItem] {
+        var seen: Set<Int64> = []
+        return candidates.filter { item in
+            guard !seen.contains(item.partId) else { return false }
+            seen.insert(item.partId)
+            return true
+        }
+    }
+
     private var uniqueAreas: [(id: Int64, label: String)] {
         var seen: Set<Int64> = []
         return candidates.compactMap { item in
@@ -1532,10 +1539,12 @@ private struct MisplacedPartSheet: View {
 
     private func saveMisplaced() {
         guard let service = appCore.warehouseService,
-              let userId = appCore.currentUser?.id,
-              let partId = selectedPartId,
-              let foundAtAreaId else {
-            errorMessage = "Service unavailable"
+              let userId = appCore.currentUser?.id else {
+            errorMessage = "Service or user unavailable."
+            return
+        }
+        guard let partId = selectedPartId, let foundAtAreaId else {
+            errorMessage = "Select a part and found-at area before saving."
             return
         }
         isSaving = true
@@ -1549,8 +1558,13 @@ private struct MisplacedPartSheet: View {
                 foundBy: userId
             )
             if resolution != "sort_later" {
+                guard let logId = log.id else {
+                    errorMessage = "Misplaced-part log was saved without an ID. Refresh and try again."
+                    isSaving = false
+                    return
+                }
                 try service.resolveMisplacedPart(
-                    logId: log.id!,
+                    logId: logId,
                     resolution: resolution,
                     resolvedBy: userId
                 )

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
@@ -17,7 +17,7 @@ struct WarehouseDashboardPage: View {
     @State private var dashKPIs: WarehouseService.DashboardKPIs?
     @State private var auditSummary: WarehouseService.AuditSummary?
     @State private var auditCards: WarehouseService.DashboardSmartCardSummary?
-    @State private var warehouseScore: WarehouseService.WarehouseOverallScore?
+    @State private var warehouseScore: Double?
     @State private var recentMovements: [WarehouseService.MovementRow] = []
     @State private var activeReceivingSessions: [WarehouseService.ReceivingSessionInfo] = []
     @State private var auditQueue: [WarehouseService.AuditQueueItem] = []
@@ -56,7 +56,9 @@ struct WarehouseDashboardPage: View {
         let color: Color
         let identifier: String
         let moduleId: String?
+        let tabId: String?
         let sheet: ActiveSheet?
+        let requiredPermission: String?
 
         var id: String { identifier }
     }
@@ -271,8 +273,9 @@ struct WarehouseDashboardPage: View {
 
     @ViewBuilder
     private var alertsWarningsBanner: some View {
-        let auditDue = auditCards?.auditDue ?? auditQueue.count
-        let lowConfidenceAreas = auditCards?.lowConfidenceAreas ?? 0
+        let canPerformAudit = appCore.hasPermission("perform_audit")
+        let auditDue = canPerformAudit ? (auditCards?.auditDue ?? auditQueue.count) : 0
+        let lowConfidenceAreas = canPerformAudit ? (auditCards?.lowConfidenceAreas ?? 0) : 0
         let lowStockWarnings = auditCards?.lowStockWarnings ?? dashKPIs?.kpis.shortfallCount ?? 0
         let activeReceiving = auditCards?.activeReceiving ?? activeReceivingSessions.count
 
@@ -487,9 +490,9 @@ struct WarehouseDashboardPage: View {
         ], spacing: 12) {
             miniKPI(
                 title: "Audit Score",
-                value: "\(Int((warehouseScore?.score ?? 100).rounded()))%",
+                value: "\(Int(warehouseScorePercent.rounded()))%",
                 icon: "gauge.with.dots.needle.bottom.50percent",
-                color: scoreColor(warehouseScore?.score ?? 100)
+                color: scoreColor(warehouseScorePercent)
             )
             miniKPI(title: "Total Stock", value: "\(totalStock)", icon: "shippingbox.fill", color: .blue)
             miniKPI(
@@ -574,7 +577,9 @@ struct WarehouseDashboardPage: View {
                 color: .blue,
                 identifier: "whAction_newMovement",
                 moduleId: nil,
-                sheet: .newMovement
+                tabId: nil,
+                sheet: .newMovement,
+                requiredPermission: nil
             ),
             WarehouseQuickAction(
                 title: "Scan QR",
@@ -582,23 +587,29 @@ struct WarehouseDashboardPage: View {
                 color: .orange,
                 identifier: "whAction_scanQR",
                 moduleId: nil,
-                sheet: .qrScanner
+                tabId: nil,
+                sheet: .qrScanner,
+                requiredPermission: nil
             ),
             WarehouseQuickAction(
                 title: "Receiving",
                 icon: "arrow.down.circle",
                 color: .green,
                 identifier: "whAction_receiving",
-                moduleId: "warehouse-receiving",
-                sheet: nil
+                moduleId: "warehouse",
+                tabId: "warehouse-receiving",
+                sheet: nil,
+                requiredPermission: nil
             ),
             WarehouseQuickAction(
                 title: "Audit Queue",
                 icon: "clipboard.fill",
                 color: .orange,
                 identifier: "whAction_auditQueue",
-                moduleId: "warehouse-audit",
-                sheet: nil
+                moduleId: "warehouse",
+                tabId: "warehouse-audit",
+                sheet: nil,
+                requiredPermission: "perform_audit"
             ),
         ]
     }
@@ -609,29 +620,36 @@ struct WarehouseDashboardPage: View {
         }
     }
 
+    @ViewBuilder
     private func quickActionTile(_ action: WarehouseQuickAction) -> some View {
-        Button { performQuickAction(action) } label: {
-            quickActionButton(
-                title: action.title,
-                icon: action.icon,
-                color: action.color
-            )
+        let tile = Button { performQuickAction(action) } label: {
+            quickActionButton(title: action.title, icon: action.icon, color: action.color)
         }
-        .buttonStyle(.plain)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(action.title)
-        .accessibilityAddTraits(.isButton)
-        .accessibilityIdentifier(action.identifier)
+            .buttonStyle(.plain)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(action.title)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityIdentifier(action.identifier)
+
+        if let requiredPermission = action.requiredPermission {
+            tile.hideWithoutPermission(requiredPermission)
+        } else {
+            tile
+        }
     }
 
     private func performQuickAction(_ action: WarehouseQuickAction) {
         if let sheet = action.sheet {
             activeSheet = sheet
         } else if let moduleId = action.moduleId {
+            var userInfo: [String: Any] = ["moduleId": moduleId]
+            if let tabId = action.tabId {
+                userInfo["tabId"] = tabId
+            }
             NotificationCenter.default.post(
                 name: .navigateToModule,
                 object: nil,
-                userInfo: ["moduleId": moduleId]
+                userInfo: userInfo
             )
         }
     }
@@ -673,12 +691,12 @@ struct WarehouseDashboardPage: View {
                 subPageLink(title: "Inventory", icon: "square.grid.3x3.fill", color: .purple, tabId: "warehouse-inventory")
                 subPageLink(title: "Locations", icon: "map.fill", color: .mint, tabId: "warehouse-locations")
                 subPageLink(title: "Audit", icon: "checkmark.shield.fill", color: .orange, tabId: "warehouse-audit")
+                    .hideWithoutPermission("perform_audit")
                 subPageLink(title: "Returns", icon: "arrow.uturn.left", color: .indigo, tabId: "warehouse-returns")
                 subPageLink(title: "Tools", icon: "wrench.and.screwdriver.fill", color: .brown, tabId: "warehouse-tools")
                 subPageLink(title: "Leaderboard", icon: "trophy.fill", color: .yellow, tabId: "warehouse-leaderboard")
                 subPageLink(title: "Network", icon: "antenna.radiowaves.left.and.right", color: .cyan, tabId: "warehouse-network")
                 subPageLink(title: "Settings", icon: "gearshape.fill", color: .gray, tabId: "warehouse-settings")
-                subPageLink(title: "Org Audit", icon: "tag.fill", color: .red, tabId: "warehouse-organization")
             }
         }
     }
@@ -1038,7 +1056,7 @@ struct WarehouseDashboardPage: View {
             dashKPIs = try service.getDashboardKPIs()
             auditSummary = try service.getAuditSummary()
             auditCards = try service.getDashboardSmartCardSummary()
-            warehouseScore = try service.getWarehouseOverallScoreBreakdown()
+            warehouseScore = try service.getWarehouseOverallScore()
             recentMovements = try service.listMovements(limit: 10)
             activeReceivingSessions = try service.getActiveSessions()
             auditQueue = try service.getAuditQueue(limit: 10)
@@ -1061,7 +1079,7 @@ struct WarehouseDashboardPage: View {
         Stock total: \(kpis?.totalStock ?? 0), health: \(kpis?.stockHealthPercent ?? 0)%, shortfalls: \(kpis?.shortfallCount ?? 0), movements today: \(kpis?.todayMovements ?? 0).
         Active receiving sessions: \(dashKPIs?.activeReceivingSessions ?? 0), pending staging: \(dashKPIs?.pendingStagingCount ?? 0), pending returns: \(dashKPIs?.pendingReturns ?? 0).
         Audit counted/total: \(auditSummary?.countedParts ?? 0)/\(auditSummary?.totalParts ?? 0), discrepancies: \(auditSummary?.discrepancies ?? 0), selected filter: \(selectedFilter?.rawValue ?? "none").
-        Warehouse audit score: \(Int((warehouseScore?.score ?? 100).rounded()))%, confidence risk areas: \(auditCards?.lowConfidenceAreas ?? 0), active audits: \(auditCards?.activeAuditSessions ?? 0), organization issues: \(auditCards?.organizationIssues ?? 0).
+        Warehouse audit score: \(Int(warehouseScorePercent.rounded()))%, confidence risk areas: \(auditCards?.lowConfidenceAreas ?? 0), audit due: \(auditCards?.auditDue ?? 0), low-stock warnings: \(auditCards?.lowStockWarnings ?? 0).
         Dashboard queues loaded: \(todaysMovements.count) moves today, \(activeReceivingSessions.count) receiving active, \(auditQueue.count) audit due, \(stagedItems.count) staged ready. Movement types: \(movementCounts.isEmpty ? "none" : movementCounts).
         Available read-only guidance: explain KPI cards, audit score components, selected activity filter, quick action locations, and warehouse sub-page links. Do not create movements or launch scanners directly.
         """
@@ -1100,6 +1118,10 @@ struct WarehouseDashboardPage: View {
         if score >= 85 { return .green }
         if score >= 70 { return .orange }
         return .red
+    }
+
+    private var warehouseScorePercent: Double {
+        max(0, min(100, (warehouseScore ?? 10.0) * 10.0))
     }
 
     private func movementLabel(_ type: String) -> String {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
@@ -1,33 +1,37 @@
 import SwiftUI
+import UIKit
 import WiredPartCore
 
 /// Warehouse dashboard showing KPI smart cards, recent activity, and quick actions.
 ///
-/// Smart cards act as toggle filters for the activity feed:
-/// Movements Today, Receiving Active, Audit Due, Staging Ready.
+/// Smart cards act as toggle filters for service-backed dashboard categories:
+/// Moves Today, Receiving Active, Audit Due, and Staged Ready.
 /// Quick actions open movement wizard and QR scanner as sheets.
 struct WarehouseDashboardPage: View {
     @EnvironmentObject private var appCore: AppCore
-
-    private var canPerformAudit: Bool {
-        appCore.hasPermission("perform_audit")
-    }
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     // MARK: - State
 
     @State private var dashKPIs: WarehouseService.DashboardKPIs?
     @State private var auditSummary: WarehouseService.AuditSummary?
+    @State private var auditCards: WarehouseService.DashboardSmartCardSummary?
+    @State private var warehouseScore: WarehouseService.WarehouseOverallScore?
     @State private var recentMovements: [WarehouseService.MovementRow] = []
+    @State private var activeReceivingSessions: [WarehouseService.ReceivingSessionInfo] = []
+    @State private var auditQueue: [WarehouseService.AuditQueueItem] = []
+    @State private var stagedItems: [WarehouseService.StagedItem] = []
     @State private var isLoading = true
     @State private var loadError: String?
     @State private var selectedFilter: DashboardFilter?
     @State private var activeSheet: ActiveSheet?
 
     private enum DashboardFilter: String, CaseIterable {
-        case movements = "Movements Today"
-        case receiving = "Receiving Active"
+        case movesToday = "Moves Today"
+        case receivingActive = "Receiving Active"
         case auditDue = "Audit Due"
-        case staging = "Staging Ready"
+        case stagedReady = "Staged Ready"
     }
 
     @State private var setupTier: WarehouseService.WarehouseSetupTier = .complete
@@ -44,6 +48,17 @@ struct WarehouseDashboardPage: View {
         case help
 
         var id: String { String(describing: self) }
+    }
+
+    private struct WarehouseQuickAction: Identifiable {
+        let title: String
+        let icon: String
+        let color: Color
+        let identifier: String
+        let moduleId: String?
+        let sheet: ActiveSheet?
+
+        var id: String { identifier }
     }
 
     var body: some View {
@@ -86,6 +101,7 @@ struct WarehouseDashboardPage: View {
         .task {
             loadData()
             appCore.onboardingManager?.markCompleted("wh-dashboard-view")
+            appCore.onboardingManager?.markCompleted("wh-dashboard-audit-score")
             // Detect warehouse setup tier for dismissable banner
             if let service = appCore.warehouseService {
                 setupTier = (try? service.getSetupProgress()) ?? .none
@@ -124,9 +140,10 @@ struct WarehouseDashboardPage: View {
             PageHelpSheet(
                 title: "Warehouse Dashboard Help",
                 sections: [
-                    ("Overview", "Monitor warehouse operations at a glance. Smart cards show today's movements, active receiving sessions, audits due, and staging status."),
-                    ("Filters", "Tap a smart card to filter the activity feed to that category. Tap again to clear the filter."),
-                    ("Quick Actions", "Use the quick action buttons to start a new movement or scan QR codes for bin lookups.")
+                    ("Overview", "Monitor warehouse operations at a glance. Smart cards show today's movements, audits due, confidence risk, active audit sessions, and organization issues."),
+                    ("Warehouse Score", "The overall score combines part confidence, organization ratings, user ratings, shelf utilization, misplacements, label accuracy, audit response time, and stock health."),
+                    ("Filters", "Tap a smart card to switch the work queue between today's movements, active receiving, audit queue, and staged parts. Tap again to clear the filter."),
+                    ("Quick Actions", "Use quick actions to start a movement, scan QR codes, continue receiving, or open the audit queue.")
                 ]
             )
         }
@@ -250,6 +267,105 @@ struct WarehouseDashboardPage: View {
         }
     }
 
+    // MARK: - Alerts
+
+    @ViewBuilder
+    private var alertsWarningsBanner: some View {
+        let auditDue = auditCards?.auditDue ?? auditQueue.count
+        let lowConfidenceAreas = auditCards?.lowConfidenceAreas ?? 0
+        let lowStockWarnings = auditCards?.lowStockWarnings ?? dashKPIs?.kpis.shortfallCount ?? 0
+        let activeReceiving = auditCards?.activeReceiving ?? activeReceivingSessions.count
+
+        if auditDue > 0 || lowConfidenceAreas > 0 || lowStockWarnings > 0 || activeReceiving > 0 {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                        .accessibilityHidden(true)
+                    Text("Alerts & Warnings")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    Spacer()
+                }
+
+                VStack(spacing: 8) {
+                    if auditDue > 0 {
+                        alertRow(
+                            title: "\(auditDue) parts need audit",
+                            subtitle: "Low confidence items are queued for verification.",
+                            icon: "checkmark.shield.fill",
+                            color: .orange,
+                            tabId: "warehouse-audit"
+                        )
+                    }
+                    if lowConfidenceAreas > 0 {
+                        alertRow(
+                            title: "\(lowConfidenceAreas) low-confidence areas",
+                            subtitle: "Review the audit queue before relying on these locations.",
+                            icon: "exclamationmark.shield.fill",
+                            color: .red,
+                            tabId: "warehouse-audit"
+                        )
+                    }
+                    if lowStockWarnings > 0 {
+                        alertRow(
+                            title: "\(lowStockWarnings) stock shortfalls",
+                            subtitle: "Open inventory to review parts below minimum level.",
+                            icon: "shippingbox.fill",
+                            color: .red,
+                            tabId: "warehouse-inventory"
+                        )
+                    }
+                    if activeReceiving > 0 {
+                        alertRow(
+                            title: "\(activeReceiving) receiving sessions active",
+                            subtitle: "Continue sorting and close sessions when complete.",
+                            icon: "arrow.down.circle.fill",
+                            color: .blue,
+                            tabId: "warehouse-receiving"
+                        )
+                    }
+                }
+            }
+            .padding(12)
+            .background(Color(.secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    private func alertRow(title: String, subtitle: String, icon: String, color: Color, tabId: String) -> some View {
+        Button {
+            navigateToWarehouseTab(tabId)
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(.body)
+                    .foregroundStyle(color)
+                    .frame(width: 28)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.primary)
+                    Text(subtitle)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+        .accessibilityHint(subtitle)
+    }
+
     // MARK: - Dashboard Content
 
     @ViewBuilder
@@ -259,11 +375,11 @@ struct WarehouseDashboardPage: View {
                 // Setup banner (dismissable)
                 setupBanner
 
+                // Service-backed alerts and warnings
+                alertsWarningsBanner
+
                 // Smart Card Filters
                 smartCardFilters
-
-                // Alerts / Warnings
-                alertsBanner
 
                 // KPI Summary
                 kpiRow
@@ -285,24 +401,24 @@ struct WarehouseDashboardPage: View {
 
     private var smartCardFilters: some View {
         let kpis = dashKPIs?.kpis
-        let movementsCount = kpis?.todayMovements ?? 0
-        let receivingCount = dashKPIs?.activeReceivingSessions ?? 0
-        let auditDueCount = auditSummary.map { $0.totalParts - $0.countedParts } ?? 0
-        let stagingCount = dashKPIs?.pendingStagingCount ?? 0
+        let movementsCount = auditCards?.movesToday ?? kpis?.todayMovements ?? 0
+        let activeReceivingCount = auditCards?.activeReceiving ?? activeReceivingSessions.count
+        let auditDueCount = auditCards?.auditDue ?? auditQueue.count
+        let stagedReadyCount = auditCards?.stagedReady ?? stagedItems.count
 
         return ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 10) {
                 smartCard(
-                    filter: .movements,
+                    filter: .movesToday,
                     count: movementsCount,
                     icon: "arrow.left.arrow.right",
                     color: .purple
                 )
                 smartCard(
-                    filter: .receiving,
-                    count: receivingCount,
-                    icon: "arrow.down.circle",
-                    color: .green
+                    filter: .receivingActive,
+                    count: activeReceivingCount,
+                    icon: "arrow.down.circle.fill",
+                    color: activeReceivingCount > 0 ? .blue : .green
                 )
                 smartCard(
                     filter: .auditDue,
@@ -311,10 +427,10 @@ struct WarehouseDashboardPage: View {
                     color: auditDueCount > 0 ? .orange : .green
                 )
                 smartCard(
-                    filter: .staging,
-                    count: stagingCount,
-                    icon: "shippingbox.and.arrow.backward",
-                    color: .blue
+                    filter: .stagedReady,
+                    count: stagedReadyCount,
+                    icon: "tray.2.fill",
+                    color: stagedReadyCount > 0 ? .teal : .green
                 )
             }
         }
@@ -353,44 +469,7 @@ struct WarehouseDashboardPage: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel("\(filter.rawValue): \(count)")
-    }
-
-    // MARK: - Alerts
-
-    @ViewBuilder
-    private var alertsBanner: some View {
-        let auditDueCount = max(0, auditSummary.map { $0.totalParts - $0.countedParts } ?? 0)
-        let lowConfidenceCount = auditSummary?.discrepancies ?? 0
-        let shortfalls = dashKPIs?.kpis.shortfallCount ?? 0
-
-        if auditDueCount > 0 || lowConfidenceCount > 0 || shortfalls > 0 {
-            VStack(alignment: .leading, spacing: 8) {
-                Label("Warehouse Alerts", systemImage: "exclamationmark.triangle.fill")
-                    .font(.headline)
-                    .foregroundStyle(.orange)
-
-                if auditDueCount > 0 {
-                    alertLine("\(auditDueCount) part\(auditDueCount == 1 ? "" : "s") still need audit coverage", icon: "clipboard")
-                }
-                if lowConfidenceCount > 0 {
-                    alertLine("\(lowConfidenceCount) low-confidence/variance area\(lowConfidenceCount == 1 ? "" : "s") need review", icon: "chart.bar.doc.horizontal")
-                }
-                if shortfalls > 0 {
-                    alertLine("\(shortfalls) stocked part\(shortfalls == 1 ? "" : "s") below minimum", icon: "shippingbox")
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(12)
-            .background(Color.orange.opacity(0.10))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.orange.opacity(0.25), lineWidth: 1))
-        }
-    }
-
-    private func alertLine(_ text: String, icon: String) -> some View {
-        Label(text, systemImage: icon)
-            .font(.caption)
-            .foregroundStyle(.primary)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
     // MARK: - KPI Row
@@ -406,6 +485,12 @@ struct WarehouseDashboardPage: View {
             GridItem(.flexible(), spacing: 12),
             GridItem(.flexible(), spacing: 12),
         ], spacing: 12) {
+            miniKPI(
+                title: "Audit Score",
+                value: "\(Int((warehouseScore?.score ?? 100).rounded()))%",
+                icon: "gauge.with.dots.needle.bottom.50percent",
+                color: scoreColor(warehouseScore?.score ?? 100)
+            )
             miniKPI(title: "Total Stock", value: "\(totalStock)", icon: "shippingbox.fill", color: .blue)
             miniKPI(
                 title: "Health",
@@ -451,39 +536,103 @@ struct WarehouseDashboardPage: View {
                 .font(.headline)
                 .padding(.horizontal, 4)
 
-            HStack(spacing: 12) {
-                Button { navigate(to: "warehouse-movements") } label: {
-                    quickActionButton(
-                        title: "Movements",
-                        icon: "arrow.left.arrow.right.circle.fill",
-                        color: .blue
-                    )
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("whAction_movements")
-
-                Button { navigate(to: "warehouse-receiving") } label: {
-                    quickActionButton(
-                        title: "Receiving",
-                        icon: "arrow.down.circle",
-                        color: .green
-                    )
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("whAction_receiving")
-
-                if canPerformAudit {
-                    Button { navigate(to: "warehouse-audit") } label: {
-                        quickActionButton(
-                            title: "Audit",
-                            icon: "clipboard.fill",
-                            color: .orange
-                        )
+            if usesCompactQuickActionGrid {
+                VStack(spacing: 12) {
+                    ForEach(Array(quickActionRows.enumerated()), id: \.offset) { _, row in
+                        HStack(spacing: 12) {
+                            ForEach(row) { action in
+                                quickActionTile(action)
+                            }
+                            if row.count == 1 {
+                                Color.clear
+                            }
+                        }
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("whAction_audit")
                 }
+                .dynamicTypeSize(...DynamicTypeSize.xxLarge)
+            } else {
+                HStack(spacing: 12) {
+                    ForEach(quickActions) { action in
+                        quickActionTile(action)
+                    }
+                }
+                .dynamicTypeSize(...DynamicTypeSize.xxLarge)
             }
+        }
+    }
+
+    private var usesCompactQuickActionGrid: Bool {
+        horizontalSizeClass == .compact &&
+            (dynamicTypeSize >= .accessibility1 || UIScreen.main.bounds.width < 360)
+    }
+
+    private var quickActions: [WarehouseQuickAction] {
+        [
+            WarehouseQuickAction(
+                title: "New Movement",
+                icon: "arrow.left.arrow.right.circle.fill",
+                color: .blue,
+                identifier: "whAction_newMovement",
+                moduleId: nil,
+                sheet: .newMovement
+            ),
+            WarehouseQuickAction(
+                title: "Scan QR",
+                icon: "qrcode.viewfinder",
+                color: .orange,
+                identifier: "whAction_scanQR",
+                moduleId: nil,
+                sheet: .qrScanner
+            ),
+            WarehouseQuickAction(
+                title: "Receiving",
+                icon: "arrow.down.circle",
+                color: .green,
+                identifier: "whAction_receiving",
+                moduleId: "warehouse-receiving",
+                sheet: nil
+            ),
+            WarehouseQuickAction(
+                title: "Audit Queue",
+                icon: "clipboard.fill",
+                color: .orange,
+                identifier: "whAction_auditQueue",
+                moduleId: "warehouse-audit",
+                sheet: nil
+            ),
+        ]
+    }
+
+    private var quickActionRows: [[WarehouseQuickAction]] {
+        stride(from: 0, to: quickActions.count, by: 2).map { start in
+            Array(quickActions[start..<min(start + 2, quickActions.count)])
+        }
+    }
+
+    private func quickActionTile(_ action: WarehouseQuickAction) -> some View {
+        Button { performQuickAction(action) } label: {
+            quickActionButton(
+                title: action.title,
+                icon: action.icon,
+                color: action.color
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(action.title)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityIdentifier(action.identifier)
+    }
+
+    private func performQuickAction(_ action: WarehouseQuickAction) {
+        if let sheet = action.sheet {
+            activeSheet = sheet
+        } else if let moduleId = action.moduleId {
+            NotificationCenter.default.post(
+                name: .navigateToModule,
+                object: nil,
+                userInfo: ["moduleId": moduleId]
+            )
         }
     }
 
@@ -497,6 +646,8 @@ struct WarehouseDashboardPage: View {
                 .font(.caption)
                 .fontWeight(.medium)
                 .foregroundStyle(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 16)
@@ -516,27 +667,25 @@ struct WarehouseDashboardPage: View {
                 GridItem(.flexible(), spacing: 10),
                 GridItem(.flexible(), spacing: 10),
             ], spacing: 10) {
-                subPageLink(title: "Movements", icon: "arrow.left.arrow.right", color: .blue, moduleId: "warehouse-movements")
-                subPageLink(title: "Receiving", icon: "arrow.down.circle", color: .green, moduleId: "warehouse-receiving")
-                subPageLink(title: "Staging", icon: "shippingbox.and.arrow.backward", color: .blue, moduleId: "warehouse-staging")
-                subPageLink(title: "Returns", icon: "arrow.uturn.left", color: .purple, moduleId: "warehouse-returns")
-                if canPerformAudit {
-                    subPageLink(title: "Audit", icon: "clipboard", color: .orange, moduleId: "warehouse-audit")
-                }
-                subPageLink(title: "Inventory", icon: "square.grid.3x3", color: .purple, moduleId: "warehouse-inventory")
-                subPageLink(title: "Locations", icon: "mappin.and.ellipse", color: .teal, moduleId: "warehouse-locations")
-                subPageLink(title: "Floor Plan", icon: "map", color: .indigo, moduleId: "warehouse-locations")
-                subPageLink(title: "Tools", icon: "wrench.and.screwdriver", color: .brown, moduleId: "warehouse-tools")
-                subPageLink(title: "Network", icon: "point.3.connected.trianglepath.dotted", color: .cyan, moduleId: "warehouse-network")
-                subPageLink(title: "Leaderboard", icon: "trophy", color: .yellow, moduleId: "warehouse-leaderboard")
-                subPageLink(title: "Settings", icon: "gearshape", color: .gray, moduleId: "warehouse-settings")
+                subPageLink(title: "Receiving", icon: "shippingbox.fill", color: .green, tabId: "warehouse-receiving")
+                subPageLink(title: "Staging", icon: "tray.2.fill", color: .teal, tabId: "warehouse-staging")
+                subPageLink(title: "Movements", icon: "arrow.left.arrow.right", color: .blue, tabId: "warehouse-movements")
+                subPageLink(title: "Inventory", icon: "square.grid.3x3.fill", color: .purple, tabId: "warehouse-inventory")
+                subPageLink(title: "Locations", icon: "map.fill", color: .mint, tabId: "warehouse-locations")
+                subPageLink(title: "Audit", icon: "checkmark.shield.fill", color: .orange, tabId: "warehouse-audit")
+                subPageLink(title: "Returns", icon: "arrow.uturn.left", color: .indigo, tabId: "warehouse-returns")
+                subPageLink(title: "Tools", icon: "wrench.and.screwdriver.fill", color: .brown, tabId: "warehouse-tools")
+                subPageLink(title: "Leaderboard", icon: "trophy.fill", color: .yellow, tabId: "warehouse-leaderboard")
+                subPageLink(title: "Network", icon: "antenna.radiowaves.left.and.right", color: .cyan, tabId: "warehouse-network")
+                subPageLink(title: "Settings", icon: "gearshape.fill", color: .gray, tabId: "warehouse-settings")
+                subPageLink(title: "Org Audit", icon: "tag.fill", color: .red, tabId: "warehouse-organization")
             }
         }
     }
 
-    private func subPageLink(title: String, icon: String, color: Color, moduleId: String) -> some View {
+    private func subPageLink(title: String, icon: String, color: Color, tabId: String) -> some View {
         Button {
-            navigate(to: moduleId)
+            navigateToWarehouseTab(tabId)
         } label: {
             HStack(spacing: 8) {
                 Image(systemName: icon)
@@ -559,14 +708,8 @@ struct WarehouseDashboardPage: View {
             .clipShape(RoundedRectangle(cornerRadius: 10))
         }
         .buttonStyle(.plain)
-    }
-
-    private func navigate(to moduleId: String) {
-        NotificationCenter.default.post(
-            name: .navigateToModule,
-            object: nil,
-            userInfo: ["moduleId": moduleId]
-        )
+        .accessibilityIdentifier("whSubPage_\(tabId)")
+        .accessibilityLabel(title)
     }
 
     // MARK: - Recent Activity
@@ -578,51 +721,113 @@ struct WarehouseDashboardPage: View {
                 .font(.headline)
                 .padding(.horizontal, 4)
 
-            let filtered = filteredMovements
-
-            if filtered.isEmpty {
-                VStack(spacing: 12) {
-                    Image(systemName: "tray")
-                        .font(.largeTitle)
-                        .foregroundStyle(.secondary)
-                        .accessibilityHidden(true)
-                    Text(selectedFilter == nil ? "No recent movements" : "No matching activity")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 24)
-                .background(Color(.secondarySystemGroupedBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-            } else {
-                VStack(spacing: 0) {
-                    ForEach(Array(filtered.enumerated()), id: \.element.id) { index, movement in
-                        movementActivityRow(movement)
-
-                        if index < filtered.count - 1 {
-                            Divider()
-                                .padding(.leading, 44)
-                        }
-                    }
-                }
-                .background(Color(.secondarySystemGroupedBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+            switch selectedFilter {
+            case .movesToday, .none:
+                movementQueue
+            case .receivingActive:
+                receivingQueue
+            case .auditDue:
+                auditDueQueue
+            case .stagedReady:
+                stagedReadyQueue
             }
         }
     }
 
-    private var filteredMovements: [WarehouseService.MovementRow] {
-        guard let filter = selectedFilter else { return recentMovements }
-        switch filter {
-        case .movements:
-            return recentMovements // Already today's movements from KPIs
-        case .receiving:
-            return recentMovements.filter { $0.movementType == "receive" }
-        case .auditDue:
-            return recentMovements.filter { $0.movementType == "adjustment" }
-        case .staging:
-            return recentMovements.filter { $0.movementType == "transfer" }
+    @ViewBuilder
+    private var movementQueue: some View {
+        let rows = selectedFilter == nil ? recentMovements : todaysMovements
+
+        if rows.isEmpty {
+            emptyQueue(
+                icon: "arrow.left.arrow.right",
+                title: selectedFilter == nil ? "No recent movements" : "No movements today",
+                subtitle: selectedFilter == nil ? "Warehouse activity will appear here as parts move." : "Today's completed movements will appear here."
+            )
+        } else {
+            VStack(spacing: 0) {
+                ForEach(Array(rows.enumerated()), id: \.element.id) { index, movement in
+                    movementActivityRow(movement)
+
+                    if index < rows.count - 1 {
+                        Divider()
+                            .padding(.leading, 44)
+                    }
+                }
+            }
+            .background(Color(.secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
         }
+    }
+
+    @ViewBuilder
+    private var receivingQueue: some View {
+        if activeReceivingSessions.isEmpty {
+            emptyQueue(
+                icon: "arrow.down.circle",
+                title: "No active receiving",
+                subtitle: "Open purchase-order receiving sessions will appear here."
+            )
+        } else {
+            VStack(spacing: 0) {
+                ForEach(Array(activeReceivingSessions.enumerated()), id: \.element.id) { index, session in
+                    receivingRow(session)
+                    if index < activeReceivingSessions.count - 1 {
+                        Divider().padding(.leading, 44)
+                    }
+                }
+            }
+            .background(Color(.secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    @ViewBuilder
+    private var auditDueQueue: some View {
+        if auditQueue.isEmpty {
+            emptyQueue(
+                icon: "checkmark.shield",
+                title: "No audits due",
+                subtitle: "Low-confidence parts will appear here when they need verification."
+            )
+        } else {
+            VStack(spacing: 0) {
+                ForEach(Array(auditQueue.enumerated()), id: \.element.partId) { index, item in
+                    auditQueueRow(item)
+                    if index < auditQueue.count - 1 {
+                        Divider().padding(.leading, 44)
+                    }
+                }
+            }
+            .background(Color(.secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    @ViewBuilder
+    private var stagedReadyQueue: some View {
+        if stagedItems.isEmpty {
+            emptyQueue(
+                icon: "tray.2",
+                title: "No staged parts ready",
+                subtitle: "Pulled parts tagged for jobs, trucks, or other destinations will appear here."
+            )
+        } else {
+            VStack(spacing: 0) {
+                ForEach(Array(stagedItems.enumerated()), id: \.element.id) { index, item in
+                    stagedItemRow(item)
+                    if index < stagedItems.count - 1 {
+                        Divider().padding(.leading, 44)
+                    }
+                }
+            }
+            .background(Color(.secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    private var todaysMovements: [WarehouseService.MovementRow] {
+        recentMovements.filter { isToday($0.createdAt) }
     }
 
     @ViewBuilder
@@ -674,6 +879,149 @@ struct WarehouseDashboardPage: View {
         .padding(.vertical, 10)
     }
 
+    private func receivingRow(_ session: WarehouseService.ReceivingSessionInfo) -> some View {
+        Button {
+            navigateToWarehouseTab("warehouse-receiving")
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "arrow.down.circle.fill")
+                    .font(.body)
+                    .foregroundStyle(.green)
+                    .frame(width: 32, height: 32)
+                    .background(Color.green.opacity(0.12))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("PO #\(session.poId)")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    Text("\(session.itemCount) items • \(session.mode.replacingOccurrences(of: "_", with: " ").capitalized)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 3) {
+                    Text(session.startedByName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(formatDate(session.createdAt))
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func auditQueueRow(_ item: WarehouseService.AuditQueueItem) -> some View {
+        Button {
+            navigateToWarehouseTab("warehouse-audit")
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "checkmark.shield.fill")
+                    .font(.body)
+                    .foregroundStyle(scoreColor(item.confidencePercent))
+                    .frame(width: 32, height: 32)
+                    .background(scoreColor(item.confidencePercent).opacity(0.12))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(item.partName)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+                    Text(item.locationCode ?? item.partCode ?? "Unassigned location")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 3) {
+                    Text("\(Int(item.confidencePercent.rounded()))%")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    Text("confidence")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func stagedItemRow(_ item: WarehouseService.StagedItem) -> some View {
+        Button {
+            navigateToWarehouseTab("warehouse-staging")
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "tray.2.fill")
+                    .font(.body)
+                    .foregroundStyle(.teal)
+                    .frame(width: 32, height: 32)
+                    .background(Color.teal.opacity(0.12))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(item.partName)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+                    Text(item.destinationLabel ?? item.destinationType?.capitalized ?? "Ready for destination")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 3) {
+                    Text("\(item.qty)")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    Text(formatDate(item.taggedAt))
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func emptyQueue(icon: String, title: String, subtitle: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text(title)
+                .font(.subheadline)
+                .fontWeight(.medium)
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 24)
+        .padding(.horizontal, 16)
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
     // MARK: - Data Loading
 
     private func loadData() {
@@ -689,7 +1037,12 @@ struct WarehouseDashboardPage: View {
         do {
             dashKPIs = try service.getDashboardKPIs()
             auditSummary = try service.getAuditSummary()
-            recentMovements = try service.listMovements(limit: 10, sortOrder: .newestFirst)
+            auditCards = try service.getDashboardSmartCardSummary()
+            warehouseScore = try service.getWarehouseOverallScoreBreakdown()
+            recentMovements = try service.listMovements(limit: 10)
+            activeReceivingSessions = try service.getActiveSessions()
+            auditQueue = try service.getAuditQueue(limit: 10)
+            stagedItems = try service.getStagedItems()
             postAIContext()
         } catch {
             loadError = userFriendlyError(error, context: "load warehouse dashboard")
@@ -708,8 +1061,9 @@ struct WarehouseDashboardPage: View {
         Stock total: \(kpis?.totalStock ?? 0), health: \(kpis?.stockHealthPercent ?? 0)%, shortfalls: \(kpis?.shortfallCount ?? 0), movements today: \(kpis?.todayMovements ?? 0).
         Active receiving sessions: \(dashKPIs?.activeReceivingSessions ?? 0), pending staging: \(dashKPIs?.pendingStagingCount ?? 0), pending returns: \(dashKPIs?.pendingReturns ?? 0).
         Audit counted/total: \(auditSummary?.countedParts ?? 0)/\(auditSummary?.totalParts ?? 0), discrepancies: \(auditSummary?.discrepancies ?? 0), selected filter: \(selectedFilter?.rawValue ?? "none").
-        Recent movement rows loaded: \(recentMovements.count), visible after filter: \(filteredMovements.count), movement types: \(movementCounts.isEmpty ? "none" : movementCounts).
-        Available read-only guidance: explain KPI cards, selected activity filter, quick action locations, and warehouse sub-page links. Do not create movements or launch scanners directly.
+        Warehouse audit score: \(Int((warehouseScore?.score ?? 100).rounded()))%, confidence risk areas: \(auditCards?.lowConfidenceAreas ?? 0), active audits: \(auditCards?.activeAuditSessions ?? 0), organization issues: \(auditCards?.organizationIssues ?? 0).
+        Dashboard queues loaded: \(todaysMovements.count) moves today, \(activeReceivingSessions.count) receiving active, \(auditQueue.count) audit due, \(stagedItems.count) staged ready. Movement types: \(movementCounts.isEmpty ? "none" : movementCounts).
+        Available read-only guidance: explain KPI cards, audit score components, selected activity filter, quick action locations, and warehouse sub-page links. Do not create movements or launch scanners directly.
         """
         NotificationCenter.default.post(
             name: .warehouseDashboardPageActive,
@@ -740,6 +1094,12 @@ struct WarehouseDashboardPage: View {
         case "adjustment": .gray
         default: .blue
         }
+    }
+
+    private func scoreColor(_ score: Double) -> Color {
+        if score >= 85 { return .green }
+        if score >= 70 { return .orange }
+        return .red
     }
 
     private func movementLabel(_ type: String) -> String {
@@ -773,4 +1133,28 @@ struct WarehouseDashboardPage: View {
         }
         return dateStr
     }
+
+    private func isToday(_ dateStr: String?) -> Bool {
+        guard let dateStr, dateStr.count >= 10 else { return false }
+        let today = DateFormatter.dashboardDayFormatter.string(from: Date())
+        return String(dateStr.prefix(10)) == today
+    }
+
+    private func navigateToWarehouseTab(_ tabId: String) {
+        NotificationCenter.default.post(
+            name: .navigateToModule,
+            object: nil,
+            userInfo: ["moduleId": "warehouse", "tabId": tabId]
+        )
+    }
+}
+
+private extension DateFormatter {
+    static let dashboardDayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
@@ -495,7 +495,10 @@ struct WarehouseLocationsPage: View {
 
     /// Moves a storage unit to a new grid position via drag-and-drop.
     private func moveUnit(unitId: Int64, toGridX gridX: Int, gridY: Int) -> Bool {
-        guard let service = appCore.warehouseService else { return false }
+        guard let service = appCore.warehouseService else {
+            loadError = "Warehouse service unavailable"
+            return false
+        }
         do {
             try service.updateStorageUnit(id: unitId, gridX: gridX, gridY: gridY)
             loadPlanData()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseOnboardingWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseOnboardingWizard.swift
@@ -398,7 +398,14 @@ struct WarehouseOnboardingWizard: View {
     }
 
     private func saveProgressToDb(currentStepForResume: Int? = nil) {
-        guard let service = appCore.warehouseService, let id = progress?.id else { return }
+        guard let service = appCore.warehouseService else {
+            loadError = "Warehouse service unavailable"
+            return
+        }
+        guard let id = progress?.id else {
+            loadError = "Warehouse onboarding progress unavailable"
+            return
+        }
         do {
             let savedStep = currentStepForResume ?? min(currentStep + 1, totalSteps)
             try service.updateOnboardingStep(
@@ -425,8 +432,12 @@ struct WarehouseOnboardingWizard: View {
     }
 
     private func finishOnboarding() {
-        guard let service = appCore.warehouseService, let id = progress?.id else {
-            dismiss()
+        guard let service = appCore.warehouseService else {
+            loadError = "Warehouse service unavailable"
+            return
+        }
+        guard let id = progress?.id else {
+            loadError = "Warehouse onboarding progress unavailable"
             return
         }
         isSaving = true

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepPlacement.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepPlacement.swift
@@ -536,7 +536,7 @@ struct WizardStepPlacement: View {
 
     private func loadBinsForCartMode() {
         guard let svc = appCore.warehouseService else {
-            stepError = "Warehouse service not available"
+            stepError = "Warehouse service unavailable"
             return
         }
         var loadedBins: [FloorPlanBinInfo] = []

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepWalkingPath.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepWalkingPath.swift
@@ -283,7 +283,7 @@ struct WizardStepWalkingPath: View {
 
     private func suggestPath() {
         guard let service = appCore.warehouseService else {
-            stepError = "Warehouse service not available"
+            stepError = "Warehouse service unavailable"
             return
         }
         do {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ZoneGridCanvas.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ZoneGridCanvas.swift
@@ -132,10 +132,6 @@ struct ZoneGridCanvas: View {
             }
         }
         .frame(width: zoneExtent(width) - 1, height: zoneExtent(height) - 1)
-        .position(
-            x: CGFloat(clampedX) * cellStride + zoneExtent(width) / 2,
-            y: CGFloat(clampedY) * cellStride + zoneExtent(height) / 2
-        )
         .contentShape(Rectangle())
         .onTapGesture {
             onSelectZone(zone)
@@ -149,6 +145,10 @@ struct ZoneGridCanvas: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(zoneTitle(zone)), \(zone.zoneTypeDisplay), starts at R\(clampedY + 1)C\(clampedX + 1), \(width) by \(height) cells")
         .accessibilityHint("Tap to select. Long press and drag to move.")
+        .position(
+            x: CGFloat(clampedX) * cellStride + zoneExtent(width) / 2,
+            y: CGFloat(clampedY) * cellStride + zoneExtent(height) / 2
+        )
     }
 
     private func zoneDragPreview(_ zone: WarehouseZone) -> some View {


### PR DESCRIPTION
## Summary
- Sanitizes WEI-1465 by replaying only the Warehouse dashboard/source slice onto current main
- Explicitly excludes the original docs/testing/artifacts screenshots from the PR
- Resolves the WarehouseDashboardPage conflict against current main while keeping the compact quick-action grid and smart-card dashboard work

## Artifact hygiene
- Original contaminated branch: wei-1465-warehouse-dashboard-ux-evidence-local
- Original contaminated paths: docs/testing/artifacts/wei-1092/*, docs/testing/artifacts/wei-1236/*, docs/testing/artifacts/wei-1306/*, docs/testing/artifacts/wei-1336/*
- Verification: git diff --cached --name-only showed only 7 source files and no .paperclip/.paperclip-sync/docs/testing/artifacts paths before commit

## Test plan
- swift test --package-path core --filter Warehouse (237 tests passed)
- Full swift test --package-path core was attempted but exceeded the 600s agent command timeout after building and running a large portion of the suite; use the Warehouse-filtered run as targeted evidence for this sanitized warehouse slice.

Paperclip: WEI-1929