### PR TITLE
Fix empty states for parts management and warehouse floor plans

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
@@ -47,6 +47,36 @@ struct IOSPartsOrderManagementPage: View {
         var id: String { "help" }
     }
 
+    private enum PartsOrderManagementEmptyReason {
+        case noSuppliersWithActivePOs
+        case selectSupplier
+        case noMatchingParts
+
+        var title: String {
+            switch self {
+            case .noSuppliersWithActivePOs: "No Suppliers"
+            case .selectSupplier, .noMatchingParts: "No Parts"
+            }
+        }
+
+        var message: String {
+            switch self {
+            case .noSuppliersWithActivePOs:
+                "No suppliers with active purchase orders. Create or activate a purchase order for a supplier to manage its parts here."
+            case .selectSupplier:
+                "Select a supplier above to view parts."
+            case .noMatchingParts:
+                "No parts match the current filters."
+            }
+        }
+    }
+
+    private var emptyReason: PartsOrderManagementEmptyReason {
+        if suppliers.isEmpty { return .noSuppliersWithActivePOs }
+        if selectedSupplierId == nil { return .selectSupplier }
+        return .noMatchingParts
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             supplierPicker
@@ -61,10 +91,8 @@ struct IOSPartsOrderManagementPage: View {
             } else if filteredRows.isEmpty {
                 EmptyStateView(
                     icon: "shippingbox",
-                    title: "No Parts",
-                    message: selectedSupplierId == nil
-                        ? "Select a supplier above to view parts."
-                        : "No parts match the current filters."
+                    title: emptyReason.title,
+                    message: emptyReason.message
                 )
             } else {
                 partsList
@@ -426,14 +454,25 @@ struct IOSPartsOrderManagementPage: View {
         }
         do {
             suppliers = try service.getSuppliersWithActivePOs()
+            if suppliers.isEmpty {
+                selectedSupplierId = nil
+                allRows = []
+                loadError = nil
+            }
         } catch {
             loadError = userFriendlyError(error, context: "load parts orders")
         }
     }
 
     private func loadData() {
-        guard let service = appCore.ordersService, let suppId = selectedSupplierId else {
+        guard let service = appCore.ordersService else {
             loadError = "Orders service not available"
+            isLoading = false
+            return
+        }
+        guard let suppId = selectedSupplierId else {
+            allRows = []
+            loadError = nil
             isLoading = false
             return
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
@@ -523,9 +523,21 @@ struct WarehouseLocationsPage: View {
 
         do {
             floorPlans = try service.listFloorPlans()
-            if selectedPlanId == nil {
+            if let selectedPlanId, floorPlans.contains(where: { $0.id == selectedPlanId }) {
+                // Keep the user's current selection when it still exists.
+            } else {
                 selectedPlanId = floorPlans.first?.id
             }
+
+            guard selectedPlanId != nil else {
+                storageUnits = []
+                floorFeatures = []
+                loadError = nil
+                isLoading = false
+                postAIContext()
+                return
+            }
+
             loadPlanData()
         } catch {
             loadError = userFriendlyError(error, context: "load locations")
@@ -534,11 +546,21 @@ struct WarehouseLocationsPage: View {
     }
 
     private func loadPlanData() {
-        guard let service = appCore.warehouseService, let planId = selectedPlanId else {
-            loadError = "Service not available"
+        guard let service = appCore.warehouseService else {
+            loadError = "Warehouse service unavailable"
             isLoading = false
             return
         }
+
+        guard let planId = selectedPlanId else {
+            storageUnits = []
+            floorFeatures = []
+            loadError = nil
+            isLoading = false
+            postAIContext()
+            return
+        }
+
         do {
             storageUnits = try service.listStorageUnits(floorPlanId: planId)
             floorFeatures = try service.listFloorFeatures(floorPlanId: planId)

--- a/tests/test_ios_parts_order_management_empty_state.py
+++ b/tests/test_ios_parts_order_management_empty_state.py
@@ -1,0 +1,27 @@
+import unittest
+from pathlib import Path
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "Weird Parts IOS" / "Weird Parts IOS" / "Features" / "Orders" / "IOSPartsOrderManagementPage.swift"
+
+
+class IOSPartsOrderManagementEmptyStateTests(unittest.TestCase):
+    def test_missing_supplier_does_not_report_orders_service_unavailable(self):
+        text = SOURCE.read_text()
+
+        self.assertIn("private enum PartsOrderManagementEmptyReason", text)
+        self.assertIn("case noSuppliersWithActivePOs", text)
+        self.assertIn("No suppliers with active purchase orders", text)
+
+        load_data_start = text.index("private func loadData()")
+        load_data_end = text.index("private func postAIContext()")
+        load_data = text[load_data_start:load_data_end]
+
+        self.assertNotIn("guard let service = appCore.ordersService, let suppId = selectedSupplierId", load_data)
+        self.assertIn("Orders service not available", load_data)
+        self.assertIn("guard let suppId = selectedSupplierId else", load_data)
+        self.assertIn("loadError = nil", load_data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Recreates the completed GH #622 / GH #623 empty-state fixes from current `origin/main` on a clean branch.
- Includes the Orders Parts Management no-selected-supplier fix from WEI-2072.
- Includes the Warehouse Locations empty floor-plan fix from WEI-2071.
- Excludes the contaminated `.paperclip/DerivedData` / cache artifacts present in PR #679.

## Verification
- `python3 -m unittest tests/test_ios_parts_order_management_empty_state.py` ✅

Fixes #622
Fixes #623

Paperclip: WEI-2071, WEI-2072, WEI-2078