### PR TITLE
test(parts): harden CSV import preview and commit

### DIFF
--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -5932,6 +5932,289 @@ public final class PartsService: Sendable {
         }
     }
 
+    /// One normalized CSV row from the parts importer.
+    public struct PartsImportParsedRow: Sendable {
+        public let rowNumber: Int
+        public let name: String
+        public let code: String?
+        public let category: String
+        public let brand: String?
+        public let fields: [String: String]
+    }
+
+    /// A validation error surfaced during import preview. The row number is 1-based
+    /// and includes the header row, matching spreadsheet line numbers.
+    public struct PartsImportError: Error, Sendable {
+        public let rowNumber: Int
+        public let message: String
+    }
+
+    public enum PartsImportConflictResolution: Sendable {
+        case ask
+        case update
+        case skip
+    }
+
+    /// A duplicate detected during import preview.
+    public struct PartsImportConflict: Sendable {
+        public let parsedRow: PartsImportParsedRow
+        public let existingPartId: Int64
+        public let existingPartName: String
+        public let existingPartCode: String?
+        public var resolution: PartsImportConflictResolution = .ask
+    }
+
+    /// Preview generated before any import writes occur.
+    public struct PartsImportPreview: Sendable {
+        public var newParts: [PartsImportParsedRow] = []
+        public var conflicts: [PartsImportConflict] = []
+        public var errors: [PartsImportError] = []
+        public var totalRows: Int = 0
+    }
+
+    /// Result of an atomic import commit.
+    public struct PartsImportCommitResult: Sendable {
+        public let created: Int
+        public let updated: Int
+        public let skipped: Int
+    }
+
+    /// Parse and validate a parts CSV without changing database state.
+    ///
+    /// Required columns: `name`, `category`.
+    /// Optional columns: `code`, `brand`, `cost_price`, `markup_percent`,
+    /// `description`, `unit_of_measure`, `shelf_location`, `bin_location`,
+    /// `part_type`.
+    public func previewPartsImportCSV(_ csv: String) throws -> PartsImportPreview {
+        let lines = csv.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard lines.count > 1 else {
+            throw PartsError.invalidInput("CSV file is empty or has no data rows.")
+        }
+
+        let headers = parseImportCSVLine(lines[0]).map { $0.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) }
+        guard let nameIdx = headers.firstIndex(of: "name") else {
+            throw PartsError.invalidInput("CSV must have a 'name' column.")
+        }
+        guard let categoryIdx = headers.firstIndex(of: "category") else {
+            throw PartsError.invalidInput("CSV must have a 'category' column.")
+        }
+        let codeIdx = headers.firstIndex(of: "code")
+        let brandIdx = headers.firstIndex(of: "brand")
+
+        var preview = PartsImportPreview(totalRows: lines.count - 1)
+        for lineIdx in 1..<lines.count {
+            let rowNumber = lineIdx + 1
+            let columns = parseImportCSVLine(lines[lineIdx])
+            func value(at index: Int?) -> String? {
+                guard let index, index < columns.count else { return nil }
+                let trimmed = columns[index].trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : trimmed
+            }
+
+            guard let name = value(at: nameIdx) else {
+                preview.errors.append(PartsImportError(rowNumber: rowNumber, message: "Missing required name"))
+                continue
+            }
+            guard let category = value(at: categoryIdx) else {
+                preview.errors.append(PartsImportError(rowNumber: rowNumber, message: "Missing required category"))
+                continue
+            }
+
+            var fields: [String: String] = [:]
+            for (index, header) in headers.enumerated() {
+                guard index < columns.count else { continue }
+                guard !["name", "code", "category", "brand"].contains(header) else { continue }
+                let trimmed = columns[index].trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { fields[header] = trimmed }
+            }
+
+            for numericHeader in ["cost_price", "markup_percent"] {
+                if let raw = fields[numericHeader] {
+                    guard let value = Double(raw) else {
+                        preview.errors.append(PartsImportError(rowNumber: rowNumber, message: "Invalid number for \(numericHeader): \(raw)"))
+                        continue
+                    }
+                    if value < 0 {
+                        preview.errors.append(PartsImportError(rowNumber: rowNumber, message: "\(numericHeader) cannot be negative"))
+                        continue
+                    }
+                }
+            }
+            if preview.errors.contains(where: { $0.rowNumber == rowNumber }) { continue }
+
+            let parsed = PartsImportParsedRow(
+                rowNumber: rowNumber,
+                name: name,
+                code: value(at: codeIdx),
+                category: category,
+                brand: value(at: brandIdx),
+                fields: fields
+            )
+
+            let existingPart = try db.writer.read { dbConn -> Part? in
+                if let code = parsed.code, !code.isEmpty,
+                   let byCode = try Part.fetchOne(dbConn, sql: "SELECT * FROM parts WHERE code = ? AND deleted_at IS NULL", arguments: [code]) {
+                    return byCode
+                }
+                return try Part.fetchOne(dbConn, sql: "SELECT * FROM parts WHERE LOWER(name) = LOWER(?) AND deleted_at IS NULL", arguments: [parsed.name])
+            }
+
+            if let existingPart, let id = existingPart.id {
+                preview.conflicts.append(PartsImportConflict(
+                    parsedRow: parsed,
+                    existingPartId: id,
+                    existingPartName: existingPart.name,
+                    existingPartCode: existingPart.code
+                ))
+            } else {
+                preview.newParts.append(parsed)
+            }
+        }
+        return preview
+    }
+
+    /// Commit a clean import preview atomically. If the preview has validation
+    /// errors, no writes are attempted. If any database write fails mid-import,
+    /// GRDB rolls back the entire transaction, preventing partial bad state.
+    public func commitPartsImportCSV(_ preview: PartsImportPreview) throws -> PartsImportCommitResult {
+        guard preview.errors.isEmpty else {
+            let first = preview.errors[0]
+            throw PartsError.invalidInput("Import has validation errors; first error row \(first.rowNumber): \(first.message)")
+        }
+
+        var created = 0
+        var updated = 0
+        var skipped = 0
+
+        try db.writer.write { dbConn in
+            func findOrCreateCategoryInTransaction(_ name: String) throws -> Int64 {
+                if let existing = try Row.fetchOne(dbConn, sql: "SELECT id FROM part_categories WHERE name = ? AND deleted_at IS NULL", arguments: [name]) {
+                    return existing["id"]
+                }
+                try Validators.requireName(name, field: "Category name")
+                try dbConn.execute(sql: """
+                    INSERT INTO part_categories (name, sort_order, is_active, created_at, updated_at)
+                    VALUES (?, 0, 1, datetime('now'), datetime('now'))
+                    """, arguments: [name])
+                return dbConn.lastInsertedRowID
+            }
+
+            func findOrCreateBrandInTransaction(_ name: String?) throws -> Int64? {
+                guard let name, !name.isEmpty else { return nil }
+                if let existing = try Row.fetchOne(dbConn, sql: "SELECT id FROM brands WHERE name = ? AND deleted_at IS NULL", arguments: [name]) {
+                    return existing["id"]
+                }
+                try Validators.requireName(name, field: "Brand name")
+                try dbConn.execute(sql: """
+                    INSERT INTO brands (name, is_active, created_at, updated_at)
+                    VALUES (?, 1, datetime('now'), datetime('now'))
+                    """, arguments: [name])
+                return dbConn.lastInsertedRowID
+            }
+
+            func create(_ row: PartsImportParsedRow) throws {
+                let categoryId = try findOrCreateCategoryInTransaction(row.category)
+                let brandId = try findOrCreateBrandInTransaction(row.brand)
+                let cost = row.fields["cost_price"].flatMap(Double.init) ?? 0
+                let markup = row.fields["markup_percent"].flatMap(Double.init) ?? 0
+                let partType = row.fields["part_type"] ?? "general"
+
+                try Validators.requireName(row.name, field: "Part name")
+                try Validators.requireText(row.code, field: "Part code", limit: Validators.Limits.code)
+                try Validators.requireNonNegative(cost, field: "Cost price")
+                try Validators.requireNonNegative(markup, field: "Markup percent")
+
+                try dbConn.execute(sql: """
+                    INSERT INTO parts (
+                        category_id, brand_id, part_type, code, name, description,
+                        unit_of_measure, company_cost_price, weighted_avg_cost,
+                        company_markup_percent, shelf_location, bin_location,
+                        auto_add_to_wishlist_when_low, is_deprecated, is_qr_tagged,
+                        is_active, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 1, datetime('now'), datetime('now'))
+                    """, arguments: [
+                        categoryId,
+                        brandId,
+                        partType,
+                        row.code,
+                        row.name,
+                        row.fields["description"],
+                        row.fields["unit_of_measure"],
+                        cost,
+                        cost,
+                        markup,
+                        row.fields["shelf_location"],
+                        row.fields["bin_location"]
+                    ])
+            }
+
+            func update(_ conflict: PartsImportConflict) throws {
+                let row = conflict.parsedRow
+                let categoryId = try findOrCreateCategoryInTransaction(row.category)
+                let brandId = try findOrCreateBrandInTransaction(row.brand)
+                let cost = row.fields["cost_price"].flatMap(Double.init)
+                let markup = row.fields["markup_percent"].flatMap(Double.init)
+
+                var clauses = [
+                    "name = ?",
+                    "code = ?",
+                    "category_id = ?",
+                    "brand_id = ?"
+                ]
+                var args: [DatabaseValueConvertible?] = [row.name, row.code, categoryId, brandId]
+
+                if let partType = row.fields["part_type"] { clauses.append("part_type = ?"); args.append(partType) }
+                if let description = row.fields["description"] { clauses.append("description = ?"); args.append(description) }
+                if let unit = row.fields["unit_of_measure"] { clauses.append("unit_of_measure = ?"); args.append(unit) }
+                if let cost { clauses.append("company_cost_price = ?"); args.append(cost); clauses.append("weighted_avg_cost = ?"); args.append(cost) }
+                if let markup { clauses.append("company_markup_percent = ?"); args.append(markup) }
+                if let shelf = row.fields["shelf_location"] { clauses.append("shelf_location = ?"); args.append(shelf) }
+                if let bin = row.fields["bin_location"] { clauses.append("bin_location = ?"); args.append(bin) }
+                clauses.append("updated_at = datetime('now')")
+                args.append(conflict.existingPartId)
+
+                try dbConn.execute(sql: "UPDATE parts SET \(clauses.joined(separator: ", ")) WHERE id = ? AND deleted_at IS NULL", arguments: StatementArguments(args))
+            }
+
+            for row in preview.newParts {
+                try create(row)
+                created += 1
+            }
+            for conflict in preview.conflicts {
+                switch conflict.resolution {
+                case .update:
+                    try update(conflict)
+                    updated += 1
+                case .skip, .ask:
+                    skipped += 1
+                }
+            }
+        }
+
+        return PartsImportCommitResult(created: created, updated: updated, skipped: skipped)
+    }
+
+    private func parseImportCSVLine(_ line: String) -> [String] {
+        var fields: [String] = []
+        var current = ""
+        var inQuotes = false
+        var iterator = line.makeIterator()
+        while let char = iterator.next() {
+            if char == "\"" {
+                inQuotes.toggle()
+            } else if char == "," && !inQuotes {
+                fields.append(current)
+                current = ""
+            } else {
+                current.append(char)
+            }
+        }
+        fields.append(current)
+        return fields
+    }
+
     // =========================================================================
     // MARK: - 11. Smart Delete
     // =========================================================================

