### PR TITLE
fix(scheduling): preselect pipeline job in schedule sheet

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateScheduleEntrySheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateScheduleEntrySheet.swift
@@ -7,6 +7,8 @@ struct CreateScheduleEntrySheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let date: String
+    var initialJobId: Int64? = nil
+    var initialJobName: String? = nil
     var onSave: () -> Void
 
     @State private var jobs: [JobsService.JobListItem] = []
@@ -23,7 +25,23 @@ struct CreateScheduleEntrySheet: View {
         NavigationStack {
             Form {
                 Section("Job") {
-                    if jobs.isEmpty {
+                    if let initialJobId {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(initialJobName ?? selectedJobName(for: initialJobId))
+                                    .foregroundStyle(.primary)
+                                Text("Opened from this job's calendar")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                                .accessibilityHidden(true)
+                        }
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("Selected job, \(initialJobName ?? selectedJobName(for: initialJobId))")
+                    } else if jobs.isEmpty {
                         Text("No active jobs")
                             .foregroundStyle(.secondary)
                     } else {
@@ -88,7 +106,12 @@ struct CreateScheduleEntrySheet: View {
             }
             .interactiveDismissDisabled(isSaving)
             .task { loadJobs() }
+            .onAppear { selectedJobId = initialJobId }
         }
+    }
+
+    private func selectedJobName(for jobId: Int64) -> String {
+        jobs.first(where: { $0.id == jobId })?.jobName ?? "Selected Job"
     }
 
     private func loadJobs() {
@@ -97,6 +120,9 @@ struct CreateScheduleEntrySheet: View {
             return
         }
         jobs = (try? service.listJobs(status: "active", limit: 200)) ?? []
+        if let initialJobId {
+            selectedJobId = initialJobId
+        }
     }
 
     private func saveEntry() {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSShortTermPipelinePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSShortTermPipelinePage.swift
@@ -112,9 +112,11 @@ struct IOSShortTermPipelinePage: View {
                     })
                 }
             case .schedule:
-                if selectedItem != nil {
+                if let item = selectedItem {
                     CreateScheduleEntrySheet(
                         date: todayString,
+                        initialJobId: item.jobId,
+                        initialJobName: item.jobName,
                         onSave: { loadData() }
                     )
                     .environmentObject(appCore)
@@ -122,7 +124,7 @@ struct IOSShortTermPipelinePage: View {
             case .help:
                 PageHelpSheet(title: "Short-Term Pipeline Help", sections: [
                     ("What This Page Does", "The Short-Term Pipeline shows jobs that are ready or nearly ready to be scheduled. Jobs are grouped into categories: Start Anytime, Schedule Needed, Favorite GC, and Small Jobs. Each category has a target count to keep your pipeline healthy."),
-                    ("How to Use It", "Review the target cards at the top to see if your pipeline is balanced. Green checkmarks mean you are at or above target; red means you need more jobs in that category. Tap the calendar icon on any job to schedule it. Tap the phone icon on callbacks to handle them."),
+                    ("How to Use It", "Review the target cards at the top to see if your pipeline is balanced. Green checkmarks mean you are at or above target; red means you need more jobs in that category. Tap the calendar icon on any job to open a scheduling sheet already tied to that job. Tap the phone icon on callbacks to handle them."),
                     ("Callbacks", "When a callback is due, it appears in the Callbacks Due section. You can mark it complete with notes, or snooze it for 1 day, 3 days, or 1 week."),
                     ("Tips", "Keep each category at or above its target number for a healthy pipeline. 'Start Anytime' jobs are your safety net for crew that finishes early. Small Jobs are great gap fillers between bigger projects.")
                 ])


### PR DESCRIPTION
## Summary
- Preselects the tapped Short-Term Pipeline job when opening the calendar/schedule sheet
- Shows a read-only selected-job summary so the user can confirm they are scheduling the intended job
- Updates the Short-Term Pipeline help copy to document the job-tied scheduling flow

## Verification
- xcrun swiftc -parse CreateScheduleEntrySheet.swift IOSShortTermPipelinePage.swift
- git diff --check
- swift test --filter SchedulingServiceTests (170 tests passed)

Paperclip: WEI-2022 / GH #616 partial acceptance for the pipeline calendar icon opening a real schedule sheet tied to the selected job.