### PR TITLE
feat: create job notebooks atomically

### DIFF
--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -596,6 +596,10 @@ public final class JobsService: Sendable {
     ) throws -> Int64 {
         guard !jobName.trimmingCharacters(in: .whitespaces).isEmpty else { throw JobsError.requiredFieldEmpty }
         guard !jobNumber.trimmingCharacters(in: .whitespaces).isEmpty else { throw JobsError.requiredFieldEmpty }
+        let notebooks = NotebooksService(db: db)
+        if let createdBy, try notebooks.getTemplates(templateType: "job").isEmpty {
+            try notebooks.seedDefaultTemplates(createdBy: createdBy)
+        }
         return try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
@@ -624,7 +628,27 @@ public final class JobsService: Sendable {
                     jobClassification
                 ]
             )
-            return dbConn.lastInsertedRowID
+            let jobId = dbConn.lastInsertedRowID
+            let notebookCreatorId: Int64?
+            if let createdBy {
+                notebookCreatorId = createdBy
+            } else {
+                notebookCreatorId = try Int64.fetchOne(dbConn, sql: """
+                    SELECT id FROM users
+                    WHERE deleted_at IS NULL
+                    ORDER BY id ASC LIMIT 1
+                    """)
+            }
+            if let notebookCreatorId {
+                _ = try notebooks.ensureJobNotebook(
+                    dbConn: dbConn,
+                    jobId: jobId,
+                    jobName: jobName,
+                    jobType: jobType,
+                    createdBy: notebookCreatorId
+                )
+            }
+            return jobId
         }
     }
 

--- a/core/Sources/WiredPartCore/Services/NotebooksService.swift
+++ b/core/Sources/WiredPartCore/Services/NotebooksService.swift
@@ -1282,6 +1282,109 @@ public final class NotebooksService: Sendable {
         }
     }
 
