### PR TITLE
fix(chat): scope unread badges to channel membership

### DIFF
--- a/core/Sources/WiredPartCore/Services/BadgeCountService.swift
+++ b/core/Sources/WiredPartCore/Services/BadgeCountService.swift
@@ -222,11 +222,17 @@ public final class BadgeCountService: Sendable {
             counts.unreadMessages = try safeCount(sql: """
                 SELECT COUNT(*) FROM chat_messages cm
                 JOIN chat_channels cc ON cm.channel_id = cc.id
+                JOIN chat_channel_members ccm
+                  ON ccm.channel_id = cm.channel_id
+                 AND ccm.user_id = ?
+                 AND ccm.left_at IS NULL
+                 AND ccm.deleted_at IS NULL
                 WHERE cm.deleted_at IS NULL
+                  AND cc.is_active = 1
                   AND cc.deleted_at IS NULL
                   AND cm.sender_id != ?
                   AND date(cm.created_at) >= date('now', '-1 day')
-            """, arguments: [uid])
+            """, arguments: [uid, uid])
         }
 
         // Oldest pending date — find the oldest pending/in-review JPO for tint calculation

--- a/core/Sources/WiredPartCore/Services/ChatService.swift
+++ b/core/Sources/WiredPartCore/Services/ChatService.swift
@@ -106,7 +106,9 @@ public final class ChatService: Sendable {
                         WHERE cm.deleted_at IS NULL
                           AND cm.id > COALESCE(
                             (SELECT crr.last_read_message_id FROM chat_read_receipts crr
-                             WHERE crr.channel_id = cm.channel_id AND crr.user_id = ?),
+                             WHERE crr.channel_id = cm.channel_id
+                               AND crr.user_id = ?
+                               AND crr.deleted_at IS NULL),
                             0
                           )
                         GROUP BY cm.channel_id
@@ -159,7 +161,9 @@ public final class ChatService: Sendable {
                     WHERE cm.deleted_at IS NULL
                       AND cm.id > COALESCE(
                         (SELECT crr.last_read_message_id FROM chat_read_receipts crr
-                         WHERE crr.channel_id = cm.channel_id AND crr.user_id = ?),
+                         WHERE crr.channel_id = cm.channel_id
+                           AND crr.user_id = ?
+                           AND crr.deleted_at IS NULL),
                         0
                       )
                     """, arguments: [userId, userId])
@@ -1399,14 +1403,24 @@ public final class ChatService: Sendable {
                        (SELECT MAX(created_at) FROM chat_messages WHERE channel_id = cc.id AND deleted_at IS NULL) AS last_message_at,
                        (SELECT COUNT(*) FROM chat_messages cm
                         WHERE cm.channel_id = cc.id AND cm.deleted_at IS NULL
-                        AND cm.created_at > COALESCE(
-                            (SELECT read_at FROM chat_read_receipts WHERE channel_id = cc.id AND user_id = ?), '1970-01-01'
-                        )) AS unread_count
+                          AND cm.id > COALESCE(
+                              (SELECT crr.last_read_message_id
+                               FROM chat_read_receipts crr
+                               WHERE crr.channel_id = cc.id
+                                 AND crr.user_id = ?
+                                 AND crr.deleted_at IS NULL), 0
+                          )) AS unread_count
                 FROM chat_channels cc
-                JOIN chat_channel_members ccm ON ccm.channel_id = cc.id AND ccm.user_id = ?
+                JOIN chat_channel_members ccm
+                    ON ccm.channel_id = cc.id
+                   AND ccm.user_id = ?
+                   AND ccm.left_at IS NULL
+                   AND ccm.deleted_at IS NULL
                 JOIN supplier_channel_bridges scb ON scb.channel_id = cc.id AND scb.deleted_at IS NULL
                 JOIN suppliers s ON s.id = scb.supplier_id AND s.deleted_at IS NULL
