### PR TITLE
fix(ios): stabilize warehouse audit subtab hit target

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
@@ -676,7 +676,14 @@ struct ModuleHostView: View {
                     } label: {
                         subTabChip(tab: tab, selected: isSelected(tab), chipH: chipH)
                     }
-                    .buttonStyle(.glass)
+                    // Glass buttons inside a horizontally scrolling, narrow iPhone
+                    // sub-tab strip can report invalid accessibility activation
+                    // points to XCTest. Keep the chip styling in `subTabChip`, but
+                    // give automation a plain, explicitly-sized hit region.
+                    .buttonStyle(.plain)
+                    .contentShape(Rectangle())
+                    .accessibilityIdentifier("subtab_\(tab.id)")
+                    .accessibilityLabel(tab.label)
                 }
             }
             .padding(.horizontal, DS.Space.lg)
@@ -696,6 +703,7 @@ struct ModuleHostView: View {
         }
         .padding(.horizontal, chipH)
         .padding(.vertical, DS.Space.sm)
+        .frame(minWidth: 44, minHeight: 44)
         .background(
             Capsule()
                 .fill(selected ? Color.accentColor : Color.clear)


### PR DESCRIPTION
Archaeology publication from Paperclip WEI-1924.

Evidence:
- Source worktree: /Users/IA/GitHub/Weird-Part-Run-2/.paperclip/worktrees/WEI-1450-audit-chip-hit-target-2
- Source Paperclip issue: WEI-1450 / GH #486 iPhone QA cannot open Audit via toolbar button
- Worktree was clean before publishing.
- Branch had no existing open/all PR and no remote branch at heartbeat time.
- Diff scope: IOSMainView audit subtab hit target stabilization.

This PR is opened as draft for review/CI rather than deleting the clean unique worktree blindly.
