### PR TITLE
fix(parts): make supplier brand linking atomic

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
@@ -627,8 +627,11 @@ private struct SupplierFormSheet: View {
                     deliveryMethod = s.deliveryMethod ?? ""
                     deliveryDays = s.deliveryDays ?? ""
                     notes = s.notes ?? ""
-                } else {
-                    loadAvailableBrandsForNewSupplier()
+                }
+            }
+            .task(id: supplier?.id) {
+                if supplier == nil {
+                    await loadAvailableBrandsForNewSupplier()
                 }
             }
         }
@@ -676,7 +679,7 @@ private struct SupplierFormSheet: View {
                 notes: notes.isEmpty ? nil : notes
             )
         } else {
-            let newSupplierId = try service.createSupplier(
+            _ = try service.createSupplier(
                 name: trimmedName,
                 contactName: contactName.isEmpty ? nil : contactName,
                 email: email.isEmpty ? nil : email,
@@ -689,14 +692,9 @@ private struct SupplierFormSheet: View {
                 deliveryMethod: deliveryMethod.isEmpty ? nil : deliveryMethod,
                 deliveryDays: deliveryDays.isEmpty ? nil : deliveryDays,
                 accountNumber: accountNumber.isEmpty ? nil : accountNumber,
-                notes: notes.isEmpty ? nil : notes
+                notes: notes.isEmpty ? nil : notes,
+                initialBrandIds: selectedBrandIdsForNewSupplier
             )
-            if !selectedBrandIdsForNewSupplier.isEmpty {
-                try service.setSupplierBrands(
-                    supplierId: newSupplierId,
-                    brandIds: selectedBrandIdsForNewSupplier
-                )
-            }
         }
     }
 
@@ -708,18 +706,26 @@ private struct SupplierFormSheet: View {
         }
     }
 
