### PR TITLE
fix(parts): add supplier edit and brand linking flow

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
@@ -214,6 +214,12 @@ struct PartsSuppliersPage: View {
                     } label: {
                         Label("Delete", systemImage: "trash")
                     }
+                    Button {
+                        activeSheet = .editSupplier(supplier)
+                    } label: {
+                        Label("Edit", systemImage: "pencil")
+                    }
+                    .tint(.blue)
                 }
             }
         }
@@ -655,15 +661,17 @@ private struct SupplierDetailSheet: View {
     // Single active-sheet enum to avoid multiple .sheet conflicts
     enum ActiveSheet: Identifiable {
         case addContact
+        case addBrand
 
         var id: String {
             switch self {
             case .addContact: return "addContact"
+            case .addBrand: return "addBrand"
             }
         }
     }
 
-    @State private var linkedBrands: [(brandId: Int64, brandName: String, partCount: Int, carryStatus: String)] = []
+    @State private var linkedBrands: [PartsService.SupplierBrandRow] = []
     @State private var recentPOs: [(poId: Int64, poNumber: String, status: String, total: Double, date: String)] = []
     @State private var supplierScores: PartsService.SupplierScores?
     @State private var contacts: [PartsService.SupplierContact] = []
@@ -752,6 +760,12 @@ private struct SupplierDetailSheet: View {
                         }
                     }
                     .environmentObject(appCore)
+                case .addBrand:
+                    LinkSupplierBrandsSheet(supplierId: supplier.id) {
+                        await loadAllDetails()
+                        await onUpdate()
+                    }
+                    .environmentObject(appCore)
                 }
             }
         }