-                WHERE cc.channel_type = 'supplier' AND cc.deleted_at IS NULL
+                WHERE cc.channel_type = 'supplier'
+                  AND cc.is_active = 1
+                  AND cc.deleted_at IS NULL
                 ORDER BY last_message_at DESC NULLS LAST
                 """, arguments: [userId, userId])
 
@@ -1491,15 +1505,27 @@ public final class ChatService: Sendable {
                        (SELECT MAX(created_at) FROM chat_messages WHERE channel_id = cc.id AND deleted_at IS NULL) AS last_message_at,
                        (SELECT COUNT(*) FROM chat_messages cm
                         WHERE cm.channel_id = cc.id AND cm.deleted_at IS NULL
-                        AND cm.created_at > COALESCE(
-                            (SELECT read_at FROM chat_read_receipts WHERE channel_id = cc.id AND user_id = ?), '1970-01-01'
-                        )) AS unread_count
+                          AND cm.id > COALESCE(
+                              (SELECT crr.last_read_message_id
+                               FROM chat_read_receipts crr
+                               WHERE crr.channel_id = cc.id
+                                 AND crr.user_id = ?
+                                 AND crr.deleted_at IS NULL), 0
+                          )) AS unread_count
                 FROM chat_channels cc
+                JOIN chat_channel_members ccm
+                    ON ccm.channel_id = cc.id
+                   AND ccm.user_id = ?
+                   AND ccm.left_at IS NULL
+                   AND ccm.deleted_at IS NULL
                 JOIN supplier_channel_bridges scb ON scb.channel_id = cc.id AND scb.deleted_at IS NULL
                 JOIN suppliers s ON s.id = scb.supplier_id AND s.deleted_at IS NULL
-                WHERE cc.channel_type = 'supplier' AND cc.job_id = ? AND cc.deleted_at IS NULL
+                WHERE cc.channel_type = 'supplier'
+                  AND cc.job_id = ?
+                  AND cc.is_active = 1
+                  AND cc.deleted_at IS NULL
                 ORDER BY last_message_at DESC NULLS LAST
-                """, arguments: [userId, jobId])
+                """, arguments: [userId, userId, jobId])
 
             return rows.map { row in
                 SupplierChannelRow(

--- a/core/Tests/WiredPartCoreTests/BadgeCountServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/BadgeCountServiceTests.swift
@@ -305,6 +305,64 @@ struct BadgeCountServiceTests {
         #expect(try service.overdueOrderCount() == 1)
     }
 
+    @Test("unreadMessages excludes channels where user is not an active member")
+    func testUnreadMessagesRequiresActiveChannelMembership() throws {
+        let env = try E2ETestHelpers.setUp()
+        let service = BadgeCountService(db: env.db)
+
+        let senderId = try env.auth.createUser(displayName: "Other Sender", pin: "1357", email: "badge-sender@test.com")
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO chat_channels (channel_type, name, created_by, is_active)
+                VALUES ('group', 'Private Badge Channel', ?, 1)
+                """, arguments: [senderId])
+            let channelId = db.lastInsertedRowID
+            try db.execute(sql: """
+                INSERT INTO chat_channel_members (channel_id, user_id, role, joined_at)
+                VALUES (?, ?, 'member', datetime('now'))
+                """, arguments: [channelId, senderId])
+            try db.execute(sql: """
+                INSERT INTO chat_messages (channel_id, sender_id, message_type, content, created_at)
+                VALUES (?, ?, 'text', 'private message', datetime('now'))
+                """, arguments: [channelId, senderId])
+        }
+
+        let counts = try service.getAllBadgeCounts(userId: env.adminUserId)
+        #expect(counts.unreadMessages == 0,
+            "Unread chat badge must only count messages in channels where the user has an active membership")
+    }
+
+    @Test("unreadMessages excludes channels whose membership was removed")
+    func testUnreadMessagesRequiresNonRemovedMembership() throws {
+        let env = try E2ETestHelpers.setUp()
+        let service = BadgeCountService(db: env.db)
+
+        let senderId = try env.auth.createUser(displayName: "Removal Sender", pin: "2468", email: "badge-removal-sender@test.com")
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO chat_channels (channel_type, name, created_by, is_active)
+                VALUES ('group', 'Removed Badge Channel', ?, 1)
+                """, arguments: [senderId])
+            let channelId = db.lastInsertedRowID
+            try db.execute(sql: """
+                INSERT INTO chat_channel_members (channel_id, user_id, role, joined_at)
+                VALUES (?, ?, 'member', datetime('now'))
+                """, arguments: [channelId, senderId])
+            try db.execute(sql: """
+                INSERT INTO chat_channel_members (channel_id, user_id, role, joined_at, left_at)
+                VALUES (?, ?, 'member', datetime('now'), datetime('now'))
+                """, arguments: [channelId, env.adminUserId])
+            try db.execute(sql: """
+                INSERT INTO chat_messages (channel_id, sender_id, message_type, content, created_at)
+                VALUES (?, ?, 'text', 'removed membership private message', datetime('now'))
+                """, arguments: [channelId, senderId])
+        }
+
+        let counts = try service.getAllBadgeCounts(userId: env.adminUserId)
+        #expect(counts.unreadMessages == 0,
+            "Unread chat badge must not count channels with left_at/deleted_at memberships")
+    }
+
     @Test("unreadNotebookEntries excludes job notebooks whose team membership was soft-deleted")
     func testUnreadNotebookEntries_ignoresSoftDeletedTeamMembership() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/ChatServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ChatServiceTests.swift
@@ -1037,4 +1037,62 @@ struct ChatServiceTests {
         }
         #expect(stored == msg2, "markRead must not move the read pointer backwards")
     }
+
+    // MARK: - Supplier channel membership security
+
+    @Test("listSupplierChannels hides supplier channels after membership is removed")
+    func testListSupplierChannelsRequiresActiveMembership() throws {
+        let env = try E2ETestHelpers.setUp()
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "Hidden Supplier Membership")
+        let memberId = try env.auth.createUser(displayName: "Removed Supplier Member", pin: "6789", email: "removed-supplier@test.com")
+        let channelId = try env.chat.createSupplierChannel(
+            name: "Hidden Supplier Channel",
+            supplierId: supplierId,
+            supplierDisplayName: "Hidden Supplier Membership",
+            contactId: nil,
+            role: nil,
+            createdBy: env.adminUserId
+        )
+
+        try env.chat.addUserToSupplierChannel(channelId: channelId, userId: memberId)
+        #expect(try env.chat.listSupplierChannels(userId: memberId).contains { $0.channelId == channelId })
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                UPDATE chat_channel_members
+                SET left_at = datetime('now')
+                WHERE channel_id = ? AND user_id = ?
+                """, arguments: [channelId, memberId])
+        }
+
+        let channelsAfterRemoval = try env.chat.listSupplierChannels(userId: memberId)
+        #expect(channelsAfterRemoval.contains { $0.channelId == channelId } == false,
+                "Supplier channel lists must not expose channels to users whose membership has ended")
+    }
+
+    @Test("listSupplierChannelsForJob requires active channel membership")
+    func testListSupplierChannelsForJobRequiresActiveMembership() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-SUP-MEMBERSHIP")
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "Job Supplier Membership")
+        let outsiderId = try env.auth.createUser(displayName: "Supplier Job Outsider", pin: "7890", email: "supplier-outsider@test.com")
+        let channelId = try env.chat.createSupplierChannel(
+            name: "Job Supplier Private Thread",
+            supplierId: supplierId,
+            supplierDisplayName: "Job Supplier Membership",
+            contactId: nil,
+            role: nil,
+            createdBy: env.adminUserId,
+            jobId: jobId
+        )
+        _ = try env.chat.sendSupplierMessage(channelId: channelId, senderId: env.adminUserId, content: "Private job supplier note", direction: "outbound")
+
+        let outsiderChannels = try env.chat.listSupplierChannelsForJob(jobId: jobId, userId: outsiderId)
+        #expect(outsiderChannels.contains { $0.channelId == channelId } == false,
+                "Job supplier channel lists must not leak private channel rows or unread counts to non-members")
+
+        let adminChannels = try env.chat.listSupplierChannelsForJob(jobId: jobId, userId: env.adminUserId)
+        #expect(adminChannels.contains { $0.channelId == channelId },
+                "Active members should still see their job-linked supplier channels")
+    }
 }

