### PR TITLE
fix(parts): open supplier picker after brand creation

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsBrandsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsBrandsPage.swift
@@ -14,12 +14,14 @@ struct PartsBrandsPage: View {
     // Single active-sheet enum to avoid multiple .sheet conflicts
     enum ActiveSheet: Identifiable {
         case addBrand
+        case addBrandSuppliers(Int64)
         case detailBrand(BrandListRow)
         case help
 
         var id: String {
             switch self {
             case .addBrand: return "addBrand"
+            case .addBrandSuppliers(let brandId): return "addBrandSuppliers-\(brandId)"
             case .detailBrand(let b): return "detail-\(b.id)"
             case .help: return "help"
             }
@@ -27,6 +29,7 @@ struct PartsBrandsPage: View {
     }
 
     @State private var activeSheet: ActiveSheet?
+    @State private var pendingAddSuppliersBrandId: Int64?
     @State private var brandToDelete: BrandListRow?
     @State private var showDeleteConfirm = false
     @State private var deleteError: String?
@@ -65,8 +68,19 @@ struct PartsBrandsPage: View {
         .sheet(item: $activeSheet) { sheet in
             switch sheet {
             case .addBrand:
-                BrandFormSheet(brand: nil) { await loadData() }
-                    .environmentObject(appCore)
+                BrandFormSheet(
+                    brand: nil,
+                    onSave: { await loadData() },
+                    onAddSuppliers: { brandId in
+                        pendingAddSuppliersBrandId = brandId
+                    }
+                )
+                .environmentObject(appCore)
+            case .addBrandSuppliers(let brandId):
+                BrandSupplierPickerSheet(brandId: brandId) {
+                    Task { await loadData() }
+                }
+                .environmentObject(appCore)
             case .detailBrand(let brandRow):
                 BrandDetailSheet(brand: brandRow) { await loadData() }
                     .environmentObject(appCore)
@@ -80,6 +94,11 @@ struct PartsBrandsPage: View {
                     ]
                 )
             }
+        }
+        .onChange(of: activeSheet?.id) { _, sheetId in
+            guard sheetId == nil, let brandId = pendingAddSuppliersBrandId else { return }
+            pendingAddSuppliersBrandId = nil
+            activeSheet = .addBrandSuppliers(brandId)
         }
         .background(DS.Background.page)
         .task {
@@ -300,6 +319,7 @@ struct BrandListRow: Identifiable, Sendable {
 private struct BrandFormSheet: View {
     let brand: BrandListRow?
     let onSave: () async -> Void
+    let onAddSuppliers: ((Int64) -> Void)?
     @EnvironmentObject private var appCore: AppCore
     @Environment(\.dismiss) private var dismiss
 
@@ -367,8 +387,14 @@ private struct BrandFormSheet: View {
             .alert("Add Suppliers?", isPresented: $showAddSuppliersPrompt) {
                 Button("Add Suppliers") {
                     Task {
+                        let brandId = newBrandId
                         dismiss()
                         await onSave()
+                        if let brandId {
+                            await MainActor.run {
+                                onAddSuppliers?(brandId)
+                            }
+                        }
                     }
                 }
                 Button("Skip", role: .cancel) {
@@ -551,9 +577,13 @@ private struct BrandDetailSheet: View {
             .sheet(item: $activeDetailSheet) { sheet in
                 switch sheet {
                 case .editBrand:
-                    BrandFormSheet(brand: brand) {
-                        await onUpdate()
-                    }
+                    BrandFormSheet(
+                        brand: brand,
+                        onSave: {
+                            await onUpdate()
+                        },
+                        onAddSuppliers: nil
+                    )
                     .environmentObject(appCore)
                 case .supplierPicker:
                     BrandSupplierPickerSheet(brandId: brand.id) {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsBrandsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsBrandsPage.swift
@@ -72,7 +72,7 @@ struct PartsBrandsPage: View {
                     brand: nil,
                     onSave: { await loadData() },
                     onAddSuppliers: { brandId in
-                        pendingAddSuppliersBrandId = brandId
+                        presentAddSuppliersPicker(for: brandId)
                     }
                 )
                 .environmentObject(appCore)
@@ -120,6 +120,14 @@ struct PartsBrandsPage: View {
     }
 
     // MARK: - Filtered
+
+    private func presentAddSuppliersPicker(for brandId: Int64) {
+        if activeSheet == nil {
+            activeSheet = .addBrandSuppliers(brandId)
+        } else {
+            pendingAddSuppliersBrandId = brandId
+        }
+    }
 
     private var filteredBrands: [BrandListRow] {
         if searchText.isEmpty { return brands }

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
@@ -16,6 +16,14 @@ final class PartsBrandsPageRegressionTests: XCTestCase {
             source.contains("onAddSuppliers?(brandId)"),
             "The Add Suppliers prompt should call through to the parent instead of dismissing as a dead-end."
         )
+        XCTAssertTrue(
+            source.contains("presentAddSuppliersPicker(for: brandId)"),
+            "The parent callback should route post-create supplier linking through the guarded presenter."
+        )
+        XCTAssertTrue(
+            source.contains("if activeSheet == nil") && source.contains("activeSheet = .addBrandSuppliers(brandId)"),
+            "The guarded presenter should immediately show the supplier picker if the add-brand sheet has already dismissed."
+        )
     }
 
     private static func readPartsBrandsPageSource(

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+final class PartsBrandsPageRegressionTests: XCTestCase {
+    func testNewBrandAddSuppliersActionPresentsSupplierPickerInsteadOfOnlyDismissing() throws {
+        let source = try Self.readPartsBrandsPageSource()
+
+        XCTAssertTrue(
+            source.contains("case addBrandSuppliers(Int64)"),
+            "PartsBrandsPage should have a dedicated sheet route for the post-create supplier picker."
+        )
+        XCTAssertTrue(
+            source.contains("BrandSupplierPickerSheet(brandId: brandId)"),
+            "The post-create route must present BrandSupplierPickerSheet for the newly created brand."
+        )
+        XCTAssertTrue(
+            source.contains("onAddSuppliers?(brandId)"),
+            "The Add Suppliers prompt should call through to the parent instead of dismissing as a dead-end."
+        )
+    }
+
+    private static func readPartsBrandsPageSource(
+        file: StaticString = #filePath
+    ) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Parts")
+            .appendingPathComponent("PartsBrandsPage.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- wires the new-brand Add Suppliers prompt to a dedicated BrandSupplierPickerSheet route for the created brand
- reloads the brand list before opening the picker and again after saving supplier links
- waits for the add-brand sheet to dismiss before presenting the supplier picker so SwiftUI does not hit a double-sheet dead end
- adds a regression test documenting the post-create picker wiring

## Root cause
The Add Suppliers alert in BrandFormSheet dismissed the sheet and reloaded the list, but never presented BrandSupplierPickerSheet. That made the existing-supplier path a dead end and left the list/detail stale after the prompt.

## Test plan
- python3 static regression check for new-brand supplier picker wiring: PASS
- xcrun swiftc -parse PartsBrandsPage.swift: PASS
- xcrun swiftc -parse PartsBrandsPageRegressionTests.swift: PASS
- swift test in core: started and compiled, but timed out after 300s during the large existing suite before completion; no failure observed before timeout

Closes #632