### PR TITLE
fix(ios): preserve Catalyst keychain fallback

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -332,6 +332,10 @@ final class AppCore: ObservableObject {
                 }
             }
         } catch {
+            let nsError = error as NSError
+            logger.error(
+                "[AppCore] bootstrap failed domain=\(nsError.domain, privacy: .public) code=\(nsError.code, privacy: .public) description=\(error.localizedDescription, privacy: .public)"
+            )
             loadError = userFriendlyError(error, context: "start app")
         }
     }
@@ -577,13 +581,17 @@ final class AppCore: ObservableObject {
         }
         let keyData = Data(keyBytes)
 
-        let addQuery: [CFString: Any] = [
+        var addQuery: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,
             kSecAttrAccount: account,
-            kSecValueData: keyData,
-            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            kSecValueData: keyData
         ]
+        #if !targetEnvironment(macCatalyst)
+        // kSecAttrAccessible is an iOS-style accessibility class. On Catalyst
+        // this can fail with errSecParam on first launch, which blocks DB setup.
+        addQuery[kSecAttrAccessible] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        #endif
         let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
         if addStatus == errSecDuplicateItem {
             // Another thread or launch already stored a bootstrap key — read and return it
@@ -603,12 +611,50 @@ final class AppCore: ObservableObject {
             if retryAddStatus == errSecSuccess {
                 return keyData.map { String(format: "%02x", $0) }.joined()
             }
+            #if targetEnvironment(macCatalyst)
+            if retryAddStatus == errSecMissingEntitlement {
+                return try catalystFallbackBootstrapKeyHex()
+            }
+            #endif
             throw CipherKeyError.keychainAccessFailed(retryAddStatus)
+        } else if addStatus == errSecMissingEntitlement {
+            #if targetEnvironment(macCatalyst)
+            return try catalystFallbackBootstrapKeyHex()
+            #else
+            throw CipherKeyError.keychainAccessFailed(addStatus)
+            #endif
         } else if addStatus != errSecSuccess {
             throw CipherKeyError.keychainAccessFailed(addStatus)
         }
         return keyData.map { String(format: "%02x", $0) }.joined()
     }
+
+    #if targetEnvironment(macCatalyst)
+    /// Catalyst fallback when Keychain is unavailable (e.g. missing entitlement in local dev).
+    /// Stores a random device key inside the app container to keep DB encryption stable
+    /// across launches on the same machine/account.
+    nonisolated private static func catalystFallbackBootstrapKeyHex() throws -> String {
+        guard let supportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            throw AppCoreError.noDocumentsDirectory
+        }
+        let dir = supportURL.appendingPathComponent("WiredPart", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let keyURL = dir.appendingPathComponent("catalyst-bootstrap-key.bin")
+
+        if let data = try? Data(contentsOf: keyURL), data.count == 32 {
+            return data.map { String(format: "%02x", $0) }.joined()
+        }
+
+        var keyBytes = [UInt8](repeating: 0, count: 32)
+        let rc = SecRandomCopyBytes(kSecRandomDefault, 32, &keyBytes)
+        guard rc == errSecSuccess else {
+            throw CipherKeyError.bootstrapKeyGenerationFailed(rc)
+        }
+        let keyData = Data(keyBytes)
+        try keyData.write(to: keyURL, options: .atomic)
+        return keyData.map { String(format: "%02x", $0) }.joined()
+    }
+    #endif
 
     // MARK: - PIN Change
 

