### PR TITLE
fix(parts): link brands while creating suppliers

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
@@ -479,6 +479,11 @@ private struct SupplierFormSheet: View {
     // Notes
     @State private var notes = ""
 
+    // Brand links for new suppliers
+    @State private var availableBrandsForNewSupplier: [(id: Int64, name: String)] = []
+    @State private var selectedBrandIdsForNewSupplier: Set<Int64> = []
+    @State private var brandLoadError: String?
+
     // Save state
     @State private var saveError: String?
     @State private var isSaving = false
@@ -503,6 +508,45 @@ private struct SupplierFormSheet: View {
                         .frame(minHeight: 44)
                     if supplier != nil {
                         Toggle("Active", isOn: $isActive)
+                    }
+                }
+
+                if supplier == nil {
+                    Section {
+                        if let error = brandLoadError {
+                            Label(error, systemImage: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                                .font(.caption)
+                        } else if availableBrandsForNewSupplier.isEmpty {
+                            Text("No existing brands yet. You can link brands after creating this supplier.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            ForEach(availableBrandsForNewSupplier, id: \.id) { brand in
+                                Button {
+                                    toggleNewSupplierBrandSelection(brand.id)
+                                } label: {
+                                    HStack {
+                                        Label(brand.name, systemImage: "tag.fill")
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                        if selectedBrandIdsForNewSupplier.contains(brand.id) {
+                                            Image(systemName: "checkmark.circle.fill")
+                                                .foregroundStyle(Color.accentColor)
+                                        }
+                                    }
+                                    .frame(minHeight: 44)
+                                    .accessibilityElement(children: .ignore)
+                                    .accessibilityLabel(brand.name)
+                                    .accessibilityValue(selectedBrandIdsForNewSupplier.contains(brand.id) ? "Selected" : "Not selected")
+                                    .accessibilityHint("Double tap to toggle whether this supplier carries this brand")
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    } header: {
+                        Text("Brands Carried")
+                    } footer: {
+                        Text("Select any existing brands this supplier carries now, or manage brand links later from the supplier detail page.")
                     }
                 }
 
@@ -583,6 +627,8 @@ private struct SupplierFormSheet: View {
                     deliveryMethod = s.deliveryMethod ?? ""
                     deliveryDays = s.deliveryDays ?? ""
                     notes = s.notes ?? ""
+                } else {
+                    loadAvailableBrandsForNewSupplier()
                 }
             }
         }
@@ -630,7 +676,7 @@ private struct SupplierFormSheet: View {
                 notes: notes.isEmpty ? nil : notes
             )
         } else {
-            _ = try service.createSupplier(
+            let newSupplierId = try service.createSupplier(
                 name: trimmedName,
                 contactName: contactName.isEmpty ? nil : contactName,
                 email: email.isEmpty ? nil : email,
@@ -645,6 +691,37 @@ private struct SupplierFormSheet: View {
                 accountNumber: accountNumber.isEmpty ? nil : accountNumber,
                 notes: notes.isEmpty ? nil : notes
             )
+            if !selectedBrandIdsForNewSupplier.isEmpty {
+                try service.setSupplierBrands(
+                    supplierId: newSupplierId,
+                    brandIds: selectedBrandIdsForNewSupplier
+                )
+            }
+        }
+    }
+
+    private func toggleNewSupplierBrandSelection(_ brandId: Int64) {
+        if selectedBrandIdsForNewSupplier.contains(brandId) {
+            selectedBrandIdsForNewSupplier.remove(brandId)
+        } else {
+            selectedBrandIdsForNewSupplier.insert(brandId)
+        }
+    }
+
+    private func loadAvailableBrandsForNewSupplier() {
+        guard let service = appCore.partsService else {
+            brandLoadError = "Parts service not available"
+            return
+        }
+        do {
+            brandLoadError = nil
+            availableBrandsForNewSupplier = try service.listBrands()
+                .compactMap { row in
+                    guard let id = row.brand.id else { return nil }
+                    return (id: id, name: row.brand.name)
+                }
+        } catch {
+            brandLoadError = userFriendlyError(error, context: "load brands")
         }
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
@@ -51,9 +51,44 @@ final class PartsBrandsPageRegressionTests: XCTestCase {
         )
     }
 
+    func testNewSupplierFormCanLinkExistingBrandsDuringCreation() throws {
+        let source = try Self.readPartsSuppliersPageSource()
+
+        XCTAssertTrue(
+            source.contains("@State private var availableBrandsForNewSupplier"),
+            "New supplier flow should load existing brands so the user can choose what the supplier carries while creating it."
+        )
+        XCTAssertTrue(
+            source.contains("Text(\"Brands Carried\")"),
+            "Supplier creation should visibly ask which existing brands this supplier carries."
+        )
+        XCTAssertTrue(
+            source.contains("selectedBrandIdsForNewSupplier"),
+            "Supplier creation should keep an explicit selected-brand set for existing brand links."
+        )
+        XCTAssertTrue(
+            source.contains("let newSupplierId = try service.createSupplier"),
+            "Supplier creation must keep the new supplier id so brand links can be saved immediately."
+        )
+        XCTAssertTrue(
+            source.contains("try service.setSupplierBrands(") && source.contains("supplierId: newSupplierId"),
+            "After creating a supplier, the form should persist selected existing brand links."
+        )
+    }
+
     private static func readPartsBrandsPageSource(
         file: StaticString = #filePath
     ) throws -> String {
+        try readPartsPageSource(named: "PartsBrandsPage.swift", file: file)
+    }
+
+    private static func readPartsSuppliersPageSource(
+        file: StaticString = #filePath
+    ) throws -> String {
+        try readPartsPageSource(named: "PartsSuppliersPage.swift", file: file)
+    }
+
+    private static func readPartsPageSource(named filename: String, file: StaticString = #filePath) throws -> String {
         let testFileURL = URL(fileURLWithPath: "\(file)")
         let projectRoot = testFileURL
             .deletingLastPathComponent() // Weird Parts IOSTests
@@ -62,7 +97,7 @@ final class PartsBrandsPageRegressionTests: XCTestCase {
             .appendingPathComponent("Weird Parts IOS")
             .appendingPathComponent("Features")
             .appendingPathComponent("Parts")
-            .appendingPathComponent("PartsBrandsPage.swift")
+            .appendingPathComponent(filename)
         return try String(contentsOf: sourceURL, encoding: .utf8)
     }
 }


### PR DESCRIPTION
## Summary
- Adds a Brands Carried section to the new supplier form so existing brands can be selected during supplier creation
- Persists selected brand links immediately after the supplier row is created
- Adds a regression test covering the supplier-creation brand-link flow alongside the existing brand-creation supplier-picker regression

## Test Plan
- xcodebuild test -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -only-testing:"Weird PartsTests/PartsBrandsPageRegressionTests"\n\nFixes #634\nRelated #632