-    private func loadAvailableBrandsForNewSupplier() {
+    private func loadAvailableBrandsForNewSupplier() async {
         guard let service = appCore.partsService else {
             brandLoadError = "Parts service not available"
             return
         }
         do {
             brandLoadError = nil
-            availableBrandsForNewSupplier = try service.listBrands()
+            let rows = try await Task.detached(priority: .userInitiated) {
+                try service.listBrands()
+            }.value
+            availableBrandsForNewSupplier = rows
                 .compactMap { row in
-                    guard let id = row.brand.id else { return nil }
+                    guard let id = row.brand.id,
+                          row.brand.isActive == 1,
+                          row.brand.deletedAt == nil else { return nil }
                     return (id: id, name: row.brand.name)
                 }
+            selectedBrandIdsForNewSupplier.formIntersection(
+                Set(availableBrandsForNewSupplier.map { $0.id })
+            )
         } catch {
             brandLoadError = userFriendlyError(error, context: "load brands")
         }

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
@@ -67,12 +67,12 @@ final class PartsBrandsPageRegressionTests: XCTestCase {
             "Supplier creation should keep an explicit selected-brand set for existing brand links."
         )
         XCTAssertTrue(
-            source.contains("let newSupplierId = try service.createSupplier"),
-            "Supplier creation must keep the new supplier id so brand links can be saved immediately."
+            source.contains("initialBrandIds: selectedBrandIdsForNewSupplier"),
+            "Supplier creation should pass selected brand ids into an atomic create/link service call."
         )
         XCTAssertTrue(
-            source.contains("try service.setSupplierBrands(") && source.contains("supplierId: newSupplierId"),
-            "After creating a supplier, the form should persist selected existing brand links."
+            source.contains("Task.detached(priority: .userInitiated)") && source.contains("row.brand.isActive == 1"),
+            "Brand loading should stay off the main actor and expose only active, non-deleted brands to the picker."
         )
     }
 

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -1711,7 +1711,8 @@ public final class PartsService: Sendable {
         deliveryMethod: String? = nil,
         deliveryDays: String? = nil,
         accountNumber: String? = nil,
-        notes: String? = nil
+        notes: String? = nil,
+        initialBrandIds: Set<Int64> = []
     ) throws -> Int64 {
         // Fix #213: validate inputs
         try Validators.requireName(name, field: "Supplier name")
@@ -1740,7 +1741,59 @@ public final class PartsService: Sendable {
         )
         record.isActive = 1
         try db.writer.write { dbConn in
+            if !initialBrandIds.isEmpty {
+                let placeholders = Array(repeating: "?", count: initialBrandIds.count).joined(separator: ",")
+                let activeBrandIds = Set(try Int64.fetchAll(
+                    dbConn,
+                    sql: """
+                        SELECT id FROM brands
+                        WHERE id IN (\(placeholders))
+                          AND is_active = 1
+                          AND deleted_at IS NULL
+                        """,
+                    arguments: StatementArguments(initialBrandIds.sorted())
+                ))
+                guard activeBrandIds.count == initialBrandIds.count else {
+                    let missingBrandId = initialBrandIds.subtracting(activeBrandIds).sorted().first ?? 0
+                    throw PartsError.brandNotFound(missingBrandId)
+                }
+            }
+
             try record.insert(dbConn)
+            guard let supplierId = record.id else {
+                throw PartsError.invalidInput("Failed to get ID after insert")
+            }
+
+            for brandId in initialBrandIds.sorted() {
+                if let existing = try Row.fetchOne(
+                    dbConn,
+                    sql: """
+                        SELECT id FROM brand_supplier_links
+                        WHERE brand_id = ? AND supplier_id = ?
+                        """,
+                    arguments: [brandId, supplierId]
+                ) {
+                    let linkId: Int64 = existing["id"]
+                    try dbConn.execute(
+                        sql: """
+                            UPDATE brand_supplier_links
+                            SET deleted_at = NULL,
+                                is_active = 1,
+                                carry_status = COALESCE(carry_status, 'carry_on_shelf')
+                            WHERE id = ?
+                            """,
+                        arguments: [linkId]
+                    )
+                } else {
+                    try dbConn.execute(
+                        sql: """
+                            INSERT INTO brand_supplier_links (brand_id, supplier_id, is_active, created_at)
+                            VALUES (?, ?, 1, datetime('now'))
+                            """,
+                        arguments: [brandId, supplierId]
+                    )
+                }
+            }
         }
         guard let id = record.id else { throw PartsError.invalidInput("Failed to get ID after insert") }
         return id

--- a/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
@@ -229,6 +229,44 @@ struct PartsServiceExtTests {
         #expect(linkedBrands.allSatisfy { $0.carryStatus == "carry_on_shelf" })
     }
 
+    @Test("Supplier creation can atomically link initial active brands")
+    func testCreateSupplierLinksInitialBrandsAtomically() throws {
+        let env = try E2ETestHelpers.setUp()
+        let firstBrandId = try env.parts.createBrand(name: "Initial Brand One")
+        let secondBrandId = try env.parts.createBrand(name: "Initial Brand Two")
+
+        let supplierId = try env.parts.createSupplier(
+            name: "Supplier With Initial Brands",
+            initialBrandIds: [firstBrandId, secondBrandId]
+        )
+
+        let linkedBrands = try env.parts.getSupplierBrandRows(supplierId: supplierId)
+        #expect(linkedBrands.map(\.brandId).sorted() == [firstBrandId, secondBrandId].sorted())
+        #expect(linkedBrands.allSatisfy { $0.carryStatus == "carry_on_shelf" })
+    }
+
+    @Test("Supplier creation rejects inactive initial brands without creating supplier")
+    func testCreateSupplierRejectsInactiveInitialBrandWithoutPartialSupplier() throws {
+        let env = try E2ETestHelpers.setUp()
+        let inactiveBrandId = try env.parts.createBrand(name: "Inactive Initial Brand")
+        try env.db.writer.write { db in
+            try db.execute(
+                sql: "UPDATE brands SET is_active = 0 WHERE id = ?",
+                arguments: [inactiveBrandId]
+            )
+        }
+
+        #expect(throws: (any Error).self) {
+            _ = try env.parts.createSupplier(
+                name: "Should Not Persist",
+                initialBrandIds: [inactiveBrandId]
+            )
+        }
+
+        let suppliers = try env.parts.listSuppliers()
+        #expect(!suppliers.contains { $0.supplier.name == "Should Not Persist" })
+    }
+
     @Test("Supplier-side brand picker only offers active unlinked brands")
     func testListBrandsAvailableForSupplierExcludesLinkedAndDeletedBrands() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Follow-up to PR #648 after Copilot identified correctness risks in the supplier brand creation path.
- Moves initial supplier-brand linking into `PartsService.createSupplier(... initialBrandIds:)` so supplier creation and selected brand links commit in one transaction.
- Filters the new-supplier brand picker to active, non-deleted brands and loads brand rows off the main actor.
- Adds core regression coverage for atomic initial brand linking and failed inactive-brand validation not leaving a partial supplier.

## Validation
- `git diff --check origin/main...HEAD`: PASS
- `git diff --check`: PASS
- Conflict-marker scan on changed files: PASS
- `swift test --package-path core --scratch-path /tmp/wei1903-pr648-build --filter 'PartsServiceExtTests/testCreateSupplierLinksInitialBrandsAtomically|PartsServiceExtTests/testCreateSupplierRejectsInactiveInitialBrandWithoutPartialSupplier|PartsServiceExtTests/testSetSupplierBrandsLinksAndUnlinksExistingBrands|PartsServiceExtTests/testListBrandsAvailableForSupplierExcludesLinkedAndDeletedBrands'`: PASS, 4 tests
- `xcodebuild build-for-testing -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "generic/platform=iOS Simulator" -derivedDataPath /tmp/wei1903-pr648-derived CODE_SIGNING_ALLOWED=NO`: PASS / TEST BUILD SUCCEEDED

Branch-drain note: PR #648 merged before this fix could land; this PR preserves the validated follow-up fixes and the accidentally recreated `WEI-1967-supplier-edit-brand-links` branch was deleted.
