### PR TITLE
fix(ios): replace warehouse network placeholder

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseNetworkPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseNetworkPage.swift
@@ -3,15 +3,24 @@ import WiredPartCore
 
 /// Warehouse network status page showing device connectivity.
 ///
-/// Displays current local device status and an intentional unavailable state
-/// for multi-device discovery until sync infrastructure is implemented.
+/// Displays current local device status, sync state, and connected-device
+/// discovery actions backed by the shared iOS sync manager.
 struct IOSWarehouseNetworkPage: View {
     @EnvironmentObject private var appCore: AppCore
     @State private var activeSheet: ActiveSheet?
 
+    private var syncManager: IOSSyncManager { appCore.syncManager }
+
     private enum ActiveSheet: Identifiable {
         case help
-        var id: String { "help" }
+        case peerBrowser
+
+        var id: String {
+            switch self {
+            case .help: return "help"
+            case .peerBrowser: return "peerBrowser"
+            }
+        }
     }
 
     var body: some View {
@@ -39,22 +48,51 @@ struct IOSWarehouseNetworkPage: View {
             }
 
             Section("Connected Devices") {
-                VStack(spacing: 16) {
-                    Image(systemName: "network")
-                        .font(.largeTitle)
-                        .foregroundStyle(.secondary)
-                    Text("Network Discovery")
-                        .font(.headline)
-                    Text("Device network discovery is not enabled yet. For now, this page confirms the local database is active; multi-device status will appear here after sync infrastructure is configured.")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "network")
+                            .font(.title2)
+                            .foregroundStyle(syncManager.isSyncAvailable ? Color.blue : Color.secondary)
+                            .accessibilityHidden(true)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(connectedDevicesSummary)
+                                .fontWeight(.medium)
+                            Text(syncManager.isSyncAvailable ? discoveryDetailText : syncSetupDetailText)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                    }
+
+                    HStack(spacing: 10) {
+                        Button {
+                            activeSheet = .peerBrowser
+                        } label: {
+                            Label("Browse Nearby Devices", systemImage: "antenna.radiowaves.left.and.right")
+                        }
+                        .buttonStyle(.borderedProminent)
+
+                        Button {
+                            syncManager.startPeerDiscovery()
+                        } label: {
+                            Label(syncManager.isScanning ? "Scanning" : "Scan", systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(syncManager.isScanning)
+                    }
+                    .labelStyle(.titleAndIcon)
+
+                    if let errorMessage = syncManager.errorMessage {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                            .accessibilityIdentifier("warehouseNetwork_syncNotice")
+                    }
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 20)
+                .padding(.vertical, 4)
             }
 
-            Section("Network Sync Roadmap") {
+            Section("Network Sync Capabilities") {
                 featureRow(icon: "wifi", label: "LAN HTTP Sync", description: "Sync with shop computer over Wi-Fi")
                 featureRow(icon: "dot.radiowaves.left.and.right", label: "Multipeer Connectivity", description: "Bluetooth and Wi-Fi P2P device pairing")
                 featureRow(icon: "lock.shield", label: "Encrypted Sync", description: "TLS transport with field-level encryption")
@@ -71,15 +109,21 @@ struct IOSWarehouseNetworkPage: View {
                 .accessibilityLabel("Help")
             }
         }
-        .sheet(item: $activeSheet) { _ in
-            PageHelpSheet(
-                title: "Network Help",
-                sections: [
-                    ("Overview", "View the network status of your device and connected shop computers, tablets, and phones."),
-                    ("Sync", "After network sync is configured, this page will show real-time connectivity and sync status for all devices on your local network."),
-                    ("Roadmap", "The next network milestones are LAN HTTP sync, Bluetooth P2P pairing, encrypted sync, and conflict resolution.")
-                ]
-            )
+        .sheet(item: $activeSheet) { sheet in
+            switch sheet {
+            case .help:
+                PageHelpSheet(
+                    title: "Network Help",
+                    sections: [
+                        ("Overview", "View this device's local database status, sync health, and nearby shop computers, tablets, and phones."),
+                        ("Browse Devices", "Use Browse Nearby Devices or Scan to open the live discovery flow backed by LAN and Bluetooth sync settings."),
+                        ("Capabilities", "Supported network milestones are LAN HTTP sync, Bluetooth P2P pairing, encrypted sync, and conflict resolution.")
+                    ]
+                )
+            case .peerBrowser:
+                IOSPeerBrowser()
+                    .environmentObject(appCore)
+            }
         }
         .onAppear { postAIContext() }
         .onDisappear {
@@ -90,15 +134,47 @@ struct IOSWarehouseNetworkPage: View {
     private func postAIContext() {
         let context = """
         Warehouse Network page. Read-only context.
-        This device status: Online, local database active. Connected device discovery is intentionally unavailable until sync infrastructure is configured.
-        Planned features shown: LAN HTTP Sync, Multipeer Connectivity, Encrypted Sync, Conflict Resolution.
-        Available read-only guidance: explain current local status and planned network sync capabilities. Do not attempt pairing, discovery, or sync actions directly.
+        This device status: Online, local database active. Sync status: \(syncStatusLabel); pending changes: \(syncManager.pendingChanges); discovered devices: \(syncManager.discoveredPeers.count).
+        Available actions: Browse Nearby Devices opens the live peer browser; Scan starts peer discovery through IOSSyncManager; Help explains network capabilities.
+        Network sync capabilities shown: LAN HTTP Sync, Multipeer Connectivity, Encrypted Sync, Conflict Resolution.
         """
         NotificationCenter.default.post(
             name: .warehouseNetworkPageActive,
             object: nil,
             userInfo: ["context": context]
         )
+    }
+
+    private var connectedDevicesSummary: String {
+        if syncManager.isScanning {
+            return "Scanning for nearby devices"
+        }
+        let count = syncManager.discoveredPeers.count
+        if count == 0 {
+            return "No nearby devices discovered"
+        }
+        return count == 1 ? "1 nearby device discovered" : "\(count) nearby devices discovered"
+    }
+
+    private var discoveryDetailText: String {
+        if syncManager.discoveredPeers.isEmpty {
+            return "Browse or scan for configured LAN/Bluetooth peers on the shop network."
+        }
+        return "Open the browser to review discovered peers and start a sync."
+    }
+
+    private var syncSetupDetailText: String {
+        "Configure Bluetooth sync or a shop server address in Settings, then scan from here."
+    }
+
+    private var syncStatusLabel: String {
+        switch syncManager.syncStatus {
+        case .idle: return "Idle"
+        case .syncing: return "Syncing"
+        case .synced: return "Synced"
+        case .error: return "Error"
+        case .offline: return "Offline"
+        }
     }
 
     private func featureRow(icon: String, label: String, description: String) -> some View {

--- a/Weird Parts IOS/Weird Parts IOSTests/WarehouseNetworkPageRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WarehouseNetworkPageRegressionTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+
+final class WarehouseNetworkPageRegressionTests: XCTestCase {
+    func testConnectedDevicesSectionUsesPeerBrowserInsteadOfStaticNotEnabledCopy() throws {
+        let source = try Self.readWarehouseNetworkPageSource()
+
+        XCTAssertTrue(
+            source.contains("case peerBrowser"),
+            "Warehouse network page should route connected-device discovery to the shared peer browser instead of remaining a static placeholder."
+        )
+        XCTAssertTrue(
+            source.contains("IOSPeerBrowser()"),
+            "Connected Devices should launch the existing peer browser so the page has real discovery behavior."
+        )
+        XCTAssertTrue(
+            source.contains("syncManager.discoveredPeers.count"),
+            "The page should summarize live discovered-peer state from IOSSyncManager."
+        )
+        XCTAssertTrue(
+            source.contains("syncManager.startPeerDiscovery()"),
+            "The page should expose a Scan button backed by the existing discovery manager."
+        )
+        XCTAssertFalse(
+            source.contains("Device network discovery is not enabled yet"),
+            "The beta-facing page must not show stale 'not enabled yet' placeholder copy now that IOSPeerBrowser exists."
+        )
+    }
+
+    private static func readWarehouseNetworkPageSource(
+        file: StaticString = #filePath
+    ) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Warehouse")
+            .appendingPathComponent("IOSWarehouseNetworkPage.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/docs/plans/wei-2027-placeholder-cleanup-evidence.md
+++ b/docs/plans/wei-2027-placeholder-cleanup-evidence.md
@@ -1,0 +1,46 @@
+# WEI-2027 Placeholder/dead-action cleanup evidence
+
+Issue: WEI-2027
+Date: 2026-05-23
+Scope: P2 sweep for placeholder/dead-text markers listed by `docs/plans/ux-audit-page-gap-list-2026-05-23.md`.
+
+## Outcome table
+
+| Page | Marker inspected | Classification | Outcome |
+| --- | --- | --- | --- |
+| `IOSDashboardQRScannerPage` | Manual code field, Look Up buttons, disabled states | Real behavior / valid affordance | QR manual lookup routes through `processManualCode()` and disables empty/in-flight submits. No placeholder cleanup needed. |
+| `IOSNotebookDetailPage` | `AsyncImage` placeholder, `NameInputSheet` TextField placeholders, todo/review copy | Valid SwiftUI placeholder/instructional copy | Image loading placeholder and text-entry hints are legitimate user-facing affordances. Todo review flows call `classifyTodoWork`; no dead action found. |
+| `IOSSpendingDashboardPage` | Static scan page hit with no remaining placeholder/TODO markers in current source | No actionable marker | Current source contains no obvious placeholder/dead-text markers. |
+| `PartsCompanionsPage` | Save/cancel disabled states in companion/alternative sheets | Real validation / valid affordance | Disabled states protect invalid or in-flight saves; no dead action found. |
+| `IOSContactDetailPage` | Save disabled until first name; dirty-dismiss guard | Real validation / valid affordance | Required-field validation and `interactiveDismissDisabled(isDirty)` are intentional. |
+| `IOSTeamsPage` | Save disabled until team name; dirty-dismiss guard | Real validation / valid affordance | Required-field validation and `interactiveDismissDisabled(isDirty)` are intentional. |
+| `IOSAuditPage` | Count dialog disabled state, save disabled state, misplaced-part required fields | Real validation / valid affordance | Disabled states prevent incomplete audit/misplaced-part writes. No dead action found. |
+| `IOSWarehouseNetworkPage` | “Device network discovery is not enabled yet” / roadmap-only connected devices panel | Confirmed dead placeholder because `IOSPeerBrowser` and `IOSSyncManager.startPeerDiscovery()` already exist | Replaced static placeholder with live sync-manager summary, Scan action, Browse Nearby Devices sheet, and updated AI/help copy. Added regression source test. |
+| `NotificationPrefsPage` | Static scan page hit with no remaining placeholder/TODO markers in current source | No actionable marker | Current source contains no obvious placeholder/dead-text markers. |
+
+## Code changes
+
+- `Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseNetworkPage.swift`
+  - Added `syncManager` binding.
+  - Added `ActiveSheet.peerBrowser` and presents `IOSPeerBrowser()`.
+  - Replaced stale “not enabled yet” copy with live discovered-peer count, sync configuration guidance, Scan button, and error notice.
+  - Updated Help and AI page context to describe real actions instead of future-only roadmap behavior.
+- `Weird Parts IOS/Weird Parts IOSTests/WarehouseNetworkPageRegressionTests.swift`
+  - Adds a source-level regression test that guards the live peer-browser route and rejects the old stale copy.
+
+## Verification
+
+- RED source check before implementation failed as expected: required peer-browser strings were absent and stale copy was present.
+- GREEN source check after implementation passed: `case peerBrowser`, `IOSPeerBrowser()`, `syncManager.discoveredPeers.count`, and `syncManager.startPeerDiscovery()` are present; stale `Device network discovery is not enabled yet` copy is absent.
+- Swift parser check passed:
+  - `xcrun swiftc -parse "Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseNetworkPage.swift" "Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift" "Weird Parts IOS/Weird Parts IOSTests/WarehouseNetworkPageRegressionTests.swift"`
+- iOS xcodebuild test could not run because the checkout does not contain a `.xcodeproj`/`.xcworkspace`.
+- `core/swift test` was attempted; it built and started running but exceeded the 600s command timeout before completion. The changed files are iOS UI/source-test files, not core package files.
+
+## Branch/workspace hygiene
+
+- Started from a clean isolated worktree because the primary checkout has unrelated dirty work.
+- `git fetch --prune origin` completed.
+- Remote branch count at start: 59, over the soft cap of 20 but below hard cap 100.
+- Open PR count at start: 0.
+- Worktree: `.paperclip/worktrees/WEI-2027-page-placeholder-cleanup`.


### PR DESCRIPTION
## Summary
- Replaces the stale Warehouse Network 'not enabled yet' placeholder with live IOSSyncManager state and actions.
- Adds a Browse Nearby Devices route that presents the existing IOSPeerBrowser.
- Documents the WEI-2027 marker-by-marker classification table and adds a source-level regression test.

## Test Plan
- [x] Source-level RED/GREEN check for peer browser route and stale copy removal
- [x] xcrun swiftc -parse WarehouseNetworkPage + IOSPeerBrowser + new regression test
- [~] core/swift test attempted; build and tests started but command timed out after 600s
- [~] iOS xcodebuild test could not run because this checkout has no .xcodeproj/.xcworkspace

Paperclip: WEI-2027