+    /// Select the best job starter template for a job type.
+    public func findBestJobTemplate(jobType: String?) throws -> NotebookTemplateItem? {
+        try db.writer.read { dbConn in
+            try findBestJobTemplate(dbConn: dbConn, jobType: jobType)
+        }
+    }
+
+    /// Ensure a job has exactly one active linked job notebook, creating and templating it when missing.
+    @discardableResult
+    public func ensureJobNotebook(
+        jobId: Int64,
+        jobName: String,
+        jobType: String?,
+        createdBy: Int64
+    ) throws -> Int64 {
+        if try getTemplates(templateType: "job").isEmpty {
+            try seedDefaultTemplates(createdBy: createdBy)
+        }
+        return try db.writer.write { dbConn in
+            try ensureJobNotebook(dbConn: dbConn, jobId: jobId, jobName: jobName, jobType: jobType, createdBy: createdBy)
+        }
+    }
+
+    func findBestJobTemplate(dbConn: Database, jobType: String?) throws -> NotebookTemplateItem? {
+        let normalized = Self.normalizedJobTemplateCategory(jobType)
+        let rows = try Row.fetchAll(dbConn, sql: """
+            SELECT id, name, description, template_type, category, is_default, created_at
+            FROM notebook_templates
+            WHERE deleted_at IS NULL AND template_type = 'job'
+            ORDER BY is_default DESC, name ASC
+            """)
+        let templates = rows.map { row in
+            NotebookTemplateItem(
+                id: row["id"] ?? 0,
+                name: row["name"] ?? "",
+                description: row["description"] as String?,
+                templateType: row["template_type"] ?? "job",
+                category: row["category"] as String?,
+                isDefault: (row["is_default"] as Int?) == 1,
+                createdAt: row["created_at"] as String?
+            )
+        }
+        if let exact = templates.first(where: { Self.normalizedJobTemplateCategory($0.category) == normalized }) {
+            return exact
+        }
+        if let service = templates.first(where: { Self.normalizedJobTemplateCategory($0.category) == "service" }) {
+            return service
+        }
+        return templates.first(where: { $0.isDefault }) ?? templates.first
+    }
+
+    @discardableResult
+    func ensureJobNotebook(
+        dbConn: Database,
+        jobId: Int64,
+        jobName: String,
+        jobType: String?,
+        createdBy: Int64
+    ) throws -> Int64 {
+        if let existing = try Int64.fetchOne(dbConn, sql: """
+            SELECT id FROM notebooks
+            WHERE job_id = ? AND notebook_type = 'job' AND deleted_at IS NULL
+            ORDER BY id ASC LIMIT 1
+            """, arguments: [jobId]) {
+            return existing
+        }
+
+        let template = try findBestJobTemplate(dbConn: dbConn, jobType: jobType)
+        let titleBase = jobName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let notebookTitle = titleBase.isEmpty ? "Job Notebook" : "\(titleBase) Notebook"
+        try dbConn.execute(sql: """
+            INSERT INTO notebooks
+            (title, notebook_type, job_id, template_id, created_by, status, created_at, updated_at)
+            VALUES (?, 'job', ?, ?, ?, 'active', datetime('now'), datetime('now'))
+            """, arguments: [notebookTitle, jobId, template?.id, createdBy])
+        let notebookId = dbConn.lastInsertedRowID
+
+        if let template {
+            try applyJobTemplate(dbConn: dbConn, templateId: template.id, notebookId: notebookId, createdBy: createdBy)
+        } else {
+            try createMinimalJobNotebookSections(dbConn: dbConn, notebookId: notebookId)
+        }
+        return notebookId
+    }
+
+    private static func normalizedJobTemplateCategory(_ value: String?) -> String {
+        let normalized = (value ?? "service")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: " ", with: "_")
+        return normalized.isEmpty ? "service" : normalized
+    }
+
+    private func createMinimalJobNotebookSections(dbConn: Database, notebookId: Int64) throws {
+        for (index, name) in ["General", "Daily Log", "Photos"].enumerated() {
+            try dbConn.execute(sql: """
+                INSERT INTO notebook_sections (notebook_id, name, section_type, sort_order, is_locked, is_collapsed, created_at, updated_at)
+                VALUES (?, ?, 'standard', ?, 0, 0, datetime('now'), datetime('now'))
+                """, arguments: [notebookId, name, index])
+        }
+    }
+
     /// Create a template.
     public func createTemplate(
         name: String,
@@ -1315,54 +1418,56 @@ public final class NotebooksService: Sendable {
             try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_templates")
         }
 
-        let templateRow = try db.writer.read { dbConn in
-            try Row.fetchOne(dbConn, sql: "SELECT template_data FROM notebook_templates WHERE id = ?", arguments: [templateId])
+        // Single transaction — partial template application is worse than no application.
+        try db.writer.write { dbConn in
+            try applyJobTemplate(dbConn: dbConn, templateId: templateId, notebookId: notebookId, createdBy: createdBy)
         }
+    }
+
+    func applyJobTemplate(dbConn: Database, templateId: Int64, notebookId: Int64, createdBy: Int64) throws {
+        let templateRow = try Row.fetchOne(dbConn, sql: "SELECT template_data FROM notebook_templates WHERE id = ?", arguments: [templateId])
         guard let jsonString = templateRow?["template_data"] as String?,
               let jsonData = jsonString.data(using: .utf8) else { return }
 
         let template = try JSONDecoder().decode(NotebookTemplateData.self, from: jsonData)
 
-        // Single transaction — partial template application is worse than no application.
-        try db.writer.write { dbConn in
-            for group in template.groups {
-                let groupMaxOrder = try Int.fetchOne(dbConn, sql: """
-                    SELECT COALESCE(MAX(sort_order), -1) FROM notebook_section_groups
+        for group in template.groups {
+            let groupMaxOrder = try Int.fetchOne(dbConn, sql: """
+                SELECT COALESCE(MAX(sort_order), -1) FROM notebook_section_groups
+                WHERE notebook_id = ? AND deleted_at IS NULL
+                """, arguments: [notebookId]) ?? -1
+            try dbConn.execute(sql: """
+                INSERT INTO notebook_section_groups (notebook_id, name, sort_order, created_at, updated_at)
+                VALUES (?, ?, ?, datetime('now'), datetime('now'))
+                """, arguments: [notebookId, group.name, groupMaxOrder + 1])
+            let groupId = dbConn.lastInsertedRowID
+
+            for section in group.sections {
+                let sectionMaxOrder = try Int.fetchOne(dbConn, sql: """
+                    SELECT COALESCE(MAX(sort_order), -1) FROM notebook_sections
                     WHERE notebook_id = ? AND deleted_at IS NULL
                     """, arguments: [notebookId]) ?? -1
                 try dbConn.execute(sql: """
-                    INSERT INTO notebook_section_groups (notebook_id, name, sort_order, created_at, updated_at)
-                    VALUES (?, ?, ?, datetime('now'), datetime('now'))
-                    """, arguments: [notebookId, group.name, groupMaxOrder + 1])
-                let groupId = dbConn.lastInsertedRowID
+                    INSERT INTO notebook_sections (notebook_id, group_id, name, section_type, sort_order, is_locked, is_collapsed, created_at, updated_at)
+                    VALUES (?, ?, ?, 'standard', ?, 0, 0, datetime('now'), datetime('now'))
+                    """, arguments: [notebookId, groupId, section.name, sectionMaxOrder + 1])
+                let sectionId = dbConn.lastInsertedRowID
 
-                for section in group.sections {
-                    let sectionMaxOrder = try Int.fetchOne(dbConn, sql: """
-                        SELECT COALESCE(MAX(sort_order), -1) FROM notebook_sections
-                        WHERE notebook_id = ? AND deleted_at IS NULL
-                        """, arguments: [notebookId]) ?? -1
-                    try dbConn.execute(sql: """
-                        INSERT INTO notebook_sections (notebook_id, group_id, name, section_type, sort_order, is_locked, is_collapsed, created_at, updated_at)
-                        VALUES (?, ?, ?, 'standard', ?, 0, 0, datetime('now'), datetime('now'))
-                        """, arguments: [notebookId, groupId, section.name, sectionMaxOrder + 1])
-                    let sectionId = dbConn.lastInsertedRowID
-
-                    for (entryIndex, entry) in section.entries.enumerated() {
-                        var checklistJson: String? = nil
-                        if let items = entry.checklistItems, let data = try? JSONSerialization.data(withJSONObject: items) {
-                            checklistJson = String(data: data, encoding: .utf8)
-                        }
-                        try dbConn.execute(sql: """
-                            INSERT INTO notebook_entries (notebook_id, section_id, entry_type, block_type, title, content,
-                                heading_level, checklist_items, sort_order, created_by, created_at)
-                            VALUES (?, ?, 'note', ?, ?, ?, ?, ?, ?, ?, datetime('now'))
-                            """, arguments: [
-                                notebookId, sectionId, entry.blockType,
-                                entry.title, entry.content,
-                                entry.headingLevel, checklistJson,
-                                entryIndex, createdBy
-                            ])
+                for (entryIndex, entry) in section.entries.enumerated() {
+                    var checklistJson: String? = nil
+                    if let items = entry.checklistItems, let data = try? JSONSerialization.data(withJSONObject: items) {
+                        checklistJson = String(data: data, encoding: .utf8)
                     }
+                    try dbConn.execute(sql: """
+                        INSERT INTO notebook_entries (notebook_id, section_id, entry_type, block_type, title, content,
+                            heading_level, checklist_items, sort_order, created_by, created_at)
+                        VALUES (?, ?, 'note', ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                        """, arguments: [
+                            notebookId, sectionId, entry.blockType,
+                            entry.title, entry.content,
+                            entry.headingLevel, checklistJson,
+                            entryIndex, createdBy
+                        ])
                 }
             }
         }

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -24,6 +24,23 @@ struct JobsServiceTests {
         #expect(jobs.contains(where: { $0.jobNumber == "J-TEST" }))
     }
 
+    @Test("createJob creates a linked job notebook")
+    func testCreateJobCreatesLinkedNotebook() throws {
+        let env = try E2ETestHelpers.setUp()
+        try env.notebooks.seedDefaultTemplates(createdBy: env.adminUserId)
+
+        let jobId = try env.jobs.createJob(
+            jobNumber: "JN-AUTO-NB",
+            jobName: "Auto Notebook Job",
+            jobType: "residential",
+            createdBy: env.adminUserId
+        )
+
+        let notebooks = try env.notebooks.listNotebooks(notebookType: "job", jobId: jobId)
+        #expect(notebooks.count == 1)
+        #expect(notebooks[0].title.contains("Auto Notebook Job"))
+    }
+
     @Test("listJobs aggregates completed labor and job-linked PO line costs without duplication")
     func testListJobsAggregatesCompletedLaborAndPOLineCosts() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
@@ -401,6 +401,84 @@ struct NotebooksServiceTests {
         #expect(noMatch.isEmpty)
     }
 
+    @Test("findBestJobTemplate matches normalized job type category")
+    func testFindBestJobTemplateMatchesJobType() throws {
+        let env = try E2ETestHelpers.setUp()
+        try env.notebooks.seedDefaultTemplates(createdBy: env.adminUserId)
+
+        let template = try env.notebooks.findBestJobTemplate(jobType: "Commercial")
+
+        #expect(template?.name == "Commercial Job")
+        #expect(template?.category == "commercial")
+    }
+
+    @Test("findBestJobTemplate falls back to service template")
+    func testFindBestJobTemplateFallsBackToService() throws {
+        let env = try E2ETestHelpers.setUp()
+        try env.notebooks.seedDefaultTemplates(createdBy: env.adminUserId)
+
+        let template = try env.notebooks.findBestJobTemplate(jobType: "unknown-special")
+
+        #expect(template?.name == "Service Call")
+        #expect(template?.category == "service")
+    }
+
+    @Test("ensureJobNotebook creates one linked notebook with matching template")
+    func testEnsureJobNotebookCreatesFromTemplate() throws {
+        let env = try E2ETestHelpers.setUp()
+        try env.notebooks.seedDefaultTemplates(createdBy: env.adminUserId)
+        let jobId = try env.jobs.createJob(
+            jobNumber: "J-NB-COMMERCIAL",
+            jobName: "Office Buildout",
+            jobType: "commercial",
+            createdBy: env.adminUserId
+        )
+        try env.db.writer.write { db in
+            try db.execute(sql: "DELETE FROM notebooks WHERE job_id = ?", arguments: [jobId])
+        }
+
+        let notebookId = try env.notebooks.ensureJobNotebook(
+            jobId: jobId,
+            jobName: "Office Buildout",
+            jobType: "commercial",
+            createdBy: env.adminUserId
+        )
+
+        let detail = try env.notebooks.getNotebookDetail(id: notebookId)
+        #expect(detail.jobId == jobId)
+        #expect(detail.notebookType == "job")
+
+        let templates = try env.notebooks.getTemplates(templateType: "job")
+        let commercial = try #require(templates.first { $0.category == "commercial" })
+        let templateId = try env.db.writer.read { db in
+            try Int64.fetchOne(db, sql: "SELECT template_id FROM notebooks WHERE id = ?", arguments: [notebookId])
+        }
+        #expect(templateId == commercial.id)
+
+        let hierarchy = try env.notebooks.getNotebookHierarchy(notebookId: notebookId)
+        #expect(!hierarchy.groups.isEmpty || !hierarchy.ungroupedSections.isEmpty)
+    }
+
+    @Test("ensureJobNotebook returns existing linked notebook without duplicate")
+    func testEnsureJobNotebookNoDuplicate() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try env.jobs.createJob(
+            jobNumber: "J-NB-DEDUP",
+            jobName: "Job A",
+            jobType: "service",
+            createdBy: env.adminUserId
+        )
+
+        let first = try env.notebooks.ensureJobNotebook(jobId: jobId, jobName: "Job A", jobType: "service", createdBy: env.adminUserId)
+        let second = try env.notebooks.ensureJobNotebook(jobId: jobId, jobName: "Job A", jobType: "service", createdBy: env.adminUserId)
+
+        #expect(first == second)
+        let count = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM notebooks WHERE job_id = ? AND deleted_at IS NULL", arguments: [jobId]) ?? 0
+        }
+        #expect(count == 1)
+    }
+
     // MARK: - 9. Create From Template (Apply Job Template)
 
     @Test("Apply job template creates groups, sections, and entries")
@@ -531,12 +609,14 @@ struct NotebooksServiceTests {
         )
 
         let job1Notebooks = try env.notebooks.listNotebooks(jobId: job1)
-        #expect(job1Notebooks.count == 1)
-        #expect(job1Notebooks[0].title == "NB for Job 1")
+        #expect(job1Notebooks.count == 2)
+        #expect(job1Notebooks.contains { $0.title == "Job Alpha Notebook" })
+        #expect(job1Notebooks.contains { $0.title == "NB for Job 1" })
 
         let job2Notebooks = try env.notebooks.listNotebooks(jobId: job2)
-        #expect(job2Notebooks.count == 1)
-        #expect(job2Notebooks[0].title == "NB for Job 2")
+        #expect(job2Notebooks.count == 2)
+        #expect(job2Notebooks.contains { $0.title == "Job Beta Notebook" })
+        #expect(job2Notebooks.contains { $0.title == "NB for Job 2" })
     }
 
     // MARK: - 13. Notebook Not Found Throws


### PR DESCRIPTION
## Summary
- Adds job template selection by normalized job type with service/default fallback.
- Ensures job creation creates one linked job notebook in the same write transaction and persists the selected template_id.
- Reuses the template application helper inside existing transactions and avoids duplicate linked notebooks.
- Adds focused JobsService and NotebooksService regression tests.

## Verification
- swift test --filter 'JobsServiceTests/testCreateJobCreatesLinkedNotebook|NotebooksServiceTests/testFindBestJobTemplateMatchesJobType|NotebooksServiceTests/testFindBestJobTemplateFallsBackToService|NotebooksServiceTests/testEnsureJobNotebookCreatesFromTemplate|NotebooksServiceTests/testEnsureJobNotebookNoDuplicate'
- swift test --filter 'JobsServiceTests|NotebooksServiceTests'
- git diff --check
- swift test (timed out after 600s while still running; no failure summary before timeout)

Fixes #626