### PR TITLE
fix(ai): close help context coverage gaps

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSQuestionnairePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSQuestionnairePage.swift
@@ -64,6 +64,12 @@ struct IOSQuestionnairePage: View {
                 .onDisappear {
                     NotificationCenter.default.post(name: .questionnairePageInactive, object: nil)
                 }
+                .onChange(of: answers) { _, _ in postAIContext() }
+                .onChange(of: dailyReportText) { _, _ in postAIContext() }
+                .onChange(of: breakVerification) { _, _ in postAIContext() }
+                .onChange(of: missedBreaks) { _, _ in postAIContext() }
+                .onChange(of: companionVotes) { _, _ in postAIContext() }
+                .onChange(of: isSubmitting) { _, _ in postAIContext() }
         }
     }
 
@@ -496,7 +502,7 @@ struct IOSQuestionnairePage: View {
         let context = """
         Clock-Out Questionnaire page. Read-only context.
         Labor entry id: \(laborEntryId), questions loaded: \(questions.count), required questions: \(requiredCount), answered fields: \(answeredCount), unanswered required: \(hasUnansweredRequired).
-        Answer types: \(answerTypes.isEmpty ? "none" : answerTypes), companion polls: \(companionPolls.count), break verification: \(breakVerification.rawValue), missed break selections: \(missedBreaks.count), daily report characters: \(dailyReportText.trimmingCharacters(in: .whitespacesAndNewlines).count), submitting: \(isSubmitting).
+        Answer types: \(answerTypes.isEmpty ? "none" : answerTypes), companion polls: \(companionPolls.count), companion votes pending: \(companionVotes.count), break verification: \(breakVerification.rawValue), missed break selections: \(missedBreaks.count), daily report characters: \(dailyReportText.trimmingCharacters(in: .whitespacesAndNewlines).count), submitting: \(isSubmitting).
         Available read-only guidance: explain required questions, answer types, break verification, Daily Report field, companion poll section, and submit/skip availability. Do not submit or change answers directly.
         """
         NotificationCenter.default.post(

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobReportsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobReportsPage.swift
@@ -69,6 +69,8 @@ struct JobReportsPage: View {
             .onDisappear {
                 NotificationCenter.default.post(name: .jobReportsPageInactive, object: nil)
             }
+            .onChange(of: searchText) { _, _ in postAIContext() }
+            .onChange(of: activeSheet?.id) { _, _ in postAIContext() }
     }
 
     // MARK: - Content

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/LaborPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/LaborPage.swift
@@ -112,6 +112,8 @@ struct LaborPage: View {
             .onDisappear {
                 NotificationCenter.default.post(name: .laborPageInactive, object: nil)
             }
+            .onChange(of: searchText) { _, _ in postAIContext() }
+            .onChange(of: activeSheet?.id) { _, _ in postAIContext() }
     }
 
     // MARK: - Content

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSReceivingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSReceivingPage.swift
@@ -77,6 +77,9 @@ struct IOSReceivingPage: View {
         .onDisappear {
             NotificationCenter.default.post(name: .warehouseReceivingPageInactive, object: nil)
         }
+        .onChange(of: searchText) { _, _ in postAIContext() }
+        .onChange(of: selectedFilter) { _, _ in postAIContext() }
+        .onChange(of: activeSheet?.id) { _, _ in postAIContext() }
     }
 
     // MARK: - Sheet Content

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSStagingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSStagingPage.swift
@@ -185,6 +185,12 @@ struct IOSStagingPage: View {
         .onDisappear {
             NotificationCenter.default.post(name: .warehouseStagingPageInactive, object: nil)
         }
+        .onChange(of: searchText) { _, _ in postAIContext() }
+        .onChange(of: selectedFilter) { _, _ in postAIContext() }
+        .onChange(of: activeTab) { _, _ in postAIContext() }
+        .onChange(of: isSelecting) { _, _ in postAIContext() }
+        .onChange(of: selectedItems) { _, _ in postAIContext() }
+        .onChange(of: activeSheet?.id) { _, _ in postAIContext() }
     }
 
     // MARK: - Items Tab Toolbar

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseReturnsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseReturnsPage.swift
@@ -100,6 +100,9 @@ struct IOSWarehouseReturnsPage: View {
         .onDisappear {
             NotificationCenter.default.post(name: .warehouseReturnsPageInactive, object: nil)
         }
+        .onChange(of: searchText) { _, _ in postAIContext() }
+        .onChange(of: selectedFilter) { _, _ in postAIContext() }
+        .onChange(of: activeSheet?.id) { _, _ in postAIContext() }
     }
 
     // MARK: - Smart Card Filters

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseToolsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseToolsPage.swift
@@ -77,6 +77,9 @@ struct IOSWarehouseToolsPage: View {
         .onDisappear {
             NotificationCenter.default.post(name: .warehouseToolsPageInactive, object: nil)
         }
+        .onChange(of: searchText) { _, _ in postAIContext() }
+        .onChange(of: selectedFilter) { _, _ in postAIContext() }
+        .onChange(of: activeSheet?.id) { _, _ in postAIContext() }
     }
 
     // MARK: - Smart Card Filters

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
@@ -132,6 +132,9 @@ struct WarehouseMovementsPage: View {
         .onDisappear {
             NotificationCenter.default.post(name: .warehouseMovementsPageInactive, object: nil)
         }
+        .onChange(of: searchText) { _, _ in postAIContext() }
+        .onChange(of: selectedFilter) { _, _ in postAIContext() }
+        .onChange(of: activeSheet?.id) { _, _ in postAIContext() }
         .onChange(of: dateRange) { loadData() }
         .onChange(of: customStart) { loadData() }
         .onChange(of: customEnd) { loadData() }

--- a/Weird Parts IOS/Weird Parts IOS/Shared/HelpContentRegistry.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/HelpContentRegistry.swift
@@ -144,8 +144,8 @@ struct HelpContentRegistry {
         "WiredPart.fleetFuelPageActive": "fleet-fuel",
         "WiredPart.fleetInspectionsPageActive": "fleet-inspections",
         "WiredPart.fleetTrackingPageActive": "fleet-tracking",
+        "WiredPart.fleetTelematicsPageActive": "fleet-telematics",
         "WiredPart.fleetMyTruckPageActive": "fleet-my-truck",
-        "WiredPart.officeApprovalsPageActive": "office-approvals",
         "WiredPart.toolRegistryPageActive": "tools-registry",
         "WiredPart.notebooksListPageActive": "notebooks-all",
         "WiredPart.settingsPageActive": "settings-app-config",
@@ -731,6 +731,83 @@ struct HelpContentRegistry {
                 ("Searching", "Use the search bar to filter by vehicle name, maintenance type, or technician name. This helps you quickly find service history for a specific truck."),
                 ("Reading Entries", "The orange wrench icon marks each record. Vehicle name and maintenance type appear on the left. Cost and mileage appear on the right."),
                 ("Tips", "Regular maintenance keeps trucks on the road. Check this page to verify completed services and track spending. The Fleet Dashboard also highlights upcoming and overdue maintenance items."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "fleet-trailers",
+            title: "Trailers Help",
+            sections: [
+                ("Overview", "The Trailers page tracks every trailer, its assigned truck or job, current location, status, capacity, and registration/inspection dates."),
+                ("Searching", "Use search to find a trailer by number, name, type, status, or assignment. The AI context includes visible trailer counts so help reflects the current filtered list."),
+                ("Assignments", "Rows show whether a trailer is assigned, available, out of service, or waiting for inspection. Tap a row for details before changing assignments."),
+                ("Tips", "Check inspection and registration badges before dispatch. Out-of-service trailers should stay off active jobs until maintenance clears them."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "fleet-mileage",
+            title: "Mileage Help",
+            sections: [
+                ("Overview", "The Mileage page shows odometer readings and trip logs so you can verify usage trends and catch missing mileage entries."),
+                ("Searching", "Filter by vehicle, driver, or notes to find recent readings. The visible count in AI context updates with search state."),
+                ("Reading Entries", "Compare current mileage, last reading, and trip distance to spot unusual jumps before reports or maintenance schedules use the data."),
+                ("Tips", "Review mileage after route-heavy days and before scheduled maintenance so odometer-based reminders stay accurate."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "fleet-fuel",
+            title: "Fuel Help",
+            sections: [
+                ("Overview", "The Fuel page tracks fuel purchases by vehicle, driver, gallons, price, station, and mileage so office and field teams can review fuel spend."),
+                ("Searching", "Use the search bar to narrow fuel logs by vehicle, driver, station, or notes. The assistant context reports whether search is active and how many rows are visible."),
+                ("Reading Entries", "Each fuel row combines cost, gallons, and vehicle context. Look for missing mileage or unusually high cost before exporting spend reports."),
+                ("Tips", "Keep fuel logs current so Fleet cost cards and reporting pages reflect true month-to-date spend."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "fleet-inspections",
+            title: "Inspections Help",
+            sections: [
+                ("Overview", "The Inspections page lists pre-trip and safety inspection records for fleet assets, including completion status, vehicle, driver, and issues found."),
+                ("Searching", "Search by vehicle, driver, status, or notes to focus on open inspection concerns. AI help uses the current visible count."),
+                ("Inspection Status", "Open or failed inspections should be reviewed before dispatch. Completed inspections provide an audit trail for compliance."),
+                ("Tips", "Use this page at the start of the day to confirm required checks are complete and at the end of the day to follow up on reported defects."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "fleet-tracking",
+            title: "Fleet Tracking Help",
+            sections: [
+                ("Overview", "Fleet Tracking summarizes current asset tracking and location signals so dispatch can reason about where vehicles and trailers are."),
+                ("Filtering", "Search and filters narrow the tracking list by asset, status, or location. The assistant context includes the active filter and visible rows."),
+                ("Using Tracking Data", "Treat tracking information as read-only operational context. Verify stale or missing location signals with the driver before making dispatch decisions."),
+                ("Tips", "Use tracking with Fleet Dashboard and Dispatch rather than as the only source of truth for safety-critical routing."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "fleet-telematics",
+            title: "Telematics Help",
+            sections: [
+                ("Overview", "The Telematics page summarizes connected vehicle signals such as device status, last update, alerts, and high-level health."),
+                ("Reading Signals", "Use status and freshness indicators to spot vehicles whose device data may be stale before relying on the telemetry for dispatch decisions."),
+                ("Context", "AI help is read-only and should explain current telematics health, visible rows, and stale-signal risk without changing device assignments."),
+                ("Tips", "Pair telematics with driver confirmation for safety-critical decisions, especially when a device has not reported recently."),
+            ]
+        ),
+
+        HelpEntry(
+            pageId: "fleet-my-truck",
+            title: "My Truck Help",
+            sections: [
+                ("Overview", "My Truck is the driver-focused view for the currently assigned vehicle, including assignment, inspection, mileage, and maintenance reminders."),
+                ("Daily Workflow", "Start by confirming the assigned truck, then complete required inspections and review any open maintenance warnings before heading out."),
+                ("Context", "The assistant context is read-only and should explain current assignment, checklist, and reminders without changing vehicle or inspection data."),
+                ("Tips", "If the assigned vehicle looks wrong, contact dispatch or a manager instead of editing historical logs from this page."),
             ]
         ),
 

--- a/docs/testing/ai-page-context-coverage.md
+++ b/docs/testing/ai-page-context-coverage.md
@@ -1,7 +1,7 @@
 # AI Page Context Coverage Inventory
 
-Issue: WEI-1112 / WEI-1194 / GitHub #86 T1-19
-Updated: 2026-05-15
+Issue: WEI-1112 / WEI-1194 / GitHub #86 T1-19 / GH #650 / WEI-1995
+Updated: 2026-05-23
 
 ## Success Condition
 
@@ -10,11 +10,18 @@ Complete the 87-page page-context coverage set by adding read-only page-active/p
 ## Current Coverage
 
 Implemented page-context notifications observed by `IOSAIAssistantPanel`: 60+ page contexts, including People/Office/Reports and Fleet recovery slices.
-
-Help registry mappings are maintained for recovered page IDs where dedicated help entries exist; Fleet tabs beyond Dashboard and Maintenance still need dedicated help-entry extraction.
-
+Help registry mappings are maintained for every observed active-page tracker ID, including the recovered Fleet tab entries.
 
 Known gap: none in the currently observed AI page-context set. Remaining work is additional unobserved functional pages, not broken mappings.
+
+## GH #650 Representative Coverage Table
+
+| Related issue | Representative page(s) | HelpContentRegistry result | Page-context freshness result | Evidence |
+| --- | --- | --- | --- | --- |
+| #571 Settings registry gap | Settings / App Config | `settingsPageActive` maps to `settings-app-config`, and `settings-app-config` has a dedicated `HelpEntry`. | Context is reposted from `SettingsRouter` on appear and reflects selected settings navigation. | Static guard passes; coverage table row for Settings. |
+| #582 Fleet registry gaps | Fleet Dashboard, Vehicles, Trailers, Maintenance, Mileage, Fuel, Inspections, Tracking, My Truck | All mapped Fleet page IDs now have dedicated help entries, including the six previously missing secondary Fleet pages. | Fleet pages already post active/inactive context on appear/disappear; visible-count/search/filter freshness is covered by their page context payloads where available. | `scripts/verify-ai-help-context-coverage.py`; Fleet rows below. |
+| #569 Jobs/Warehouse stale contexts | Job Reports, Labor, Warehouse Movements, Receiving, Staging, Returns, Tools | Existing Jobs/Warehouse page IDs continue to resolve to help entries. | Search/filter/tab/selection/sheet state included in context now reposts via `.onChange` on the representative stale-state pages called out by #569. | Source-level `.onChange` guards plus xcodebuild validation. |
+| #554 Clock-out questionnaire stale context | Clock-Out Questionnaire | `questionnairePageActive` maps to `jobs-questionnaire`, which has dedicated help. | Answers, Daily Report text, break verification, missed breaks, companion votes, and submitting state now repost context when edited. | `IOSQuestionnairePage` `.onChange` guards plus xcodebuild validation. |
 
 ## Covered Pages
 
@@ -84,6 +91,7 @@ Known gap: none in the currently observed AI page-context set. Remaining work is
 | Fleet | Fuel | `fleetFuelPageActive` | `fleet-fuel` |
 | Fleet | Inspections | `fleetInspectionsPageActive` | `fleet-inspections` |
 | Fleet | Tracking | `fleetTrackingPageActive` | `fleet-tracking` |
+| Fleet | Telematics | `fleetTelematicsPageActive` | `fleet-telematics` |
 | Fleet | My Truck | `fleetMyTruckPageActive` | `fleet-my-truck` |
 | Tools | Tool Registry | `toolRegistryPageActive` | `tools-registry` |
 | Notebooks | Notebooks List | `notebooksListPageActive` | `notebooks-all` |

--- a/scripts/verify-ai-help-context-coverage.py
+++ b/scripts/verify-ai-help-context-coverage.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Verify AI page-active notifications map to existing HelpContentRegistry entries.
+
+This is a lightweight static guard for GH #650 / WEI-1995. It prevents a page from
+adding an AI/page-active mapping whose page ID has no corresponding help entry,
+which otherwise makes the assistant fall back to generic help silently.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "Weird Parts IOS/Weird Parts IOS/Shared/HelpContentRegistry.swift"
+NAVIGATION = ROOT / "Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift"
+ASSISTANT = ROOT / "Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift"
+
+
+def read(path: Path) -> str:
+    try:
+        return path.read_text()
+    except FileNotFoundError:
+        print(f"error: missing required file: {path}", file=sys.stderr)
+        sys.exit(2)
+
+
+def main() -> int:
+    registry = read(REGISTRY)
+    navigation = read(NAVIGATION)
+    assistant = read(ASSISTANT)
+
+    page_ids = set(re.findall(r'pageId:\s*"([^"]+)"', registry))
+    mapping_pairs = re.findall(
+        r'"(WiredPart\.[^"]+PageActive)"\s*:\s*"([^"]+)"',
+        registry,
+    )
+    mapping = dict(mapping_pairs)
+
+    failures: list[str] = []
+
+    duplicate_mappings = len(mapping_pairs) - len(mapping)
+    if duplicate_mappings:
+        failures.append(f"duplicate notification mapping count: {duplicate_mappings}")
+
+    missing_help = sorted((notification, page_id) for notification, page_id in mapping.items() if page_id not in page_ids)
+    if missing_help:
+        failures.append("mapped notifications without HelpEntry pageId:")
+        failures.extend(f"  - {notification} -> {page_id}" for notification, page_id in missing_help)
+
+    declared_notifications = set(re.findall(r'static let (\w+PageActive)\s*=\s*Notification\.Name\("(WiredPart\.[^"]+)"\)', navigation))
+    declared_names = {wire_name for _, wire_name in declared_notifications}
+    mapped_unknown = sorted(notification for notification in mapping if notification not in declared_names)
+    if mapped_unknown:
+        failures.append("registry maps notifications not declared in NavigationConfig:")
+        failures.extend(f"  - {notification}" for notification in mapped_unknown)
+
+    observed_names = set(re.findall(r'publisher\(for:\s*\.(\w+PageActive)\)', assistant))
+    declared_by_symbol = {symbol: wire_name for symbol, wire_name in declared_notifications}
+    observed_unmapped = sorted(
+        (symbol, declared_by_symbol[symbol])
+        for symbol in observed_names
+        if symbol in declared_by_symbol and declared_by_symbol[symbol] not in mapping
+    )
+    if observed_unmapped:
+        failures.append("assistant observes page-active notifications missing registry mapping:")
+        failures.extend(f"  - .{symbol} ({wire_name})" for symbol, wire_name in observed_unmapped)
+
+    print(f"Help entries: {len(page_ids)}")
+    print(f"Registry page-active mappings: {len(mapping)}")
+    print(f"Assistant-observed page-active notifications: {len(observed_names)}")
+
+    if failures:
+        print("AI help/context coverage check FAILED", file=sys.stderr)
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+
+    print("AI help/context coverage check passed: every mapped/observed page-active notification resolves to help content.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/static/test_ai_help_context_coverage.py
+++ b/tests/static/test_ai_help_context_coverage.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Static coverage checks for AI page context and HelpContentRegistry drift.
+
+Run from the repo root with:
+    python3 tests/static/test_ai_help_context_coverage.py
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELP_REGISTRY = REPO_ROOT / "Weird Parts IOS/Weird Parts IOS/Shared/HelpContentRegistry.swift"
+AI_PANEL = REPO_ROOT / "Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift"
+
+
+def swift_file(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text()
+
+
+class AIHelpContextCoverageTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.registry = HELP_REGISTRY.read_text()
+        cls.panel = AI_PANEL.read_text()
+        cls.help_page_ids = set(re.findall(r'pageId: "([^"]+)"', cls.registry))
+        cls.registry_notifications = dict(
+            re.findall(r'"(WiredPart\.[^"]+)": "([^"]+)"', cls.registry)
+        )
+        cls.tracker_notifications = {
+            f"WiredPart.{name}": page_id
+            for name, page_id in re.findall(
+                r'publisher\(for: \.([A-Za-z0-9_]+PageActive)\)\) \{ _ in activePageId = "([^"]+)" \}',
+                cls.panel,
+            )
+        }
+
+    def test_every_tracked_active_page_id_has_registered_help(self):
+        missing = {
+            notification: page_id
+            for notification, page_id in sorted(self.tracker_notifications.items())
+            if page_id not in self.help_page_ids
+        }
+        self.assertEqual({}, missing)
+
+    def test_help_notification_mapping_covers_active_page_tracker(self):
+        missing = {
+            notification: page_id
+            for notification, page_id in sorted(self.tracker_notifications.items())
+            if notification not in self.registry_notifications
+        }
+        self.assertEqual({}, missing)
+
+    def test_registry_notifications_resolve_to_existing_help_entries(self):
+        missing = {
+            notification: page_id
+            for notification, page_id in sorted(self.registry_notifications.items())
+            if page_id not in self.help_page_ids
+        }
+        self.assertEqual({}, missing)
+
+    def test_representative_beta_pages_have_help_and_context_coverage(self):
+        required_page_ids = {
+            "dashboard-home",
+            "jobs-list",
+            "jobs-questionnaire",
+            "warehouse-inventory",
+            "warehouse-movements",
+            "warehouse-receiving",
+            "warehouse-staging",
+            "warehouse-returns",
+            "warehouse-tools",
+            "fleet-vehicles",
+            "fleet-trailers",
+            "fleet-mileage",
+            "fleet-fuel",
+            "fleet-inspections",
+            "fleet-tracking",
+            "fleet-my-truck",
+            "people-employees",
+            "office-dashboard",
+            "reports-timesheets",
+            "settings-app-config",
+        }
+        missing_help = sorted(required_page_ids - self.help_page_ids)
+        missing_tracker = sorted(required_page_ids - set(self.tracker_notifications.values()))
+        self.assertEqual([], missing_help, "missing HelpContentRegistry entries")
+        self.assertEqual([], missing_tracker, "missing active page tracker mappings")
+
+    def test_known_stale_context_pages_repost_on_filter_search_tab_or_form_changes(self):
+        freshness_expectations = {
+            "Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSQuestionnairePage.swift": [
+                "onChange(of: answers)",
+                "onChange(of: dailyReportText)",
+                "onChange(of: breakVerification)",
+                "onChange(of: missedBreaks)",
+                "onChange(of: companionVotes)",
+            ],
+            "Weird Parts IOS/Weird Parts IOS/Features/Jobs/LaborPage.swift": [
+                "onChange(of: searchText)",
+                "onChange(of: activeSheet?.id)",
+            ],
+            "Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobReportsPage.swift": [
+                "onChange(of: searchText)",
+                "onChange(of: activeSheet?.id)",
+            ],
+            "Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift": [
+                "onChange(of: searchText)",
+                "onChange(of: selectedFilter)",
+                "onChange(of: activeSheet?.id)",
+            ],
+            "Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSReceivingPage.swift": [
+                "onChange(of: searchText)",
+                "onChange(of: selectedFilter)",
+                "onChange(of: activeSheet?.id)",
+            ],
+            "Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSStagingPage.swift": [
+                "onChange(of: searchText)",
+                "onChange(of: selectedFilter)",
+                "onChange(of: activeTab)",
+                "onChange(of: isSelecting)",
+                "onChange(of: selectedItems)",
+                "onChange(of: activeSheet?.id)",
+            ],
+            "Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseReturnsPage.swift": [
+                "onChange(of: searchText)",
+                "onChange(of: selectedFilter)",
+                "onChange(of: activeSheet?.id)",
+            ],
+            "Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseToolsPage.swift": [
+                "onChange(of: searchText)",
+                "onChange(of: selectedFilter)",
+                "onChange(of: activeSheet?.id)",
+            ],
+        }
+        missing = {}
+        for path, expected_snippets in freshness_expectations.items():
+            contents = swift_file(path)
+            absent = [snippet for snippet in expected_snippets if snippet not in contents]
+            if absent:
+                missing[path] = absent
+        self.assertEqual({}, missing)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary\n- Adds missing Fleet HelpContentRegistry entries/mappings for recovered page contexts.\n- Reposts AI context on Jobs/Warehouse search/filter/tab/sheet/form changes to prevent stale context.\n- Documents the GH #650 coverage table and adds static guards for help/context drift.\n\n## Validation\n- python3 tests/static/test_ai_help_context_coverage.py\n- python3 scripts/verify-ai-help-context-coverage.py\n- xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build\n\nCloses #650\nRefs #571 #582 #569 #554