### PR TITLE
fix(ux): guard fleet sheet dismissals

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSAssignDriverSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSAssignDriverSheet.swift
@@ -19,8 +19,13 @@ struct IOSAssignDriverSheet: View {
     @State private var isLoading = true
     @State private var isSaving = false
     @State private var loadError: String?
+    @State private var showDiscardConfirmation = false
 
     private let assignmentTypes = ["primary", "secondary", "temporary"]
+
+    private var isDirty: Bool {
+        selectedEmployeeId != nil || assignmentType != "primary" || isTakeHome
+    }
 
     var body: some View {
         NavigationStack {
@@ -31,10 +36,22 @@ struct IOSAssignDriverSheet: View {
             .navigationTitle("Assign Driver")
             .navigationBarTitleDisplayMode(.inline)
             .searchable(text: $searchText, prompt: "Search employees...")
-            .interactiveDismissDisabled(isSaving)
+            .dismissSafety(
+                isDirty: isDirty,
+                isSaving: isSaving,
+                showDiscardConfirmation: $showDiscardConfirmation,
+                onDiscard: { dismiss() }
+            )
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button("Cancel") {
+                        DismissSafety.cancelOrConfirm(
+                            isDirty: isDirty,
+                            isSaving: isSaving,
+                            dismiss: dismiss,
+                            showDiscardConfirmation: $showDiscardConfirmation
+                        )
+                    }
                         .disabled(isSaving)
                 }
                 ToolbarItem(placement: .confirmationAction) {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSCreateTrailerSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSCreateTrailerSheet.swift
@@ -11,8 +11,15 @@ struct IOSCreateTrailerSheet: View {
     @State private var notes = ""
     @State private var isSaving = false
     @State private var errorMessage: String?
+    @State private var showDiscardConfirmation = false
 
     private let trailerTypes = ["flatbed", "enclosed", "utility", "dump", "lowboy", "other"]
+
+    private var isDirty: Bool {
+        !trailerNumber.trimmingCharacters(in: .whitespaces).isEmpty ||
+        trailerType != "flatbed" ||
+        !notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
 
     var body: some View {
         NavigationStack {
@@ -41,10 +48,22 @@ struct IOSCreateTrailerSheet: View {
             }
             .navigationTitle("New Trailer")
             .navigationBarTitleDisplayMode(.inline)
-            .interactiveDismissDisabled(isSaving)
+            .dismissSafety(
+                isDirty: isDirty,
+                isSaving: isSaving,
+                showDiscardConfirmation: $showDiscardConfirmation,
+                onDiscard: { dismiss() }
+            )
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button("Cancel") {
+                        DismissSafety.cancelOrConfirm(
+                            isDirty: isDirty,
+                            isSaving: isSaving,
+                            dismiss: dismiss,
+                            showDiscardConfirmation: $showDiscardConfirmation
+                        )
+                    }
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") { saveTrailer() }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSCreateVehicleSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSCreateVehicleSheet.swift
@@ -18,8 +18,22 @@ struct IOSCreateVehicleSheet: View {
     @State private var notes = ""
     @State private var isSaving = false
     @State private var errorMessage: String?
+    @State private var showDiscardConfirmation = false
 
     private let vehicleTypes = ["truck", "van", "car", "suv", "trailer", "other"]
+
+    private var isDirty: Bool {
+        !vehicleNumber.trimmingCharacters(in: .whitespaces).isEmpty ||
+        !vehicleName.trimmingCharacters(in: .whitespaces).isEmpty ||
+        vehicleType != "truck" ||
+        !make.trimmingCharacters(in: .whitespaces).isEmpty ||
+        !model.trimmingCharacters(in: .whitespaces).isEmpty ||
+        !yearText.trimmingCharacters(in: .whitespaces).isEmpty ||
+        !color.trimmingCharacters(in: .whitespaces).isEmpty ||
+        !vin.trimmingCharacters(in: .whitespaces).isEmpty ||
+        !licensePlate.trimmingCharacters(in: .whitespaces).isEmpty ||
+        !notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
 
     var body: some View {
         NavigationStack {
@@ -39,10 +53,22 @@ struct IOSCreateVehicleSheet: View {
             }
             .navigationTitle("New Vehicle")
             .navigationBarTitleDisplayMode(.inline)
-            .interactiveDismissDisabled(isSaving)
+            .dismissSafety(
+                isDirty: isDirty,
+                isSaving: isSaving,
+                showDiscardConfirmation: $showDiscardConfirmation,
+                onDiscard: { dismiss() }
+            )
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button("Cancel") {
+                        DismissSafety.cancelOrConfirm(
+                            isDirty: isDirty,
+                            isSaving: isSaving,
+                            dismiss: dismiss,
+                            showDiscardConfirmation: $showDiscardConfirmation
+                        )
+                    }
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") { saveVehicle() }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/PreTripInspectionView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/PreTripInspectionView.swift
@@ -25,6 +25,14 @@ struct PreTripInspectionView: View {
     @State private var saveError: String?
     @State private var isLoading = true
     @State private var loadError: String?
+    @State private var showDiscardConfirmation = false
+
+    private var isDirty: Bool {
+        !generalNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+        !odometerReading.trimmingCharacters(in: .whitespaces).isEmpty ||
+        fuelLevel != 1.0 ||
+        checklistItems.contains { !$0.status.isEmpty || !$0.notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    }
 
     // MARK: - Init
 
@@ -65,10 +73,22 @@ struct PreTripInspectionView: View {
             }
             .navigationTitle("Pre-Trip Inspection")
             .navigationBarTitleDisplayMode(.inline)
-            .interactiveDismissDisabled(isSaving)
+            .dismissSafety(
+                isDirty: isDirty,
+                isSaving: isSaving,
+                showDiscardConfirmation: $showDiscardConfirmation,
+                onDiscard: { dismiss() }
+            )
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button("Cancel") {
+                        DismissSafety.cancelOrConfirm(
+                            isDirty: isDirty,
+                            isSaving: isSaving,
+                            dismiss: dismiss,
+                            showDiscardConfirmation: $showDiscardConfirmation
+                        )
+                    }
                         .disabled(isSaving)
                 }
                 ToolbarItem(placement: .confirmationAction) {

--- a/Weird Parts IOS/Weird Parts IOS/Shared/DismissSafety.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/DismissSafety.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// Shared dismiss-safety helpers for form/action sheets.
+///
+/// Sheets with unsaved user input should use this modifier so swipe-down
+/// dismissal is disabled while there is dirty input or an in-flight save. Pair
+/// explicit Cancel buttons with `DismissSafety.cancelOrConfirm` so taps either
+/// dismiss clean sheets immediately or ask before discarding user work.
+struct DismissSafety {
+    static func cancelOrConfirm(isDirty: Bool, isSaving: Bool, dismiss: DismissAction, showDiscardConfirmation: Binding<Bool>) {
+        guard !isSaving else { return }
+        if isDirty {
+            showDiscardConfirmation.wrappedValue = true
+        } else {
+            dismiss()
+        }
+    }
+}
+
+struct DismissSafetyModifier: ViewModifier {
+    let isDirty: Bool
+    let isSaving: Bool
+    let title: String
+    let message: String
+    let onDiscard: () -> Void
+
+    @Binding var showDiscardConfirmation: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .interactiveDismissDisabled(isDirty || isSaving)
+            .confirmationDialog(
+                title,
+                isPresented: $showDiscardConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Discard Changes", role: .destructive) {
+                    onDiscard()
+                }
+                Button("Keep Editing", role: .cancel) {}
+            } message: {
+                Text(message)
+            }
+    }
+}
+
+extension View {
+    func dismissSafety(
+        isDirty: Bool,
+        isSaving: Bool = false,
+        showDiscardConfirmation: Binding<Bool>,
+        title: String = "Discard Changes?",
+        message: String = "You have unsaved changes. Discard them and close this sheet?",
+        onDiscard: @escaping () -> Void
+    ) -> some View {
+        modifier(DismissSafetyModifier(
+            isDirty: isDirty,
+            isSaving: isSaving,
+            title: title,
+            message: message,
+            onDiscard: onDiscard,
+            showDiscardConfirmation: showDiscardConfirmation
+        ))
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOS/Shared/FormSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/FormSheet.swift
@@ -17,11 +17,13 @@ struct FormSheet<Content: View>: View {
     @Binding var isSaving: Bool
     var isValid: Bool = true
     var saveLabel: String = "Save"
+    var isDirty: Bool = false
     var onSave: () -> Void
     var onCancel: (() -> Void)?
     @ViewBuilder let content: Content
 
     @Environment(\.dismiss) private var dismiss
+    @State private var showDiscardConfirmation = false
 
     var body: some View {
         NavigationStack {
@@ -36,7 +38,12 @@ struct FormSheet<Content: View>: View {
                         if let onCancel {
                             onCancel()
                         } else {
-                            dismiss()
+                            DismissSafety.cancelOrConfirm(
+                                isDirty: isDirty,
+                                isSaving: isSaving,
+                                dismiss: dismiss,
+                                showDiscardConfirmation: $showDiscardConfirmation
+                            )
                         }
                     }
                     .disabled(isSaving)
@@ -49,7 +56,12 @@ struct FormSheet<Content: View>: View {
                     .disabled(!isValid || isSaving)
                 }
             }
-            .interactiveDismissDisabled(isSaving)
+            .dismissSafety(
+                isDirty: isDirty,
+                isSaving: isSaving,
+                showDiscardConfirmation: $showDiscardConfirmation,
+                onDiscard: { dismiss() }
+            )
         }
     }
 }

--- a/docs/plans/dismiss-safety-verification-2026-05-23.md
+++ b/docs/plans/dismiss-safety-verification-2026-05-23.md
@@ -1,0 +1,99 @@
+# Dismiss-safety verification — WEI-2025 (2026-05-23)
+
+Source issue: WEI-2025
+Scope: `.sheet` / form-like unsaved-state audit for Tools, Fleet, Reports, Warehouse, Orders, Settings.
+
+## Canonical checklist used
+
+For each sheet-like presentation:
+
+1. Identify the sheet purpose from the `.sheet` body or sheet view.
+2. Classify as one of:
+   - Read-only/help/share/scanner: no persisted user draft; may intentionally dismiss.
+   - Action flow: selection/scan/action state is either immediately applied, recoverable from the parent page, or protected during in-flight work.
+   - Form/edit flow: local user input can be lost; must block swipe dismiss when dirty/saving and Cancel must confirm discard or be intentionally safe.
+3. Confirm each form/action sheet either:
+   - Uses `interactiveDismissDisabled` directly,
+   - Uses a guarded form wrapper/modifier, or
+   - Is documented as a false positive because there is no unsaved user work.
+
+## Static scan summary
+
+Command pattern used:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+root = Path('Weird Parts IOS/Weird Parts IOS/Features')
+for area in ['Tools','Fleet','Reports','Warehouse','Orders','Settings']:
+    for p in sorted((root/area).rglob('*.swift')):
+        text = p.read_text(errors='ignore')
+        if '.sheet' in text:
+            print(area, p.relative_to(root), text.count('.sheet'), text.count('interactiveDismissDisabled'))
+PY
+```
+
+Target-area findings before this patch:
+
+- Tools: `IOSToolDetailPage` sheet content already has local guards; unguarded Tools sheets are scanner/help/label-print surfaces with no draft text.
+- Fleet: most list pages present read-only help sheets; vehicle/trailer/driver/inspection form sheets had save-only protection but not dirty-input discard confirmation.
+- Reports: sheets are help/share/export surfaces. Report filters live on the page, not in the sheet, and are not lost by sheet dismissal.
+- Warehouse: wizard/action sheets mostly already guard saving/moving; scanner/help/detail sheets are read-only or recoverable. Existing receiving quantity flow is documented as auto-save/no discard.
+- Orders: purchase order/JPO/wishlist/return sheets already guard saving or require confirmation for destructive/cancel actions; scanners/help are false positives.
+- Settings: several form pages have local dirty guards (`CompanyProfilesPage`, `IOSClockOutQuestionsPage`, `IOSReportTemplatesPage`); the rest of detected `.sheet` occurrences are help/preview/export flows or page-level forms.
+
+## Code changes made
+
+Added shared dismiss-safety helper:
+
+- `Weird Parts IOS/Weird Parts IOS/Shared/DismissSafety.swift`
+  - `DismissSafety.cancelOrConfirm(...)`
+  - `.dismissSafety(isDirty:isSaving:showDiscardConfirmation:onDiscard:)`
+
+Updated shared wrapper:
+
+- `Shared/FormSheet.swift`
+  - Added optional `isDirty` input.
+  - Swipe dismiss now blocks while dirty or saving.
+  - Default Cancel path confirms before discarding dirty input.
+
+Hardened Fleet form/action sheets found by the scan:
+
+- `Features/Fleet/IOSCreateVehicleSheet.swift`
+  - Dirty detection includes all create-vehicle fields.
+  - Swipe dismiss blocks while dirty/saving.
+  - Cancel confirms discard when dirty.
+- `Features/Fleet/IOSCreateTrailerSheet.swift`
+  - Dirty detection includes trailer number/type/notes.
+  - Swipe dismiss blocks while dirty/saving.
+  - Cancel confirms discard when dirty.
+- `Features/Fleet/IOSAssignDriverSheet.swift`
+  - Dirty detection includes selected driver, assignment type, and take-home flag.
+  - Swipe dismiss blocks while dirty/saving.
+  - Cancel confirms discard when dirty.
+- `Features/Fleet/PreTripInspectionView.swift`
+  - Dirty detection includes odometer, fuel level, general notes, checklist statuses, and checklist notes.
+  - Swipe dismiss blocks while dirty/saving.
+  - Cancel confirms discard when dirty.
+
+## False positives documented
+
+- `PageHelpSheet` and help-only `NavigationStack` sheets: read-only educational content, no unsaved user work.
+- `QRScanSheet` scanner sheets: scan result is immediately applied to parent state or dismissed; no typed draft inside scanner is discarded.
+- `ReportShareSheet` / export share sheets: generated artifact URL is owned by the parent/exporter; sheet dismissal does not erase user input.
+- Warehouse receiving quantities: existing code comments document auto-save behavior, so dismissal is intentionally safe.
+- Page-level filters/search/pickers detected by file-level scan are not sheet-local unsaved drafts.
+
+## Verification performed
+
+- `swiftc -parse` on the new/changed Swift files passed.
+- `git diff --check` passed.
+- Branch hygiene preflight:
+  - `git fetch --prune origin` performed.
+  - Remote branches after prune: 57 (still above soft cap 20; no new branch cleanup attempted in this UX patch).
+  - Open PRs at work start: 0.
+  - Work was done in isolated worktree `/private/tmp/wei-2025-dismiss-safety-sheets` on branch `WEI-2025-dismiss-safety-sheets`, based on `origin/main`, to avoid the divergent primary `main` worktree.
+
+## Remaining notes
+
+The static scan still lists many `.sheet` sites because read-only help sheets are intentionally unguarded. New form sheets should use `DismissSafety` or `FormSheet(isDirty:)` rather than save-only `interactiveDismissDisabled(isSaving)`.

--- a/xcode-ai/prompt-results-log.md
+++ b/xcode-ai/prompt-results-log.md
@@ -3266,3 +3266,25 @@ All 136 prompts verified and implemented. Program ready for review.
 - Confirmed IOSFlexPoolPage already has .refreshable on the current base branch.
 **Issues Found:** None
 **Build:** PARTIAL — `swift build` PASS; `swift test` FAILS in pre-existing NotebooksServiceTests jobId filter expectations unrelated to this UI refreshability change. App-target validation was not run during this initial pass.
+
+## Prompt WEI-2025 — Dismiss-safety verification for remaining sheet-based pages (2026-05-23)
+
+**Status:** SUCCESS
+**Files Changed:**
+- `Weird Parts IOS/Weird Parts IOS/Shared/DismissSafety.swift`
+- `Weird Parts IOS/Weird Parts IOS/Shared/FormSheet.swift`
+- `Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSCreateVehicleSheet.swift`
+- `Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSCreateTrailerSheet.swift`
+- `Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSAssignDriverSheet.swift`
+- `Weird Parts IOS/Weird Parts IOS/Features/Fleet/PreTripInspectionView.swift`
+- `docs/plans/dismiss-safety-verification-2026-05-23.md`
+**What Was Done:**
+- Ran the PE-044-style static dismiss-safety checklist across Tools, Fleet, Reports, Warehouse, Orders, and Settings `.sheet` sites.
+- Added a shared `DismissSafety` helper/modifier for dirty/saving sheet protection and discard confirmation.
+- Upgraded `FormSheet` so future users can pass `isDirty` and receive consistent swipe-dismiss blocking plus Cancel discard confirmation.
+- Hardened Fleet create vehicle, create trailer, assign driver, and pre-trip inspection sheets so dirty local input cannot be silently lost.
+- Documented read-only/help/scanner/share false positives and branch/workspace hygiene evidence.
+**Issues Found:**
+- The repo still has 57 remote branches after prune, above the 20 branch soft cap; no open PRs existed at start.
+- The primary local `main` worktree is divergent, so work was isolated in `/private/tmp/wei-2025-dismiss-safety-sheets` based on `origin/main`.
+**Build:** PASS (`swiftc -parse` on changed Swift files; `git diff --check`)


### PR DESCRIPTION
## Summary
- Adds shared DismissSafety helpers for dirty/saving sheet dismissal protection.
- Updates FormSheet to support dirty-state discard confirmation.
- Hardens Fleet create vehicle, create trailer, assign driver, and pre-trip inspection sheets so dirty local input cannot be silently lost.
- Adds WEI-2025 dismiss-safety verification notes documenting target-area scan false positives.

## Verification
- git diff --check
- swiftc -parse on changed Swift files

Paperclip: WEI-2025