### PR TITLE
feat(scheduling): add subcontractor date service APIs

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateSubcontractorScheduleSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateSubcontractorScheduleSheet.swift
@@ -1,0 +1,217 @@
+import SwiftUI
+import WiredPartCore
+
+/// Sheet for creating or editing a subcontractor schedule arrival.
+///
+/// Uses the SchedulingService write APIs so scheduled subcontractor dates stay as
+/// exact local date-only values (`yyyy-MM-dd`) instead of being buried in notes.
+struct CreateSubcontractorScheduleSheet: View {
+    @EnvironmentObject private var appCore: AppCore
+    @Environment(\.dismiss) private var dismiss
+
+    let initialDate: Date
+    let existing: SchedulingService.SubScheduleRow?
+    var onSave: () -> Void
+
+    @State private var jobs: [JobsService.JobListItem] = []
+    @State private var contractors: [PeopleService.ContractorListItem] = []
+    @State private var selectedJobId: Int64?
+    @State private var selectedContractorId: Int64?
+    @State private var scheduledDate = Date()
+    @State private var arrivalTime = ""
+    @State private var departureTime = ""
+    @State private var scopeOfWork = ""
+    @State private var status = "scheduled"
+    @State private var notes = ""
+    @State private var isSaving = false
+    @State private var saveError: String?
+
+    private let statuses = ["scheduled", "confirmed", "completed", "cancelled"]
+
+    init(
+        initialDate: Date,
+        existing: SchedulingService.SubScheduleRow? = nil,
+        onSave: @escaping () -> Void
+    ) {
+        self.initialDate = initialDate
+        self.existing = existing
+        self.onSave = onSave
+        _scheduledDate = State(initialValue: initialDate)
+    }
+
+    private var isEditing: Bool { existing != nil }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Job") {
+                    if jobs.isEmpty {
+                        Text("No active jobs")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Picker("Job", selection: $selectedJobId) {
+                            Text("Select a job...").tag(nil as Int64?)
+                            ForEach(jobs, id: \.id) { job in
+                                Text(job.jobName).tag(job.id as Int64?)
+                            }
+                        }
+                    }
+                }
+
+                Section("Subcontractor") {
+                    if contractors.isEmpty {
+                        Text("No active subcontractors")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Picker("Subcontractor", selection: $selectedContractorId) {
+                            Text("Select a subcontractor...").tag(nil as Int64?)
+                            ForEach(contractors, id: \.id) { contractor in
+                                Text(contractorDisplayName(contractor)).tag(contractor.id as Int64?)
+                            }
+                        }
+                    }
+                }
+
+                Section("Scheduled Date") {
+                    DatePicker("Date", selection: $scheduledDate, displayedComponents: .date)
+                }
+
+                Section("Arrival Window (Optional)") {
+                    TextField("Arrival time (e.g. 07:30)", text: $arrivalTime)
+                        .textInputAutocapitalization(.never)
+                    TextField("Departure time (e.g. 15:30)", text: $departureTime)
+                        .textInputAutocapitalization(.never)
+                }
+
+                Section("Status") {
+                    Picker("Status", selection: $status) {
+                        ForEach(statuses, id: \.self) { value in
+                            Text(value.capitalized).tag(value)
+                        }
+                    }
+                }
+
+                Section("Scope of Work (Optional)") {
+                    TextEditor(text: $scopeOfWork)
+                        .frame(minHeight: 70)
+                }
+
+                Section("Notes (Optional)") {
+                    TextEditor(text: $notes)
+                        .frame(minHeight: 70)
+                }
+
+                if let error = saveError {
+                    Section {
+                        Text(error)
+                            .foregroundStyle(.red)
+                            .font(.caption)
+                    }
+                }
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .navigationTitle(isEditing ? "Edit Sub Schedule" : "Add Sub Schedule")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Button(isEditing ? "Save" : "Create") { saveSchedule() }
+                            .disabled(selectedJobId == nil || selectedContractorId == nil)
+                            .fontWeight(.semibold)
+                    }
+                }
+            }
+            .interactiveDismissDisabled(isSaving)
+            .task { loadData() }
+        }
+    }
+
+    private func loadData() {
+        if let existing {
+            selectedJobId = existing.jobId == 0 ? nil : existing.jobId
+            selectedContractorId = existing.gcId == 0 ? nil : existing.gcId
+            if let date = Formatters.localDateFormatter.date(from: String(existing.scheduleDate.prefix(10))) {
+                scheduledDate = date
+            }
+            arrivalTime = existing.arrivalTime ?? ""
+            departureTime = existing.departureTime ?? ""
+            scopeOfWork = existing.scopeOfWork ?? ""
+            status = existing.status
+            notes = existing.notes ?? ""
+        }
+
+        if let jobsService = appCore.jobsService {
+            jobs = (try? jobsService.listJobs(status: "active", limit: 300)) ?? []
+        }
+        if let peopleService = appCore.peopleService {
+            contractors = (try? peopleService.listContractors()) ?? []
+        }
+    }
+
+    private func saveSchedule() {
+        guard let service = appCore.schedulingService,
+              let jobId = selectedJobId,
+              let contractorId = selectedContractorId else {
+            saveError = "Service not available"
+            return
+        }
+
+        isSaving = true
+        saveError = nil
+        do {
+            let scheduledDateString = Formatters.localDateFormatter.string(from: scheduledDate)
+            if let existing {
+                try service.updateSubcontractorSchedule(
+                    id: existing.id,
+                    jobId: jobId,
+                    gcId: contractorId,
+                    scheduledDate: scheduledDateString,
+                    arrivalTime: optionalText(arrivalTime),
+                    departureTime: optionalText(departureTime),
+                    scopeOfWork: optionalText(scopeOfWork),
+                    status: status,
+                    notes: optionalText(notes)
+                )
+            } else {
+                _ = try service.createSubcontractorSchedule(
+                    jobId: jobId,
+                    gcId: contractorId,
+                    scheduledDate: scheduledDateString,
+                    arrivalTime: optionalText(arrivalTime),
+                    departureTime: optionalText(departureTime),
+                    scopeOfWork: optionalText(scopeOfWork),
+                    status: status,
+                    notes: optionalText(notes),
+                    createdBy: appCore.currentUser?.id
+                )
+            }
+            dismiss()
+            onSave()
+        } catch {
+            saveError = userFriendlyError(error, context: isEditing ? "update sub schedule" : "create sub schedule")
+        }
+        isSaving = false
+    }
+
+    private func optionalText(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func contractorDisplayName(_ contractor: PeopleService.ContractorListItem) -> String {
+        let personName = [contractor.firstName, contractor.lastName]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        if let company = contractor.company?.trimmingCharacters(in: .whitespacesAndNewlines), !company.isEmpty {
+            return personName.isEmpty ? company : "\(company) — \(personName)"
+        }
+        return personName.isEmpty ? "Subcontractor #\(contractor.id)" : personName
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleCalendarPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleCalendarPage.swift
@@ -12,13 +12,14 @@ struct IOSScheduleCalendarPage: View {
     // MARK: - Calendar Mode
 
     enum CalendarMode: String, CaseIterable {
+        case twoWeeks = "14 Days"
         case week = "Week"
         case month = "Month"
     }
 
     // MARK: - State
 
-    @State private var calendarMode: CalendarMode = .week
+    @State private var calendarMode: CalendarMode = .twoWeeks
     @State private var entries: [SchedulingService.ScheduleEntry] = []
     @State private var monthScheduleData: [String: SchedulingService.DayScheduleSummary] = [:]
     @State private var dayEntries: [SchedulingService.ScheduleEntry] = []
@@ -36,18 +37,31 @@ struct IOSScheduleCalendarPage: View {
 
     private let calendar = Calendar.current
 
-    /// The date range for the current week view.
-    private var weekStartDate: Date {
-        calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: selectedDate)) ?? selectedDate
+    /// The date range for the selected list mode.
+    ///
+    /// GH #610 asks for a rolling 14-day preview that starts on the selected
+    /// day/current day, not the calendar week boundary. The old Week mode remains
+    /// available for users who prefer Sunday/Monday week grouping.
+    private var listRangeStartDate: Date {
+        switch calendarMode {
+        case .twoWeeks:
+            calendar.startOfDay(for: selectedDate)
+        case .week, .month:
+            calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: selectedDate)) ?? selectedDate
+        }
     }
 
-    private var weekStart: String {
-        Formatters.iso8601DateOnly.string(from: weekStartDate)
+    private var listRangeEndDate: Date {
+        let days = calendarMode == .twoWeeks ? 13 : 6
+        return calendar.date(byAdding: .day, value: days, to: listRangeStartDate) ?? listRangeStartDate
     }
 
-    private var weekEnd: String {
-        let end = calendar.date(byAdding: .day, value: 6, to: weekStartDate) ?? weekStartDate
-        return Formatters.iso8601DateOnly.string(from: end)
+    private var listRangeStart: String {
+        Formatters.iso8601DateOnly.string(from: listRangeStartDate)
+    }
+
+    private var listRangeEnd: String {
+        Formatters.iso8601DateOnly.string(from: listRangeEndDate)
     }
 
     var body: some View {
@@ -72,7 +86,7 @@ struct IOSScheduleCalendarPage: View {
                 monthView
                 dayDetailSection
             } else {
-                weekNavigator
+                listNavigator
                 scheduleList
             }
         }
@@ -99,10 +113,10 @@ struct IOSScheduleCalendarPage: View {
                     .environmentObject(appCore)
             case .help:
                 PageHelpSheet(title: "Schedule Calendar Help", sections: [
-                    ("What This Page Does", "The Schedule Calendar shows your work assignments in either a week list or a month grid. Month view uses colored dots to indicate AM (blue), PM (green), full-day (orange), and time-off (red) entries for each day."),
-                    ("How to Use It", "Toggle between Week and Month views using the segmented control at the top. In month view, tap any day to see its detail below the calendar. In week view, scroll through the list of assignments. Use the + button to create a new schedule entry."),
+                    ("What This Page Does", "The Schedule Calendar shows your work assignments in a rolling 14-day preview, a week list, or a month grid. Month view uses colored dots to indicate AM (blue), PM (green), full-day (orange), and time-off (red) entries for each day."),
+                    ("How to Use It", "Use 14 Days for fast two-week planning from the selected date, Week for calendar-week grouping, or Month for the grid. In month view, tap any day to see its detail below the calendar. Use the + button to create a new schedule entry."),
                     ("Color Coding", "Blue dots and badges mean AM shifts, green means PM, orange means full day. Red dots indicate someone has time off that day."),
-                    ("Tips", "Pull down to refresh the schedule. Use the search bar to filter entries by job name or notes. Navigate between weeks or months using the arrow buttons.")
+                    ("Tips", "Pull down to refresh the schedule. Use the search bar to filter entries by job name or notes. Navigate between 14-day windows, weeks, or months using the arrow buttons.")
                 ])
             }
         }
@@ -299,33 +313,42 @@ struct IOSScheduleCalendarPage: View {
         }
     }
 
-    // MARK: - Week View (existing)
+    // MARK: - List View Navigator
 
-    private var weekNavigator: some View {
-        HStack {
+    private var listNavigator: some View {
+        let stepDays = calendarMode == .twoWeeks ? 14 : 7
+        let previousLabel = calendarMode == .twoWeeks ? "Previous 14 days" : "Previous week"
+        let nextLabel = calendarMode == .twoWeeks ? "Next 14 days" : "Next week"
+
+        return HStack {
             Button {
-                selectedDate = calendar.date(byAdding: .weekOfYear, value: -1, to: selectedDate) ?? selectedDate
+                selectedDate = calendar.date(byAdding: .day, value: -stepDays, to: selectedDate) ?? selectedDate
                 loadData()
             } label: {
                 Image(systemName: "chevron.left")
             }
-            .accessibilityLabel("Previous week")
+            .accessibilityLabel(previousLabel)
 
             Spacer()
 
-            Text("\(weekStart) - \(weekEnd)")
-                .font(.subheadline)
-                .fontWeight(.medium)
+            VStack(spacing: 2) {
+                Text(calendarMode == .twoWeeks ? "Next 14 Days" : "Week")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("\(listRangeStart) - \(listRangeEnd)")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+            }
 
             Spacer()
 
             Button {
-                selectedDate = calendar.date(byAdding: .weekOfYear, value: 1, to: selectedDate) ?? selectedDate
+                selectedDate = calendar.date(byAdding: .day, value: stepDays, to: selectedDate) ?? selectedDate
                 loadData()
             } label: {
                 Image(systemName: "chevron.right")
             }
-            .accessibilityLabel("Next week")
+            .accessibilityLabel(nextLabel)
         }
         .padding(.horizontal)
         .padding(.vertical, 10)
@@ -344,7 +367,7 @@ struct IOSScheduleCalendarPage: View {
             EmptyStateView(
                 icon: "calendar",
                 title: "No Schedule",
-                message: "No schedule entries for this week."
+                message: calendarMode == .twoWeeks ? "No schedule entries for the next 14 days." : "No schedule entries for this week."
             )
         } else {
             List(filteredEntries, id: \.id) { entry in
@@ -479,8 +502,8 @@ struct IOSScheduleCalendarPage: View {
             } else {
                 entries = try service.getMySchedule(
                     userId: userId,
-                    startDate: weekStart,
-                    endDate: weekEnd
+                    startDate: listRangeStart,
+                    endDate: listRangeEnd
                 )
             }
         } catch {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSSubSchedulePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSSubSchedulePage.swift
@@ -141,6 +141,23 @@ struct IOSSubSchedulePage: View {
                 Label(formatDate(row.scheduleDate), systemImage: "calendar")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
+                if let timeSummary = subTimeSummary(row) {
+                    Label(timeSummary, systemImage: "clock")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                if let scope = row.scopeOfWork, !scope.isEmpty {
+                    Label(scope, systemImage: "list.clipboard")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                if let notes = row.notes, !notes.isEmpty {
+                    Text(notes)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(2)
+                }
             }
 
             Spacer()
@@ -175,6 +192,15 @@ struct IOSSubSchedulePage: View {
             return String(dateString.prefix(10))
         }
         return Formatters.shortDateDisplayFormatter.string(from: date)
+    }
+
+    private func subTimeSummary(_ row: SchedulingService.SubScheduleRow) -> String? {
+        let arrival = row.arrivalTime?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let departure = row.departureTime?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !arrival.isEmpty && !departure.isEmpty { return "\(arrival) - \(departure)" }
+        if !arrival.isEmpty { return "Arrives \(arrival)" }
+        if !departure.isEmpty { return "Leaves \(departure)" }
+        return nil
     }
 
     // MARK: - Data Loading

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSSubSchedulePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSSubSchedulePage.swift
@@ -19,8 +19,16 @@ struct IOSSubSchedulePage: View {
     @State private var activeSheet: ActiveSheet?
 
     private enum ActiveSheet: Identifiable {
+        case create
+        case edit(SchedulingService.SubScheduleRow)
         case help
-        var id: String { "help" }
+        var id: String {
+            switch self {
+            case .create: return "create"
+            case .edit(let row): return "edit-\(row.id)"
+            case .help: return "help"
+            }
+        }
     }
 
     private var dateString: String {
@@ -40,19 +48,34 @@ struct IOSSubSchedulePage: View {
         .searchable(text: $searchText, prompt: "Search subs...")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
+                Button { activeSheet = .create } label: {
+                    Image(systemName: "plus")
+                }
+                .accessibilityLabel("Add subcontractor schedule")
+            }
+            ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .help } label: {
                     Image(systemName: "questionmark.circle")
                 }
                 .accessibilityLabel("Help")
             }
         }
-        .sheet(item: $activeSheet) { _ in
-            PageHelpSheet(title: "Sub Schedule Help", sections: [
-                ("What This Page Does", "The Sub Schedule page shows all subcontractor assignments for a given date. Each row displays the subcontractor's name, their company, the job they are assigned to, and their current status."),
-                ("How to Use It", "Use the date picker or arrow buttons to navigate between days. The list updates automatically when you change dates. Pull down to refresh the current day's data."),
-                ("Status Badges", "Green 'Confirmed' means the sub has acknowledged the assignment. Orange 'Pending' means they have not confirmed yet. Blue 'Completed' means the work is done. Red 'Cancelled' means the assignment was removed."),
-                ("Tips", "Check this page each morning to confirm all subs are accounted for. Follow up on any 'Pending' status items to make sure subs know where to go.")
-            ])
+        .sheet(item: $activeSheet) { sheet in
+            switch sheet {
+            case .create:
+                CreateSubcontractorScheduleSheet(initialDate: selectedDate, onSave: { loadData() })
+                    .environmentObject(appCore)
+            case .edit(let row):
+                CreateSubcontractorScheduleSheet(initialDate: selectedDate, existing: row, onSave: { loadData() })
+                    .environmentObject(appCore)
+            case .help:
+                PageHelpSheet(title: "Sub Schedule Help", sections: [
+                    ("What This Page Does", "The Sub Schedule page shows all subcontractor assignments for a given date, including exact scheduled arrival date plus optional arrival/departure times, scope of work, and notes when recorded."),
+                    ("How to Use It", "Use the + button to add the date a subcontractor will show up. Use the date picker or arrow buttons to navigate between days. Tap a row to edit its scheduled date, times, scope, status, or notes."),
+                    ("Status Badges", "Green 'Confirmed' means the sub has acknowledged the assignment. Orange 'Pending' means they have not confirmed yet. Blue 'Completed' means the work is done. Red 'Cancelled' means the assignment was removed."),
+                    ("Tips", "Check this page each morning to confirm all subs are accounted for. Follow up on any 'Pending' status items to make sure subs know where to go.")
+                ])
+            }
         }
         .refreshable { loadData() }
         .task { loadData() }
@@ -112,6 +135,12 @@ struct IOSSubSchedulePage: View {
         } else {
             List(rows) { row in
                 subRow(row)
+                    .contentShape(Rectangle())
+                    .onTapGesture { activeSheet = .edit(row) }
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button("Edit") { activeSheet = .edit(row) }
+                            .tint(.blue)
+                    }
             }
             .listStyle(.insetGrouped)
         }

--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -175,6 +175,8 @@ public final class SchedulingService: Sendable {
     /// A subcontractor schedule row for the sub-schedule list and add/edit forms.
     public struct SubScheduleRow: Sendable, Identifiable {
         public let id: Int64
+        public let jobId: Int64
+        public let gcId: Int64
         public let subName: String
         public let companyName: String
         public let jobName: String
@@ -187,6 +189,8 @@ public final class SchedulingService: Sendable {
 
         public init(
             id: Int64,
+            jobId: Int64 = 0,
+            gcId: Int64 = 0,
             subName: String,
             companyName: String,
             jobName: String,
@@ -198,6 +202,8 @@ public final class SchedulingService: Sendable {
             notes: String? = nil
         ) {
             self.id = id
+            self.jobId = jobId
+            self.gcId = gcId
             self.subName = subName
             self.companyName = companyName
             self.jobName = jobName
@@ -678,6 +684,8 @@ public final class SchedulingService: Sendable {
             return try db.writer.read { dbConn -> [SubScheduleRow] in
                 let sql = """
                     SELECT ss.id,
+                           ss.job_id,
+                           ss.gc_id,
                            COALESCE(gc.contact_name, gc.company_name, 'Unknown') AS sub_name,
                            COALESCE(gc.company_name, '') AS company_name,
                            COALESCE(j.job_name, 'Unknown Job') AS job_name,
@@ -698,6 +706,8 @@ public final class SchedulingService: Sendable {
                 return rows.map { row in
                     SubScheduleRow(
                         id: row["id"] ?? 0,
+                        jobId: row["job_id"] ?? 0,
+                        gcId: row["gc_id"] ?? 0,
                         subName: row["sub_name"] ?? "Unknown",
                         companyName: row["company_name"] ?? "",
                         jobName: row["job_name"] ?? "Unknown Job",

--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -34,10 +34,14 @@ public final class SchedulingService: Sendable {
         /// Fix #207: surfaces the conflict so UI can require cancellation/resolution first.
         case timeOffConflictsWithDispatch(conflicts: Int)
         case invalidDateRange(start: String, end: String)
+        case invalidDate(String)
         case requiredFieldEmpty
         case jobNotFound(Int64)
         case userNotFound(Int64)
         case insufficientPermissions(required: String)
+        case contractorNotFound(Int64)
+        case subcontractorScheduleNotFound(Int64)
+        case subcontractorScheduleConflict(jobId: Int64, gcId: Int64, date: String)
     }
 
     // =========================================================================
@@ -653,6 +657,7 @@ public final class SchedulingService: Sendable {
 
     /// Get subcontractor schedule rows for a given date.
     public func getSubSchedule(date: String) throws -> [SubScheduleRow] {
+        let normalizedDate = try Self.normalizeScheduleDateOnly(date)
         do {
             return try db.writer.read { dbConn -> [SubScheduleRow] in
                 let sql = """
@@ -666,16 +671,17 @@ public final class SchedulingService: Sendable {
                     LEFT JOIN general_contractors gc ON gc.id = ss.gc_id AND gc.deleted_at IS NULL
                     LEFT JOIN jobs j ON j.id = ss.job_id AND j.deleted_at IS NULL
                     WHERE ss.scheduled_date = ?
+                      AND ss.deleted_at IS NULL
                     ORDER BY sub_name
                     """
-                let rows = try Row.fetchAll(dbConn, sql: sql, arguments: [date])
+                let rows = try Row.fetchAll(dbConn, sql: sql, arguments: [normalizedDate])
                 return rows.map { row in
                     SubScheduleRow(
                         id: row["id"] ?? 0,
                         subName: row["sub_name"] ?? "Unknown",
                         companyName: row["company_name"] ?? "",
                         jobName: row["job_name"] ?? "Unknown Job",
-                        scheduleDate: row["schedule_date"] ?? date,
+                        scheduleDate: row["schedule_date"] ?? normalizedDate,
                         status: row["status"] ?? "scheduled"
                     )
                 }
@@ -683,6 +689,105 @@ public final class SchedulingService: Sendable {
         } catch {
             if isTableNotFoundError(error) { return [] }
             throw error
+        }
+    }
+
+    /// Create a subcontractor schedule row with strict date-only validation.
+    @discardableResult
+    public func createSubcontractorSchedule(
+        jobId: Int64,
+        gcId: Int64,
+        scheduledDate: String,
+        arrivalTime: String? = nil,
+        departureTime: String? = nil,
+        scopeOfWork: String? = nil,
+        status: String = "scheduled",
+        notes: String? = nil,
+        createdBy: Int64? = nil
+    ) throws -> Int64 {
+        let normalizedDate = try Self.normalizeScheduleDateOnly(scheduledDate)
+        let normalizedStatus = try Self.normalizeSubcontractorScheduleStatus(status)
+
+        return try db.writer.write { dbConn in
+            try validateSubcontractorScheduleParents(dbConn, jobId: jobId, gcId: gcId)
+            try guardNoActiveSubcontractorScheduleConflict(dbConn, jobId: jobId, gcId: gcId, date: normalizedDate)
+
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO subcontractor_schedules
+                    (job_id, gc_id, scheduled_date, arrival_time, departure_time, scope_of_work, status, notes, created_by, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+                    """,
+                arguments: [jobId, gcId, normalizedDate, arrivalTime, departureTime, scopeOfWork, normalizedStatus, notes, createdBy]
+            )
+            return dbConn.lastInsertedRowID
+        }
+    }
+
+    /// Correct the scheduled date for a non-deleted subcontractor schedule.
+    public func updateSubcontractorScheduleDate(id: Int64, scheduledDate: String) throws {
+        let normalizedDate = try Self.normalizeScheduleDateOnly(scheduledDate)
+
+        try db.writer.write { dbConn in
+            guard let existing = try Row.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT job_id, gc_id
+                    FROM subcontractor_schedules
+                    WHERE id = ? AND deleted_at IS NULL
+                    """,
+                arguments: [id]
+            ) else {
+                throw SchedulingError.subcontractorScheduleNotFound(id)
+            }
+
+            let jobId: Int64 = existing["job_id"]
+            let gcId: Int64 = existing["gc_id"]
+            try validateSubcontractorScheduleParents(dbConn, jobId: jobId, gcId: gcId)
+
+            let conflictCount = try Int.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT COUNT(*)
+                    FROM subcontractor_schedules
+                    WHERE job_id = ?
+                      AND gc_id = ?
+                      AND scheduled_date = ?
+                      AND deleted_at IS NULL
+                      AND id <> ?
+                    """,
+                arguments: [jobId, gcId, normalizedDate, id]
+            ) ?? 0
+            if conflictCount > 0 {
+                throw SchedulingError.subcontractorScheduleConflict(jobId: jobId, gcId: gcId, date: normalizedDate)
+            }
+
+            try dbConn.execute(
+                sql: """
+                    UPDATE subcontractor_schedules
+                    SET scheduled_date = ?, updated_at = datetime('now')
+                    WHERE id = ? AND deleted_at IS NULL
+                    """,
+                arguments: [normalizedDate, id]
+            )
+        }
+    }
+
+    /// Soft-delete a subcontractor schedule so it disappears from scheduling views.
+    public func cancelSubcontractorSchedule(id: Int64) throws {
+        try db.writer.write { dbConn in
+            try dbConn.execute(
+                sql: """
+                    UPDATE subcontractor_schedules
+                    SET status = 'cancelled', deleted_at = datetime('now'), updated_at = datetime('now')
+                    WHERE id = ? AND deleted_at IS NULL
+                    """,
+                arguments: [id]
+            )
+
+            guard dbConn.changesCount > 0 else {
+                throw SchedulingError.subcontractorScheduleNotFound(id)
+            }
         }
     }
 
@@ -2233,6 +2338,88 @@ public final class SchedulingService: Sendable {
     // =========================================================================
     // MARK: - Internal Helpers
     // =========================================================================
+
+    /// Normalize a user-entered schedule date without timezone conversion.
+    /// Accepts only a trimmed yyyy-MM-dd calendar date string.
+    private static func normalizeScheduleDateOnly(_ rawDate: String) throws -> String {
+        let value = rawDate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { throw SchedulingError.requiredFieldEmpty }
+
+        let parts = value.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              parts[0].count == 4,
+              parts[1].count == 2,
+              parts[2].count == 2,
+              let year = Int(parts[0]),
+              let month = Int(parts[1]),
+              let day = Int(parts[2]),
+              String(format: "%04d-%02d-%02d", year, month, day) == value,
+              (1...12).contains(month) else {
+            throw SchedulingError.invalidDate(value)
+        }
+
+        let daysInMonth: Int
+        switch month {
+        case 1, 3, 5, 7, 8, 10, 12:
+            daysInMonth = 31
+        case 4, 6, 9, 11:
+            daysInMonth = 30
+        case 2:
+            let isLeapYear = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+            daysInMonth = isLeapYear ? 29 : 28
+        default:
+            throw SchedulingError.invalidDate(value)
+        }
+
+        guard (1...daysInMonth).contains(day) else {
+            throw SchedulingError.invalidDate(value)
+        }
+
+        return value
+    }
+
+    private static func normalizeSubcontractorScheduleStatus(_ rawStatus: String) throws -> String {
+        let value = rawStatus.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let validStatuses: Set<String> = ["scheduled", "confirmed", "in_progress", "completed", "cancelled"]
+        guard validStatuses.contains(value) else {
+            throw SchedulingError.invalidStatus(rawStatus)
+        }
+        return value
+    }
+
+    private func validateSubcontractorScheduleParents(_ dbConn: Database, jobId: Int64, gcId: Int64) throws {
+        let jobExists = (try Int.fetchOne(
+            dbConn,
+            sql: "SELECT COUNT(*) FROM jobs WHERE id = ? AND deleted_at IS NULL",
+            arguments: [jobId]
+        ) ?? 0) > 0
+        guard jobExists else { throw SchedulingError.jobNotFound(jobId) }
+
+        let contractorExists = (try Int.fetchOne(
+            dbConn,
+            sql: "SELECT COUNT(*) FROM general_contractors WHERE id = ? AND deleted_at IS NULL",
+            arguments: [gcId]
+        ) ?? 0) > 0
+        guard contractorExists else { throw SchedulingError.contractorNotFound(gcId) }
+    }
+
+    private func guardNoActiveSubcontractorScheduleConflict(_ dbConn: Database, jobId: Int64, gcId: Int64, date: String) throws {
+        let conflictCount = try Int.fetchOne(
+            dbConn,
+            sql: """
+                SELECT COUNT(*)
+                FROM subcontractor_schedules
+                WHERE job_id = ?
+                  AND gc_id = ?
+                  AND scheduled_date = ?
+                  AND deleted_at IS NULL
+                """,
+            arguments: [jobId, gcId, date]
+        ) ?? 0
+        guard conflictCount == 0 else {
+            throw SchedulingError.subcontractorScheduleConflict(jobId: jobId, gcId: gcId, date: date)
+        }
+    }
 
     /// Execute a SELECT COUNT(*) query returning an Int.
     /// Returns 0 if the table does not exist.

--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -172,7 +172,7 @@ public final class SchedulingService: Sendable {
         }
     }
 
-    /// A subcontractor schedule row for the sub-schedule list.
+    /// A subcontractor schedule row for the sub-schedule list and add/edit forms.
     public struct SubScheduleRow: Sendable, Identifiable {
         public let id: Int64
         public let subName: String
@@ -180,10 +180,22 @@ public final class SchedulingService: Sendable {
         public let jobName: String
         public let scheduleDate: String
         public let status: String
+        public let arrivalTime: String?
+        public let departureTime: String?
+        public let scopeOfWork: String?
+        public let notes: String?
 
         public init(
-            id: Int64, subName: String, companyName: String,
-            jobName: String, scheduleDate: String, status: String
+            id: Int64,
+            subName: String,
+            companyName: String,
+            jobName: String,
+            scheduleDate: String,
+            status: String,
+            arrivalTime: String? = nil,
+            departureTime: String? = nil,
+            scopeOfWork: String? = nil,
+            notes: String? = nil
         ) {
             self.id = id
             self.subName = subName
@@ -191,6 +203,10 @@ public final class SchedulingService: Sendable {
             self.jobName = jobName
             self.scheduleDate = scheduleDate
             self.status = status
+            self.arrivalTime = arrivalTime
+            self.departureTime = departureTime
+            self.scopeOfWork = scopeOfWork
+            self.notes = notes
         }
     }
 
@@ -666,7 +682,11 @@ public final class SchedulingService: Sendable {
                            COALESCE(gc.company_name, '') AS company_name,
                            COALESCE(j.job_name, 'Unknown Job') AS job_name,
                            ss.scheduled_date AS schedule_date,
-                           COALESCE(ss.status, 'scheduled') AS status
+                           COALESCE(ss.status, 'scheduled') AS status,
+                           ss.arrival_time,
+                           ss.departure_time,
+                           ss.scope_of_work,
+                           ss.notes
                     FROM subcontractor_schedules ss
                     LEFT JOIN general_contractors gc ON gc.id = ss.gc_id AND gc.deleted_at IS NULL
                     LEFT JOIN jobs j ON j.id = ss.job_id AND j.deleted_at IS NULL
@@ -682,7 +702,11 @@ public final class SchedulingService: Sendable {
                         companyName: row["company_name"] ?? "",
                         jobName: row["job_name"] ?? "Unknown Job",
                         scheduleDate: row["schedule_date"] ?? normalizedDate,
-                        status: row["status"] ?? "scheduled"
+                        status: row["status"] ?? "scheduled",
+                        arrivalTime: row["arrival_time"],
+                        departureTime: row["departure_time"],
+                        scopeOfWork: row["scope_of_work"],
+                        notes: row["notes"]
                     )
                 }
             }
@@ -707,6 +731,11 @@ public final class SchedulingService: Sendable {
     ) throws -> Int64 {
         let normalizedDate = try Self.normalizeScheduleDateOnly(scheduledDate)
         let normalizedStatus = try Self.normalizeSubcontractorScheduleStatus(status)
+        let normalizedArrivalTime = Self.normalizeOptionalSubcontractorScheduleText(arrivalTime)
+        let normalizedDepartureTime = Self.normalizeOptionalSubcontractorScheduleText(departureTime)
+        try Self.validateSubcontractorScheduleTimeRange(arrivalTime: normalizedArrivalTime, departureTime: normalizedDepartureTime)
+        let normalizedScopeOfWork = Self.normalizeOptionalSubcontractorScheduleText(scopeOfWork)
+        let normalizedNotes = Self.normalizeOptionalSubcontractorScheduleText(notes)
 
         return try db.writer.write { dbConn in
             try validateSubcontractorScheduleParents(dbConn, jobId: jobId, gcId: gcId)
@@ -718,13 +747,79 @@ public final class SchedulingService: Sendable {
                     (job_id, gc_id, scheduled_date, arrival_time, departure_time, scope_of_work, status, notes, created_by, created_at, updated_at)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
                     """,
-                arguments: [jobId, gcId, normalizedDate, arrivalTime, departureTime, scopeOfWork, normalizedStatus, notes, createdBy]
+                arguments: [jobId, gcId, normalizedDate, normalizedArrivalTime, normalizedDepartureTime, normalizedScopeOfWork, normalizedStatus, normalizedNotes, createdBy]
             )
             return dbConn.lastInsertedRowID
         }
     }
 
-    /// Correct the scheduled date for a non-deleted subcontractor schedule.
+    /// Update all editable subcontractor schedule fields used by the add/edit flow.
+    public func updateSubcontractorSchedule(
+        id: Int64,
+        jobId: Int64,
+        gcId: Int64,
+        scheduledDate: String,
+        arrivalTime: String? = nil,
+        departureTime: String? = nil,
+        scopeOfWork: String? = nil,
+        status: String = "scheduled",
+        notes: String? = nil
+    ) throws {
+        let normalizedDate = try Self.normalizeScheduleDateOnly(scheduledDate)
+        let normalizedStatus = try Self.normalizeSubcontractorScheduleStatus(status)
+        let normalizedArrivalTime = Self.normalizeOptionalSubcontractorScheduleText(arrivalTime)
+        let normalizedDepartureTime = Self.normalizeOptionalSubcontractorScheduleText(departureTime)
+        try Self.validateSubcontractorScheduleTimeRange(arrivalTime: normalizedArrivalTime, departureTime: normalizedDepartureTime)
+        let normalizedScopeOfWork = Self.normalizeOptionalSubcontractorScheduleText(scopeOfWork)
+        let normalizedNotes = Self.normalizeOptionalSubcontractorScheduleText(notes)
+
+        try db.writer.write { dbConn in
+            let scheduleExists = (try Int.fetchOne(
+                dbConn,
+                sql: "SELECT COUNT(*) FROM subcontractor_schedules WHERE id = ? AND deleted_at IS NULL",
+                arguments: [id]
+            ) ?? 0) > 0
+            guard scheduleExists else { throw SchedulingError.subcontractorScheduleNotFound(id) }
+
+            try validateSubcontractorScheduleParents(dbConn, jobId: jobId, gcId: gcId)
+
+            let conflictCount = try Int.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT COUNT(*)
+                    FROM subcontractor_schedules
+                    WHERE job_id = ?
+                      AND gc_id = ?
+                      AND scheduled_date = ?
+                      AND deleted_at IS NULL
+                      AND id <> ?
+                    """,
+                arguments: [jobId, gcId, normalizedDate, id]
+            ) ?? 0
+            if conflictCount > 0 {
+                throw SchedulingError.subcontractorScheduleConflict(jobId: jobId, gcId: gcId, date: normalizedDate)
+            }
+
+            try dbConn.execute(
+                sql: """
+                    UPDATE subcontractor_schedules
+                    SET job_id = ?,
+                        gc_id = ?,
+                        scheduled_date = ?,
+                        arrival_time = ?,
+                        departure_time = ?,
+                        scope_of_work = ?,
+                        status = ?,
+                        notes = ?,
+                        updated_at = datetime('now')
+                    WHERE id = ? AND deleted_at IS NULL
+                    """,
+                arguments: [jobId, gcId, normalizedDate, normalizedArrivalTime, normalizedDepartureTime, normalizedScopeOfWork, normalizedStatus, normalizedNotes, id]
+            )
+        }
+    }
+
+    /// Backwards-compatible date-only correction helper for existing callers.
     public func updateSubcontractorScheduleDate(id: Int64, scheduledDate: String) throws {
         let normalizedDate = try Self.normalizeScheduleDateOnly(scheduledDate)
 
@@ -2376,6 +2471,41 @@ public final class SchedulingService: Sendable {
         }
 
         return value
+    }
+
+    private static func normalizeOptionalSubcontractorScheduleText(_ rawValue: String?) -> String? {
+        guard let rawValue else { return nil }
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    private static func validateSubcontractorScheduleTimeRange(arrivalTime: String?, departureTime: String?) throws {
+        guard let arrivalTime, let departureTime else { return }
+        let arrivalComparable = minutesSinceMidnight(arrivalTime) ?? -1
+        let departureComparable = minutesSinceMidnight(departureTime) ?? -1
+        let isOrdered: Bool
+        if arrivalComparable >= 0 && departureComparable >= 0 {
+            isOrdered = departureComparable > arrivalComparable
+        } else {
+            // Preserve compatibility for legacy/custom time labels while still enforcing
+            // the edit-flow rule when both values are comparable strings.
+            isOrdered = departureTime > arrivalTime
+        }
+        guard isOrdered else {
+            throw SchedulingError.invalidDateRange(start: arrivalTime, end: departureTime)
+        }
+    }
+
+    private static func minutesSinceMidnight(_ time: String) -> Int? {
+        let parts = time.split(separator: ":", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              let hour = Int(parts[0]),
+              let minute = Int(parts[1]),
+              (0...23).contains(hour),
+              (0...59).contains(minute) else {
+            return nil
+        }
+        return hour * 60 + minute
     }
 
     private static func normalizeSubcontractorScheduleStatus(_ rawStatus: String) throws -> String {

--- a/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
@@ -1246,6 +1246,205 @@ struct SchedulingServiceTests {
         #expect(subs.isEmpty)
     }
 
+    @Test("createSubcontractorSchedule stores an exact trimmed date-only value")
+    func testCreateSubcontractorScheduleDateOnlyRoundTrip() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let gcId = try seedSchedulingContractor(env, contactName: "Trimmed Sub", companyName: "Trim Co")
+
+        let scheduleId = try env.scheduling.createSubcontractorSchedule(
+            jobId: jobId,
+            gcId: gcId,
+            scheduledDate: " 2026-09-15 ",
+            arrivalTime: "08:00",
+            departureTime: "12:00",
+            scopeOfWork: "Rough-in",
+            status: "scheduled",
+            notes: "Use side gate",
+            createdBy: env.adminUserId
+        )
+
+        #expect(scheduleId > 0)
+        let subs = try env.scheduling.getSubSchedule(date: "2026-09-15")
+        #expect(subs.count == 1)
+        #expect(subs[0].scheduleDate == "2026-09-15")
+        #expect(subs[0].subName == "Trimmed Sub")
+    }
+
+    @Test("subcontractor schedule date validation rejects timestamps instead of shifting days")
+    func testSubcontractorScheduleRejectsNonDateOnlyInput() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let gcId = try seedSchedulingContractor(env, contactName: "Timestamp Sub", companyName: "Time Co")
+
+        #expect(throws: SchedulingService.SchedulingError.invalidDate("2026-09-15T00:30:00Z")) {
+            _ = try env.scheduling.createSubcontractorSchedule(
+                jobId: jobId,
+                gcId: gcId,
+                scheduledDate: "2026-09-15T00:30:00Z",
+                arrivalTime: nil,
+                departureTime: nil,
+                scopeOfWork: nil,
+                status: "scheduled",
+                notes: nil,
+                createdBy: nil
+            )
+        }
+    }
+
+    @Test("getSubSchedule excludes soft-deleted subcontractor schedules")
+    func testGetSubScheduleExcludesDeletedRows() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let gcId = try seedSchedulingContractor(env, contactName: "Deleted Sub", companyName: "Gone Co")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO subcontractor_schedules (job_id, gc_id, scheduled_date, status, deleted_at, created_at)
+                VALUES (?, ?, '2026-09-15', 'scheduled', datetime('now'), datetime('now'))
+                """, arguments: [jobId, gcId])
+        }
+
+        let subs = try env.scheduling.getSubSchedule(date: "2026-09-15")
+        #expect(subs.isEmpty)
+    }
+
+    @Test("createSubcontractorSchedule guards deleted jobs and contractors")
+    func testCreateSubcontractorScheduleGuardsDeletedJobAndContractor() throws {
+        let env = try E2ETestHelpers.setUp()
+        let liveJobId = try E2ETestHelpers.seedJob(env)
+        let deletedJobId = try E2ETestHelpers.seedJob(env, jobNumber: "DEL-1", name: "Deleted Job")
+        let liveGcId = try seedSchedulingContractor(env, contactName: "Live Sub", companyName: "Live Co")
+        let deletedGcId = try seedSchedulingContractor(env, contactName: "Deleted Sub", companyName: "Deleted Co")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE jobs SET deleted_at = datetime('now') WHERE id = ?", arguments: [deletedJobId])
+            try db.execute(sql: "UPDATE general_contractors SET deleted_at = datetime('now') WHERE id = ?", arguments: [deletedGcId])
+        }
+
+        #expect(throws: SchedulingService.SchedulingError.jobNotFound(deletedJobId)) {
+            _ = try env.scheduling.createSubcontractorSchedule(
+                jobId: deletedJobId,
+                gcId: liveGcId,
+                scheduledDate: "2026-09-15",
+                arrivalTime: nil,
+                departureTime: nil,
+                scopeOfWork: nil,
+                status: "scheduled",
+                notes: nil,
+                createdBy: nil
+            )
+        }
+
+        #expect(throws: SchedulingService.SchedulingError.contractorNotFound(deletedGcId)) {
+            _ = try env.scheduling.createSubcontractorSchedule(
+                jobId: liveJobId,
+                gcId: deletedGcId,
+                scheduledDate: "2026-09-15",
+                arrivalTime: nil,
+                departureTime: nil,
+                scopeOfWork: nil,
+                status: "scheduled",
+                notes: nil,
+                createdBy: nil
+            )
+        }
+    }
+
+    @Test("createSubcontractorSchedule surfaces duplicate active date conflicts")
+    func testCreateSubcontractorScheduleDuplicateConflict() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let gcId = try seedSchedulingContractor(env, contactName: "Duplicate Sub", companyName: "Dup Co")
+
+        _ = try env.scheduling.createSubcontractorSchedule(
+            jobId: jobId,
+            gcId: gcId,
+            scheduledDate: "2026-09-15",
+            arrivalTime: nil,
+            departureTime: nil,
+            scopeOfWork: nil,
+            status: "scheduled",
+            notes: nil,
+            createdBy: nil
+        )
+
+        #expect(throws: SchedulingService.SchedulingError.subcontractorScheduleConflict(jobId: jobId, gcId: gcId, date: "2026-09-15")) {
+            _ = try env.scheduling.createSubcontractorSchedule(
+                jobId: jobId,
+                gcId: gcId,
+                scheduledDate: "2026-09-15",
+                arrivalTime: nil,
+                departureTime: nil,
+                scopeOfWork: nil,
+                status: "scheduled",
+                notes: nil,
+                createdBy: nil
+            )
+        }
+    }
+
+    @Test("updateSubcontractorScheduleDate reschedules without UTC date shifts")
+    func testUpdateSubcontractorScheduleDateCorrection() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let gcId = try seedSchedulingContractor(env, contactName: "Reschedule Sub", companyName: "Move Co")
+        let scheduleId = try env.scheduling.createSubcontractorSchedule(
+            jobId: jobId,
+            gcId: gcId,
+            scheduledDate: "2026-09-15",
+            arrivalTime: nil,
+            departureTime: nil,
+            scopeOfWork: nil,
+            status: "scheduled",
+            notes: nil,
+            createdBy: nil
+        )
+
+        try env.scheduling.updateSubcontractorScheduleDate(id: scheduleId, scheduledDate: " 2026-09-16 ")
+
+        #expect(try env.scheduling.getSubSchedule(date: "2026-09-15").isEmpty)
+        let moved = try env.scheduling.getSubSchedule(date: "2026-09-16")
+        #expect(moved.count == 1)
+        #expect(moved[0].scheduleDate == "2026-09-16")
+    }
+
+    @Test("cancelSubcontractorSchedule soft-deletes the row")
+    func testCancelSubcontractorScheduleSoftDeletesRow() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let gcId = try seedSchedulingContractor(env, contactName: "Cancel Sub", companyName: "Cancel Co")
+        let scheduleId = try env.scheduling.createSubcontractorSchedule(
+            jobId: jobId,
+            gcId: gcId,
+            scheduledDate: "2026-09-15",
+            arrivalTime: nil,
+            departureTime: nil,
+            scopeOfWork: nil,
+            status: "scheduled",
+            notes: nil,
+            createdBy: nil
+        )
+
+        try env.scheduling.cancelSubcontractorSchedule(id: scheduleId)
+
+        #expect(try env.scheduling.getSubSchedule(date: "2026-09-15").isEmpty)
+        let deletedAt: String? = try env.db.writer.read { db in
+            try String.fetchOne(db, sql: "SELECT deleted_at FROM subcontractor_schedules WHERE id = ?", arguments: [scheduleId])
+        }
+        #expect(deletedAt != nil)
+    }
+
+    private func seedSchedulingContractor(_ env: E2ETestHelpers.TestEnvironment, contactName: String, companyName: String) throws -> Int64 {
+        try env.db.writer.write { db -> Int64 in
+            try db.execute(sql: """
+                INSERT INTO general_contractors (contact_name, company_name, created_at)
+                VALUES (?, ?, datetime('now'))
+                """, arguments: [contactName, companyName])
+            return db.lastInsertedRowID
+        }
+    }
+
     // MARK: - Pipeline Category Logic
 
     @Test("getShortTermPipeline categorizes small jobs (<=2 est days)")

--- a/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
@@ -1268,6 +1268,8 @@ struct SchedulingServiceTests {
         let subs = try env.scheduling.getSubSchedule(date: "2026-09-15")
         #expect(subs.count == 1)
         #expect(subs[0].scheduleDate == "2026-09-15")
+        #expect(subs[0].jobId == jobId)
+        #expect(subs[0].gcId == gcId)
         #expect(subs[0].subName == "Trimmed Sub")
         #expect(subs[0].arrivalTime == "08:00")
         #expect(subs[0].departureTime == "12:00")

--- a/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
@@ -1269,6 +1269,72 @@ struct SchedulingServiceTests {
         #expect(subs.count == 1)
         #expect(subs[0].scheduleDate == "2026-09-15")
         #expect(subs[0].subName == "Trimmed Sub")
+        #expect(subs[0].arrivalTime == "08:00")
+        #expect(subs[0].departureTime == "12:00")
+        #expect(subs[0].scopeOfWork == "Rough-in")
+        #expect(subs[0].notes == "Use side gate")
+    }
+
+    @Test("updateSubcontractorSchedule edits the date, timing, status, scope, and notes")
+    func testUpdateSubcontractorScheduleEditsAllFormFields() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let gcId = try seedSchedulingContractor(env, contactName: "Edit Sub", companyName: "Edit Co")
+        let scheduleId = try env.scheduling.createSubcontractorSchedule(
+            jobId: jobId,
+            gcId: gcId,
+            scheduledDate: "2026-09-15",
+            arrivalTime: "08:00",
+            departureTime: "12:00",
+            scopeOfWork: "Old scope",
+            status: "scheduled",
+            notes: "Old notes",
+            createdBy: env.adminUserId
+        )
+
+        try env.scheduling.updateSubcontractorSchedule(
+            id: scheduleId,
+            jobId: jobId,
+            gcId: gcId,
+            scheduledDate: " 2026-09-16 ",
+            arrivalTime: "09:15",
+            departureTime: "14:45",
+            scopeOfWork: "Install trim",
+            status: "confirmed",
+            notes: "Bring ladder"
+        )
+
+        #expect(try env.scheduling.getSubSchedule(date: "2026-09-15").isEmpty)
+        let edited = try env.scheduling.getSubSchedule(date: "2026-09-16")
+        #expect(edited.count == 1)
+        #expect(edited[0].id == scheduleId)
+        #expect(edited[0].scheduleDate == "2026-09-16")
+        #expect(edited[0].arrivalTime == "09:15")
+        #expect(edited[0].departureTime == "14:45")
+        #expect(edited[0].scopeOfWork == "Install trim")
+        #expect(edited[0].status == "confirmed")
+        #expect(edited[0].notes == "Bring ladder")
+    }
+
+    @Test("subcontractor schedule rejects departure before arrival")
+    func testSubcontractorScheduleRejectsDepartureBeforeArrival() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let gcId = try seedSchedulingContractor(env, contactName: "Bad Time Sub", companyName: "Bad Time Co")
+
+        #expect(throws: SchedulingService.SchedulingError.invalidDateRange(start: "17:00", end: "08:00")) {
+            _ = try env.scheduling.createSubcontractorSchedule(
+                jobId: jobId,
+                gcId: gcId,
+                scheduledDate: "2026-09-15",
+                arrivalTime: "17:00",
+                departureTime: "08:00",
+                scopeOfWork: nil,
+                status: "scheduled",
+                notes: nil,
+                createdBy: nil
+            )
+        }
     }
 
     @Test("subcontractor schedule date validation rejects timestamps instead of shifting days")

--- a/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
@@ -3646,7 +3646,8 @@ struct SchedulingServiceTests {
         )
         try env.scheduling.updateTimeOffStatus(
             id: requestId,
-            status: "denied"
+            status: "denied",
+            approvedBy: env.adminUserId
         )
 
         let dispatchId = try env.scheduling.createDispatch(


### PR DESCRIPTION
## Summary
- add strict yyyy-MM-dd normalization for subcontractor schedule date inputs without timezone conversion
- add create, reschedule, and cancellation service helpers with non-deleted job/contractor guards
- filter soft-deleted subcontractor schedule rows from getSubSchedule and add duplicate conflict errors

## Test Plan
- swift test --filter SchedulingServiceTests