### PR TITLE
fix(parts): harden supplier brand creation

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
@@ -627,9 +627,11 @@ private struct SupplierFormSheet: View {
                     deliveryMethod = s.deliveryMethod ?? ""
                     deliveryDays = s.deliveryDays ?? ""
                     notes = s.notes ?? ""
-                } else {
-                    loadAvailableBrandsForNewSupplier()
                 }
+            }
+            .task {
+                guard supplier == nil else { return }
+                await loadAvailableBrandsForNewSupplier()
             }
         }
         .interactiveDismissDisabled(isSaving)
@@ -676,7 +678,7 @@ private struct SupplierFormSheet: View {
                 notes: notes.isEmpty ? nil : notes
             )
         } else {
-            let newSupplierId = try service.createSupplier(
+            _ = try service.createSupplier(
                 name: trimmedName,
                 contactName: contactName.isEmpty ? nil : contactName,
                 email: email.isEmpty ? nil : email,
@@ -689,14 +691,9 @@ private struct SupplierFormSheet: View {
                 deliveryMethod: deliveryMethod.isEmpty ? nil : deliveryMethod,
                 deliveryDays: deliveryDays.isEmpty ? nil : deliveryDays,
                 accountNumber: accountNumber.isEmpty ? nil : accountNumber,
-                notes: notes.isEmpty ? nil : notes
+                notes: notes.isEmpty ? nil : notes,
+                initialBrandIds: selectedBrandIdsForNewSupplier
             )
-            if !selectedBrandIdsForNewSupplier.isEmpty {
-                try service.setSupplierBrands(
-                    supplierId: newSupplierId,
-                    brandIds: selectedBrandIdsForNewSupplier
-                )
-            }
         }
     }
 
@@ -708,18 +705,23 @@ private struct SupplierFormSheet: View {
         }
     }
 