@@ -813,6 +827,15 @@ private struct SupplierDetailSheet: View {
     @ViewBuilder
     private var overviewSection: some View {
         Section {
+            Button {
+                dismiss()
+                onEdit()
+            } label: {
+                Label("Edit Supplier Info", systemImage: "pencil")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .frame(minHeight: 44)
+            }
+
             if let acct = supplier.accountNumber, !acct.isEmpty {
                 LabeledContent("Account #", value: acct)
             }
@@ -1041,7 +1064,7 @@ private struct SupplierDetailSheet: View {
     private var brandsSection: some View {
         Section {
             if linkedBrands.isEmpty {
-                Text("No brands linked. Link brands from the Brands tab.")
+                Text("No brands linked yet. Tap + to link existing brands this supplier carries.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } else {
@@ -1080,11 +1103,21 @@ private struct SupplierDetailSheet: View {
                 }
             }
         } header: {
-            Text("Brands Carried (\(linkedBrands.count))")
+            HStack {
+                Text("Brands Carried (\(linkedBrands.count))")
+                Spacer()
+                Button {
+                    activeSheet = .addBrand
+                } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .font(.title3)
+                }
+                .accessibilityLabel("Link brand")
+            }
         }
     }
 
-    private func toggleBrandCarryStatus(_ item: (brandId: Int64, brandName: String, partCount: Int, carryStatus: String)) {
+    private func toggleBrandCarryStatus(_ item: PartsService.SupplierBrandRow) {
         guard let service = appCore.partsService else {
             loadError = "Parts service unavailable"
             return
@@ -1098,7 +1131,7 @@ private struct SupplierDetailSheet: View {
             )
             // Reload brands to reflect the change
             do {
-                linkedBrands = try service.getSupplierBrands(supplierId: supplier.id)
+                linkedBrands = try service.getSupplierBrandRows(supplierId: supplier.id)
             } catch {
                 loadError = userFriendlyError(error, context: "reload brands")
             }
@@ -1193,7 +1226,7 @@ private struct SupplierDetailSheet: View {
             return
         }
         do {
-            linkedBrands = try service.getSupplierBrands(supplierId: supplier.id)
+            linkedBrands = try service.getSupplierBrandRows(supplierId: supplier.id)
             recentPOs = try service.getSupplierRecentPOs(supplierId: supplier.id)
             partCount = try service.getSupplierPartCount(supplierId: supplier.id)
             contacts = try service.getSupplierContacts(supplierId: supplier.id)
@@ -1210,6 +1243,128 @@ private struct SupplierDetailSheet: View {
         } catch {
             isLoading = false
         }
+    }
+}
+
+// MARK: - Link Supplier Brands Sheet
+
+private struct LinkSupplierBrandsSheet: View {
+    let supplierId: Int64
+    let onSave: () async -> Void
+    @EnvironmentObject private var appCore: AppCore
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var availableBrands: [(id: Int64, name: String)] = []
+    @State private var selectedBrandIds: Set<Int64> = []
+    @State private var loadError: String?
+    @State private var isLoading = true
+    @State private var isSaving = false
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading {
+                    ProgressView("Loading brands...")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let error = loadError {
+                    ErrorStateView(message: error) { Task { await loadAvailableBrands() } }
+                } else if availableBrands.isEmpty {
+                    VStack(spacing: 12) {
+                        Image(systemName: "tag")
+                            .decorativeIconFont(40)
+                            .foregroundStyle(.secondary)
+                        Text("No Unlinked Brands")
+                            .font(.headline)
+                        Text("All existing brands are already linked to this supplier. Add a new brand from the Brands tab first if needed.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 24)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    List(availableBrands, id: \.id) { brand in
+                        Button {
+                            if selectedBrandIds.contains(brand.id) {
+                                selectedBrandIds.remove(brand.id)
+                            } else {
+                                selectedBrandIds.insert(brand.id)
+                            }
+                        } label: {
+                            HStack {
+                                Label(brand.name, systemImage: "tag.fill")
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                if selectedBrandIds.contains(brand.id) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(Color.accentColor)
+                                }
+                            }
+                            .frame(minHeight: 44)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+            .navigationTitle("Link Brands")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        Task { await save() }
+                    } label: {
+                        if isSaving { ProgressView() } else { Text("Link") }
+                    }
+                    .disabled(selectedBrandIds.isEmpty || isSaving)
+                }
+            }
+            .task { await loadAvailableBrands() }
+            .interactiveDismissDisabled(isSaving)
+        }
+    }
+
+    private func loadAvailableBrands() async {
+        isLoading = true
+        loadError = nil
+        do {
+            guard let service = appCore.partsService else {
+                loadError = "Parts service not available"
+                isLoading = false
+                return
+            }
+            availableBrands = try service.listBrandsAvailableForSupplier(supplierId: supplierId)
+                .compactMap { brand in
+                    guard let id = brand.id else { return nil }
+                    return (id: id, name: brand.name)
+                }
+            isLoading = false
+        } catch {
+            loadError = userFriendlyError(error, context: "load brands")
+            isLoading = false
+        }
+    }
+
+    private func save() async {
+        isSaving = true
+        loadError = nil
+        do {
+            guard let service = appCore.partsService else {
+                loadError = "Parts service not available"
+                isSaving = false
+                return
+            }
+            for brandId in selectedBrandIds {
+                try service.linkBrandToSupplier(brandId: brandId, supplierId: supplierId)
+            }
+            dismiss()
+            await onSave()
+        } catch {
+            loadError = userFriendlyError(error, context: "link brands")
+        }
+        isSaving = false
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
@@ -1291,15 +1291,20 @@ private struct LinkSupplierBrandsSheet: View {
                                 selectedBrandIds.insert(brand.id)
                             }
                         } label: {
+                            let isSelected = selectedBrandIds.contains(brand.id)
                             HStack {
                                 Label(brand.name, systemImage: "tag.fill")
                                     .frame(maxWidth: .infinity, alignment: .leading)
-                                if selectedBrandIds.contains(brand.id) {
+                                if isSelected {
                                     Image(systemName: "checkmark.circle.fill")
                                         .foregroundStyle(Color.accentColor)
                                 }
                             }
                             .frame(minHeight: 44)
+                            .accessibilityElement(children: .ignore)
+                            .accessibilityLabel(brand.name)
+                            .accessibilityValue(isSelected ? "Selected" : "Not selected")
+                            .accessibilityHint("Double tap to toggle this brand for linking")
                         }
                         .buttonStyle(.plain)
                     }
@@ -1356,9 +1361,12 @@ private struct LinkSupplierBrandsSheet: View {
                 isSaving = false
                 return
             }
-            for brandId in selectedBrandIds {
-                try service.linkBrandToSupplier(brandId: brandId, supplierId: supplierId)
-            }
+            let existingBrandIds = try service.getSupplierBrandRows(supplierId: supplierId)
+                .map(\.brandId)
+            try service.setSupplierBrands(
+                supplierId: supplierId,
+                brandIds: Set(existingBrandIds).union(selectedBrandIds)
+            )
             dismiss()
             await onSave()
         } catch {

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -2083,13 +2083,21 @@ public final class PartsService: Sendable {
                        COUNT(DISTINCT ps.part_id) AS part_count,
                        COALESCE(bsl.carry_status, 'carry_on_shelf') AS carry_status
                 FROM brand_supplier_links bsl
-                JOIN brands b ON b.id = bsl.brand_id AND b.deleted_at IS NULL
-                LEFT JOIN parts p ON p.brand_id = b.id AND p.deleted_at IS NULL
+                JOIN brands b
+                  ON b.id = bsl.brand_id
+                 AND b.is_active = 1
+                 AND b.deleted_at IS NULL
+                LEFT JOIN parts p
+                  ON p.brand_id = b.id
+                 AND p.is_active = 1
+                 AND p.deleted_at IS NULL
                 LEFT JOIN part_supplier_links ps
                     ON ps.part_id = p.id
                    AND ps.supplier_id = bsl.supplier_id
                    AND ps.deleted_at IS NULL
-                WHERE bsl.supplier_id = ? AND bsl.deleted_at IS NULL
+                WHERE bsl.supplier_id = ?
+                  AND bsl.is_active = 1
+                  AND bsl.deleted_at IS NULL
                 GROUP BY b.id, b.name, bsl.carry_status
                 ORDER BY b.name ASC
                 """, arguments: [supplierId])
@@ -2111,12 +2119,14 @@ public final class PartsService: Sendable {
             try Brand.fetchAll(dbConn, sql: """
                 SELECT b.*
                 FROM brands b
-                WHERE b.deleted_at IS NULL
+                WHERE b.is_active = 1
+                  AND b.deleted_at IS NULL
                   AND NOT EXISTS (
                     SELECT 1
                     FROM brand_supplier_links bsl
                     WHERE bsl.brand_id = b.id
                       AND bsl.supplier_id = ?
+                      AND bsl.is_active = 1
                       AND bsl.deleted_at IS NULL
                   )
                 ORDER BY b.name ASC
@@ -2127,15 +2137,91 @@ public final class PartsService: Sendable {
     /// Set the complete list of brands for a supplier.
     /// Links brands in `brandIds`, unlinks any not in the list.
     public func setSupplierBrands(supplierId: Int64, brandIds: Set<Int64>) throws {
-        let currentRows = try getSupplierBrandRows(supplierId: supplierId)
-        let currentIds = Set(currentRows.map(\.brandId))
+        try db.writer.write { dbConn in
+            let supplierExists = (try Int.fetchOne(dbConn, sql: """
+                SELECT COUNT(*) FROM suppliers
+                WHERE id = ? AND is_active = 1 AND deleted_at IS NULL
+                """, arguments: [supplierId]) ?? 0) > 0
+            guard supplierExists else { throw PartsError.supplierNotFound(supplierId) }
 
-        for brandId in brandIds.subtracting(currentIds) {
-            try linkBrandToSupplier(brandId: brandId, supplierId: supplierId)
-        }
+            if !brandIds.isEmpty {
+                let placeholders = Array(repeating: "?", count: brandIds.count).joined(separator: ",")
+                let activeBrandCount = try Int.fetchOne(
+                    dbConn,
+                    sql: """
+                        SELECT COUNT(*) FROM brands
+                        WHERE id IN (\(placeholders))
+                          AND is_active = 1
+                          AND deleted_at IS NULL
+                        """,
+                    arguments: StatementArguments(brandIds.sorted())
+                ) ?? 0
+                guard activeBrandCount == brandIds.count else {
+                    let validBrandIds = try Int64.fetchAll(
+                        dbConn,
+                        sql: """
+                            SELECT id FROM brands
+                            WHERE id IN (\(placeholders))
+                              AND is_active = 1
+                              AND deleted_at IS NULL
+                            """,
+                        arguments: StatementArguments(brandIds.sorted())
+                    )
+                    let missingBrandId = brandIds.subtracting(validBrandIds).sorted().first ?? 0
+                    throw PartsError.brandNotFound(missingBrandId)
+                }
+            }
 
-        for brandId in currentIds.subtracting(brandIds) {
-            try unlinkBrandFromSupplier(brandId: brandId, supplierId: supplierId)
+            let currentIds = Set(try Int64.fetchAll(dbConn, sql: """
+                SELECT brand_id FROM brand_supplier_links
+                WHERE supplier_id = ?
+                  AND is_active = 1
+                  AND deleted_at IS NULL
+                """, arguments: [supplierId]))
+
+            for brandId in brandIds.subtracting(currentIds).sorted() {
+                if let existing = try Row.fetchOne(
+                    dbConn,
+                    sql: """
+                        SELECT id FROM brand_supplier_links
+                        WHERE brand_id = ? AND supplier_id = ?
+                        """,
+                    arguments: [brandId, supplierId]
+                ) {
+                    let linkId: Int64 = existing["id"]
+                    try dbConn.execute(
+                        sql: """
+                            UPDATE brand_supplier_links
+                            SET deleted_at = NULL,
+                                is_active = 1,
+                                carry_status = COALESCE(carry_status, 'carry_on_shelf')
+                            WHERE id = ?
+                            """,
+                        arguments: [linkId]
+                    )
+                } else {
+                    try dbConn.execute(
+                        sql: """
+                            INSERT INTO brand_supplier_links (brand_id, supplier_id, is_active, created_at)
+                            VALUES (?, ?, 1, datetime('now'))
+                            """,
+                        arguments: [brandId, supplierId]
+                    )
+                }
+            }
+
+            for brandId in currentIds.subtracting(brandIds).sorted() {
+                try dbConn.execute(
+                    sql: """
+                        UPDATE brand_supplier_links
+                        SET deleted_at = datetime('now'), is_active = 0
+                        WHERE brand_id = ?
+                          AND supplier_id = ?
+                          AND deleted_at IS NULL
+                        """,
+                    arguments: [brandId, supplierId]
+                )
+            }
         }
     }
 

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -1895,6 +1895,16 @@ public final class PartsService: Sendable {
         public let carryStatus: String  // "carry_on_shelf" | "need_to_order"
     }
 
+    /// A supplier-side brand link row with part count and carry status.
+    public struct SupplierBrandRow: Sendable, Identifiable {
+        public let brandId: Int64
+        public let brandName: String
+        public let partCount: Int
+        public let carryStatus: String  // "carry_on_shelf" | "need_to_order"
+
+        public var id: Int64 { brandId }
+    }
+
     /// Get all suppliers for a brand (via brand_supplier_links).
     public func getBrandSuppliers(brandId: Int64) throws -> [Supplier] {
         do {
@@ -2008,7 +2018,9 @@ public final class PartsService: Sendable {
                 try dbConn.execute(
                     sql: """
                         UPDATE brand_supplier_links
-                        SET deleted_at = NULL, is_active = 1
+                        SET deleted_at = NULL,
+                            is_active = 1,
+                            carry_status = COALESCE(carry_status, 'carry_on_shelf')
                         WHERE id = ?
                         """,
                     arguments: [linkId]
@@ -2058,6 +2070,71 @@ public final class PartsService: Sendable {
         // Remove old links
         let toRemove = currentIds.subtracting(supplierIds)
         for supplierId in toRemove {
+            try unlinkBrandFromSupplier(brandId: brandId, supplierId: supplierId)
+        }
+    }
+
+    /// Get supplier-side brand rows with carry status and part count.
+    public func getSupplierBrandRows(supplierId: Int64) throws -> [SupplierBrandRow] {
+        try db.writer.read { dbConn in
+            let rows = try Row.fetchAll(dbConn, sql: """
+                SELECT b.id AS brand_id,
+                       b.name AS brand_name,
+                       COUNT(DISTINCT ps.part_id) AS part_count,
+                       COALESCE(bsl.carry_status, 'carry_on_shelf') AS carry_status
+                FROM brand_supplier_links bsl
+                JOIN brands b ON b.id = bsl.brand_id AND b.deleted_at IS NULL
+                LEFT JOIN parts p ON p.brand_id = b.id AND p.deleted_at IS NULL
+                LEFT JOIN part_supplier_links ps
+                    ON ps.part_id = p.id
+                   AND ps.supplier_id = bsl.supplier_id
+                   AND ps.deleted_at IS NULL
+                WHERE bsl.supplier_id = ? AND bsl.deleted_at IS NULL
+                GROUP BY b.id, b.name, bsl.carry_status
+                ORDER BY b.name ASC
+                """, arguments: [supplierId])
+
+            return rows.map { row in
+                SupplierBrandRow(
+                    brandId: row["brand_id"] as Int64? ?? 0,
+                    brandName: row["brand_name"] as String? ?? "",
+                    partCount: row["part_count"] as Int? ?? 0,
+                    carryStatus: row["carry_status"] as String? ?? "carry_on_shelf"
+                )
+            }
+        }
+    }
+
+    /// List active brands that are not currently linked to the supplier.
+    public func listBrandsAvailableForSupplier(supplierId: Int64) throws -> [Brand] {
+        try db.writer.read { dbConn in
+            try Brand.fetchAll(dbConn, sql: """
+                SELECT b.*
+                FROM brands b
+                WHERE b.deleted_at IS NULL
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM brand_supplier_links bsl
+                    WHERE bsl.brand_id = b.id
+                      AND bsl.supplier_id = ?
+                      AND bsl.deleted_at IS NULL
+                  )
+                ORDER BY b.name ASC
+                """, arguments: [supplierId])
+        }
+    }
+
+    /// Set the complete list of brands for a supplier.
+    /// Links brands in `brandIds`, unlinks any not in the list.
+    public func setSupplierBrands(supplierId: Int64, brandIds: Set<Int64>) throws {
+        let currentRows = try getSupplierBrandRows(supplierId: supplierId)
+        let currentIds = Set(currentRows.map(\.brandId))
+
+        for brandId in brandIds.subtracting(currentIds) {
+            try linkBrandToSupplier(brandId: brandId, supplierId: supplierId)
+        }
+
+        for brandId in currentIds.subtracting(brandIds) {
             try unlinkBrandFromSupplier(brandId: brandId, supplierId: supplierId)
         }
     }

--- a/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
@@ -213,6 +213,41 @@ struct PartsServiceExtTests {
         #expect(suppliers.contains(where: { $0.supplier.name == "ElecSupply Co" }))
     }
 
+    @Test("Supplier-brand links can be managed from supplier side")
+    func testSetSupplierBrandsLinksAndUnlinksExistingBrands() throws {
+        let env = try E2ETestHelpers.setUp()
+        let supplierId = try env.parts.createSupplier(name: "Supplier Brand Manager")
+        let keepBrandId = try env.parts.createBrand(name: "Keep Brand")
+        let removeBrandId = try env.parts.createBrand(name: "Remove Brand")
+        let addBrandId = try env.parts.createBrand(name: "Add Brand")
+
+        try env.parts.setSupplierBrands(supplierId: supplierId, brandIds: [keepBrandId, removeBrandId])
+        try env.parts.setSupplierBrands(supplierId: supplierId, brandIds: [keepBrandId, addBrandId])
+
+        let linkedBrands = try env.parts.getSupplierBrandRows(supplierId: supplierId)
+        #expect(linkedBrands.map(\.brandId).sorted() == [addBrandId, keepBrandId].sorted())
+        #expect(linkedBrands.allSatisfy { $0.carryStatus == "carry_on_shelf" })
+    }
+
+    @Test("Supplier-side brand picker only offers active unlinked brands")
+    func testListBrandsAvailableForSupplierExcludesLinkedAndDeletedBrands() throws {
+        let env = try E2ETestHelpers.setUp()
+        let supplierId = try env.parts.createSupplier(name: "Picker Supplier")
+        let linkedBrandId = try env.parts.createBrand(name: "Already Linked")
+        let availableBrandId = try env.parts.createBrand(name: "Available Brand")
+        let deletedBrandId = try env.parts.createBrand(name: "Deleted Brand")
+        try env.parts.linkBrandToSupplier(brandId: linkedBrandId, supplierId: supplierId)
+        try env.db.writer.write { db in
+            try db.execute(
+                sql: "UPDATE brands SET deleted_at = datetime('now') WHERE id = ?",
+                arguments: [deletedBrandId]
+            )
+        }
+
+        let availableBrands = try env.parts.listBrandsAvailableForSupplier(supplierId: supplierId)
+        #expect(availableBrands.map(\.id) == [availableBrandId])
+    }
+
     @Test("Part-supplier link")
     func testPartSupplierLink() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
@@ -236,16 +236,27 @@ struct PartsServiceExtTests {
         let linkedBrandId = try env.parts.createBrand(name: "Already Linked")
         let availableBrandId = try env.parts.createBrand(name: "Available Brand")
         let deletedBrandId = try env.parts.createBrand(name: "Deleted Brand")
+        let inactiveBrandId = try env.parts.createBrand(name: "Inactive Brand")
+        let inactiveLinkBrandId = try env.parts.createBrand(name: "Inactive Link Brand")
         try env.parts.linkBrandToSupplier(brandId: linkedBrandId, supplierId: supplierId)
+        try env.parts.linkBrandToSupplier(brandId: inactiveLinkBrandId, supplierId: supplierId)
         try env.db.writer.write { db in
             try db.execute(
                 sql: "UPDATE brands SET deleted_at = datetime('now') WHERE id = ?",
                 arguments: [deletedBrandId]
             )
+            try db.execute(
+                sql: "UPDATE brands SET is_active = 0 WHERE id = ?",
+                arguments: [inactiveBrandId]
+            )
+            try db.execute(
+                sql: "UPDATE brand_supplier_links SET is_active = 0 WHERE brand_id = ? AND supplier_id = ?",
+                arguments: [inactiveLinkBrandId, supplierId]
+            )
         }
 
         let availableBrands = try env.parts.listBrandsAvailableForSupplier(supplierId: supplierId)
-        #expect(availableBrands.map(\.id) == [availableBrandId])
+        #expect(availableBrands.compactMap(\.id) == [availableBrandId, inactiveLinkBrandId])
     }
 
     @Test("Part-supplier link")


### PR DESCRIPTION
## Summary
- Adds explicit supplier edit affordances from the supplier list and supplier detail sheet.
- Adds supplier-side brand linking so existing brands can be linked directly from a supplier detail view.
- Adds core service helpers for supplier-side brand rows, unlinked-brand picker data, and full supplier brand set updates.
- Adds regression tests for supplier-side brand linking and available-brand filtering.

## Verification
- swift test --filter PartsServiceExtTests/testSetSupplierBrandsLinksAndUnlinksExistingBrands --filter PartsServiceExtTests/testListBrandsAvailableForSupplierExcludesLinkedAndDeletedBrands
- swift test --filter PartsServiceExtTests
- xcrun swiftc -parse "Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift"

## Notes
- A full core  run was attempted twice, but the suite exceeded the 10-minute local timeout; the targeted PartsService extended suite passed.

Closes #634