### PR TITLE
fix(inventory): centralize stock movement UI contract

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
@@ -1230,7 +1230,7 @@ private struct JPOMovementDetailContent: View {
             } else if let m = movement {
                 List {
                     Section("Movement Info") {
-                        LabeledContent("Type", value: m.movementType.replacingOccurrences(of: "_", with: " ").capitalized)
+                        LabeledContent("Type", value: StockMovement.MovementType.displayName(forRawValue: m.movementType))
                         LabeledContent("Quantity", value: "\(m.qty)")
                         if let reason = m.reason, !reason.isEmpty {
                             LabeledContent("Reason", value: reason)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
@@ -54,9 +54,9 @@ struct IOSMovementWizard: View {
     // Derived
     private var movementType: String {
         switch (fromLocationType, toLocationType) {
-        case ("job", _): return "return_to_supplier"
-        case (_, "job"): return "consume"
-        default: return "transfer"
+        case ("job", _): return StockMovement.MovementType.returnToSupplier.rawValue
+        case (_, "job"): return StockMovement.MovementType.consume.rawValue
+        default: return StockMovement.MovementType.transfer.rawValue
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
@@ -1093,24 +1093,23 @@ struct WarehouseDashboardPage: View {
     // MARK: - Helpers
 
     private func movementIcon(_ type: String) -> String {
-        switch type {
-        case "transfer": "arrow.left.arrow.right"
-        case "receive": "arrow.down.circle"
-        case "consume": "flame"
-        case "return_to_supplier": "arrow.uturn.left"
-        case "adjustment": "plus.forwardslash.minus"
-        default: "arrow.left.arrow.right"
-        }
+        StockMovement.MovementType.systemImageName(forRawValue: type)
     }
 
     private func movementColor(_ type: String) -> Color {
-        switch type {
-        case "transfer": .blue
-        case "receive": .green
-        case "consume": .orange
-        case "return_to_supplier": .purple
-        case "adjustment": .gray
-        default: .blue
+        switch StockMovement.MovementType(rawValue: type) {
+        case .transfer, .restockFromShop:
+            return .blue
+        case .receive, .receiving, .receivingStaged, .receipt:
+            return .green
+        case .consume, .pull, .usage, .jobPull:
+            return .orange
+        case .stockReturn, .returnToSupplier:
+            return .purple
+        case .adjustment, .addStock, .writeOff:
+            return .gray
+        case nil:
+            return .blue
         }
     }
 
@@ -1125,14 +1124,7 @@ struct WarehouseDashboardPage: View {
     }
 
     private func movementLabel(_ type: String) -> String {
-        switch type {
-        case "transfer": "Transfer"
-        case "receive": "Received"
-        case "consume": "Consumed"
-        case "return_to_supplier": "Returned"
-        case "adjustment": "Adjustment"
-        default: type.capitalized
-        }
+        StockMovement.MovementType.displayName(forRawValue: type)
     }
 
     private func auditSummaryText(for movement: WarehouseService.MovementRow) -> String? {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
@@ -25,22 +25,39 @@ struct WarehouseMovementsPage: View {
     private var effectiveStart: Date { dateRange.dateInterval?.start ?? customStart }
     private var effectiveEnd: Date { dateRange.dateInterval?.end ?? customEnd }
 
-    private enum MovementFilter: String, CaseIterable {
-        case all = "All"
-        case transfers = "Transfer"
-        case receives = "Received"
-        case consumed = "Consumed"
-        case returns = "Return"
-        case adjustments = "Adjustment"
+    private enum MovementFilter: Hashable {
+        case all
+        case type(StockMovement.MovementType)
+
+        static var allCases: [MovementFilter] {
+            [.all] + StockMovement.MovementType.primaryUIFilterTypes.map { .type($0) }
+        }
+
+        var title: String {
+            switch self {
+            case .all: "All"
+            case .type(let type): type.displayName
+            }
+        }
 
         var movementType: String? {
             switch self {
             case .all: nil
-            case .transfers: "transfer"
-            case .receives: "receive"
-            case .consumed: "consume"
-            case .returns: "return_to_supplier"
-            case .adjustments: "adjustment"
+            case .type(let type): type.rawValue
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .all: "tray.full"
+            case .type(let type): type.systemImageName
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .all: .accentColor
+            case .type(let type): WarehouseMovementsPage.movementColor(for: type.rawValue)
             }
         }
     }
@@ -155,20 +172,17 @@ struct WarehouseMovementsPage: View {
     // MARK: - Smart Card Filters
 
     private var smartCardFilters: some View {
-        let transferCount = dateFilteredMovements.filter { $0.movementType == "transfer" }.count
-        let receiveCount = dateFilteredMovements.filter { $0.movementType == "receive" }.count
-        let consumedCount = dateFilteredMovements.filter { $0.movementType == "consume" }.count
-        let returnCount = dateFilteredMovements.filter { $0.movementType == "return_to_supplier" }.count
-        let adjustCount = dateFilteredMovements.filter { $0.movementType == "adjustment" }.count
+        let countsByType = Dictionary(grouping: dateFilteredMovements, by: \.movementType)
+            .mapValues(\.count)
 
         return ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                filterCard(.all, count: dateFilteredMovements.count, icon: "tray.full", color: .accentColor)
-                filterCard(.transfers, count: transferCount, icon: "arrow.left.arrow.right", color: .blue)
-                filterCard(.receives, count: receiveCount, icon: "arrow.down.circle", color: .green)
-                filterCard(.consumed, count: consumedCount, icon: "flame", color: .orange)
-                filterCard(.returns, count: returnCount, icon: "arrow.uturn.left", color: .purple)
-                filterCard(.adjustments, count: adjustCount, icon: "plus.forwardslash.minus", color: .gray)
+                ForEach(MovementFilter.allCases, id: \.self) { filter in
+                    filterCard(
+                        filter,
+                        count: filter.movementType.map { countsByType[$0, default: 0] } ?? dateFilteredMovements.count
+                    )
+                }
             }
             .padding(.horizontal)
             .padding(.vertical, 8)
@@ -176,28 +190,28 @@ struct WarehouseMovementsPage: View {
         .background(Color(.secondarySystemGroupedBackground))
     }
 
-    private func filterCard(_ filter: MovementFilter, count: Int, icon: String, color: Color) -> some View {
+    private func filterCard(_ filter: MovementFilter, count: Int) -> some View {
         let isSelected = selectedFilter == filter
 
         return Button {
             selectedFilter = filter == .all || isSelected ? nil : filter
         } label: {
             HStack(spacing: 6) {
-                Image(systemName: icon)
+                Image(systemName: filter.icon)
                     .font(.caption)
-                Text("\(filter.rawValue) (\(count))")
+                Text("\(filter.title) (\(count))")
                     .font(.caption)
                     .fontWeight(isSelected ? .bold : .regular)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
             .background(
-                Capsule().fill(isSelected ? color.opacity(0.15) : Color.secondary.opacity(0.08))
+                Capsule().fill(isSelected ? filter.color.opacity(0.15) : Color.secondary.opacity(0.08))
             )
             .overlay(
-                Capsule().stroke(isSelected ? color : Color.clear, lineWidth: 1.5)
+                Capsule().stroke(isSelected ? filter.color : Color.clear, lineWidth: 1.5)
             )
-            .foregroundStyle(isSelected ? color : .primary)
+            .foregroundStyle(isSelected ? filter.color : .primary)
         }
         .buttonStyle(.plain)
     }
@@ -381,7 +395,7 @@ struct WarehouseMovementsPage: View {
             .joined(separator: ", ")
         let context = """
         Warehouse Movements page. Read-only context.
-        Loaded movements: \(movements.count), visible after filters: \(filteredMovements.count), selected filter: \(selectedFilter?.rawValue ?? "none"), search active: \(!searchText.isEmpty).
+        Loaded movements: \(movements.count), visible after filters: \(filteredMovements.count), selected filter: \(selectedFilter?.title ?? "none"), search active: \(!searchText.isEmpty).
         Date range: \(dateRange.rawValue), movement types: \(movementTypes.isEmpty ? "none" : movementTypes).
         Available read-only guidance: explain movement history, date range, filter chips, search, detail rows, QR scan entry, and new movement entry point. Do not create movements, launch scanners, or change filters directly.
         """
@@ -395,36 +409,32 @@ struct WarehouseMovementsPage: View {
     // MARK: - Helpers
 
     private func movementIcon(_ type: String) -> String {
-        switch type {
-        case "transfer": "arrow.left.arrow.right"
-        case "receive": "arrow.down.circle"
-        case "consume": "flame"
-        case "return_to_supplier": "arrow.uturn.left"
-        case "adjustment": "plus.forwardslash.minus"
-        default: "arrow.left.arrow.right"
-        }
+        StockMovement.MovementType.systemImageName(forRawValue: type)
     }
 
     private func movementColor(_ type: String) -> Color {
-        switch type {
-        case "transfer": .blue
-        case "receive": .green
-        case "consume": .orange
-        case "return_to_supplier": .purple
-        case "adjustment": .gray
-        default: .blue
+        Self.movementColor(for: type)
+    }
+
+    private static func movementColor(for type: String) -> Color {
+        switch StockMovement.MovementType(rawValue: type) {
+        case .transfer, .restockFromShop:
+            return .blue
+        case .receive, .receiving, .receivingStaged, .receipt:
+            return .green
+        case .consume, .pull, .usage, .jobPull:
+            return .orange
+        case .stockReturn, .returnToSupplier:
+            return .purple
+        case .adjustment, .addStock, .writeOff:
+            return .gray
+        case nil:
+            return .blue
         }
     }
 
     private func movementLabel(_ type: String) -> String {
-        switch type {
-        case "transfer": "Transfer"
-        case "receive": "Received"
-        case "consume": "Consumed"
-        case "return_to_supplier": "Returned"
-        case "adjustment": "Adjustment"
-        default: type.capitalized
-        }
+        StockMovement.MovementType.displayName(forRawValue: type)
     }
 
     private func auditSummaryText(for movement: WarehouseService.MovementRow) -> String? {
@@ -570,13 +580,6 @@ private struct MovementDetailSheet: View {
     }
 
     private func movementLabel(_ type: String) -> String {
-        switch type {
-        case "transfer": "Transfer"
-        case "receive": "Received"
-        case "consume": "Consumed"
-        case "return_to_supplier": "Returned"
-        case "adjustment": "Adjustment"
-        default: type.capitalized
-        }
+        StockMovement.MovementType.displayName(forRawValue: type)
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
@@ -40,10 +40,10 @@ struct WarehouseMovementsPage: View {
             }
         }
 
-        var movementType: String? {
+        var movementTypes: Set<String>? {
             switch self {
             case .all: nil
-            case .type(let type): type.rawValue
+            case .type(let type): type.primaryUIFilterRawValues
             }
         }
 
@@ -180,7 +180,11 @@ struct WarehouseMovementsPage: View {
                 ForEach(MovementFilter.allCases, id: \.self) { filter in
                     filterCard(
                         filter,
-                        count: filter.movementType.map { countsByType[$0, default: 0] } ?? dateFilteredMovements.count
+                        count: filter.movementTypes.map { rawValues in
+                            rawValues.reduce(0) { total, rawValue in
+                                total + countsByType[rawValue, default: 0]
+                            }
+                        } ?? dateFilteredMovements.count
                     )
                 }
             }
@@ -220,8 +224,8 @@ struct WarehouseMovementsPage: View {
 
     private var filteredMovements: [WarehouseService.MovementRow] {
         var result = dateFilteredMovements
-        if let filter = selectedFilter, let movementType = filter.movementType {
-            result = result.filter { $0.movementType == movementType }
+        if let filter = selectedFilter, let movementTypes = filter.movementTypes {
+            result = result.filter { movementTypes.contains($0.movementType) }
         }
         if !searchText.isEmpty {
             let query = searchText.lowercased()

--- a/core/Sources/WiredPartCore/Models/Warehouse/WarehouseModels.swift
+++ b/core/Sources/WiredPartCore/Models/Warehouse/WarehouseModels.swift
@@ -41,6 +41,71 @@ public struct StockMovement: Codable, FetchableRecord, MutablePersistableRecord,
             .consume, .pull, .usage, .jobPull
         ]
 
+        /// Canonical movement types exposed as top-level filters in stock movement UI flows.
+        /// Picker/list/history screens should derive their options from this source instead
+        /// of hard-coding raw `movement_type` strings.
+        public static let primaryUIFilterTypes: [MovementType] = [
+            .transfer, .receive, .consume, .returnToSupplier, .adjustment
+        ]
+
+        public var displayName: String {
+            switch self {
+            case .transfer:
+                return "Transfer"
+            case .receive, .receiving, .receipt:
+                return "Received"
+            case .receivingStaged:
+                return "Receiving Staged"
+            case .stockReturn:
+                return "Returned"
+            case .returnToSupplier:
+                return "Returned"
+            case .adjustment:
+                return "Adjustment"
+            case .addStock:
+                return "Add Stock"
+            case .writeOff:
+                return "Write Off"
+            case .consume, .pull, .usage, .jobPull:
+                return "Consumed"
+            case .restockFromShop:
+                return "Restock From Shop"
+            }
+        }
+
+        public var systemImageName: String {
+            switch self {
+            case .transfer, .restockFromShop:
+                return "arrow.left.arrow.right"
+            case .receive, .receiving, .receivingStaged, .receipt:
+                return "arrow.down.circle"
+            case .consume, .pull, .usage, .jobPull:
+                return "flame"
+            case .stockReturn, .returnToSupplier:
+                return "arrow.uturn.left"
+            case .adjustment, .addStock, .writeOff:
+                return "plus.forwardslash.minus"
+            }
+        }
+
+        public static func displayName(forRawValue rawValue: String) -> String {
+            if let type = MovementType(rawValue: rawValue) {
+                return type.displayName
+            }
+
+            return rawValue
+                .split(separator: "_")
+                .map { part in
+                    guard let first = part.first else { return "" }
+                    return first.uppercased() + part.dropFirst().lowercased()
+                }
+                .joined(separator: " ")
+        }
+
+        public static func systemImageName(forRawValue rawValue: String) -> String {
+            MovementType(rawValue: rawValue)?.systemImageName ?? "arrow.triangle.2.circlepath"
+        }
+
         /// SQL literal list for static movement-type `IN (...)` clauses.
         /// Empty input deliberately produces a no-match list instead of invalid
         /// `IN ()` SQL so callers can safely compose from filtered type arrays.

--- a/core/Sources/WiredPartCore/Models/Warehouse/WarehouseModels.swift
+++ b/core/Sources/WiredPartCore/Models/Warehouse/WarehouseModels.swift
@@ -48,6 +48,36 @@ public struct StockMovement: Codable, FetchableRecord, MutablePersistableRecord,
             .transfer, .receive, .consume, .returnToSupplier, .adjustment
         ]
 
+        /// Persisted raw movement types represented by this top-level UI filter.
+        ///
+        /// Some legacy/current writers store semantically equivalent movement
+        /// values (`pull`, `usage`, `job_pull`) while the UI intentionally shows
+        /// one worker-facing category ("Consumed"). Filter chips must count and
+        /// select every raw value in the category so their totals match the rows
+        /// rendered with the same canonical label/icon.
+        public var primaryUIFilterTypes: [MovementType] {
+            switch self {
+            case .transfer:
+                return [.transfer]
+            case .receive:
+                return [.receive, .receiving, .receipt]
+            case .consume:
+                return [.consume, .pull, .usage, .jobPull]
+            case .returnToSupplier:
+                return [.stockReturn, .returnToSupplier]
+            case .adjustment:
+                return [.adjustment]
+            case .receiving, .receivingStaged, .receipt,
+                 .stockReturn, .addStock, .writeOff,
+                 .pull, .usage, .jobPull, .restockFromShop:
+                return [self]
+            }
+        }
+
+        public var primaryUIFilterRawValues: Set<String> {
+            Set(primaryUIFilterTypes.map(\.rawValue))
+        }
+
         public var displayName: String {
             switch self {
             case .transfer:

--- a/core/Tests/WiredPartCoreTests/StockMovementTypeContractTests.swift
+++ b/core/Tests/WiredPartCoreTests/StockMovementTypeContractTests.swift
@@ -14,6 +14,15 @@ struct StockMovementTypeContractTests {
         #expect(filterTypes.map(\.systemImageName) == ["arrow.left.arrow.right", "arrow.down.circle", "flame", "arrow.uturn.left", "plus.forwardslash.minus"])
     }
 
+    @Test("Primary UI filters include every raw movement value rendered with the same label")
+    func primaryUIFiltersIncludeGroupedRawValues() {
+        #expect(StockMovement.MovementType.transfer.primaryUIFilterRawValues == Set(["transfer"]))
+        #expect(StockMovement.MovementType.receive.primaryUIFilterRawValues == Set(["receive", "receiving", "receipt"]))
+        #expect(StockMovement.MovementType.consume.primaryUIFilterRawValues == Set(["consume", "pull", "usage", "job_pull"]))
+        #expect(StockMovement.MovementType.returnToSupplier.primaryUIFilterRawValues == Set(["return", "return_to_supplier"]))
+        #expect(StockMovement.MovementType.adjustment.primaryUIFilterRawValues == Set(["adjustment"]))
+    }
+
     @Test("Movement type display fallback normalizes raw persisted values")
     func displayFallbackNormalizesRawPersistedValues() {
         #expect(StockMovement.MovementType.displayName(forRawValue: "return_to_supplier") == "Returned")

--- a/core/Tests/WiredPartCoreTests/StockMovementTypeContractTests.swift
+++ b/core/Tests/WiredPartCoreTests/StockMovementTypeContractTests.swift
@@ -1,0 +1,23 @@
+import Testing
+@testable import WiredPartCore
+
+@Suite("Stock Movement Type Contract Tests")
+struct StockMovementTypeContractTests {
+
+    @Test("UI movement filters use the canonical stock movement type contract")
+    func uiMovementFiltersUseCanonicalContract() {
+        let filterTypes = StockMovement.MovementType.primaryUIFilterTypes
+
+        #expect(filterTypes == [.transfer, .receive, .consume, .returnToSupplier, .adjustment])
+        #expect(filterTypes.map(\.rawValue) == ["transfer", "receive", "consume", "return_to_supplier", "adjustment"])
+        #expect(filterTypes.map(\.displayName) == ["Transfer", "Received", "Consumed", "Returned", "Adjustment"])
+        #expect(filterTypes.map(\.systemImageName) == ["arrow.left.arrow.right", "arrow.down.circle", "flame", "arrow.uturn.left", "plus.forwardslash.minus"])
+    }
+
+    @Test("Movement type display fallback normalizes raw persisted values")
+    func displayFallbackNormalizesRawPersistedValues() {
+        #expect(StockMovement.MovementType.displayName(forRawValue: "return_to_supplier") == "Returned")
+        #expect(StockMovement.MovementType.displayName(forRawValue: "receiving_staged") == "Receiving Staged")
+        #expect(StockMovement.MovementType.displayName(forRawValue: "custom_type") == "Custom Type")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a canonical StockMovement.MovementType presentation contract for UI filter options, labels, and SF Symbols.
- Routes warehouse movement filters/list/detail presentation and JPO movement detail display through the shared contract.
- Replaces movement wizard raw write values with StockMovement.MovementType constants.
- Adds regression coverage for the UI movement contract and raw-value display fallback.

## Test Plan
- swift test --filter StockMovementTypeContractTests
- xcodebuild build -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO

## Notes
- Full `swift test` was also attempted; it exceeded the 600s local timeout after surfacing existing PartsServiceAdvancedTests permission failures unrelated to this change.

Refs #638