### PR TITLE
Add clock-out daily report capture

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSQuestionnairePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSQuestionnairePage.swift
@@ -25,6 +25,7 @@ struct IOSQuestionnairePage: View {
     @State private var isLoading = true
     @State private var isSubmitting = false
     @State private var errorMessage: String?
+    @State private var dailyReportText = ""
 
     // Companion poll questions
     @State private var companionPolls: [(pollId: Int64, questionText: String, hasVoted: Bool)] = []
@@ -169,6 +170,32 @@ struct IOSQuestionnairePage: View {
                     }
                 }
 
+                // Daily report narrative captured at clock-out
+                Section {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Daily Report")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+
+                        Text("Add the work summary, progress, blockers, or notes the office needs from today.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        TextField("What got done today?", text: $dailyReportText, axis: .vertical)
+                            .lineLimit(3...8)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.subheadline)
+                    }
+                    .padding(.vertical, 4)
+                } header: {
+                    HStack {
+                        Image(systemName: "doc.text")
+                            .foregroundStyle(.blue)
+                            .accessibilityHidden(true)
+                        Text("Daily Report")
+                    }
+                }
+
                 // Companion poll questions (always optional)
                 if !companionPolls.isEmpty {
                     Section {
@@ -296,11 +323,22 @@ struct IOSQuestionnairePage: View {
         let responses: [(questionId: Int64, answer: String)] = questions.map { q in
             (questionId: q.questionId, answer: answers[q.questionId] ?? "")
         }
+        let configuredDailyReportAnswers = questions
+            .filter { $0.questionText.localizedCaseInsensitiveContains("daily report") }
+            .compactMap { answers[$0.questionId]?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let dailyReportBody = ([dailyReportText.trimmingCharacters(in: .whitespacesAndNewlines)] + configuredDailyReportAnswers)
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n\n")
 
         do {
             try service.saveClockOutResponses(
                 laborEntryId: laborEntryId,
                 responses: responses
+            )
+            try service.saveClockOutDailyReport(
+                laborEntryId: laborEntryId,
+                dailyReport: dailyReportBody
             )
 
             // Handle break verification
@@ -431,8 +469,8 @@ struct IOSQuestionnairePage: View {
         let context = """
         Clock-Out Questionnaire page. Read-only context.
         Labor entry id: \(laborEntryId), questions loaded: \(questions.count), required questions: \(requiredCount), answered fields: \(answeredCount), unanswered required: \(hasUnansweredRequired).
-        Answer types: \(answerTypes.isEmpty ? "none" : answerTypes), companion polls: \(companionPolls.count), break verification: \(breakVerification.rawValue), missed break selections: \(missedBreaks.count), submitting: \(isSubmitting).
-        Available read-only guidance: explain required questions, answer types, break verification, companion poll section, and submit/skip availability. Do not submit or change answers directly.
+        Answer types: \(answerTypes.isEmpty ? "none" : answerTypes), companion polls: \(companionPolls.count), break verification: \(breakVerification.rawValue), missed break selections: \(missedBreaks.count), daily report characters: \(dailyReportText.trimmingCharacters(in: .whitespacesAndNewlines).count), submitting: \(isSubmitting).
+        Available read-only guidance: explain required questions, answer types, break verification, Daily Report field, companion poll section, and submit/skip availability. Do not submit or change answers directly.
         """
         NotificationCenter.default.post(
             name: .questionnairePageActive,

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSQuestionnairePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSQuestionnairePage.swift
@@ -99,7 +99,7 @@ struct IOSQuestionnairePage: View {
                 }
 
                 // Question list
-                ForEach(questions, id: \.questionId) { question in
+                ForEach(displayedQuestions, id: \.questionId) { question in
                     Section {
                         VStack(alignment: .leading, spacing: 8) {
                             HStack(alignment: .top, spacing: 6) {
@@ -177,6 +177,12 @@ struct IOSQuestionnairePage: View {
                             .font(.subheadline)
                             .fontWeight(.medium)
 
+                        if isDailyReportRequired {
+                            Text("*")
+                                .foregroundStyle(.red)
+                                .fontWeight(.bold)
+                        }
+
                         Text("Add the work summary, progress, blockers, or notes the office needs from today.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -185,6 +191,12 @@ struct IOSQuestionnairePage: View {
                             .lineLimit(3...8)
                             .textFieldStyle(.roundedBorder)
                             .font(.subheadline)
+
+                        if isDailyReportRequired && dailyReportAnswer.isEmpty {
+                            Label("This question is required", systemImage: "exclamationmark.circle")
+                                .font(.caption2)
+                                .foregroundStyle(.red)
+                        }
                     }
                     .padding(.vertical, 4)
                 } header: {
@@ -300,14 +312,35 @@ struct IOSQuestionnairePage: View {
 
     /// True when at least one required question has no answer yet.
     private var hasUnansweredRequired: Bool {
-        questions.contains { question in
+        let hasUnansweredConfiguredQuestion = displayedQuestions.contains { question in
             question.isRequired &&
             (answers[question.questionId] ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
+        return hasUnansweredConfiguredQuestion || (isDailyReportRequired && dailyReportAnswer.isEmpty)
     }
 
     private var allRequiredAnswered: Bool {
         !hasUnansweredRequired
+    }
+
+    private var displayedQuestions: [JobsService.QuestionnaireItem] {
+        questions.filter { !isDailyReportQuestion($0) }
+    }
+
+    private var dailyReportQuestions: [JobsService.QuestionnaireItem] {
+        questions.filter(isDailyReportQuestion)
+    }
+
+    private var isDailyReportRequired: Bool {
+        dailyReportQuestions.contains { $0.isRequired }
+    }
+
+    private var dailyReportAnswer: String {
+        dailyReportText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func isDailyReportQuestion(_ question: JobsService.QuestionnaireItem) -> Bool {
+        question.questionText.localizedCaseInsensitiveContains("daily report")
     }
 
     // MARK: - Actions
@@ -321,15 +354,9 @@ struct IOSQuestionnairePage: View {
         errorMessage = nil
 
         let responses: [(questionId: Int64, answer: String)] = questions.map { q in
-            (questionId: q.questionId, answer: answers[q.questionId] ?? "")
+            (questionId: q.questionId, answer: isDailyReportQuestion(q) ? dailyReportAnswer : (answers[q.questionId] ?? ""))
         }
-        let configuredDailyReportAnswers = questions
-            .filter { $0.questionText.localizedCaseInsensitiveContains("daily report") }
-            .compactMap { answers[$0.questionId]?.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        let dailyReportBody = ([dailyReportText.trimmingCharacters(in: .whitespacesAndNewlines)] + configuredDailyReportAnswers)
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n\n")
+        let dailyReportBody = dailyReportAnswer
 
         do {
             try service.saveClockOutResponses(

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -129,6 +129,7 @@ extension AppDatabase {
         registerMigration090NotebookClassificationPermissions(&migrator)
         registerMigration091MultiUserAuditResolutionColumns(&migrator)
         registerMigration092VehicleLocationLatestLookupIndex(&migrator)
+        registerMigration093DailyReportClockOutQuestion(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -5342,6 +5343,37 @@ extension AppDatabase {
                     )
                 }
             }
+        }
+    }
+
+    // MARK: - Migration 093: Daily Report clock-out prompt
+
+    private static func registerMigration093DailyReportClockOutQuestion(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("093_daily_report_clock_out_question") { db in
+            let existingCount = try Int.fetchOne(
+                db,
+                sql: """
+                    SELECT COUNT(*)
+                    FROM clock_out_questions
+                    WHERE lower(question_text) LIKE '%daily report%'
+                      AND is_active = 1
+                    """
+            ) ?? 0
+            guard existingCount == 0 else { return }
+
+            let nextSortOrder = (try Int.fetchOne(
+                db,
+                sql: "SELECT COALESCE(MAX(sort_order), 0) + 1 FROM clock_out_questions"
+            ) ?? 1)
+
+            try db.execute(
+                sql: """
+                    INSERT INTO clock_out_questions
+                        (question_text, answer_type, is_required, sort_order, is_active, created_at, updated_at)
+                    VALUES (?, 'text', 1, ?, 1, datetime('now'), datetime('now'))
+                    """,
+                arguments: ["Daily Report: What did you accomplish today, and what should the office know for tomorrow?", nextSortOrder]
+            )
         }
     }
 }

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -1506,6 +1506,7 @@ public final class JobsService: Sendable {
         }
     }
 
+
     /// Get responses for a specific labor entry with question text.
     public func getResponsesForEntry(laborEntryId: Int64) throws -> [QuestionnaireItem] {
         do {
@@ -1684,6 +1685,127 @@ public final class JobsService: Sendable {
     // =========================================================================
     // MARK: - 5. Daily Reports
     // =========================================================================
+
+    /// Save the clock-out Daily Report answer into the job's Daily Report notebook.
+    ///
+    /// Blank answers are ignored so optional/accidental whitespace does not create empty reports.
+    /// The notebook is scoped to the labor entry's job and worker so reports remain tied to the
+    /// job that was just clocked out.
+    @discardableResult
+    public func saveClockOutDailyReport(laborEntryId: Int64, dailyReport: String) throws -> Int64? {
+        let trimmedReport = dailyReport.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedReport.isEmpty else { return nil }
+
+        return try db.writer.write { dbConn in
+            guard let labor = try Row.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT le.job_id, le.user_id, le.clock_in,
+                           COALESCE(j.job_name, j.job_number, 'Shop / Warehouse') AS job_name
+                    FROM labor_entries le
+                    LEFT JOIN jobs j ON j.id = le.job_id AND j.deleted_at IS NULL
+                    WHERE le.id = ? AND le.deleted_at IS NULL
+                    """,
+                arguments: [laborEntryId]
+            ) else {
+                throw JobsError.laborEntryNotFound(laborEntryId)
+            }
+
+            let jobId: Int64 = labor["job_id"] ?? 0
+            let userId: Int64 = labor["user_id"] ?? 0
+            let jobName: String = labor["job_name"] ?? "Shop / Warehouse"
+            let clockIn: String = labor["clock_in"] ?? ""
+            let clockDate = String(clockIn.prefix(10))
+            let reportDate = clockDate.isEmpty ? Self.localDateString() : clockDate
+
+            var notebookId = try Int64.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT id FROM notebooks
+                    WHERE notebook_type = 'daily-report'
+                      AND job_id = ?
+                      AND created_by = ?
+                      AND deleted_at IS NULL
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """,
+                arguments: [jobId, userId]
+            )
+
+            if notebookId == nil {
+                try dbConn.execute(
+                    sql: """
+                        INSERT INTO notebooks
+                            (title, description, job_id, created_by, notebook_type, status, created_at, updated_at)
+                        VALUES (?, ?, ?, ?, 'daily-report', 'active', datetime('now'), datetime('now'))
+                        """,
+                    arguments: ["Daily Reports — \(jobName)", "Clock-out daily reports captured from the end-of-day questionnaire.", jobId, userId]
+                )
+                notebookId = dbConn.lastInsertedRowID
+            }
+
+            guard let nbId = notebookId else { return nil }
+
+            var sectionId = try Int64.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT id FROM notebook_sections
+                    WHERE notebook_id = ? AND name = 'Reports' AND deleted_at IS NULL
+                    ORDER BY sort_order ASC, id ASC
+                    LIMIT 1
+                    """,
+                arguments: [nbId]
+            )
+
+            if sectionId == nil {
+                try dbConn.execute(
+                    sql: """
+                        INSERT INTO notebook_sections (notebook_id, name, section_type, sort_order, created_at)
+                        VALUES (?, 'Reports', 'notes', 0, datetime('now'))
+                        """,
+                    arguments: [nbId]
+                )
+                sectionId = dbConn.lastInsertedRowID
+            }
+
+            guard let secId = sectionId else { return nil }
+
+            let content = """
+                ## Daily Report — \(reportDate)
+
+                ### Job
+                \(jobName)
+
+                ### Clock-Out Daily Report
+                \(trimmedReport)
+
+                _Captured at clock-out from labor entry #\(laborEntryId)._
+                """
+
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO notebook_entries
+                        (section_id, title, content, entry_type, created_by, updated_by, sort_order, created_at, updated_at)
+                    VALUES (?, ?, ?, 'daily-report', ?, ?, 0, datetime('now'), datetime('now'))
+                    """,
+                arguments: [secId, "Daily Report — \(reportDate)", content, userId, userId]
+            )
+            let entryId = dbConn.lastInsertedRowID
+
+            try dbConn.execute(
+                sql: "UPDATE notebooks SET updated_at = datetime('now') WHERE id = ?",
+                arguments: [nbId]
+            )
+
+            return entryId
+        }
+    }
+
+    private static func localDateString() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date())
+    }
 
     /// List daily reports, optionally filtered by job.
     public func listReports(jobId: Int64? = nil, limit: Int = 50) throws -> [DailyReportRow] {

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -618,15 +618,23 @@ struct JobsServiceTests {
             sortOrder: 1
         )
 
+        let dailyReportQuestionId = try #require(try env.jobs.getActiveQuestions().first { question in
+            question.questionText.localizedCaseInsensitiveContains("daily report")
+        }?.questionId)
+
         try env.jobs.saveClockOutResponses(
             laborEntryId: laborEntryId,
-            responses: [(questionId: qId, answer: "No issues")]
+            responses: [
+                (questionId: qId, answer: "No issues"),
+                (questionId: dailyReportQuestionId, answer: "Completed panel labeling and staged tomorrow's materials")
+            ]
         )
 
         let responses = try env.jobs.getResponsesForEntry(laborEntryId: laborEntryId)
-        #expect(responses.count == 1)
-        #expect(responses[0].answer == "No issues")
-        #expect(responses[0].questionText == "Any safety concerns?")
+        #expect(responses.count == 2)
+        let safetyResponse = responses.first { $0.questionId == qId }
+        #expect(safetyResponse?.answer == "No issues")
+        #expect(safetyResponse?.questionText == "Any safety concerns?")
 
         try env.jobs.clockOut(laborEntryId: laborEntryId)
     }
@@ -1673,8 +1681,15 @@ struct JobsServiceTests {
         try env.db.writer.write { db in
             try db.execute(sql: "UPDATE clock_out_questions SET is_active = 0 WHERE id = ?", arguments: [qId])
         }
-        // Should succeed because inactive questions are not enforced
-        try env.jobs.saveClockOutResponses(laborEntryId: laborEntryId, responses: [])
+        let dailyReportQuestionId = try #require(try env.jobs.getActiveQuestions().first { question in
+            question.questionText.localizedCaseInsensitiveContains("daily report")
+        }?.questionId)
+        // Should succeed because the inactive custom question is not enforced; the default Daily Report
+        // prompt remains active/required and must still be answered.
+        try env.jobs.saveClockOutResponses(
+            laborEntryId: laborEntryId,
+            responses: [(questionId: dailyReportQuestionId, answer: "Finished rough-in notes")]
+        )
     }
 
     @Test("setPaymentHold throws invalidAmount for zero amount")

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -311,6 +311,22 @@ struct JobsServiceTests {
         #expect(questions.count >= 0) // May have default questions
     }
 
+    @Test("Default clock-out questions include daily report prompt")
+    func testDefaultClockOutQuestionsIncludeDailyReportPrompt() throws {
+        let env = try E2ETestHelpers.setUp()
+        let questions = try env.jobs.getActiveQuestions()
+
+        let dailyReportQuestion = questions.first { question in
+            question.questionText.localizedCaseInsensitiveContains("daily report")
+        }
+
+        #expect(dailyReportQuestion != nil)
+        #expect(dailyReportQuestion?.answerType == "text")
+        #expect(dailyReportQuestion?.isRequired == true)
+    }
+
+    // MARK: - One-Time Questions
+
     @Test("Create one-time question")
     func testOneTimeQuestion() throws {
         let env = try E2ETestHelpers.setUp()
@@ -615,6 +631,47 @@ struct JobsServiceTests {
         #expect(responses[0].questionText == "Any safety concerns?")
 
         try env.jobs.clockOut(laborEntryId: laborEntryId)
+    }
+
+    @Test("saveClockOutDailyReport creates a job-scoped daily report notebook entry")
+    func testSaveClockOutDailyReportCreatesNotebookEntry() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-DR-CLOCK", name: "Clockout Daily Report Job")
+        let laborEntryId = try env.jobs.clockIn(userId: env.adminUserId, jobId: jobId)
+
+        let entryId = try #require(try env.jobs.saveClockOutDailyReport(
+            laborEntryId: laborEntryId,
+            dailyReport: "  Pulled feeder wire, finished panel labeling, and staged tomorrow's materials.  "
+        ))
+
+        let row = try env.db.writer.read { db in
+            try Row.fetchOne(db, sql: """
+                SELECT ne.title, ne.content, ne.entry_type, nb.notebook_type, nb.job_id, nb.created_by
+                FROM notebook_entries ne
+                JOIN notebook_sections ns ON ns.id = ne.section_id
+                JOIN notebooks nb ON nb.id = ns.notebook_id
+                WHERE ne.id = ?
+                """, arguments: [entryId])
+        }
+
+        #expect(row?["entry_type"] as String? == "daily-report")
+        #expect(row?["notebook_type"] as String? == "daily-report")
+        #expect(row?["job_id"] as Int64? == jobId)
+        #expect(row?["created_by"] as Int64? == env.adminUserId)
+        let title = row?["title"] as String? ?? ""
+        let content = row?["content"] as String? ?? ""
+        #expect(title.contains("Daily Report"))
+        #expect(content.contains("Pulled feeder wire, finished panel labeling, and staged tomorrow's materials."))
+    }
+
+    @Test("saveClockOutDailyReport ignores blank clock-out daily report text")
+    func testSaveClockOutDailyReportIgnoresBlankText() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let laborEntryId = try env.jobs.clockIn(userId: env.adminUserId, jobId: jobId)
+
+        let entryId = try env.jobs.saveClockOutDailyReport(laborEntryId: laborEntryId, dailyReport: "  \n\t  ")
+        #expect(entryId == nil)
     }
 
     // MARK: - One-Time Questions


### PR DESCRIPTION
## Summary
- add a default required Daily Report clock-out question via migration
- capture a dedicated Daily Report field on the iOS clock-out questionnaire and persist it on submit
- save clock-out daily report text into job-scoped daily-report notebooks with tests

## Tests
- swift test --filter JobsServiceTests/testDefaultClockOutQuestionsIncludeDailyReportPrompt
- swift test --filter JobsServiceTests/testSaveClockOutDailyReportCreatesNotebookEntry
- swift test --filter JobsServiceTests/testSaveClockOutDailyReportIgnoresBlankText
- swift test --filter E2EWarehouseAndMovementsTests
- swift test (timed out after 600s after running broadly with no observed failure before timeout)