### PR TITLE
feat(scheduling): add 14-day availability preview

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSSubSchedulePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSSubSchedulePage.swift
@@ -130,8 +130,12 @@ struct IOSSubSchedulePage: View {
             EmptyStateView(
                 icon: "person.badge.clock",
                 title: "No Subs Scheduled",
-                message: "No subcontractors scheduled for \(displayDate)."
-            )
+                message: "No subcontractors scheduled for \(displayDate).",
+                actionLabel: "Add subcontractor schedule for \(displayDate)",
+                actionIcon: "plus"
+            ) {
+                activeSheet = .create
+            }
         } else {
             List(rows) { row in
                 subRow(row)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSWeeklyAvailabilityPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSWeeklyAvailabilityPage.swift
@@ -1,21 +1,22 @@
 import SwiftUI
 import WiredPartCore
 
-/// Weekly availability grid page for iOS.
+/// Rolling 14-day availability planning preview for iOS.
 ///
-/// Displays employee rows with day-of-week availability indicators
-/// adapted for mobile. Each employee row shows their name and colored
-/// dots for each day of the week (Mon-Sun). Data is loaded via
-/// `SchedulingService`. Supports week navigation and pull-to-refresh.
+/// Displays employee rows with day-by-day availability indicators in two
+/// readable seven-day bands. The preview defaults to local today through
+/// today + 13 and reuses the existing weekly availability service twice so
+/// the first slice stays frontend-focused.
 struct IOSWeeklyAvailabilityPage: View {
     @EnvironmentObject private var appCore: AppCore
 
     // MARK: - State
 
-    @State private var rows: [SchedulingService.WeeklyAvailabilityRow] = []
+    @State private var weekOneRows: [SchedulingService.WeeklyAvailabilityRow] = []
+    @State private var weekTwoRows: [SchedulingService.WeeklyAvailabilityRow] = []
     @State private var isLoading = true
     @State private var loadError: String?
-    @State private var weekOffset = 0
+    @State private var fourteenDayStart = Calendar.current.startOfDay(for: Date())
     @State private var searchText = ""
     @State private var activeSheet: ActiveSheet?
 
@@ -24,30 +25,27 @@ struct IOSWeeklyAvailabilityPage: View {
         var id: String { "help" }
     }
 
-    private let dayLabels = ["M", "T", "W", "T", "F", "S", "S"]
+    private var calendar: Calendar { Calendar.current }
 
-    private var weekStart: Date {
-        let cal = Calendar.current
-        let today = cal.date(byAdding: .weekOfYear, value: weekOffset, to: Date()) ?? Date()
-        return cal.date(from: cal.dateComponents([.yearForWeekOfYear, .weekOfYear], from: today)) ?? today
+    private var fourteenDayEnd: Date {
+        calendar.date(byAdding: .day, value: 13, to: fourteenDayStart) ?? fourteenDayStart
     }
 
-    private var weekLabel: String {
-        let f = DateFormatter()
-        f.dateFormat = "MMM d"
-        let end = Calendar.current.date(byAdding: .day, value: 6, to: weekStart) ?? weekStart
-        return "\(f.string(from: weekStart)) - \(f.string(from: end))"
+    private var fourteenDayRangeLabel: String {
+        "\(shortDate(fourteenDayStart)) - \(shortDate(fourteenDayEnd))"
     }
 
-    private var weekStartString: String {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd"
-        return f.string(from: weekStart)
+    private var hasAnyRows: Bool {
+        !weekOneRows.isEmpty || !weekTwoRows.isEmpty
+    }
+
+    private var bodyRowsAreFilteredEmpty: Bool {
+        hasAnyRows && filteredRows(weekOneRows).isEmpty && filteredRows(weekTwoRows).isEmpty
     }
 
     var body: some View {
         VStack(spacing: 0) {
-            weekNavigator
+            fourteenDayNavigator
             availabilityContent
         }
         .navigationTitle("Availability")
@@ -60,11 +58,11 @@ struct IOSWeeklyAvailabilityPage: View {
             }
         }
         .sheet(item: $activeSheet) { _ in
-            PageHelpSheet(title: "Weekly Availability Help", sections: [
-                ("What This Page Does", "The Weekly Availability page shows a grid of all employees and their availability for each day of the week. Green dots mean the person is available that day; red dots mean they are not."),
-                ("How to Use It", "Navigate between weeks using the left and right arrows. The grid shows Monday through Sunday columns. Each employee row has colored dots indicating their availability for each day. Pull down to refresh."),
-                ("Reading the Grid", "Green dot means the employee is available to work that day. Red dot means they are unavailable, whether due to time off, personal schedule, or other reasons."),
-                ("Tips", "Use this view when planning the dispatch board to quickly see who is free each day. Cross-reference with the Dispatch Board to make sure you are not assigning people on their days off.")
+            PageHelpSheet(title: "14-Day Planning Preview Help", sections: [
+                ("What This Page Does", "The Availability page shows a 14-day planning preview of employee capacity from the selected local start date through the next 13 days. Green checkmarks mean the person is available; muted slashes mean unavailable."),
+                ("How to Use It", "Navigate with Previous 14 days, Today, and Next 14 days. Search filters employee rows across both seven-day bands without changing the selected planning range."),
+                ("Reading the Grid", "Each band keeps seven day columns readable on iPhone. Today is outlined when visible and weekends have a subtle secondary tint, but availability is always shown with labels and symbols, not color alone."),
+                ("Scheduling Model", "Use Calendar for assigned employee jobs; use Sub Schedule for contractor commitments. Availability answers who can work; Calendar answers where employees are dispatched; Sub Schedule answers which contractors are committed.")
             ])
         }
         .searchable(text: $searchText, prompt: "Search employees...")
@@ -72,45 +70,65 @@ struct IOSWeeklyAvailabilityPage: View {
         .task { loadData() }
     }
 
-    // MARK: - Week Navigator
+    // MARK: - 14-Day Navigator
 
-    private var weekNavigator: some View {
-        HStack {
-            Button {
-                weekOffset -= 1
-                loadData()
-            } label: {
-                Image(systemName: "chevron.left")
+    private var fourteenDayNavigator: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Planning Preview")
+                        .font(.headline)
+                    Text(fourteenDayRangeLabel)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                HStack(spacing: 8) {
+                    Button {
+                        shiftFourteenDayRange(by: -14)
+                    } label: {
+                        Image(systemName: "chevron.left")
+                    }
+                    .accessibilityLabel("Previous 14 days")
+
+                    Button("Today") {
+                        fourteenDayStart = calendar.startOfDay(for: Date())
+                        loadData()
+                    }
+                    .font(.caption.weight(.semibold))
+                    .accessibilityLabel("Jump to today")
+
+                    Button {
+                        shiftFourteenDayRange(by: 14)
+                    } label: {
+                        Image(systemName: "chevron.right")
+                    }
+                    .accessibilityLabel("Next 14 days")
+                }
             }
-            .accessibilityLabel("Previous week")
 
-            Spacer()
-
-            Text(weekLabel)
-                .font(.subheadline)
-                .fontWeight(.medium)
-
-            Spacer()
-
-            Button {
-                weekOffset += 1
-                loadData()
-            } label: {
-                Image(systemName: "chevron.right")
-            }
-            .accessibilityLabel("Next week")
+            Text("Use Calendar for assigned employee jobs; use Sub Schedule for contractor commitments.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Availability is people capacity. Use Calendar for assigned employee jobs. Use Sub Schedule for contractor commitments.")
         }
         .padding(.horizontal)
         .padding(.vertical, 10)
     }
 
+    private func shiftFourteenDayRange(by days: Int) {
+        fourteenDayStart = calendar.date(byAdding: .day, value: days, to: fourteenDayStart) ?? fourteenDayStart
+        loadData()
+    }
+
     // MARK: - Filtered Data
 
-    private var filteredRows: [SchedulingService.WeeklyAvailabilityRow] {
-        if searchText.isEmpty { return rows }
-        return rows.filter {
-            $0.employeeName.localizedCaseInsensitiveContains(searchText)
-        }
+    private func filteredRows(_ rows: [SchedulingService.WeeklyAvailabilityRow]) -> [SchedulingService.WeeklyAvailabilityRow] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return rows }
+        return rows.filter { $0.employeeName.localizedCaseInsensitiveContains(query) }
     }
 
     // MARK: - Content
@@ -118,49 +136,84 @@ struct IOSWeeklyAvailabilityPage: View {
     @ViewBuilder
     private var availabilityContent: some View {
         if isLoading {
-            ProgressView("Loading availability...")
+            ProgressView("Loading 14-day planning preview...")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
-        } else if rows.isEmpty {
+        } else if !hasAnyRows {
             EmptyStateView(
                 icon: "calendar.badge.exclamationmark",
-                title: "No Data",
-                message: "No availability data for this week."
+                title: "No Availability Data",
+                message: "No availability data for \(fourteenDayRangeLabel)."
             )
+        } else if bodyRowsAreFilteredEmpty {
+            EmptyStateView(
+                icon: "magnifyingglass",
+                title: "No Employees Match",
+                message: "No employees match \"\(searchText)\".",
+                actionLabel: "Clear Search",
+                actionIcon: "xmark.circle"
+            ) {
+                searchText = ""
+            }
         } else {
             List {
-                // Day header row
-                Section {
-                    HStack(spacing: 0) {
-                        Text("Employee")
-                            .font(.caption)
-                            .fontWeight(.semibold)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                weekBand(
+                    title: "Week 1",
+                    startDate: fourteenDayStart,
+                    rows: filteredRows(weekOneRows)
+                )
 
-                        ForEach(Array(dayLabels.enumerated()), id: \.offset) { _, label in
-                            Text(label)
-                                .font(.system(.caption2, weight: .bold))
-                                .frame(width: 30)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-
-                Section {
-                    ForEach(filteredRows) { row in
-                        availabilityRow(row)
-                    }
-                }
+                weekBand(
+                    title: "Week 2",
+                    startDate: calendar.date(byAdding: .day, value: 7, to: fourteenDayStart) ?? fourteenDayStart,
+                    rows: filteredRows(weekTwoRows)
+                )
             }
             .listStyle(.insetGrouped)
         }
     }
 
-    // MARK: - Row
+    // MARK: - Week Bands
 
-    private func availabilityRow(_ row: SchedulingService.WeeklyAvailabilityRow) -> some View {
+    private func weekBand(title: String, startDate: Date, rows: [SchedulingService.WeeklyAvailabilityRow]) -> some View {
+        let dates = sevenDates(startingAt: startDate)
+        return Section {
+            dayHeaderRow(dates: dates)
+            ForEach(rows) { row in
+                availabilityRow(row, dates: dates)
+            }
+        } header: {
+            Text("\(title) · \(shortDate(startDate)) - \(shortDate(dates.last ?? startDate))")
+        }
+    }
+
+    private func dayHeaderRow(dates: [Date]) -> some View {
         HStack(spacing: 0) {
+            Text("Employee")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            ForEach(0..<7, id: \.self) { dayIndex in
+                let date = dates[dayIndex]
+                Text(dayColumnLabel(date))
+                    .font(.system(.caption2, weight: .bold))
+                    .multilineTextAlignment(.center)
+                    .frame(width: 36)
+                    .padding(.vertical, 4)
+                    .background(dayHeaderBackground(date))
+                    .clipShape(RoundedRectangle(cornerRadius: 7))
+                    .overlay(todayOutline(date))
+                    .foregroundStyle(isWeekend(date) ? Color.secondary : Color.primary)
+                    .accessibilityLabel(dayAccessibilityLabel(date))
+            }
+        }
+    }
+
+    private func availabilityRow(_ row: SchedulingService.WeeklyAvailabilityRow, dates: [Date]) -> some View {
+        let availableCount = row.days.prefix(7).filter { $0 }.count
+        return HStack(spacing: 0) {
             Text(row.employeeName)
                 .font(.subheadline)
                 .fontWeight(.medium)
@@ -168,14 +221,77 @@ struct IOSWeeklyAvailabilityPage: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
             ForEach(0..<7, id: \.self) { dayIndex in
-                Circle()
-                    .fill(dayIndex < row.days.count && row.days[dayIndex] ? Color.green : Color.red.opacity(0.3))
-                    .frame(width: 14, height: 14)
-                    .frame(width: 30)
-                    .accessibilityLabel(dayIndex < row.days.count && row.days[dayIndex] ? "Status: Available" : "Status: Unavailable")
+                let available = dayIndex < row.days.count && row.days[dayIndex]
+                Image(systemName: available ? "checkmark.circle.fill" : "slash.circle")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(available ? Color.green : Color.red.opacity(0.45))
+                    .frame(width: 36, height: 30)
+                    .background(isWeekend(dates[dayIndex]) ? Color.secondary.opacity(0.06) : Color.clear)
+                    .clipShape(RoundedRectangle(cornerRadius: 7))
+                    .overlay(todayOutline(dates[dayIndex]))
+                    .accessibilityLabel("\(row.employeeName), \(fullDate(dates[dayIndex])), \(available ? "available" : "unavailable")")
             }
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, 3)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(row.employeeName): available \(availableCount) of next 7 days in this band")
+    }
+
+    // MARK: - Date Helpers
+
+    private func sevenDates(startingAt startDate: Date) -> [Date] {
+        (0..<7).map { offset in
+            calendar.date(byAdding: .day, value: offset, to: startDate) ?? startDate
+        }
+    }
+
+    private func isToday(_ date: Date) -> Bool {
+        calendar.isDateInToday(date)
+    }
+
+    private func isWeekend(_ date: Date) -> Bool {
+        calendar.isDateInWeekend(date)
+    }
+
+    private func dayHeaderBackground(_ date: Date) -> Color {
+        if isToday(date) { return Color.accentColor.opacity(0.14) }
+        if isWeekend(date) { return Color.secondary.opacity(0.10) }
+        return Color.clear
+    }
+
+    @ViewBuilder
+    private func todayOutline(_ date: Date) -> some View {
+        if isToday(date) {
+            RoundedRectangle(cornerRadius: 7)
+                .stroke(Color.accentColor, lineWidth: 1.5)
+        }
+    }
+
+    private func dayColumnLabel(_ date: Date) -> String {
+        let weekday = DateFormatter()
+        weekday.dateFormat = "E"
+        let day = calendar.component(.day, from: date)
+        return "\(weekday.string(from: date))\n\(day)"
+    }
+
+    private func dayAccessibilityLabel(_ date: Date) -> String {
+        var label = fullDate(date)
+        if isToday(date) { label += ", today" }
+        if isWeekend(date) { label += ", weekend" }
+        return label
+    }
+
+    private func shortDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        return formatter.string(from: date)
+    }
+
+    private func fullDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .full
+        formatter.timeStyle = .none
+        return formatter.string(from: date)
     }
 
     // MARK: - Data Loading
@@ -186,12 +302,14 @@ struct IOSWeeklyAvailabilityPage: View {
             isLoading = false
             return
         }
-        isLoading = rows.isEmpty
+        isLoading = !hasAnyRows
         loadError = nil
         do {
-            rows = try service.getWeeklyAvailability(weekStartDate: weekStart)
+            let weekTwoStart = calendar.date(byAdding: .day, value: 7, to: fourteenDayStart) ?? fourteenDayStart
+            weekOneRows = try service.getWeeklyAvailability(weekStartDate: fourteenDayStart)
+            weekTwoRows = try service.getWeeklyAvailability(weekStartDate: weekTwoStart)
         } catch {
-            loadError = userFriendlyError(error, context: "load availability")
+            loadError = userFriendlyError(error, context: "load 14-day planning preview")
         }
         isLoading = false
     }

--- a/tests/static/test_scheduling_14_day_availability.py
+++ b/tests/static/test_scheduling_14_day_availability.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Static guards for the Scheduling 14-day availability UX vertical slice."""
+from pathlib import Path
+import re
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+AVAILABILITY_PAGE = ROOT / "Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSWeeklyAvailabilityPage.swift"
+SUB_SCHEDULE_PAGE = ROOT / "Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSSubSchedulePage.swift"
+
+
+class SchedulingFourteenDayAvailabilityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.availability = AVAILABILITY_PAGE.read_text()
+        cls.sub_schedule = SUB_SCHEDULE_PAGE.read_text()
+
+    def test_availability_defaults_to_rolling_fourteen_day_preview(self):
+        self.assertIn("Planning Preview", self.availability)
+        self.assertIn("fourteenDayStart", self.availability)
+        self.assertIn("fourteenDayRangeLabel", self.availability)
+        self.assertIn("by: 14", self.availability)
+        self.assertIn("value: 13", self.availability)
+        self.assertNotIn("weekOffset", self.availability)
+
+    def test_availability_renders_two_seven_day_bands_with_today_and_weekend_treatment(self):
+        self.assertIn("Week 1", self.availability)
+        self.assertIn("Week 2", self.availability)
+        self.assertIn("weekBand", self.availability)
+        self.assertIn("isToday", self.availability)
+        self.assertIn("isWeekend", self.availability)
+        self.assertRegex(self.availability, r"ForEach\(0\.\.<7")
+
+    def test_availability_copy_and_accessibility_explain_cross_scheduling_model(self):
+        self.assertIn("Previous 14 days", self.availability)
+        self.assertIn("Jump to today", self.availability)
+        self.assertIn("Next 14 days", self.availability)
+        self.assertIn("Use Calendar for assigned employee jobs; use Sub Schedule for contractor commitments.", self.availability)
+        self.assertIn("14-day planning preview", self.availability)
+        self.assertIn("available", self.availability)
+        self.assertIn("unavailable", self.availability)
+
+    def test_sub_schedule_has_add_edit_and_empty_state_cta(self):
+        self.assertIn("Add subcontractor schedule", self.sub_schedule)
+        self.assertIn("CreateSubcontractorScheduleSheet", self.sub_schedule)
+        self.assertIn("Add subcontractor schedule for", self.sub_schedule)
+        self.assertIn("onTapGesture { activeSheet = .edit(row) }", self.sub_schedule)
+        self.assertIn("scopeOfWork", self.sub_schedule)
+        self.assertIn("arrivalTime", self.sub_schedule)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Replaces the iOS Availability one-week view with a rolling 14-day Planning Preview rendered as two readable 7-day bands.
- Adds Previous 14 days / Today / Next 14 days navigation, today/weekend visual treatment, non-color-only availability symbols, accessibility labels, updated help text, and mental-model copy linking Availability, Calendar, and Sub Schedule.
- Adds Sub Schedule empty-state CTA for creating a subcontractor schedule on the selected date.
- Adds static coverage for the GH #610 / GH #612 vertical-slice UX requirements.

## Test Plan
- [x] python3 tests/static/test_scheduling_14_day_availability.py
- [x] swift test --package-path core --filter SchedulingServiceTests
- [x] xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build

Refs WEI-2043
Refs #610
Refs #612