--- a/core/Sources/WiredPartCore/Security/CipherKeyManager.swift
+++ b/core/Sources/WiredPartCore/Security/CipherKeyManager.swift
@@ -78,6 +78,13 @@ public final class CipherKeyManager: Sendable {
         if let existing = readSaltFromKeychain() {
             return existing
         }
+        #if targetEnvironment(macCatalyst)
+        // Local Catalyst builds can run without keychain entitlements.
+        // Reuse a sandbox-stored salt so derived keys remain stable per install.
+        if let fallback = try readCatalystFallbackSalt() {
+            return fallback
+        }
+        #endif
 
         let salt = try Self.generateSalt()
 
@@ -95,6 +102,12 @@ public final class CipherKeyManager: Sendable {
             Self.logger.error("CipherKeyManager: salt write raced (errSecDuplicateItem) and re-read also failed")
             throw CipherKeyError.keychainAccessFailed(errSecDuplicateItem)
         } catch {
+            #if targetEnvironment(macCatalyst)
+            if case CipherKeyError.keychainAccessFailed(errSecMissingEntitlement) = error {
+                try writeCatalystFallbackSalt(salt)
+                return salt
+            }
+            #endif
             // Any other write failure (e.g. errSecNotAvailable, errSecAuthFailed) — surface
             // the original error directly so callers get the real failure reason.
             throw error
@@ -171,13 +184,16 @@ public final class CipherKeyManager: Sendable {
     }
 
     private func writeSaltToKeychain(_ salt: Data) throws {
-        let addQuery: [CFString: Any] = [
+        var addQuery: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: Self.keychainService,
             kSecAttrAccount: Self.keychainAccount,
-            kSecValueData: salt,
-            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            kSecValueData: salt
         ]
+        #if !targetEnvironment(macCatalyst)
+        // Catalyst keychain can reject iOS accessibility classes with errSecParam.
+        addQuery[kSecAttrAccessible] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        #endif
         let status = SecItemAdd(addQuery as CFDictionary, nil)
         guard status == errSecSuccess || status == errSecDuplicateItem else {
             throw CipherKeyError.keychainAccessFailed(status)
@@ -190,6 +206,30 @@ public final class CipherKeyManager: Sendable {
             throw CipherKeyError.keychainAccessFailed(status)
         }
     }
+
+    #if targetEnvironment(macCatalyst)
+    private func catalystFallbackSaltURL() throws -> URL {
+        guard let supportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            throw CipherKeyError.keychainAccessFailed(errSecParam)
+        }
+        let dir = supportURL.appendingPathComponent("WiredPart", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("catalyst-dbcipher-salt.bin")
+    }
+
+    private func readCatalystFallbackSalt() throws -> Data? {
+        let url = try catalystFallbackSaltURL()
+        guard let data = try? Data(contentsOf: url), data.count == 32 else {
+            return nil
+        }
+        return data
+    }
+
+    private func writeCatalystFallbackSalt(_ salt: Data) throws {
+        let url = try catalystFallbackSaltURL()
+        try salt.write(to: url, options: .atomic)
+    }
+    #endif
 }
 
 // MARK: - CipherKeyError


### PR DESCRIPTION
## Summary
- Reconstructs the useful top commit from stale PR #618 onto current `main` without the old artifact-heavy stack.
- Preserves Catalyst startup behavior when Keychain is unavailable/missing entitlement by omitting the iOS-only accessibility class on Catalyst and falling back to a stable app-container bootstrap key/salt.
- Keeps current trunk self-healing behavior for corrupt/legacy bootstrap keychain entries.

## Branch-drain evidence
- Original PR #618 branch was 83 commits behind and carried a large stale artifact stack.
- This PR contains only the two intended source changes from `e794de984` plus conflict resolution against current `main`.

## Validation
- `git diff --check origin/main...HEAD`: PASS
- Conflict-marker scan: PASS
- `swift test --package-path core --scratch-path /tmp/wei1903-pr618-core-build --filter 'AppDatabaseCipherTests|AuthServiceTests/testEncryptedDatabaseSurvivesPinChange'`: PASS (AppDatabaseCipherTests ran 11 tests; build succeeded)
- `xcodebuild -project 'Weird Parts IOS/Weird Parts.xcodeproj' -scheme 'Weird Parts' -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1' -derivedDataPath /tmp/wei1903-pr618-derived CODE_SIGNING_ALLOWED=NO build`: PASS

Supersedes stale PR #618.