-    private func loadAvailableBrandsForNewSupplier() {
+    @MainActor
+    private func loadAvailableBrandsForNewSupplier() async {
         guard let service = appCore.partsService else {
             brandLoadError = "Parts service not available"
             return
         }
+        brandLoadError = nil
         do {
-            brandLoadError = nil
-            availableBrandsForNewSupplier = try service.listBrands()
-                .compactMap { row in
-                    guard let id = row.brand.id else { return nil }
-                    return (id: id, name: row.brand.name)
-                }
+            let brands = try await Task.detached(priority: .userInitiated) {
+                try service.listBrands()
+                    .compactMap { row in
+                        guard let id = row.brand.id else { return nil }
+                        return (id: id, name: row.brand.name)
+                    }
+            }.value
+            availableBrandsForNewSupplier = brands
+            selectedBrandIdsForNewSupplier.formIntersection(Set(brands.map { $0.id }))
         } catch {
             brandLoadError = userFriendlyError(error, context: "load brands")
         }

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
@@ -67,12 +67,12 @@ final class PartsBrandsPageRegressionTests: XCTestCase {
             "Supplier creation should keep an explicit selected-brand set for existing brand links."
         )
         XCTAssertTrue(
-            source.contains("let newSupplierId = try service.createSupplier"),
-            "Supplier creation must keep the new supplier id so brand links can be saved immediately."
+            source.contains("initialBrandIds: selectedBrandIdsForNewSupplier"),
+            "Supplier creation should pass selected brand IDs into the create call so supplier + initial links are saved atomically."
         )
         XCTAssertTrue(
-            source.contains("try service.setSupplierBrands(") && source.contains("supplierId: newSupplierId"),
-            "After creating a supplier, the form should persist selected existing brand links."
+            source.contains("Task.detached(priority: .userInitiated)") && source.contains("try service.listBrands()"),
+            "The new-supplier brand picker should load existing brands off the main actor instead of doing synchronous DB work on appear."
         )
     }
 

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -1711,7 +1711,8 @@ public final class PartsService: Sendable {
         deliveryMethod: String? = nil,
         deliveryDays: String? = nil,
         accountNumber: String? = nil,
-        notes: String? = nil
+        notes: String? = nil,
+        initialBrandIds: Set<Int64> = []
     ) throws -> Int64 {
         // Fix #213: validate inputs
         try Validators.requireName(name, field: "Supplier name")
@@ -1740,7 +1741,15 @@ public final class PartsService: Sendable {
         )
         record.isActive = 1
         try db.writer.write { dbConn in
+            let activeInitialBrandIds = try Self.activeBrandIds(from: initialBrandIds, dbConn: dbConn)
             try record.insert(dbConn)
+            guard let id = record.id else { throw PartsError.invalidInput("Failed to get ID after insert") }
+            try Self.setSupplierBrandLinksInternal(
+                dbConn: dbConn,
+                supplierId: id,
+                brandIds: activeInitialBrandIds,
+                validateSupplier: false
+            )
         }
         guard let id = record.id else { throw PartsError.invalidInput("Failed to get ID after insert") }
         return id
@@ -2134,94 +2143,108 @@ public final class PartsService: Sendable {
         }
     }
 
-    /// Set the complete list of brands for a supplier.
-    /// Links brands in `brandIds`, unlinks any not in the list.
-    public func setSupplierBrands(supplierId: Int64, brandIds: Set<Int64>) throws {
-        try db.writer.write { dbConn in
+    private static func activeBrandIds(from brandIds: Set<Int64>, dbConn: Database) throws -> Set<Int64> {
+        guard !brandIds.isEmpty else { return [] }
+
+        let sortedBrandIds = brandIds.sorted()
+        let placeholders = Array(repeating: "?", count: sortedBrandIds.count).joined(separator: ",")
+        return Set(try Int64.fetchAll(
+            dbConn,
+            sql: """
+                SELECT id FROM brands
+                WHERE id IN (\(placeholders))
+                  AND is_active = 1
+                  AND deleted_at IS NULL
+                """,
+            arguments: StatementArguments(sortedBrandIds)
+        ))
+    }
+
+    private static func validateActiveBrandIds(_ brandIds: Set<Int64>, dbConn: Database) throws {
+        let validBrandIds = try activeBrandIds(from: brandIds, dbConn: dbConn)
+        guard validBrandIds.count == brandIds.count else {
+            let missingBrandId = brandIds.subtracting(validBrandIds).sorted().first ?? 0
+            throw PartsError.brandNotFound(missingBrandId)
+        }
+    }
+
+    private static func setSupplierBrandLinksInternal(
+        dbConn: Database,
+        supplierId: Int64,
+        brandIds: Set<Int64>,
+        validateSupplier: Bool = true
+    ) throws {
+        if validateSupplier {
             let supplierExists = (try Int.fetchOne(dbConn, sql: """
                 SELECT COUNT(*) FROM suppliers
                 WHERE id = ? AND is_active = 1 AND deleted_at IS NULL
                 """, arguments: [supplierId]) ?? 0) > 0
             guard supplierExists else { throw PartsError.supplierNotFound(supplierId) }
+        }
 
-            if !brandIds.isEmpty {
-                let placeholders = Array(repeating: "?", count: brandIds.count).joined(separator: ",")
-                let activeBrandCount = try Int.fetchOne(
-                    dbConn,
-                    sql: """
-                        SELECT COUNT(*) FROM brands
-                        WHERE id IN (\(placeholders))
-                          AND is_active = 1
-                          AND deleted_at IS NULL
-                        """,
-                    arguments: StatementArguments(brandIds.sorted())
-                ) ?? 0
-                guard activeBrandCount == brandIds.count else {
-                    let validBrandIds = try Int64.fetchAll(
-                        dbConn,
-                        sql: """
-                            SELECT id FROM brands
-                            WHERE id IN (\(placeholders))
-                              AND is_active = 1
-                              AND deleted_at IS NULL
-                            """,
-                        arguments: StatementArguments(brandIds.sorted())
-                    )
-                    let missingBrandId = brandIds.subtracting(validBrandIds).sorted().first ?? 0
-                    throw PartsError.brandNotFound(missingBrandId)
-                }
-            }
+        try validateActiveBrandIds(brandIds, dbConn: dbConn)
 
-            let currentIds = Set(try Int64.fetchAll(dbConn, sql: """
-                SELECT brand_id FROM brand_supplier_links
-                WHERE supplier_id = ?
-                  AND is_active = 1
-                  AND deleted_at IS NULL
-                """, arguments: [supplierId]))
+        let currentIds = Set(try Int64.fetchAll(dbConn, sql: """
+            SELECT brand_id FROM brand_supplier_links
+            WHERE supplier_id = ?
+              AND is_active = 1
+              AND deleted_at IS NULL
+            """, arguments: [supplierId]))
 
-            for brandId in brandIds.subtracting(currentIds).sorted() {
-                if let existing = try Row.fetchOne(
-                    dbConn,
-                    sql: """
-                        SELECT id FROM brand_supplier_links
-                        WHERE brand_id = ? AND supplier_id = ?
-                        """,
-                    arguments: [brandId, supplierId]
-                ) {
-                    let linkId: Int64 = existing["id"]
-                    try dbConn.execute(
-                        sql: """
-                            UPDATE brand_supplier_links
-                            SET deleted_at = NULL,
-                                is_active = 1,
-                                carry_status = COALESCE(carry_status, 'carry_on_shelf')
-                            WHERE id = ?
-                            """,
-                        arguments: [linkId]
-                    )
-                } else {
-                    try dbConn.execute(
-                        sql: """
-                            INSERT INTO brand_supplier_links (brand_id, supplier_id, is_active, created_at)
-                            VALUES (?, ?, 1, datetime('now'))
-                            """,
-                        arguments: [brandId, supplierId]
-                    )
-                }
-            }
-
-            for brandId in currentIds.subtracting(brandIds).sorted() {
+        for brandId in brandIds.subtracting(currentIds).sorted() {
+            if let existing = try Row.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT id FROM brand_supplier_links
+                    WHERE brand_id = ? AND supplier_id = ?
+                    """,
+                arguments: [brandId, supplierId]
+            ) {
+                let linkId: Int64 = existing["id"]
                 try dbConn.execute(
                     sql: """
                         UPDATE brand_supplier_links
-                        SET deleted_at = datetime('now'), is_active = 0
-                        WHERE brand_id = ?
-                          AND supplier_id = ?
-                          AND deleted_at IS NULL
+                        SET deleted_at = NULL,
+                            is_active = 1,
+                            carry_status = COALESCE(carry_status, 'carry_on_shelf')
+                        WHERE id = ?
+                        """,
+                    arguments: [linkId]
+                )
+            } else {
+                try dbConn.execute(
+                    sql: """
+                        INSERT INTO brand_supplier_links (brand_id, supplier_id, is_active, created_at)
+                        VALUES (?, ?, 1, datetime('now'))
                         """,
                     arguments: [brandId, supplierId]
                 )
             }
+        }
+
+        for brandId in currentIds.subtracting(brandIds).sorted() {
+            try dbConn.execute(
+                sql: """
+                    UPDATE brand_supplier_links
+                    SET deleted_at = datetime('now'), is_active = 0
+                    WHERE brand_id = ?
+                      AND supplier_id = ?
+                      AND deleted_at IS NULL
+                    """,
+                arguments: [brandId, supplierId]
+            )
+        }
+    }
+
+    /// Set the complete list of brands for a supplier.
+    /// Links brands in `brandIds`, unlinks any not in the list.
+    public func setSupplierBrands(supplierId: Int64, brandIds: Set<Int64>) throws {
+        try db.writer.write { dbConn in
+            try Self.setSupplierBrandLinksInternal(
+                dbConn: dbConn,
+                supplierId: supplierId,
+                brandIds: brandIds
+            )
         }
     }
 

--- a/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
@@ -213,6 +213,41 @@ struct PartsServiceExtTests {
         #expect(suppliers.contains(where: { $0.supplier.name == "ElecSupply Co" }))
     }
 
+    @Test("Supplier creation links selected brands in the same transaction")
+    func testCreateSupplierAtomicallyLinksInitialBrands() throws {
+        let env = try E2ETestHelpers.setUp()
+        let brandId = try env.parts.createBrand(name: "Creation Link Brand")
+
+        let supplierId = try env.parts.createSupplier(
+            name: "Atomic Link Supplier",
+            initialBrandIds: [brandId]
+        )
+
+        let linkedBrands = try env.parts.getSupplierBrandRows(supplierId: supplierId)
+        #expect(linkedBrands.map(\.brandId) == [brandId])
+    }
+
+    @Test("Supplier creation ignores stale initial brand selections")
+    func testCreateSupplierIgnoresStaleInitialBrandSelections() throws {
+        let env = try E2ETestHelpers.setUp()
+        let activeBrandId = try env.parts.createBrand(name: "Still Active Brand")
+        let inactiveBrandId = try env.parts.createBrand(name: "Stale Inactive Brand")
+        try env.db.writer.write { db in
+            try db.execute(
+                sql: "UPDATE brands SET is_active = 0 WHERE id = ?",
+                arguments: [inactiveBrandId]
+            )
+        }
+
+        let supplierId = try env.parts.createSupplier(
+            name: "Stale Safe Supplier",
+            initialBrandIds: [activeBrandId, inactiveBrandId]
+        )
+
+        let linkedBrands = try env.parts.getSupplierBrandRows(supplierId: supplierId)
+        #expect(linkedBrands.map(\.brandId) == [activeBrandId])
+    }
+
     @Test("Supplier-brand links can be managed from supplier side")
     func testSetSupplierBrandsLinksAndUnlinksExistingBrands() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
Follow-up for WEI-1990 after PR #648 merged before the CEO-block fixes landed.\n\nAddresses the blocking risks called out on supplier-brand linking:\n- Saves supplier creation and initial brand links through one PartsService transaction.\n- Ignores stale/inactive initial brand selections during creation so a stale picker row does not block supplier save or create retry duplicates.\n- Moves new-supplier brand loading off the SwiftUI appear path with Task.detached.\n\nValidation:\n- git diff --check\n- swift test --package-path core --filter PartsServiceExtTests (76 tests passed)\n- source assertion smoke for PartsBrandsPageRegressionTests expectations\n\nNote: xcodebuild UI regression execution could not run because this checkout has no .xcodeproj file; the source-level assertions were smoke-checked instead.