### PR TITLE
feat(notebooks): add page-sidebar detail layout

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -22,6 +22,8 @@ struct IOSNotebookDetailPage: View {
     @State private var panelSchedule = PanelSchedule()
     @State private var blockConflicts: [NotebookBlockConflict] = []
     @State private var pendingDelete: PendingDelete?
+    @State private var selectedPageId: Int64?
+    @State private var compactPageId: Int64?
 
     // MARK: - PendingDelete
 
@@ -169,142 +171,231 @@ struct IOSNotebookDetailPage: View {
         notebook?.status == "locked" || notebook?.status == "archived"
     }
 
+    private struct NotebookPage: Identifiable {
+        let id: Int64
+        let section: NotebooksService.SectionWithEntries
+        let groupName: String?
+        let derivedPreview: String
+        let updatedText: String?
+
+        var title: String { section.name }
+        var blockCountText: String {
+            "\(section.entries.count) block\(section.entries.count == 1 ? "" : "s")"
+        }
+    }
+
     @ViewBuilder
     private var notebookShell: some View {
         if horizontalSizeClass == .regular {
             HStack(spacing: 0) {
-                notebookSidebar
-                    .frame(width: 292)
+                pageSidebar
+                    .frame(width: 320)
                     .background(Color(.secondarySystemGroupedBackground))
                 Divider()
-                contentList
+                selectedPageSurface
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
             .background(Color(.systemGroupedBackground))
         } else {
-            contentList
+            if compactPageId == nil {
+                compactPageList
+            } else {
+                compactSelectedPageSurface
+            }
         }
     }
 
-    private var notebookSidebar: some View {
+    private var notebookPages: [NotebookPage] {
+        var pages: [NotebookPage] = []
+        hierarchy?.groups.forEach { group in
+            group.sections.forEach { section in
+                pages.append(makeNotebookPage(section: section, groupName: group.name))
+            }
+        }
+        hierarchy?.ungroupedSections.forEach { section in
+            pages.append(makeNotebookPage(section: section, groupName: nil))
+        }
+        return pages
+    }
+
+    private var selectedPage: NotebookPage? {
+        let pages = notebookPages
+        if let selectedPageId, let page = pages.first(where: { $0.id == selectedPageId }) {
+            return page
+        }
+        return pages.first
+    }
+
+    private func makeNotebookPage(section: NotebooksService.SectionWithEntries, groupName: String?) -> NotebookPage {
+        NotebookPage(
+            id: section.id,
+            section: section,
+            groupName: groupName,
+            derivedPreview: derivedPreview(for: section),
+            updatedText: updatedText(for: section)
+        )
+    }
+
+    private func selectPage(_ page: NotebookPage, compact: Bool = false) {
+        selectedPageId = page.id
+        if compact {
+            compactPageId = page.id
+        }
+    }
+
+    private var pageSidebar: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 14) {
                 notebookSummaryCard
-                sidebarRow(
-                    id: "overview",
-                    title: "Overview",
-                    systemImage: "doc.text",
-                    badge: nil,
-                    isSelected: true
-                )
-                sidebarRow(
-                    id: "dailyLogs",
-                    title: "Daily Logs",
-                    systemImage: "calendar",
-                    badge: nil,
-                    isSelected: false
-                )
-                sidebarRow(
-                    id: "todos",
-                    title: "To-Dos",
-                    systemImage: "checklist",
-                    badge: todoBadgeText,
-                    isSelected: false
-                )
-                sidebarRow(
-                    id: "photos",
-                    title: "Photos",
-                    systemImage: "photo.on.rectangle",
-                    badge: nil,
-                    isSelected: false
-                )
-                sidebarRow(
-                    id: "panelSchedules",
-                    title: "Panel Schedules",
-                    systemImage: "bolt.rectangle",
-                    badge: nil,
-                    isSelected: false
-                )
                 if !blockConflicts.isEmpty {
-                    sidebarRow(
-                        id: "openConflicts",
-                        title: "Open conflicts",
-                        systemImage: "exclamationmark.triangle",
-                        badge: "\(blockConflicts.count)",
-                        isSelected: false
-                    )
+                    Button {
+                        activeSheet = .conflictResolution
+                    } label: {
+                        Label("Open conflicts", systemImage: "exclamationmark.triangle")
+                            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                    }
+                    .buttonStyle(.bordered)
+                    .accessibilityIdentifier("notebookSidebar_openConflicts")
                 }
-                hierarchySidebarContent
+                Text("Pages")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 4)
+                if notebookPages.isEmpty {
+                    Text("No pages yet. Create a section to start this notebook.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    pageSidebarGroups
+                }
             }
             .padding(14)
         }
-        .accessibilityIdentifier("notebookSidebar")
-    }
-
-    private var notebookSummaryCard: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Label(notebook?.jobName ?? "Job notebook", systemImage: "hammer")
-                .font(.subheadline)
-                .fontWeight(.semibold)
-            Text(notebook?.title ?? "Notebook")
-                .font(.headline)
-                .fixedSize(horizontal: false, vertical: true)
-            HStack(spacing: 8) {
-                statusBadge(notebook?.status ?? "active")
-                if let updated = notebook?.updatedAt {
-                    Text("Updated \(String(updated.prefix(10)))")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(12)
-        .background(Color(.systemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .accessibilityIdentifier("notebookPageSidebar")
     }
 
     @ViewBuilder
-    private var hierarchySidebarContent: some View {
+    private var pageSidebarGroups: some View {
         if let groups = hierarchy?.groups, !groups.isEmpty {
-            Text("Sections")
-                .font(.caption)
-                .fontWeight(.semibold)
-                .foregroundStyle(.secondary)
-                .padding(.top, 4)
             ForEach(groups) { group in
-                Text(group.name)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 8)
-                    .padding(.top, 4)
+                pageGroupHeader(group)
                 ForEach(group.sections) { section in
-                    sidebarRow(
-                        id: "section_\(section.id)",
-                        title: section.name,
-                        systemImage: "doc.text",
-                        badge: "\(section.entries.count)",
-                        isSelected: false
-                    )
+                    let page = makeNotebookPage(section: section, groupName: group.name)
+                    pageSidebarRow(page, compact: false)
                 }
             }
         }
         if let sections = hierarchy?.ungroupedSections, !sections.isEmpty {
-            Text("Pages")
+            Text("Ungrouped")
                 .font(.caption)
                 .fontWeight(.semibold)
                 .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
                 .padding(.top, 4)
             ForEach(sections) { section in
-                sidebarRow(
-                    id: "section_\(section.id)",
-                    title: section.name,
-                    systemImage: "doc.text",
-                    badge: "\(section.entries.count)",
-                    isSelected: false
-                )
+                let page = makeNotebookPage(section: section, groupName: nil)
+                pageSidebarRow(page, compact: false)
             }
         }
+    }
+
+    private func pageGroupHeader(_ group: NotebooksService.SectionGroupWithChildren) -> some View {
+        HStack(spacing: 8) {
+            Text(group.name)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            Spacer()
+            Menu {
+                Button { activeSheet = .editGroup(groupId: group.id, name: group.name) } label: {
+                    Label("Rename Group", systemImage: "pencil")
+                }
+                Button { activeSheet = .addSection(groupId: group.id) } label: {
+                    Label("Add Section", systemImage: "plus")
+                }
+                Button(role: .destructive) { pendingDelete = .group(group.id) } label: {
+                    Label("Delete Group", systemImage: "trash")
+                }
+            } label: {
+                Image(systemName: "ellipsis.circle")
+                    .frame(width: 44, height: 44)
+            }
+            .disabled(isReadOnly)
+            .accessibilityLabel("Group actions for \(group.name)")
+        }
+        .padding(.horizontal, 8)
+        .padding(.top, 4)
+    }
+
+    private func pageSidebarRow(_ page: NotebookPage, compact: Bool) -> some View {
+        let isSelected = selectedPage?.id == page.id
+        return Button {
+            selectPage(page, compact: compact)
+        } label: {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "doc.text")
+                        .frame(width: 20)
+                        .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(page.title)
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.primary)
+                            .lineLimit(2)
+                        Text(page.derivedPreview)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                        HStack(spacing: 6) {
+                            Text(page.blockCountText)
+                            if let groupName = page.groupName {
+                                Text("•")
+                                Text(groupName)
+                            }
+                            if let updatedText = page.updatedText {
+                                Text("•")
+                                Text(updatedText)
+                            }
+                        }
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                    }
+                    Spacer()
+                    Menu {
+                        Button { activeSheet = .editSection(sectionId: page.id, name: page.title) } label: {
+                            Label("Rename Page", systemImage: "pencil")
+                        }
+                        Button { activeSheet = .addEntry(sectionId: page.id) } label: {
+                            Label("Add Block", systemImage: "plus.circle")
+                        }
+                        Button(role: .destructive) { pendingDelete = .section(page.id) } label: {
+                            Label("Delete Page", systemImage: "trash")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .frame(width: 44, height: 44)
+                    }
+                    .disabled(isReadOnly)
+                    .accessibilityLabel("Page actions for \(page.title)")
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(isSelected ? Color.accentColor.opacity(0.14) : Color(.systemBackground))
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabelForPageRow(page, isSelected: isSelected))
+        .accessibilityIdentifier("notebookPageRow_\(page.id)")
     }
 
     private func sidebarRow(id: String, title: String, systemImage: String, badge: String?, isSelected: Bool) -> some View {
@@ -337,9 +428,327 @@ struct IOSNotebookDetailPage: View {
         .accessibilityIdentifier("notebookSidebar_\(id)")
     }
 
-    private var todoBadgeText: String? {
-        let count = allEntries.filter { $0.blockType == "todo" && !$0.isCompleted }.count
-        return count > 0 ? "\(count)" : nil
+    private var compactPageList: some View {
+        List {
+            actionErrorSection
+            syncConflictBannerSection
+            managerReviewSection
+            if notebookPages.isEmpty {
+                Section {
+                    EmptyStateView(
+                        icon: "note.text",
+                        title: "No pages yet",
+                        message: "Create a section to start this notebook."
+                    )
+                    Button {
+                        activeSheet = .addSection(groupId: nil)
+                    } label: {
+                        Label("Create page", systemImage: "doc.badge.plus")
+                            .frame(minHeight: 44)
+                    }
+                    .disabled(isReadOnly)
+                }
+            } else {
+                Section("Pages") {
+                    ForEach(notebookPages) { page in
+                        pageSidebarRow(page, compact: true)
+                    }
+                }
+            }
+            panelScheduleSection
+            notebookInfoSection
+        }
+        .listStyle(.insetGrouped)
+        .accessibilityIdentifier("notebookCompactPageList")
+    }
+
+    private var selectedPageSurface: some View {
+        List {
+            selectedPageContentSections
+        }
+        .listStyle(.insetGrouped)
+        .accessibilityIdentifier("notebookSelectedPageSurface")
+    }
+
+    private var compactSelectedPageSurface: some View {
+        List {
+            Section {
+                Button {
+                    compactPageId = nil
+                } label: {
+                    Label("Back to pages", systemImage: "chevron.left")
+                        .frame(minHeight: 44)
+                }
+            }
+            selectedPageContentSections
+        }
+        .listStyle(.insetGrouped)
+        .accessibilityIdentifier("notebookCompactSelectedPageSurface")
+    }
+
+    @ViewBuilder
+    private var selectedPageContentSections: some View {
+        actionErrorSection
+        syncConflictBannerSection
+        managerReviewSection
+        if let page = selectedPage {
+            selectedPageHeader(page)
+            Section {
+                if page.section.entries.isEmpty {
+                    EmptyStateView(
+                        icon: "text.badge.plus",
+                        title: "Empty page",
+                        message: "This page has no blocks yet. Add the first block when you're ready."
+                    )
+                } else {
+                    ForEach(page.section.entries) { entry in
+                        entryRow(entry)
+                    }
+                }
+                Button {
+                    activeSheet = .addEntry(sectionId: page.id)
+                } label: {
+                    Label("Add Block", systemImage: "plus.circle")
+                        .frame(minHeight: 44)
+                }
+                .disabled(isReadOnly)
+            } header: {
+                Text("Page Blocks")
+            } footer: {
+                Text("Showing only the selected page's blocks, not the whole notebook.")
+            }
+        } else {
+            Section {
+                EmptyStateView(
+                    icon: "note.text",
+                    title: "No pages yet",
+                    message: "Create a section to organize this job notebook."
+                )
+                Button {
+                    activeSheet = .addSection(groupId: nil)
+                } label: {
+                    Label("Create page", systemImage: "doc.badge.plus")
+                        .frame(minHeight: 44)
+                }
+                .disabled(isReadOnly)
+            }
+        }
+        legacyEntriesSection
+        panelScheduleSection
+        notebookInfoSection
+    }
+
+    private func selectedPageHeader(_ page: NotebookPage) -> some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(page.title)
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(page.derivedPreview)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                HStack(spacing: 8) {
+                    statusBadge(notebook?.status ?? "active")
+                    Text(page.blockCountText)
+                    if let groupName = page.groupName {
+                        Text("• \(groupName)")
+                    }
+                    if let updatedText = page.updatedText {
+                        Text("• \(updatedText)")
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                HStack(spacing: 12) {
+                    Button {
+                        activeSheet = .editSection(sectionId: page.id, name: page.title)
+                    } label: {
+                        Label("Rename", systemImage: "pencil")
+                            .frame(minHeight: 44)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(isReadOnly)
+                    Button {
+                        activeSheet = .addEntry(sectionId: page.id)
+                    } label: {
+                        Label("Add Block", systemImage: "plus.circle")
+                            .frame(minHeight: 44)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isReadOnly)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    @ViewBuilder
+    private var actionErrorSection: some View {
+        if let error = actionError {
+            Section {
+                Text(error).foregroundStyle(.red).font(.caption)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var syncConflictBannerSection: some View {
+        if !blockConflicts.isEmpty {
+            Section {
+                Button {
+                    activeSheet = .conflictResolution
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.white)
+                            .font(.title3)
+                            .accessibilityHidden(true)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("\(blockConflicts.count) Sync Conflict\(blockConflicts.count == 1 ? "" : "s")")
+                                .font(.subheadline)
+                                .fontWeight(.semibold)
+                                .foregroundStyle(.white)
+                            Text("Tap to review and resolve")
+                                .font(.caption)
+                                .foregroundStyle(.white.opacity(0.85))
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.7))
+                            .accessibilityHidden(true)
+                    }
+                    .padding(12)
+                    .background(Color.orange)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+                .buttonStyle(.plain)
+                .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var managerReviewSection: some View {
+        if isWarrantyJob && appCore.hasPermission("manage_jobs") && !todosNeedingReview.isEmpty {
+            Section {
+                ForEach(todosNeedingReview) { entry in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(entry.title ?? entry.content)
+                                .font(.subheadline)
+                            Text("Classified as: \(entry.workClassification ?? "unset")")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Button("Approve") {
+                            approveClassification(entryId: entry.id)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.green)
+                        .controlSize(.small)
+                    }
+                    .frame(minHeight: 44)
+                }
+            } header: {
+                Text("Needs Review (\(todosNeedingReview.count))")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var legacyEntriesSection: some View {
+        let legacyEntries = notebook?.entries ?? []
+        if !legacyEntries.isEmpty && notebookPages.isEmpty {
+            Section {
+                ForEach(legacyEntries) { entry in
+                    entryRow(entry)
+                }
+            } header: {
+                Text("Entries")
+            } footer: {
+                Text("Legacy entries are shown only when this notebook has no pages yet.")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var panelScheduleSection: some View {
+        if notebook?.notebookType == "panel_schedule" {
+            Section("Panel Schedule") {
+                Button {
+                    activeSheet = .panelScheduleEditor
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: "bolt.fill")
+                            .foregroundStyle(.yellow)
+                            .frame(width: 28)
+                            .accessibilityHidden(true)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Open Panel Schedule Builder")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            Text("Edit circuit breaker assignments")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .accessibilityHidden(true)
+                    }
+                    .frame(minHeight: 44)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var notebookInfoSection: some View {
+        Section {
+            if let nb = notebook {
+                detailRow("Type", nb.notebookType)
+                detailRow("Status", nb.status.capitalized)
+                if let created = nb.createdAt {
+                    detailRow("Created", String(created.prefix(10)))
+                }
+                if let updated = nb.updatedAt {
+                    detailRow("Updated", String(updated.prefix(10)))
+                }
+                if let jobName = nb.jobName {
+                    detailRow("Job", jobName)
+                }
+            }
+        } header: {
+            Text("Notebook Info")
+        }
+    }
+
+    private var notebookSummaryCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(notebook?.jobName ?? "Job notebook", systemImage: "hammer")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+            Text(notebook?.title ?? "Notebook")
+                .font(.headline)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 8) {
+                statusBadge(notebook?.status ?? "active")
+                if let updated = notebook?.updatedAt {
+                    Text("Updated \(String(updated.prefix(10)))")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 
     private var allEntries: [NotebooksService.NotebookEntryRow] {
@@ -351,6 +760,31 @@ struct IOSNotebookDetailPage: View {
         return entries
     }
 
+    private var todoBadgeText: String? {
+        let count = allEntries.filter { $0.blockType == "todo" && !$0.isCompleted }.count
+        return count > 0 ? "\(count)" : nil
+    }
+
+    private func derivedPreview(for section: NotebooksService.SectionWithEntries) -> String {
+        for entry in section.entries {
+            let title = (entry.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if !title.isEmpty { return title }
+            let content = entry.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !content.isEmpty { return content }
+        }
+        return "This page has no blocks yet."
+    }
+
+    private func updatedText(for section: NotebooksService.SectionWithEntries) -> String? {
+        section.entries.compactMap(\.createdAt).last.map { "Updated \(String($0.prefix(10)))" }
+    }
+
+    private func accessibilityLabelForPageRow(_ page: NotebookPage, isSelected: Bool) -> String {
+        [page.title, page.derivedPreview, page.blockCountText, isSelected ? "selected" : nil]
+            .compactMap { $0 }
+            .joined(separator: ", ")
+    }
+
     private func accessibilityLabelForSidebarRow(title: String, badge: String?, isSelected: Bool) -> String {
         [title, badge.map { "\($0) items" }, isSelected ? "selected" : nil]
             .compactMap { $0 }
@@ -358,219 +792,6 @@ struct IOSNotebookDetailPage: View {
     }
 
     // MARK: - Content List
-
-    private var contentList: some View {
-        List {
-            if let error = actionError {
-                Section {
-                    Text(error).foregroundStyle(.red).font(.caption)
-                }
-            }
-
-            // Sync Conflict Banner (62J)
-            if !blockConflicts.isEmpty {
-                Section {
-                    Button {
-                        activeSheet = .conflictResolution
-                    } label: {
-                        HStack(spacing: 12) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .foregroundStyle(.white)
-                                .font(.title3)
-                                .accessibilityHidden(true)
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("\(blockConflicts.count) Sync Conflict\(blockConflicts.count == 1 ? "" : "s")")
-                                    .font(.subheadline)
-                                    .fontWeight(.semibold)
-                                    .foregroundStyle(.white)
-                                Text("Tap to review and resolve")
-                                    .font(.caption)
-                                    .foregroundStyle(.white.opacity(0.85))
-                            }
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .font(.caption)
-                                .foregroundStyle(.white.opacity(0.7))
-                                .accessibilityHidden(true)
-                        }
-                        .padding(12)
-                        .background(Color.orange)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
-                    }
-                    .buttonStyle(.plain)
-                    .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
-                }
-            }
-
-            // Manager Review Section (45D)
-            if isWarrantyJob && appCore.hasPermission("manage_jobs") && !todosNeedingReview.isEmpty {
-                Section {
-                    ForEach(todosNeedingReview) { entry in
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(entry.title ?? entry.content)
-                                    .font(.subheadline)
-                                Text("Classified as: \(entry.workClassification ?? "unset")")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            Button("Approve") {
-                                approveClassification(entryId: entry.id)
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .tint(.green)
-                            .controlSize(.small)
-                        }
-                    }
-                } header: {
-                    Text("Needs Review (\(todosNeedingReview.count))")
-                }
-            }
-
-            // Section Groups (collapsible)
-            if let groups = hierarchy?.groups, !groups.isEmpty {
-                ForEach(groups) { groupItem in
-                    Section {
-                        DisclosureGroup(
-                            isExpanded: groupBinding(groupItem.id)
-                        ) {
-                            ForEach(groupItem.sections) { sectionItem in
-                                sectionRow(sectionItem)
-                            }
-                            Button {
-                                activeSheet = .addSection(groupId: groupItem.id)
-                            } label: {
-                                Label("Add Section", systemImage: "plus")
-                                    .font(.caption)
-                                    .foregroundStyle(.blue)
-                                    .frame(minHeight: 44)
-                            }
-                            .disabled(isReadOnly)
-                        } label: {
-                            HStack {
-                                Image(systemName: "folder.fill")
-                                    .foregroundStyle(.orange)
-                                    .accessibilityHidden(true)
-                                Text(groupItem.name).font(.headline)
-                                Spacer()
-                                Text("\(groupItem.sections.count) sections")
-                                    .font(.caption).foregroundStyle(.secondary)
-                            }
-                            .contextMenu {
-                                Button {
-                                    activeSheet = .editGroup(groupId: groupItem.id, name: groupItem.name)
-                                } label: {
-                                    Label("Rename", systemImage: "pencil")
-                                }
-                                Button {
-                                    activeSheet = .addSection(groupId: groupItem.id)
-                                } label: {
-                                    Label("Add Section", systemImage: "plus")
-                                }
-                                Button(role: .destructive) {
-                                    pendingDelete = .group(groupItem.id)
-                                } label: {
-                                    Label("Delete Group", systemImage: "trash")
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Ungrouped sections
-            if let ungrouped = hierarchy?.ungroupedSections, !ungrouped.isEmpty {
-                Section {
-                    ForEach(ungrouped) { sectionItem in
-                        sectionRow(sectionItem)
-                    }
-                } header: {
-                    Text("Pages")
-                }
-            }
-
-            // Empty state
-            if hierarchy?.groups.isEmpty == true && hierarchy?.ungroupedSections.isEmpty == true {
-                Section {
-                    EmptyStateView(
-                        icon: "note.text",
-                        title: "No sections yet",
-                        message: "Create a section to organize this job notebook."
-                    )
-                    Button {
-                        activeSheet = .addSection(groupId: nil)
-                    } label: {
-                        Label("Create section", systemImage: "doc.badge.plus")
-                            .frame(minHeight: 44)
-                    }
-                    .disabled(isReadOnly)
-                }
-            }
-
-            // Legacy entries (entries without sections from before the hierarchy)
-            let legacyEntries = notebook?.entries ?? []
-            if !legacyEntries.isEmpty && hierarchy?.groups.isEmpty == true && hierarchy?.ungroupedSections.isEmpty == true {
-                Section {
-                    ForEach(legacyEntries) { entry in
-                        entryRow(entry)
-                    }
-                } header: {
-                    Text("Entries")
-                }
-            }
-
-            // Panel Schedule Builder (for panel_schedule notebooks)
-            if notebook?.notebookType == "panel_schedule" {
-                Section("Panel Schedule") {
-                    Button {
-                        activeSheet = .panelScheduleEditor
-                    } label: {
-                        HStack(spacing: 12) {
-                            Image(systemName: "bolt.fill")
-                                .foregroundStyle(.yellow)
-                                .frame(width: 28)
-                                .accessibilityHidden(true)
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("Open Panel Schedule Builder")
-                                    .font(.subheadline)
-                                    .fontWeight(.medium)
-                                Text("Edit circuit breaker assignments")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .font(.caption)
-                                .foregroundStyle(.tertiary)
-                                .accessibilityHidden(true)
-                        }
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-
-            // Info section
-            Section {
-                if let nb = notebook {
-                    detailRow("Type", nb.notebookType)
-                    detailRow("Status", nb.status.capitalized)
-                    if let created = nb.createdAt {
-                        detailRow("Created", String(created.prefix(10)))
-                    }
-                    if let updated = nb.updatedAt {
-                        detailRow("Updated", String(updated.prefix(10)))
-                    }
-                    if let jobName = nb.jobName {
-                        detailRow("Job", jobName)
-                    }
-                }
-            } header: {
-                Text("Notebook Info")
-            }
-        }
-        .listStyle(.insetGrouped)
-    }
 
     private func statusBadge(_ status: String) -> some View {
         let color: Color = switch status {
@@ -1120,6 +1341,15 @@ struct IOSNotebookDetailPage: View {
                 hierarchy?.groups.forEach { g in ids.append(contentsOf: g.sections.map(\.id)) }
                 hierarchy?.ungroupedSections.forEach { s in ids.append(s.id) }
                 expandedSections = Set(ids)
+            }
+            let currentPages = notebookPages
+            if let selectedPageId, !currentPages.contains(where: { $0.id == selectedPageId }) {
+                self.selectedPageId = currentPages.first?.id
+            } else if selectedPageId == nil {
+                selectedPageId = currentPages.first?.id
+            }
+            if let compactPageId, !currentPages.contains(where: { $0.id == compactPageId }) {
+                self.compactPageId = nil
             }
             // Check for sync conflicts on this notebook's entries (62J)
             blockConflicts = (try? service.detectBlockConflicts(notebookId: notebookId)) ?? []

--- a/tools/check_wei_2010_notebook_sidebar.py
+++ b/tools/check_wei_2010_notebook_sidebar.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Source-level regression checks for WEI-2010 notebook page-sidebar UX."""
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+DETAIL = ROOT / "Weird Parts IOS" / "Weird Parts IOS" / "Features" / "Notebooks" / "IOSNotebookDetailPage.swift"
+source = DETAIL.read_text()
+
+checks = [
+    ("page model derives sections as selectable notebook pages", "private struct NotebookPage" in source and "derivedPreview" in source),
+    ("selected page state drives regular and compact detail panes", "@State private var selectedPageId" in source and "@State private var compactPageId" in source),
+    ("regular width renders persistent page sidebar plus selected page surface", "pageSidebar" in source and "selectedPageSurface" in source and "notebookPageSidebar" in source),
+    ("compact width starts with page list and drills into one selected page", "compactPageList" in source and "compactSelectedPageSurface" in source and "Back to pages" in source),
+    ("page rows expose title, derived preview, metadata, count/status, and selection", "pageSidebarRow" in source and "notebookPageRow_" in source and "blockCountText" in source and "updatedText" in source),
+    ("selected page content is scoped to the selected section entries", re.search(r"ForEach\(page\.section\.entries\).*entryRow", source, re.S) is not None),
+    ("empty page copy is clear", "This page has no blocks yet." in source),
+    ("old full hierarchy dump is not rendered as the primary content", "// Section Groups (collapsible)" not in source and "// Ungrouped sections" not in source),
+]
+
+failed = [name for name, ok in checks if not ok]
+if failed:
+    print("WEI-2010 notebook sidebar checks failed:")
+    for name in failed:
+        print(f"- {name}")
+    sys.exit(1)
+
+print("WEI-2010 notebook sidebar source checks passed")


### PR DESCRIPTION
## Summary
- Treat notebook sections as selectable pages with derived previews and metadata.
- Add regular-width persistent page sidebar and compact list-to-detail drill-in flow.
- Scope detail content to the selected page's blocks while preserving conflict, warranty review, panel schedule, group, and section actions.

## Verification
- python3 tools/check_wei_2010_notebook_sidebar.py
- git diff --check
- xcodebuild build-for-testing -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'generic/platform=iOS Simulator' -derivedDataPath .paperclip/DerivedData-WEI-2010 CODE_SIGNING_ALLOWED=NO

Paperclip: WEI-2010
GitHub: #631