### PR TITLE
fix(warehouse): surface unknown-part receiving route errors

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ReceivingRoutingFlow.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ReceivingRoutingFlow.swift
@@ -20,6 +20,14 @@ import WiredPartCore
 /// - Parts for a job go to staging directly
 /// - Used parts cannot be returned to supplier
 /// - Damaged parts cannot go on shelf
+enum ReceivingRoutingValidation {
+    static let missingLinkedPartRouteError = "This receiving item is no longer linked to an active part. Mark it as a wrong part or fix the PO line before routing damaged or used inventory."
+
+    static func missingLinkedPartError(partId: Int64?) -> String? {
+        partId == nil ? missingLinkedPartRouteError : nil
+    }
+}
+
 struct ReceivingRoutingFlow: View {
     @EnvironmentObject private var appCore: AppCore
 
@@ -1055,7 +1063,11 @@ struct ReceivingRoutingFlow: View {
 
     @MainActor
     private func stageForJob(_ link: WarehouseService.POLineJobLink) async {
-        guard let partId = item.partId else { return }
+        guard let partId = item.partId else {
+            routingError = ReceivingRoutingValidation.missingLinkedPartRouteError
+            isProcessing = false
+            return
+        }
         isProcessing = true
         routingError = nil
 
@@ -1084,7 +1096,11 @@ struct ReceivingRoutingFlow: View {
 
     @MainActor
     private func stageForJPODemand(_ demand: WarehouseService.ActiveJPODemand) async {
-        guard let partId = item.partId else { return }
+        guard let partId = item.partId else {
+            routingError = ReceivingRoutingValidation.missingLinkedPartRouteError
+            isProcessing = false
+            return
+        }
         isProcessing = true
         routingError = nil
 
@@ -1114,8 +1130,12 @@ struct ReceivingRoutingFlow: View {
 
     @MainActor
     private func processDamagedReturn() async {
-        guard let partId = item.partId,
-              let action = selectedDamageAction else { return }
+        guard let partId = item.partId else {
+            routingError = ReceivingRoutingValidation.missingLinkedPartRouteError
+            isProcessing = false
+            return
+        }
+        guard let action = selectedDamageAction else { return }
         isProcessing = true
         routingError = nil
 
@@ -1144,7 +1164,11 @@ struct ReceivingRoutingFlow: View {
 
     @MainActor
     private func processWriteOff() async {
-        guard let partId = item.partId else { return }
+        guard let partId = item.partId else {
+            routingError = ReceivingRoutingValidation.missingLinkedPartRouteError
+            isProcessing = false
+            return
+        }
         isProcessing = true
         routingError = nil
 

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -158,6 +158,12 @@ struct Weird_Parts_IOSTests {
         #expect(processableItems.map(\.id) == [transferSuccess.id, normalPendingLine.id])
     }
 
+    @MainActor
+    @Test func receivingRoutingShowsActionableErrorForUnknownPartRoutes() throws {
+        #expect(ReceivingRoutingValidation.missingLinkedPartError(partId: nil) == "This receiving item is no longer linked to an active part. Mark it as a wrong part or fix the PO line before routing damaged or used inventory.")
+        #expect(ReceivingRoutingValidation.missingLinkedPartError(partId: 6) == nil)
+    }
+
     @Test func uiTestingFixturesSeedJPOFlowDataForQASmoke() throws {
         let db = try AppDatabase.openInMemoryDatabase()
         let auth = AuthService(db: db)


### PR DESCRIPTION
## Summary
- Fixes GH #572 by replacing silent nil-part returns in receiving routing actions with a visible actionable error.
- Covers damaged return, used write-off, direct job staging, and JPO-demand staging route actions when an item is no longer linked to an active part.
- Adds a focused iOS unit regression for the unknown-part routing validation message.

## Verification
- RED: focused test failed before implementation because ReceivingRoutingValidation did not exist.
- GREEN: xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:"Weird PartsTests/Weird_Parts_IOSTests/receivingRoutingShowsActionableErrorForUnknownPartRoutes" -derivedDataPath .tmp/WEI-2020-GREEN-DerivedData — TEST SUCCEEDED.
- swift test --package-path core --filter WarehouseAuditTests — 52 tests passed; verifies GH #555 misplaced-part SQL path remains fixed.
- xcodebuild build -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath .tmp/WEI-2020-BUILD-DerivedData — BUILD SUCCEEDED.

## Warehouse QA triage notes
- GH #555 appears fixed on origin/main via subquery UPDATE; WarehouseAuditTests now pass after a clean build.
- GH #501 fixture hooks are present on origin/main: QA Fixture section, qaFixtureVerifyButton, qaFixturePartRow, and UITEST-MUV-001 lookup in IOSAuditPage.
- GH #567 has existing committed evidence at docs/testing/wei-1185-warehouse-zone-placement-qa-2026-05-13.md stating persistence after Save & Exit/resume verified; no product code change needed in this PR.

## Branch/workspace hygiene
- Preflight: git fetch --prune completed; repo had 58 remote branches and 1 open PR before this branch.
- Existing open PR (#664 / GH #568 categories auth) is unrelated, so this high-priority warehouse batch used a focused issue branch.
- Worktree retained at /private/tmp/wei-2020-warehouse-qa for Paperclip verification.

Closes #572