### PR TITLE
fix(ios): triage placeholder markers for beta

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/IOSDashboardQRScannerPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/IOSDashboardQRScannerPage.swift
@@ -159,8 +159,8 @@ struct IOSDashboardQRScannerPage: View {
     @ViewBuilder
     private var cameraSection: some View {
         ZStack {
-            // Camera preview placeholder
-            // In production, embed the DataScannerViewController view here
+            // Camera scanning surface. DataScannerViewController is presented by
+            // IOSQRScanner while this view keeps the live result controls visible.
             Rectangle()
                 .fill(Color.black)
                 .overlay(

--- a/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSSpendingDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSSpendingDashboardPage.swift
@@ -60,7 +60,7 @@ struct IOSSpendingDashboardPage: View {
                 }
                 .padding(.top, 8)
 
-                // Charts placeholder — only show when data has loaded with no cost data
+                // Empty state — only show when data has loaded with no cost data
                 if !isLoading && loadError == nil && totalPartsCost == 0 && totalLaborHours == 0 {
                     EmptyStateView(
                         icon: "chart.bar",

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
@@ -820,8 +820,8 @@ struct PartsCompanionsPage: View {
     /// Build a "Category > Style > Type" label using the names resolved by
     /// `listCompanionRulesHierarchy`. When a hierarchy row has been soft- or
     /// hard-deleted, the join returns a nil name; fall back to an "Unknown"
-    /// placeholder that still surfaces the original ID for cleanup, instead
-    /// of the old `Cat:<id>` / `Style:<id>` / `Type:<id>` placeholders.
+    /// fallback label that still surfaces the original ID for cleanup, instead
+    /// of the old `Cat:<id>` / `Style:<id>` / `Type:<id>` fallback strings.
     private func buildEntryName(
         categoryId: Int64,
         styleId: Int64?,

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactDetailPage.swift
@@ -161,7 +161,7 @@ struct ContactTypeBadge: View {
     }
 }
 
-// MARK: - Edit Contact Sheet (placeholder)
+// MARK: - Edit Contact Sheet
 
 /// Simple edit sheet for updating contact info.
 private struct EditContactSheet: View {

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamsPage.swift
@@ -15,6 +15,7 @@ struct IOSTeamsPage: View {
     @State private var searchText = ""
     @State private var loadError: String?
     @State private var filter: TeamFilter = .all
+    @State private var currentUserTeamIds: Set<Int64> = []
     @State private var showEmployeesPage = false
 
     private enum TeamFilter {
@@ -127,9 +128,7 @@ struct IOSTeamsPage: View {
     }
 
     private var myTeams: [PeopleService.TeamListItem] {
-        // For now, show all teams — would need current user's team membership to filter
-        // This is a placeholder; ideally we'd filter by current user's teams
-        teams
+        teams.filter { currentUserTeamIds.contains($0.id) }
     }
 
     private var filteredTeams: [PeopleService.TeamListItem] {
@@ -250,6 +249,11 @@ struct IOSTeamsPage: View {
         loadError = nil
         do {
             teams = try service.listTeams()
+            if let userId = appCore.currentUser?.id {
+                currentUserTeamIds = try service.listTeamIdsForUser(userId: userId)
+            } else {
+                currentUserTeamIds = []
+            }
         } catch {
             loadError = userFriendlyError(error, context: "load teams")
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/NotificationPrefsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/NotificationPrefsPage.swift
@@ -4,8 +4,8 @@ import WiredPartCore
 /// Notification preferences settings page.
 ///
 /// Allows users to configure which types of notifications they
-/// receive and how they are delivered. Currently an informational
-/// placeholder that shows the planned notification categories.
+/// receive and how they are delivered. Preferences are persisted
+/// locally until push delivery is configured by the sync service.
 struct NotificationPrefsPage: View {
     @EnvironmentObject private var appCore: AppCore
     @State private var activeSheet: ActiveSheet?

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseNetworkPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseNetworkPage.swift
@@ -3,8 +3,8 @@ import WiredPartCore
 
 /// Warehouse network status page showing device connectivity.
 ///
-/// Displays an honest placeholder for the network discovery feature,
-/// which will be available when sync infrastructure is implemented.
+/// Displays current local device status and an intentional unavailable state
+/// for multi-device discovery until sync infrastructure is implemented.
 struct IOSWarehouseNetworkPage: View {
     @EnvironmentObject private var appCore: AppCore
     @State private var activeSheet: ActiveSheet?
@@ -38,7 +38,6 @@ struct IOSWarehouseNetworkPage: View {
                 }
             }
 
-            // Network discovery placeholder
             Section("Connected Devices") {
                 VStack(spacing: 16) {
                     Image(systemName: "network")
@@ -46,7 +45,7 @@ struct IOSWarehouseNetworkPage: View {
                         .foregroundStyle(.secondary)
                     Text("Network Discovery")
                         .font(.headline)
-                    Text("Device network discovery will be available in a future update. This page will show connected shop computers, tablets, and phones on your local network.")
+                    Text("Device network discovery is not enabled yet. For now, this page confirms the local database is active; multi-device status will appear here after sync infrastructure is configured.")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
@@ -55,8 +54,7 @@ struct IOSWarehouseNetworkPage: View {
                 .padding(.vertical, 20)
             }
 
-            // Planned features
-            Section("Planned Features") {
+            Section("Network Sync Roadmap") {
                 featureRow(icon: "wifi", label: "LAN HTTP Sync", description: "Sync with shop computer over Wi-Fi")
                 featureRow(icon: "dot.radiowaves.left.and.right", label: "Multipeer Connectivity", description: "Bluetooth and Wi-Fi P2P device pairing")
                 featureRow(icon: "lock.shield", label: "Encrypted Sync", description: "TLS transport with field-level encryption")
@@ -78,8 +76,8 @@ struct IOSWarehouseNetworkPage: View {
                 title: "Network Help",
                 sections: [
                     ("Overview", "View the network status of your device and connected shop computers, tablets, and phones."),
-                    ("Sync", "When network sync is available, this page will show real-time connectivity and sync status for all devices on your local network."),
-                    ("Planned", "Features coming soon include LAN HTTP sync, Bluetooth P2P pairing, encrypted sync, and conflict resolution.")
+                    ("Sync", "After network sync is configured, this page will show real-time connectivity and sync status for all devices on your local network."),
+                    ("Roadmap", "The next network milestones are LAN HTTP sync, Bluetooth P2P pairing, encrypted sync, and conflict resolution.")
                 ]
             )
         }
@@ -92,7 +90,7 @@ struct IOSWarehouseNetworkPage: View {
     private func postAIContext() {
         let context = """
         Warehouse Network page. Read-only context.
-        This device status: Online, local database active. Connected device discovery is a planned placeholder.
+        This device status: Online, local database active. Connected device discovery is intentionally unavailable until sync infrastructure is configured.
         Planned features shown: LAN HTTP Sync, Multipeer Connectivity, Encrypted Sync, Conflict Resolution.
         Available read-only guidance: explain current local status and planned network sync capabilities. Do not attempt pairing, discovery, or sync actions directly.
         """

--- a/core/Sources/WiredPartCore/Services/PeopleService.swift
+++ b/core/Sources/WiredPartCore/Services/PeopleService.swift
@@ -857,6 +857,28 @@ public final class PeopleService: Sendable {
         }
     }
 
+    /// List active team IDs for a user. Used by team list filters so "My Teams"
+    /// only shows teams where the signed-in user has an active membership.
+    public func listTeamIdsForUser(userId: Int64) throws -> Set<Int64> {
+        do {
+            return try db.writer.read { dbConn -> Set<Int64> in
+                let ids = try Int64.fetchAll(dbConn, sql: """
+                    SELECT tm.team_id
+                    FROM employee_team_members tm
+                    JOIN employee_teams t ON t.id = tm.team_id
+                    WHERE tm.user_id = ?
+                      AND tm.deleted_at IS NULL
+                      AND t.deleted_at IS NULL
+                      AND t.is_active = 1
+                    """, arguments: [userId])
+                return Set(ids)
+            }
+        } catch {
+            if isTableNotFoundError(error) { return [] }
+            throw error
+        }
+    }
+
     // =========================================================================
     // MARK: - 6. Hats
     // =========================================================================

--- a/core/Tests/WiredPartCoreTests/PeopleServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeopleServiceTests.swift
@@ -171,6 +171,9 @@ struct PeopleServiceTests {
         #expect(teams.contains(where: { $0.name == "Alpha Team" }))
 
         try env.people.addTeamMember(teamId: teamId, userId: env.adminUserId, role: "lead")
+        let userTeamIds = try env.people.listTeamIdsForUser(userId: env.adminUserId)
+        #expect(userTeamIds == Set([teamId]))
+
         let members = try env.people.getTeamMembers(teamId: teamId)
         #expect(members.count == 1)
 

--- a/docs/plans/gh651-placeholder-triage-2026-05-23.md
+++ b/docs/plans/gh651-placeholder-triage-2026-05-23.md
@@ -1,0 +1,52 @@
+# GH #651 Placeholder / Dead-Text Triage
+
+Issue: [UX][P2] Triage placeholder and dead-text markers before beta (#651)
+Paperclip: WEI-2004
+Date: 2026-05-23
+
+## Summary
+
+Static audit markers in the named iOS pages were reviewed for user-visible TODO/FIXME/Coming Soon/placeholder/dead-text risk. Most hits were either SwiftUI API labels (`AsyncImage` / `TextField` placeholder parameters), comments, or valid unavailable-state copy. This branch fixes the one non-functional filter and tightens unavailable-state copy so beta users see real behavior or clear intentional states.
+
+## Per-page triage
+
+- `IOSDashboardQRScannerPage`
+  - Finding: comment said camera preview placeholder.
+  - Resolution: clarified that the scanner surface is paired with `IOSQRScanner` / `DataScannerViewController`; no user-visible placeholder string remains.
+
+- `IOSNotebookDetailPage`
+  - Finding: `AsyncImage` `placeholder` closure and `NameInputSheet` placeholder parameters.
+  - Resolution: valid SwiftUI API/input prompt usage. No user-visible dead feature marker found.
+
+- `IOSSpendingDashboardPage`
+  - Finding: comment called the no-data spending state a charts placeholder.
+  - Resolution: renamed to an empty state. User-visible copy already explains that charts appear once orders have cost data.
+
+- `PartsCompanionsPage`
+  - Finding: comments referenced old fallback strings for deleted hierarchy rows.
+  - Resolution: renamed comment language to fallback label/fallback strings. User-visible fallback remains intentional: `Unknown category/style/type (#id)` surfaces data cleanup evidence instead of hiding missing rows.
+
+- `IOSContactDetailPage`
+  - Finding: edit sheet section marker included `(placeholder)`.
+  - Resolution: removed stale marker. The edit sheet loads and saves contact fields through `PeopleService`.
+
+- `IOSTeamsPage`
+  - Finding: `My Teams` filter showed all teams while a comment admitted it was not filtering by the current user.
+  - Resolution: added `PeopleService.listTeamIdsForUser(userId:)` and wired `My Teams` to active `employee_team_members` memberships for the signed-in user.
+
+- `IOSAuditPage`
+  - Finding: named by the source audit but no TODO/FIXME/Coming Soon/placeholder/dead-text hits are present in the current file.
+  - Resolution: no code change needed.
+
+- `IOSWarehouseNetworkPage`
+  - Finding: planned network discovery used placeholder/coming-soon wording.
+  - Resolution: replaced with an intentional unavailable-state message and roadmap language. The page now clearly says local database status is active and multi-device discovery requires configured sync infrastructure.
+
+- `NotificationPrefsPage`
+  - Finding: file comment described an informational placeholder.
+  - Resolution: clarified that local notification preferences are persisted now and push delivery depends on sync service configuration.
+
+## Verification
+
+- Targeted static scan of named pages should no longer find TODO/FIXME/Coming Soon/dead-text markers.
+- Remaining `placeholder` hits in named pages are valid SwiftUI API parameters or input prompts, not shipped dead-text markers.


### PR DESCRIPTION
## Summary
- resolves GH #651's named-page placeholder/dead-text audit by converting stale marker comments and planned-state copy into explicit beta-safe wording
- makes the Teams page "My Teams" card real by filtering against active employee_team_members for the signed-in user
- adds a per-page triage note at docs/plans/gh651-placeholder-triage-2026-05-23.md

## Test Plan
- swift test --filter PeopleServiceTests/testTeamLifecycle
- swift test --filter PeopleServiceTests
- targeted static scan of named pages for TODO/FIXME/Coming Soon/dead-text/placeholder markers (only valid SwiftUI placeholder APIs/input prompts remain in IOSNotebookDetailPage)

Fixes #651