--- a/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
@@ -163,6 +163,88 @@ struct PartsServiceAdvancedTests {
         #expect(stats.totalCategories >= 0)
     }
 
+    // MARK: - Import preview and commit
+
+    @Test("previewPartsImportCSV classifies new rows, conflicts, and visible validation errors")
+    func testPreviewPartsImportCSVClassifiesRows() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "Existing Category")
+        _ = try env.parts.createPart(categoryId: catId, name: "Existing Part", code: "EX-001")
+
+        let csv = """
+        name,code,category,brand,cost_price,markup_percent,description
+        New Part,NP-001,Import Category,Acme,12.50,25,"quoted, description"
+        Existing Replacement,EX-001,Existing Category,Acme,9,10,
+        Missing Category,MC-001,,Acme,1,1,
+        Bad Cost,BC-001,Import Category,Acme,not-a-number,1,
+        """
+
+        let preview = try env.parts.previewPartsImportCSV(csv)
+
+        #expect(preview.totalRows == 4)
+        #expect(preview.newParts.count == 1)
+        #expect(preview.newParts.first?.name == "New Part")
+        #expect(preview.newParts.first?.fields["description"] == "quoted, description")
+        #expect(preview.conflicts.count == 1)
+        #expect(preview.conflicts.first?.existingPartCode == "EX-001")
+        #expect(preview.errors.count == 2)
+        #expect(preview.errors.map(\.rowNumber).contains(4))
+        #expect(preview.errors.map(\.rowNumber).contains(5))
+    }
+
+    @Test("commitPartsImportCSV rejects preview errors before writing partial state")
+    func testCommitPartsImportCSVRejectsErrorsWithoutPartialWrites() throws {
+        let env = try E2ETestHelpers.setUp()
+        let before = try env.parts.getImportExportStats()
+        let csv = """
+        name,code,category,brand,cost_price
+        Good Row,GOOD-001,Rollback Category,Acme,5
+        Bad Row,BAD-001,,Acme,6
+        """
+
+        let preview = try env.parts.previewPartsImportCSV(csv)
+        #expect(preview.newParts.count == 1)
+        #expect(preview.errors.count == 1)
+        do {
+            _ = try env.parts.commitPartsImportCSV(preview)
+            Issue.record("commitPartsImportCSV should reject previews with validation errors")
+        } catch {
+            let after = try env.parts.getImportExportStats()
+            #expect(after.totalParts == before.totalParts)
+            #expect(after.totalCategories == before.totalCategories)
+            #expect(try env.parts.findPartByCode("GOOD-001") == nil)
+        }
+    }
+
+    @Test("commitPartsImportCSV creates and updates rows atomically from a clean preview")
+    func testCommitPartsImportCSVCreatesAndUpdates() throws {
+        let env = try E2ETestHelpers.setUp()
+        let existingCategoryId = try E2ETestHelpers.seedCategory(env, name: "Existing Category")
+        let existingId = try env.parts.createPart(categoryId: existingCategoryId, name: "Existing Part", code: "EX-002")
+
+        var preview = try env.parts.previewPartsImportCSV("""
+        name,code,category,brand,cost_price,markup_percent,unit_of_measure,shelf_location,bin_location
+        Created Part,NEW-002,Created Category,Created Brand,7.5,20,each,A1,B2
+        Updated Name,EX-002,Existing Category,Created Brand,8.5,30,box,C3,D4
+        """)
+        preview.conflicts = preview.conflicts.map { conflict in
+            var editable = conflict
+            editable.resolution = .update
+            return editable
+        }
+
+        let result = try env.parts.commitPartsImportCSV(preview)
+
+        #expect(result.created == 1)
+        #expect(result.updated == 1)
+        #expect(result.skipped == 0)
+        let created = try #require(try env.parts.findPartByCode("NEW-002"))
+        #expect(created.name == "Created Part")
+        let updated = try #require(try env.parts.findPartByCode("EX-002"))
+        #expect(updated.id == existingId)
+        #expect(updated.name == "Updated Name")
+    }
+
     // MARK: - approveScheduledDeletion
 
     @Test("approveScheduledDeletion soft-deletes the entity and marks schedule approved")


