### PR TITLE
Fix notebook block editing history

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/AddNotebookEntrySheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/AddNotebookEntrySheet.swift
@@ -323,7 +323,9 @@ struct AddNotebookEntrySheet: View {
                     blockType: blockType,
                     title: title.isEmpty ? nil : title,
                     content: content.isEmpty ? nil : content,
-                    blockData: blockData,
+                    blockData: blockType == "checklist" ? nil : blockData,
+                    headingLevel: blockType == "heading" ? headingLevel : nil,
+                    checklistItems: blockType == "checklist" ? blockData : nil,
                     createdBy: userId
                 )
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/AddNotebookEntrySheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/AddNotebookEntrySheet.swift
@@ -303,8 +303,12 @@ struct AddNotebookEntrySheet: View {
                 let blockData = blockType == "checklist" ? encodeChecklistItems() : nil
                 try service.updateBlockEntry(
                     entryId: entry.id,
+                    title: title,
                     content: content.isEmpty ? nil : content,
-                    blockData: blockData
+                    blockData: blockType == "checklist" ? nil : blockData,
+                    headingLevel: blockType == "heading" ? headingLevel : nil,
+                    checklistItems: blockType == "checklist" ? blockData : nil,
+                    updatedBy: userId
                 )
             } else {
                 // Create new entry

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -1179,6 +1179,10 @@ struct IOSNotebookDetailPage: View {
             loadError = "Service not available"
             return
         }
+        guard let userId = appCore.currentUser?.id else {
+            loadError = "Not logged in. Please log in and try again."
+            return
+        }
         guard let notebookId = notebook?.id else {
             loadError = "No notebook loaded"
             return
@@ -1192,15 +1196,16 @@ struct IOSNotebookDetailPage: View {
         do {
             if let existingEntryId = findPanelScheduleEntryId() {
                 // Update existing panel schedule entry
-                try service.updateBlockEntry(entryId: existingEntryId, content: nil, blockData: jsonString)
+                try service.updateBlockEntry(
+                    entryId: existingEntryId,
+                    content: nil,
+                    blockData: jsonString,
+                    updatedBy: userId
+                )
             } else {
                 // Create new panel_schedule block entry in the first available section
                 guard let sectionId = try findOrCreateDefaultSectionId(service: service, notebookId: notebookId) else {
                     loadError = "No section available for panel schedule"
-                    return
-                }
-                guard let userId = appCore.currentUser?.id else {
-                    loadError = "Not logged in. Please log in and try again."
                     return
                 }
                 _ = try service.createBlockEntry(

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -640,7 +640,8 @@ struct IOSNotebookDetailPage: View {
 
     @ViewBuilder
     private func entryRow(_ entry: NotebooksService.NotebookEntryRow) -> some View {
-        Group {
+        HStack(alignment: .top, spacing: 8) {
+            Group {
             switch entry.blockType {
             case "heading":
                 Text(entry.title ?? entry.content)
@@ -802,6 +803,18 @@ struct IOSNotebookDetailPage: View {
                     }
                 }
             }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button {
+                activeSheet = .editEntry(entry)
+            } label: {
+                Image(systemName: "pencil.circle")
+                    .imageScale(.large)
+            }
+            .buttonStyle(.borderless)
+            .accessibilityLabel("Edit block")
+            .accessibilityHint("Opens this block for editing while preserving change history")
         }
         .contextMenu {
             Button {

--- a/core/Sources/WiredPartCore/Services/NotebooksService.swift
+++ b/core/Sources/WiredPartCore/Services/NotebooksService.swift
@@ -918,6 +918,8 @@ public final class NotebooksService: Sendable {
         title: String? = nil,
         content: String? = nil,
         blockData: String? = nil,
+        headingLevel: Int? = nil,
+        checklistItems: String? = nil,
         createdBy: Int64,
         sortOrder: Int? = nil
     ) throws -> Int64 {
@@ -943,14 +945,18 @@ public final class NotebooksService: Sendable {
             try dbConn.execute(sql: """
                 INSERT INTO notebook_entries
                 (section_id, notebook_id, title, content, entry_type, block_type, block_data,
-                 field_required, is_deleted, is_completed, sort_order, created_by, created_at, updated_at)
-                VALUES (?, ?, ?, ?, 'note', ?, ?, 0, 0, 0, ?, ?, datetime('now'), datetime('now'))
-                """, arguments: [sectionId, notebookId, title ?? "", content, blockType, blockData, order, createdBy])
+                 heading_level, checklist_items, field_required, is_deleted, is_completed,
+                 sort_order, created_by, created_at, updated_at)
+                VALUES (?, ?, ?, ?, 'note', ?, ?, ?, ?, 0, 0, 0, ?, ?, datetime('now'), datetime('now'))
+                """, arguments: [
+                    sectionId, notebookId, title ?? "", content, blockType, blockData,
+                    headingLevel, checklistItems, order, createdBy
+                ])
             return dbConn.lastInsertedRowID
         }
     }
 
-    /// Update a block entry's editable fields and record a minimal audit/change-log entry.
+    /// Update a block entry's editable fields and record a sync-compatible change-log entry.
     public func updateBlockEntry(
         entryId: Int64,
         title: String? = nil,
@@ -958,9 +964,11 @@ public final class NotebooksService: Sendable {
         blockData: String?,
         headingLevel: Int? = nil,
         checklistItems: String? = nil,
-        updatedBy: Int64? = nil
+        updatedBy: Int64
     ) throws {
         try db.writer.write { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: updatedBy, permissionKey: "manage_notebooks")
+
             guard let existing = try Row.fetchOne(dbConn, sql: """
                 SELECT title, content, block_data, heading_level, checklist_items
                 FROM notebook_entries
@@ -981,12 +989,12 @@ public final class NotebooksService: Sendable {
                 WHERE id = ? AND deleted_at IS NULL
                 """, arguments: [newTitle, content, blockData, headingLevel, checklistItems, updatedBy, entryId])
 
-            var changedFields: [String] = []
-            var oldValues: [String: Any?] = [:]
+            var changedFields: [String: Any] = [:]
+            var oldValues: [String: Any] = [:]
             func track<T: Equatable>(_ field: String, old: T?, new: T?) {
                 if old != new {
-                    changedFields.append(field)
-                    oldValues[field] = old
+                    changedFields[field] = new ?? NSNull()
+                    oldValues[field] = old ?? NSNull()
                 }
             }
             track("title", old: oldTitle, new: newTitle)
@@ -996,19 +1004,16 @@ public final class NotebooksService: Sendable {
             track("checklist_items", old: oldChecklistItems, new: checklistItems)
 
             if !changedFields.isEmpty {
-                let changedFieldsData = try JSONSerialization.data(withJSONObject: changedFields)
-                let oldValuesData = try JSONSerialization.data(
-                    withJSONObject: oldValues.mapValues { $0 ?? NSNull() }
-                )
+                let changedFieldsData = try JSONSerialization.data(withJSONObject: changedFields, options: [.sortedKeys])
+                let oldValuesData = try JSONSerialization.data(withJSONObject: oldValues, options: [.sortedKeys])
+                guard let changedFieldsJSON = String(data: changedFieldsData, encoding: .utf8),
+                      let oldValuesJSON = String(data: oldValuesData, encoding: .utf8) else { return }
+
                 try dbConn.execute(sql: """
                     INSERT INTO _change_log
                     (device_id, table_name, record_id, operation, changed_fields, old_values, timestamp)
                     VALUES ('local', 'notebook_entries', ?, 'UPDATE', ?, ?, datetime('now'))
-                    """, arguments: [
-                        entryId,
-                        String(data: changedFieldsData, encoding: .utf8),
-                        String(data: oldValuesData, encoding: .utf8)
-                    ])
+                    """, arguments: [entryId, changedFieldsJSON, oldValuesJSON])
             }
         }
     }

--- a/core/Sources/WiredPartCore/Services/NotebooksService.swift
+++ b/core/Sources/WiredPartCore/Services/NotebooksService.swift
@@ -950,13 +950,66 @@ public final class NotebooksService: Sendable {
         }
     }
 
-    /// Update a block entry's content and/or block data.
-    public func updateBlockEntry(entryId: Int64, content: String?, blockData: String?) throws {
+    /// Update a block entry's editable fields and record a minimal audit/change-log entry.
+    public func updateBlockEntry(
+        entryId: Int64,
+        title: String? = nil,
+        content: String?,
+        blockData: String?,
+        headingLevel: Int? = nil,
+        checklistItems: String? = nil,
+        updatedBy: Int64? = nil
+    ) throws {
         try db.writer.write { dbConn in
-            try dbConn.execute(sql: """
-                UPDATE notebook_entries SET content = ?, block_data = ?, updated_at = datetime('now')
+            guard let existing = try Row.fetchOne(dbConn, sql: """
+                SELECT title, content, block_data, heading_level, checklist_items
+                FROM notebook_entries
                 WHERE id = ? AND deleted_at IS NULL
-                """, arguments: [content, blockData, entryId])
+                """, arguments: [entryId]) else { return }
+
+            let newTitle = title ?? (existing["title"] as String? ?? "")
+            let oldTitle = existing["title"] as String? ?? ""
+            let oldContent = existing["content"] as String?
+            let oldBlockData = existing["block_data"] as String?
+            let oldHeadingLevel = existing["heading_level"] as Int?
+            let oldChecklistItems = existing["checklist_items"] as String?
+
+            try dbConn.execute(sql: """
+                UPDATE notebook_entries
+                SET title = ?, content = ?, block_data = ?, heading_level = ?, checklist_items = ?,
+                    updated_by = ?, updated_at = datetime('now')
+                WHERE id = ? AND deleted_at IS NULL
+                """, arguments: [newTitle, content, blockData, headingLevel, checklistItems, updatedBy, entryId])
+
+            var changedFields: [String] = []
+            var oldValues: [String: Any?] = [:]
+            func track<T: Equatable>(_ field: String, old: T?, new: T?) {
+                if old != new {
+                    changedFields.append(field)
+                    oldValues[field] = old
+                }
+            }
+            track("title", old: oldTitle, new: newTitle)
+            track("content", old: oldContent, new: content)
+            track("block_data", old: oldBlockData, new: blockData)
+            track("heading_level", old: oldHeadingLevel, new: headingLevel)
+            track("checklist_items", old: oldChecklistItems, new: checklistItems)
+
+            if !changedFields.isEmpty {
+                let changedFieldsData = try JSONSerialization.data(withJSONObject: changedFields)
+                let oldValuesData = try JSONSerialization.data(
+                    withJSONObject: oldValues.mapValues { $0 ?? NSNull() }
+                )
+                try dbConn.execute(sql: """
+                    INSERT INTO _change_log
+                    (device_id, table_name, record_id, operation, changed_fields, old_values, timestamp)
+                    VALUES ('local', 'notebook_entries', ?, 'UPDATE', ?, ?, datetime('now'))
+                    """, arguments: [
+                        entryId,
+                        String(data: changedFieldsData, encoding: .utf8),
+                        String(data: oldValuesData, encoding: .utf8)
+                    ])
+            }
         }
     }
 

--- a/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
@@ -130,6 +130,53 @@ struct NotebooksServiceTests {
         #expect(updated?.content == "Revised content")
     }
 
+    @Test("Editing a block entry updates title and records change history")
+    func testUpdateBlockEntryTitleAndHistory() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        let nbId = try env.notebooks.createNotebook(
+            title: "Editable Blocks",
+            notebookType: "general",
+            createdBy: env.adminUserId
+        )
+        let sectionId = try env.notebooks.createSection(
+            notebookId: nbId, groupId: nil, name: "Info"
+        )
+        let entryId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "heading",
+            title: "Original heading",
+            content: nil,
+            createdBy: env.adminUserId
+        )
+
+        try env.notebooks.updateBlockEntry(
+            entryId: entryId,
+            title: "Revised heading",
+            content: nil,
+            blockData: nil,
+            updatedBy: env.adminUserId
+        )
+
+        let hierarchy = try env.notebooks.getNotebookHierarchy(notebookId: nbId)
+        let updated = hierarchy.ungroupedSections.flatMap(\.entries).first { $0.id == entryId }
+        #expect(updated?.title == "Revised heading")
+
+        let historyRows = try env.db.writer.read { dbConn in
+            try Row.fetchAll(dbConn, sql: """
+                SELECT changed_fields, old_values
+                FROM _change_log
+                WHERE table_name = 'notebook_entries'
+                  AND record_id = ?
+                  AND operation = 'UPDATE'
+                ORDER BY id DESC
+                """, arguments: [entryId])
+        }
+        #expect(historyRows.count == 1)
+        #expect((historyRows.first?["changed_fields"] as String?)?.contains("title") == true)
+        #expect((historyRows.first?["old_values"] as String?)?.contains("Original heading") == true)
+    }
+
     // MARK: - 5. Delete Entry (Soft Delete)
 
     @Test("Soft-delete a block entry removes it from hierarchy")

--- a/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
@@ -119,7 +119,8 @@ struct NotebooksServiceTests {
         try env.notebooks.updateBlockEntry(
             entryId: entryId,
             content: "Revised content",
-            blockData: nil
+            blockData: nil,
+            updatedBy: env.adminUserId
         )
 
         // Verify through hierarchy
@@ -173,8 +174,17 @@ struct NotebooksServiceTests {
                 """, arguments: [entryId])
         }
         #expect(historyRows.count == 1)
-        #expect((historyRows.first?["changed_fields"] as String?)?.contains("title") == true)
-        #expect((historyRows.first?["old_values"] as String?)?.contains("Original heading") == true)
+        let changedFieldsJSON = historyRows.first?["changed_fields"] as String?
+        let oldValuesJSON = historyRows.first?["old_values"] as String?
+        #expect(changedFieldsJSON?.contains("title") == true)
+        #expect(oldValuesJSON?.contains("Original heading") == true)
+
+        let changedFieldsData = try #require(changedFieldsJSON?.data(using: .utf8))
+        let oldValuesData = try #require(oldValuesJSON?.data(using: .utf8))
+        let changedFields = try #require(JSONSerialization.jsonObject(with: changedFieldsData) as? [String: Any])
+        let oldValues = try #require(JSONSerialization.jsonObject(with: oldValuesData) as? [String: Any])
+        #expect(changedFields["title"] as? String == "Revised heading")
+        #expect(oldValues["title"] as? String == "Original heading")
     }
 
     // MARK: - 5. Delete Entry (Soft Delete)
@@ -1646,7 +1656,7 @@ struct NotebooksServiceTests {
         try env.db.writer.write { db in
             try db.execute(sql: "UPDATE notebook_entries SET deleted_at = datetime('now'), is_deleted = 1 WHERE id = ?", arguments: [entryId])
         }
-        try env.notebooks.updateBlockEntry(entryId: entryId, content: "MUTATED", blockData: nil)
+        try env.notebooks.updateBlockEntry(entryId: entryId, content: "MUTATED", blockData: nil, updatedBy: env.adminUserId)
         let content = try env.db.writer.read { db in
             try String.fetchOne(db, sql: "SELECT content FROM notebook_entries WHERE id = ?", arguments: [entryId])
         }


### PR DESCRIPTION
Fixes #628.

## Summary
- Adds a visible edit button to each notebook block row on the Notebook Detail page instead of requiring users to discover long-press context menus.
- Updates the block edit save path so title-only blocks such as headings/todos can actually be changed.
- Records notebook entry edits to `_change_log` with changed fields and old values so change history is preserved.

## Verification
- `swift test --filter NotebooksServiceTests/testUpdateBlockEntryTitleAndHistory`
- `swift test --filter NotebooksServiceTests`
- `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build CODE_SIGNING_ALLOWED=NO`

Note: a full `swift test` run was attempted but exceeded the 600s local timeout while still running; the focused notebooks suite and iOS build passed.