--- a/docs/testing/wei-2024-chat-rfi-qa-notes-2026-05-22.md
+++ b/docs/testing/wei-2024-chat-rfi-qa-notes-2026-05-22.md
@@ -1,0 +1,52 @@
+# WEI-2024 Chat/RFI QA Notes
+
+Date: 2026-05-22 MDT
+Issue: WEI-2024
+Related GitHub issue: #553
+
+## Automated coverage added
+
+- `BadgeCountServiceTests.testUnreadMessagesRequiresActiveChannelMembership`
+  - Verifies the Chat tab unread badge does not count messages from channels where the current user has no active `chat_channel_members` row.
+- `BadgeCountServiceTests.testUnreadMessagesRequiresNonRemovedMembership`
+  - Verifies the Chat tab unread badge ignores channels where the current user's membership has `left_at` set.
+- `ChatServiceTests.testListSupplierChannelsRequiresActiveMembership`
+  - Verifies supplier-channel lists hide channels after a user's channel membership is removed.
+- `ChatServiceTests.testListSupplierChannelsForJobRequiresActiveMembership`
+  - Verifies job-linked supplier channels do not leak private channel rows or unread counts to non-members while remaining visible to active members.
+
+## Manual UI walkthrough checklist
+
+These flows still need device/simulator walkthrough evidence because the SwiftUI navigation, badges, attachment pickers, and escalation affordances are UI-level behavior:
+
+1. Channel membership + unread badges
+   - Sign in as a user who is not a member of a private/supplier channel.
+   - Confirm the Chat tab badge and `IOSChannelsPage` do not include that channel's unread activity.
+   - Add the user as a member and confirm the channel appears.
+   - Remove/leave the membership and confirm the channel and unread count disappear after refresh.
+
+2. Channel/thread page
+   - Open an allowed channel from `IOSChannelsPage`.
+   - Confirm message thread load marks read and the channel badge drops after returning to the list.
+   - Confirm a disallowed channel cannot be reached via stale navigation/deep link if such a link exists in the UI.
+
+3. Attachments/reference picker
+   - From an allowed channel/thread, attach or reference a job/supplier/PO item using the picker.
+   - Confirm the item appears in the composed message and persists after reload.
+   - Confirm no picker path exposes restricted channels to a non-member.
+
+4. Q&A/RFI walkthrough
+   - Create a Q&A item from `IOSQuestionsPage`.
+   - Walk escalation forward/back through `IOSEscalationTimeline`.
+   - Resolve/reopen where UI supports it and verify list filters update.
+   - Create or view an RFI from `IOSRFIListPage`; verify status chips/transitions shown by the UI match the backend state.
+
+## TODO/FIXME review notes
+
+Chat-page TODO markers found during WEI-2024 review are due-date fallback comments in timeline color handling:
+
+- `IOSRFIListPage.swift`
+- `IOSQuestionsPage.swift`
+- `IOSEscalationTimeline.swift`
+
+They are not dead actions in the chat/RFI flow. They should remain until `QAThreadRow` / RFI rows gain due-date fields, then be converted to `TimelinePriorityColor.color(priority:dueDateString:)`.


### PR DESCRIPTION
## Summary
- Fixes GitHub #553 by requiring active channel membership for Chat tab unread badge counts.
- Hardens chat/supplier unread queries to ignore deleted read receipts, inactive channels, and removed channel memberships.
- Adds regression tests for non-member/removed-member badge leaks and supplier job channel membership scoping.
- Adds WEI-2024 manual UI QA walkthrough notes for channel badges, attachments/reference picker, and Q&A/RFI flows.

## Test Plan
- swift test --filter 'BadgeCountServiceTests|ChatServiceTests' (77 tests passed)
- swift test (attempted full suite; hit existing PartsServiceCoverageTests failure: updateCompanyCostSetting stores and retrieves value -> insufficientPermissions(required: "parts.manage_company_costs"), then timed out at 600s)

## Branch/workspace hygiene
- Preflight: 60 remote branches, above soft cap 20; 0 open PRs before this PR.
- Main workspace had unrelated dirty WEI-2003 changes, so this work used isolated worktree/branch: WEI-2024-chat-unread-security.
- Branch rebased onto origin/main before push.

Fixes #553