### PR TITLE
feat(scheduling): enable pipeline drag and drop

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSShortTermPipelinePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSShortTermPipelinePage.swift
@@ -26,6 +26,7 @@ struct IOSShortTermPipelinePage: View {
     }
     @State private var activeSheet: ActiveSheet?
     @State private var selectedItem: SchedulingService.PipelineItem?
+    @State private var targetedDropCategory: String?
 
     // AI Dispatch
     @State private var aiSuggestions: [AIDispatchService.DispatchSuggestion] = []
@@ -167,25 +168,29 @@ struct IOSShortTermPipelinePage: View {
             // Start Anytime
             pipelineSection(
                 title: "Start Anytime", target: 3,
-                items: startAnytimeItems, icon: "bolt.fill", color: .green
+                category: "start_anytime", items: startAnytimeItems,
+                icon: "bolt.fill", color: .green
             )
 
             // Schedule Needed
             pipelineSection(
                 title: "Schedule Needed", target: 2,
-                items: scheduleNeededItems, icon: "calendar.badge.exclamationmark", color: .blue
+                category: "schedule_needed", items: scheduleNeededItems,
+                icon: "calendar.badge.exclamationmark", color: .blue
             )
 
             // Favorite GC
             pipelineSection(
                 title: "Favorite GC", target: 1,
-                items: favoriteGCItems, icon: "star.fill", color: .purple
+                category: "favorite_gc", items: favoriteGCItems,
+                icon: "star.fill", color: .purple
             )
 
             // Small Jobs
             pipelineSection(
                 title: "Small Jobs", target: nil,
-                items: smallJobItems, icon: "rectangle.compress.vertical", color: .orange
+                category: "small_job", items: smallJobItems,
+                icon: "rectangle.compress.vertical", color: .orange
             )
 
             // Callbacks Due
@@ -230,6 +235,7 @@ struct IOSShortTermPipelinePage: View {
 
     private func pipelineSection(
         title: String, target: Int?,
+        category: String,
         items: [SchedulingService.PipelineItem], icon: String, color: Color
     ) -> some View {
         Section {
@@ -246,6 +252,10 @@ struct IOSShortTermPipelinePage: View {
             }
             ForEach(items, id: \.id) { item in
                 pipelineRow(item)
+                    .draggable(String(item.jobId)) {
+                        Label(item.jobName, systemImage: "line.3.horizontal")
+                            .padding(8)
+                    }
             }
         } header: {
             HStack {
@@ -260,6 +270,20 @@ struct IOSShortTermPipelinePage: View {
                         .foregroundStyle(items.count >= target ? .green : .red)
                 }
             }
+            .padding(.vertical, targetedDropCategory == category ? 6 : 0)
+            .padding(.horizontal, targetedDropCategory == category ? 8 : 0)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(targetedDropCategory == category ? color.opacity(0.18) : Color.clear)
+            )
+        }
+        .dropDestination(for: String.self) { droppedIds, _ in
+            guard let rawId = droppedIds.first,
+                  let jobId = Int64(rawId) else { return false }
+            movePipelineItem(jobId: jobId, to: category)
+            return true
+        } isTargeted: { isTargeted in
+            targetedDropCategory = isTargeted ? category : nil
         }
     }
 
@@ -319,6 +343,36 @@ struct IOSShortTermPipelinePage: View {
             loadError = userFriendlyError(error, context: "load pipeline data")
         }
         activeSheet = nil
+    }
+
+    private func movePipelineItem(jobId: Int64, to category: String) {
+        guard let service = appCore.schedulingService else {
+            loadError = "Scheduling service not available"
+            return
+        }
+        guard let item = pipelineItems.first(where: { $0.jobId == jobId }) else { return }
+        guard item.pipelineCategory != category else { return }
+
+        do {
+            try service.updateShortTermPipelineCategory(jobId: jobId, category: category)
+            pipelineItems = pipelineItems.map { current in
+                guard current.jobId == jobId else { return current }
+                return SchedulingService.PipelineItem(
+                    id: current.id,
+                    jobId: current.jobId,
+                    jobName: current.jobName,
+                    customerName: current.customerName,
+                    estimatedDays: current.estimatedDays,
+                    pipelineCategory: category,
+                    callbackDate: current.callbackDate,
+                    callbackSnoozedUntil: current.callbackSnoozedUntil,
+                    notes: current.notes
+                )
+            }
+        } catch {
+            loadError = userFriendlyError(error, context: "move pipeline job")
+            loadData()
+        }
     }
 
     // MARK: - Data Loading

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -130,6 +130,7 @@ extension AppDatabase {
         registerMigration091MultiUserAuditResolutionColumns(&migrator)
         registerMigration092VehicleLocationLatestLookupIndex(&migrator)
         registerMigration093DailyReportClockOutQuestion(&migrator)
+        registerMigration094ShortTermPipelineCategoryOverride(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -5374,6 +5375,27 @@ extension AppDatabase {
                     """,
                 arguments: ["Daily Report: What did you accomplish today, and what should the office know for tomorrow?", nextSortOrder]
             )
+        }
+    }
+
+    // MARK: - Migration 094: Short-term pipeline manual category override
+
+    private static func registerMigration094ShortTermPipelineCategoryOverride(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("094_short_term_pipeline_category_override") { db in
+            // GH #616: allow dispatchers to drag jobs between Short-Term Pipeline
+            // columns/sections and have that planning choice survive reloads. When
+            // NULL, SchedulingService keeps using the derived readiness category.
+            try addColumnIfMissing(
+                db,
+                table: "jobs",
+                column: "short_term_pipeline_category",
+                type: .text
+            )
+            try db.execute(sql: """
+                CREATE INDEX IF NOT EXISTS idx_jobs_short_term_pipeline_category
+                ON jobs(short_term_pipeline_category)
+                WHERE deleted_at IS NULL
+                """)
         }
     }
 }

--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -1648,6 +1648,13 @@ public final class SchedulingService: Sendable {
         }
     }
 
+    private static let validShortTermPipelineCategories: Set<String> = [
+        "start_anytime",
+        "schedule_needed",
+        "favorite_gc",
+        "small_job",
+    ]
+
     /// Get the short-term pipeline: active jobs categorized by readiness.
     /// Categories: start_anytime (no blockers), schedule_needed (need dispatch),
     /// favorite_gc (from preferred GCs), small_job (<=2 est. days).
@@ -1661,6 +1668,7 @@ public final class SchedulingService: Sendable {
                            CAST(COALESCE(j.estimated_hours, 0) / 8 AS INTEGER) AS estimated_days,
                            j.notes,
                            j.due_date AS callback_date,
+                           j.short_term_pipeline_category AS manual_pipeline_category,
                            (SELECT COUNT(*) FROM job_dispatch jd
                             WHERE jd.job_id = j.id
                               AND jd.dispatch_date >= date('now')
@@ -1680,10 +1688,15 @@ public final class SchedulingService: Sendable {
                     let futureDispatches: Int = row["future_dispatches"] ?? 0
                     let callbackDate: String? = row["callback_date"] as String?
                     let notes: String? = row["notes"] as String?
+                    let manualCategory: String? = row["manual_pipeline_category"] as String?
 
-                    // Categorize
+                    // Categorize. Manual drag/drop overrides win; otherwise keep the
+                    // derived readiness buckets so existing jobs continue to organize
+                    // themselves without user maintenance.
                     let category: String
-                    if let days = estimatedDays, days <= 2 {
+                    if let manualCategory, Self.validShortTermPipelineCategories.contains(manualCategory) {
+                        category = manualCategory
+                    } else if let days = estimatedDays, days <= 2 {
                         category = "small_job"
                     } else if futureDispatches == 0 {
                         category = "start_anytime"
@@ -1705,6 +1718,31 @@ public final class SchedulingService: Sendable {
         } catch {
             if isTableNotFoundError(error) { return [] }
             throw error
+        }
+    }
+
+    /// Persist a dispatcher-controlled Short-Term Pipeline bucket move.
+    ///
+    /// Drag/drop is a planning override, so it intentionally does not create or
+    /// delete dispatches. Passing one of the four visible section identifiers pins
+    /// the job in that section until another move updates the override.
+    public func updateShortTermPipelineCategory(jobId: Int64, category: String) throws {
+        guard Self.validShortTermPipelineCategories.contains(category) else {
+            throw SchedulingError.invalidStatus(category)
+        }
+
+        try db.writer.write { dbConn in
+            try dbConn.execute(
+                sql: """
+                    UPDATE jobs
+                    SET short_term_pipeline_category = ?, updated_at = datetime('now')
+                    WHERE id = ? AND deleted_at IS NULL
+                    """,
+                arguments: [category, jobId]
+            )
+            if dbConn.changesCount == 0 {
+                throw SchedulingError.jobNotFound(jobId)
+            }
         }
     }
 

--- a/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
@@ -1624,6 +1624,27 @@ struct SchedulingServiceTests {
         #expect(item?.pipelineCategory == "schedule_needed")
     }
 
+    @Test("updateShortTermPipelineCategory persists a manual drag/drop category override")
+    func testUpdateShortTermPipelineCategoryPersistsOverride() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try env.db.writer.write { db -> Int64 in
+            try db.execute(sql: """
+                INSERT INTO jobs (job_name, job_number, status, estimated_hours, deleted_at, created_at, updated_at)
+                VALUES ('Dragged Pipeline Job', 'J-DRAG-01', 'active', 40, NULL, datetime('now'), datetime('now'))
+                """)
+            return db.lastInsertedRowID
+        }
+
+        #expect(try env.scheduling.getShortTermPipeline().first(where: { $0.id == jobId })?.pipelineCategory == "start_anytime")
+
+        try env.scheduling.updateShortTermPipelineCategory(jobId: jobId, category: "favorite_gc")
+
+        let pipeline = try env.scheduling.getShortTermPipeline()
+        let item = pipeline.first(where: { $0.id == jobId })
+        #expect(item != nil)
+        #expect(item?.pipelineCategory == "favorite_gc")
+    }
+
     // MARK: - updateTimeOffStatus Cancelled
 
     @Test("updateTimeOffStatus with cancelled status")


### PR DESCRIPTION
## Summary
- Adds a persisted Short-Term Pipeline category override for dispatcher drag/drop moves.
- Wires IOSShortTermPipelinePage rows as draggable and sections as drop targets with visual highlighting.
- Keeps derived readiness categories as the fallback for jobs without a manual override.

## Test Plan
- xcrun swiftc -parse "Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSShortTermPipelinePage.swift"
- swift test --filter SchedulingServiceTests
- git diff --check

Refs WEI-2022 / GH #616.