### PR DESCRIPTION
## Summary
- Adds `PartsService.previewPartsImportCSV(_:)` for a no-write import preview with row-level validation errors and duplicate conflict detection.
- Adds `PartsService.commitPartsImportCSV(_:)` for atomic CSV import commits: validation errors stop before writes, and database writes run in one GRDB transaction to avoid partial bad state.
- Adds backend tests covering representative import preview, visible validation rows, no-partial-write rejection, and clean create/update commit behavior.

## Verification
- `swift test --filter 'PartsServiceAdvancedTests/test(PreviewPartsImportCSVClassifiesRows|CommitPartsImportCSVRejectsErrorsWithoutPartialWrites|CommitPartsImportCSVCreatesAndUpdates)'` ✅
- `swift test --filter 'PartsServiceExtTests/test(NamedOnlyVariant|SearchBySkuPartNumber|ColorPoolIsGlobal|ColorBrandSKUUniqueConstraintReturnsSameId)'` ✅
- `swift test --filter PartsServiceAdvancedTests` currently has 2 pre-existing permission failures in approveScheduledDeletion tests (`parts.approve_scheduled_deletion`), unrelated to this branch; the new import tests pass.

## Paperclip
- Supports WEI-2023 / GitHub #597 import verification acceptance for preview, errors, rollback/no partial bad state, and service/import tests.
- PE-COLORS backend verification remains green for named-only variants, SKU part-number search, global color pool, and unique SKU upsert.
