### PR TITLE
feat(scheduling): show day assignment detail in schedule sheet

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateScheduleEntrySheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateScheduleEntrySheet.swift
@@ -18,6 +18,8 @@ struct CreateScheduleEntrySheet: View {
     @State private var startTime = ""
     @State private var endTime = ""
     @State private var notes = ""
+    @State private var assignmentDetail: SchedulingService.JobDayAssignmentDetail?
+    @State private var isLoadingAssignmentDetail = false
     @State private var isSaving = false
     @State private var saveError: String?
 
@@ -56,6 +58,10 @@ struct CreateScheduleEntrySheet: View {
 
                 Section("Date") {
                     DatePicker("Date", selection: $entryDate, displayedComponents: .date)
+                }
+
+                if initialJobId != nil || selectedJobId != nil {
+                    dayAssignmentsSection
                 }
 
                 Section("Time Slot") {
@@ -106,8 +112,109 @@ struct CreateScheduleEntrySheet: View {
             }
             .interactiveDismissDisabled(isSaving)
             .task { loadJobs() }
-            .onAppear { selectedJobId = initialJobId }
+            .onAppear {
+                selectedJobId = initialJobId
+                loadAssignmentDetail()
+            }
+            .onChange(of: entryDate) { _ in loadAssignmentDetail() }
+            .onChange(of: selectedJobId) { _ in loadAssignmentDetail() }
         }
+    }
+
+    @ViewBuilder
+    private var dayAssignmentsSection: some View {
+        Section("Day Assignments") {
+            if isLoadingAssignmentDetail {
+                ProgressView("Checking crew availability...")
+            } else if let detail = assignmentDetail {
+                if detail.assignedToJob.isEmpty,
+                   detail.assignedToOtherJobs.isEmpty,
+                   detail.timeOffWorkers.isEmpty {
+                    Text("No crew assignments or approved time off found for this date.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    if !detail.assignedToJob.isEmpty {
+                        assignmentGroup(
+                            title: "Assigned to this job",
+                            rows: detail.assignedToJob,
+                            color: .green,
+                            systemImage: "checkmark.circle.fill"
+                        )
+                    }
+                    if !detail.assignedToOtherJobs.isEmpty {
+                        assignmentGroup(
+                            title: "Assigned to other jobs",
+                            rows: detail.assignedToOtherJobs,
+                            color: .orange,
+                            systemImage: "exclamationmark.triangle.fill"
+                        )
+                    }
+                    if !detail.timeOffWorkers.isEmpty {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Label("Approved time off", systemImage: "person.crop.circle.badge.xmark")
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                                .foregroundStyle(.red)
+                            ForEach(detail.timeOffWorkers) { row in
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(row.userName)
+                                        .font(.caption)
+                                    if let reason = row.reason, !reason.isEmpty {
+                                        Text(reason)
+                                            .font(.caption2)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                Text("Pick a job to see who is assigned, busy elsewhere, or off on this date.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func assignmentGroup(
+        title: String,
+        rows: [SchedulingService.JobDayAssignmentRow],
+        color: Color,
+        systemImage: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(title, systemImage: systemImage)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(color)
+            ForEach(rows) { row in
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack {
+                        Text(row.userName)
+                            .font(.caption)
+                            .fontWeight(.medium)
+                        Spacer()
+                        Text(row.timeSlot.uppercased())
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(row.jobName)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    if let notes = row.notes, !notes.isEmpty {
+                        Text(notes)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            }
+        }
+    }
+
+    private var selectedDateString: String {
+        Formatters.localDateFormatter.string(from: entryDate)
     }
 
     private func selectedJobName(for jobId: Int64) -> String {
@@ -123,6 +230,27 @@ struct CreateScheduleEntrySheet: View {
         if let initialJobId {
             selectedJobId = initialJobId
         }
+        loadAssignmentDetail()
+    }
+
+    private func loadAssignmentDetail() {
+        guard let service = appCore.schedulingService,
+              let jobId = selectedJobId else {
+            assignmentDetail = nil
+            return
+        }
+
+        isLoadingAssignmentDetail = true
+        do {
+            assignmentDetail = try service.getJobDayAssignmentDetail(
+                jobId: jobId,
+                date: selectedDateString
+            )
+        } catch {
+            assignmentDetail = nil
+            saveError = userFriendlyError(error, context: "load day assignments")
+        }
+        isLoadingAssignmentDetail = false
     }
 
     private func saveEntry() {

--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -100,6 +100,74 @@ public final class SchedulingService: Sendable {
         }
     }
 
+    /// One worker's scheduling state for a specific job/date detail view.
+    public struct JobDayAssignmentRow: Sendable, Identifiable {
+        public let id: Int64
+        public let userName: String
+        public let jobName: String
+        public let timeSlot: String
+        public let startTime: String?
+        public let endTime: String?
+        public let status: String
+        public let notes: String?
+
+        public init(
+            id: Int64,
+            userName: String,
+            jobName: String,
+            timeSlot: String,
+            startTime: String?,
+            endTime: String?,
+            status: String,
+            notes: String?
+        ) {
+            self.id = id
+            self.userName = userName
+            self.jobName = jobName
+            self.timeSlot = timeSlot
+            self.startTime = startTime
+            self.endTime = endTime
+            self.status = status
+            self.notes = notes
+        }
+    }
+
+    /// Approved time-off row included in a job/date detail view.
+    public struct JobDayTimeOffRow: Sendable, Identifiable {
+        public let id: Int64
+        public let userName: String
+        public let reason: String?
+
+        public init(id: Int64, userName: String, reason: String?) {
+            self.id = id
+            self.userName = userName
+            self.reason = reason
+        }
+    }
+
+    /// Day-by-day scheduling context for a selected job.
+    public struct JobDayAssignmentDetail: Sendable {
+        public let jobId: Int64
+        public let date: String
+        public let assignedToJob: [JobDayAssignmentRow]
+        public let assignedToOtherJobs: [JobDayAssignmentRow]
+        public let timeOffWorkers: [JobDayTimeOffRow]
+
+        public init(
+            jobId: Int64,
+            date: String,
+            assignedToJob: [JobDayAssignmentRow],
+            assignedToOtherJobs: [JobDayAssignmentRow],
+            timeOffWorkers: [JobDayTimeOffRow]
+        ) {
+            self.jobId = jobId
+            self.date = date
+            self.assignedToJob = assignedToJob
+            self.assignedToOtherJobs = assignedToOtherJobs
+            self.timeOffWorkers = timeOffWorkers
+        }
+    }
+
     /// A flex-pool dispatch assignment waiting on manager approval.
     public struct ScheduleChangeApproval: Sendable, Identifiable {
         public let id: Int64
@@ -363,6 +431,101 @@ public final class SchedulingService: Sendable {
             if isTableNotFoundError(error) { return [] }
             throw error
         }
+    }
+
+    /// Get day-by-day crew context for one job/date.
+    ///
+    /// Used by scheduling UI opened from a pipeline job's calendar action so the
+    /// dispatcher can see who is already assigned to this job, who is already
+    /// committed to another job, and who has approved time off for that day.
+    public func getJobDayAssignmentDetail(jobId: Int64, date: String) throws -> JobDayAssignmentDetail {
+        do {
+            return try db.writer.read { dbConn -> JobDayAssignmentDetail in
+                let dispatchSQL = """
+                    SELECT jd.id, jd.shift_start AS start_time, jd.shift_end AS end_time,
+                           jd.status, jd.notes, COALESCE(jd.time_slot, 'full') AS time_slot,
+                           COALESCE(u.display_name, u.email, 'Unknown') AS user_name,
+                           COALESCE(j.job_name, 'Unassigned') AS job_name
+                    FROM job_dispatch jd
+                    LEFT JOIN users u ON u.id = jd.user_id AND u.deleted_at IS NULL
+                    LEFT JOIN jobs j ON j.id = jd.job_id AND j.deleted_at IS NULL
+                    WHERE jd.dispatch_date = ?
+                      AND jd.job_id = ?
+                      AND jd.deleted_at IS NULL
+                    ORDER BY u.display_name ASC, jd.shift_start ASC
+                    """
+                let assignedToJob = try Row.fetchAll(dbConn, sql: dispatchSQL, arguments: [date, jobId])
+                    .map(Self.makeJobDayAssignmentRow)
+
+                let otherDispatchSQL = """
+                    SELECT jd.id, jd.shift_start AS start_time, jd.shift_end AS end_time,
+                           jd.status, jd.notes, COALESCE(jd.time_slot, 'full') AS time_slot,
+                           COALESCE(u.display_name, u.email, 'Unknown') AS user_name,
+                           COALESCE(j.job_name, 'Unassigned') AS job_name
+                    FROM job_dispatch jd
+                    LEFT JOIN users u ON u.id = jd.user_id AND u.deleted_at IS NULL
+                    LEFT JOIN jobs j ON j.id = jd.job_id AND j.deleted_at IS NULL
+                    WHERE jd.dispatch_date = ?
+                      AND jd.job_id != ?
+                      AND jd.deleted_at IS NULL
+                    ORDER BY u.display_name ASC, jd.shift_start ASC
+                    """
+                let assignedToOtherJobs = try Row.fetchAll(dbConn, sql: otherDispatchSQL, arguments: [date, jobId])
+                    .map(Self.makeJobDayAssignmentRow)
+
+                let timeOffSQL = """
+                    SELECT se.id, se.reason,
+                           COALESCE(u.display_name, u.email, 'Unknown') AS user_name
+                    FROM schedule_exceptions se
+                    LEFT JOIN users u ON u.id = se.user_id AND u.deleted_at IS NULL
+                    WHERE se.exception_type = 'time_off'
+                      AND se.exception_date = ?
+                      AND se.is_approved = 1
+                      AND se.deleted_at IS NULL
+                    ORDER BY user_name ASC
+                    """
+                let timeOffWorkers = try Row.fetchAll(dbConn, sql: timeOffSQL, arguments: [date])
+                    .map { row in
+                        JobDayTimeOffRow(
+                            id: row["id"] ?? 0,
+                            userName: row["user_name"] ?? "Unknown",
+                            reason: row["reason"] as String?
+                        )
+                    }
+
+                return JobDayAssignmentDetail(
+                    jobId: jobId,
+                    date: date,
+                    assignedToJob: assignedToJob,
+                    assignedToOtherJobs: assignedToOtherJobs,
+                    timeOffWorkers: timeOffWorkers
+                )
+            }
+        } catch {
+            if isTableNotFoundError(error) {
+                return JobDayAssignmentDetail(
+                    jobId: jobId,
+                    date: date,
+                    assignedToJob: [],
+                    assignedToOtherJobs: [],
+                    timeOffWorkers: []
+                )
+            }
+            throw error
+        }
+    }
+
+    private static func makeJobDayAssignmentRow(_ row: Row) -> JobDayAssignmentRow {
+        JobDayAssignmentRow(
+            id: row["id"] ?? 0,
+            userName: row["user_name"] ?? "Unknown",
+            jobName: row["job_name"] ?? "Unassigned",
+            timeSlot: row["time_slot"] ?? "full",
+            startTime: row["start_time"] as String?,
+            endTime: row["end_time"] as String?,
+            status: row["status"] ?? "scheduled",
+            notes: row["notes"] as String?
+        )
     }
 
     // =========================================================================

--- a/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
@@ -52,6 +52,55 @@ struct SchedulingServiceTests {
         #expect(schedule[0].userName == "TestAdmin")
     }
 
+    @Test("getJobDayAssignmentDetail separates selected-job crew, other-job crew, and time-off workers")
+    func testGetJobDayAssignmentDetail() throws {
+        let env = try E2ETestHelpers.setUp()
+        let targetJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-DETAIL-01", name: "Target Detail Job")
+        let otherJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-DETAIL-02", name: "Other Detail Job")
+        let otherUserId = try env.auth.createUser(displayName: "OtherWorker", pin: "1234")
+        let timeOffUserId = try env.auth.createUser(displayName: "TimeOffWorker", pin: "1234")
+
+        _ = try env.scheduling.createScheduleEntry(
+            userId: env.adminUserId,
+            jobId: targetJobId,
+            date: "2026-06-15",
+            startTime: "08:00",
+            endTime: "17:00",
+            notes: "target crew",
+            timeSlot: "full"
+        )
+        _ = try env.scheduling.createScheduleEntry(
+            userId: otherUserId,
+            jobId: otherJobId,
+            date: "2026-06-15",
+            startTime: "08:00",
+            endTime: "12:00",
+            notes: "already booked elsewhere",
+            timeSlot: "am"
+        )
+        let requestId = try env.scheduling.createTimeOffRequest(
+            userId: timeOffUserId,
+            startDate: "2026-06-15",
+            endDate: "2026-06-15",
+            reason: "Vacation"
+        )
+        try env.scheduling.updateTimeOffStatus(
+            id: requestId,
+            status: "approved",
+            approvedBy: env.adminUserId
+        )
+
+        let detail = try env.scheduling.getJobDayAssignmentDetail(jobId: targetJobId, date: "2026-06-15")
+
+        #expect(detail.date == "2026-06-15")
+        #expect(detail.jobId == targetJobId)
+        #expect(detail.assignedToJob.map(\.userName) == ["TestAdmin"])
+        #expect(detail.assignedToOtherJobs.map(\.userName) == ["OtherWorker"])
+        #expect(detail.assignedToOtherJobs.first?.jobName == "Other Detail Job")
+        #expect(detail.timeOffWorkers.map(\.userName) == ["TimeOffWorker"])
+        #expect(detail.timeOffWorkers.first?.reason == "Vacation")
+    }
+
     // MARK: - 2. Submit Time-Off Request
 
     @Test("createTimeOffRequest inserts a pending time-off entry")


### PR DESCRIPTION
## Summary
- Adds SchedulingService day-assignment detail for a selected job/date
- Shows selected-job crew, workers already assigned to other jobs, and approved time-off workers in CreateScheduleEntrySheet
- Covers the GH #616 day-by-day assignment detail gap from WEI-2022

## Test Plan
- xcrun swiftc -parse "Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateScheduleEntrySheet.swift" "Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSShortTermPipelinePage.swift"
- git diff --check
- cd core && swift test --filter SchedulingServiceTests

Refs #616