### PR TITLE
fix(notebooks): harden block edit history

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -1187,10 +1187,6 @@ struct IOSNotebookDetailPage: View {
             loadError = "No notebook loaded"
             return
         }
-        guard let userId = appCore.currentUser?.id else {
-            loadError = "Not logged in. Please log in and try again."
-            return
-        }
         guard let json = try? JSONEncoder().encode(schedule),
               let jsonString = String(data: json, encoding: .utf8) else {
             loadError = "Failed to encode panel schedule"

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -1187,6 +1187,10 @@ struct IOSNotebookDetailPage: View {
             loadError = "No notebook loaded"
             return
         }
+        guard let userId = appCore.currentUser?.id else {
+            loadError = "Not logged in. Please log in and try again."
+            return
+        }
         guard let json = try? JSONEncoder().encode(schedule),
               let jsonString = String(data: json, encoding: .utf8) else {
             loadError = "Failed to encode panel schedule"

--- a/core/Sources/WiredPartCore/Services/NotebooksService.swift
+++ b/core/Sources/WiredPartCore/Services/NotebooksService.swift
@@ -27,6 +27,7 @@ public final class NotebooksService: Sendable {
         case entryNotFound(Int64)
         case requiredFieldEmpty
         case invalidDuration(Int64)
+        case invalidData(String)
         case insufficientPermissions(required: String)
 
         public var errorDescription: String? {
@@ -41,6 +42,8 @@ public final class NotebooksService: Sendable {
                 return "A required field is empty."
             case .invalidDuration(let duration):
                 return "Invalid duration: \(duration)."
+            case .invalidData(let message):
+                return message
             }
         }
     }
@@ -942,6 +945,9 @@ public final class NotebooksService: Sendable {
                 SELECT notebook_id FROM notebook_sections WHERE id = ?
                 """, arguments: [sectionId])
 
+            let storedBlockData = blockType == "checklist" ? nil : blockData
+            let storedChecklistItems = checklistItems ?? (blockType == "checklist" ? blockData : nil)
+
             try dbConn.execute(sql: """
                 INSERT INTO notebook_entries
                 (section_id, notebook_id, title, content, entry_type, block_type, block_data,
@@ -949,8 +955,8 @@ public final class NotebooksService: Sendable {
                  sort_order, created_by, created_at, updated_at)
                 VALUES (?, ?, ?, ?, 'note', ?, ?, ?, ?, 0, 0, 0, ?, ?, datetime('now'), datetime('now'))
                 """, arguments: [
-                    sectionId, notebookId, title ?? "", content, blockType, blockData,
-                    headingLevel, checklistItems, order, createdBy
+                    sectionId, notebookId, title ?? "", content, blockType, storedBlockData,
+                    headingLevel, storedChecklistItems, order, createdBy
                 ])
             return dbConn.lastInsertedRowID
         }
@@ -991,23 +997,31 @@ public final class NotebooksService: Sendable {
 
             var changedFields: [String: Any] = [:]
             var oldValues: [String: Any] = [:]
-            func track<T: Equatable>(_ field: String, old: T?, new: T?) {
+            func trackString(_ field: String, old: String?, new: String?) {
                 if old != new {
                     changedFields[field] = new ?? NSNull()
                     oldValues[field] = old ?? NSNull()
                 }
             }
-            track("title", old: oldTitle, new: newTitle)
-            track("content", old: oldContent, new: content)
-            track("block_data", old: oldBlockData, new: blockData)
-            track("heading_level", old: oldHeadingLevel, new: headingLevel)
-            track("checklist_items", old: oldChecklistItems, new: checklistItems)
+            func trackInt(_ field: String, old: Int?, new: Int?) {
+                if old != new {
+                    changedFields[field] = new ?? NSNull()
+                    oldValues[field] = old ?? NSNull()
+                }
+            }
+            trackString("title", old: oldTitle, new: newTitle)
+            trackString("content", old: oldContent, new: content)
+            trackString("block_data", old: oldBlockData, new: blockData)
+            trackInt("heading_level", old: oldHeadingLevel, new: headingLevel)
+            trackString("checklist_items", old: oldChecklistItems, new: checklistItems)
 
             if !changedFields.isEmpty {
                 let changedFieldsData = try JSONSerialization.data(withJSONObject: changedFields, options: [.sortedKeys])
                 let oldValuesData = try JSONSerialization.data(withJSONObject: oldValues, options: [.sortedKeys])
                 guard let changedFieldsJSON = String(data: changedFieldsData, encoding: .utf8),
-                      let oldValuesJSON = String(data: oldValuesData, encoding: .utf8) else { return }
+                      let oldValuesJSON = String(data: oldValuesData, encoding: .utf8) else {
+                    throw NotebooksError.invalidData("Unable to encode notebook change history")
+                }
 
                 try dbConn.execute(sql: """
                     INSERT INTO _change_log

--- a/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
@@ -187,6 +187,77 @@ struct NotebooksServiceTests {
         #expect(oldValues["title"] as? String == "Original heading")
     }
 
+    @Test("Creating checklist block entries stores checklist items in the canonical column")
+    func testCreateChecklistBlockEntryStoresChecklistItems() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        let nbId = try env.notebooks.createNotebook(
+            title: "Checklist Blocks",
+            notebookType: "general",
+            createdBy: env.adminUserId
+        )
+        let sectionId = try env.notebooks.createSection(
+            notebookId: nbId, groupId: nil, name: "Checklist"
+        )
+        let checklistJSON = """
+        [{"text":"Verify breaker labels","checked":"false"}]
+        """
+
+        let entryId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "checklist",
+            title: "Commissioning",
+            content: nil,
+            blockData: nil,
+            checklistItems: checklistJSON,
+            createdBy: env.adminUserId
+        )
+
+        let stored = try env.db.writer.read { dbConn in
+            try Row.fetchOne(dbConn, sql: """
+                SELECT block_data, checklist_items
+                FROM notebook_entries
+                WHERE id = ?
+                """, arguments: [entryId])
+        }
+        #expect((stored?["block_data"] as String?) == nil)
+        #expect((stored?["checklist_items"] as String?) == checklistJSON)
+
+        let hierarchy = try env.notebooks.getNotebookHierarchy(notebookId: nbId)
+        let entry = hierarchy.ungroupedSections.flatMap(\.entries).first { $0.id == entryId }
+        #expect(entry?.checklistItems == checklistJSON)
+    }
+
+    @Test("Updating block entries requires manage_notebooks permission")
+    func testUpdateBlockEntryRequiresManageNotebooksPermission() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        let nbId = try env.notebooks.createNotebook(
+            title: "Permissioned Blocks",
+            notebookType: "general",
+            createdBy: env.adminUserId
+        )
+        let sectionId = try env.notebooks.createSection(
+            notebookId: nbId, groupId: nil, name: "Main"
+        )
+        let entryId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "text",
+            title: "Protected",
+            content: "Original",
+            createdBy: env.adminUserId
+        )
+
+        #expect(throws: ServicePermissionGate.GateError.self) {
+            try env.notebooks.updateBlockEntry(
+                entryId: entryId,
+                content: "Unauthorized",
+                blockData: nil,
+                updatedBy: 999_999
+            )
+        }
+    }
+
     // MARK: - 5. Delete Entry (Soft Delete)
 
     @Test("Soft-delete a block entry removes it from hierarchy")


### PR DESCRIPTION
Follow-up to merged PR #637.\n\n## Summary\n- Enforce manage_notebooks permission on block-entry edits that write updated_by/change history.\n- Keep notebook entry change history sync-compatible by writing changed_fields as a field->newValue JSON object and old_values as Foundation JSON values.\n- Preserve checklist block items in the canonical checklist_items column on create.\n- Pass current user identity through panel-schedule block updates.\n\n## Validation\n- git diff --check origin/main...HEAD\n- Conflict-marker scan on PR diff\n- swift test --package-path core --scratch-path /tmp/wei1903-pr637-clean-build --filter 'NotebooksServiceTests/testUpdateBlockEntry|NotebooksServiceTests/testUpdateBlockEntryTitleAndHistory|NotebooksServiceTests/testCreateChecklistBlockEntryStoresChecklistItems|NotebooksServiceTests/testUpdateBlockEntryRequiresManageNotebooksPermission'\n- xcodebuild build-for-testing -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "generic/platform=iOS Simulator" -derivedDataPath /tmp/wei1903-pr637-clean-derived-* CODE_SIGNING_ALLOWED=NO\n\nBranch-drain context: #637 merged while the heartbeat was resolving review comments, so this PR carries the clean follow-up diff on current main.