### PR TITLE
feat(parts): preview XLSX imports via shared pipeline

### DIFF
--- a/core/Package.resolved
+++ b/core/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2d2d1aba8f4bf765315b25b460fcf204beadd1651c35e143bb7a4af34ada8d42",
+  "originHash" : "943222eba1b397a39b50f7555c76e613ff16df63703b0e87580fcef0a874f13a",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "80cae244b20530bc3a4aae93ed2f211167ac08c0",
         "version" : "2.4.2-1"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation",
+      "state" : {
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],

--- a/core/Package.swift
+++ b/core/Package.swift
@@ -22,12 +22,14 @@ let package = Package(
         // `swift test` with "cannot find 'strcmp' in scope" in Swift 6 strict-module mode.
         // Package.resolved is committed to pin every environment to this exact revision.
         .package(url: "https://github.com/duckduckgo/GRDB.swift", exact: "2.4.2-1"),
+        .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.19"),
     ],
     targets: [
         .target(
             name: "WiredPartCore",
             dependencies: [
                 .product(name: "GRDB", package: "GRDB.swift"),
+                .product(name: "ZIPFoundation", package: "ZIPFoundation"),
             ]
         ),
         .testTarget(

--- a/core/Sources/WiredPartCore/Services/PartsService+XLSXImport.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService+XLSXImport.swift
@@ -12,12 +12,12 @@ extension PartsService {
             throw PartsError.invalidInput("XLSX sheet '\(workbook.sheetName)' is empty or has no data rows.")
         }
 
-        let csv = workbook.rows
-            .map { row in row.map(Self.escapeImportCSVField).joined(separator: ",") }
-            .joined(separator: "\n")
         var preview: PartsImportPreview
         do {
-            preview = try previewPartsImportCSV(csv)
+            preview = try previewPartsImportRows(
+                workbook.rows.map { PartsImportTabularRow(rowNumber: $0.rowNumber, columns: $0.columns) },
+                emptyDescription: "XLSX sheet '\(workbook.sheetName)' is empty or has no data rows."
+            )
         } catch PartsError.invalidInput(let message) {
             throw PartsError.invalidInput("XLSX sheet '\(workbook.sheetName)' row 1: \(message)")
         }
@@ -31,20 +31,23 @@ extension PartsService {
         return preview
     }
 
-    private static func escapeImportCSVField(_ field: String) -> String {
-        if field.contains(",") || field.contains("\"") || field.contains("\n") || field.contains("\r") {
-            return "\"\(field.replacingOccurrences(of: "\"", with: "\"\""))\""
-        }
-        return field
-    }
 }
 
 private struct PartsImportXLSXWorksheet {
     let sheetName: String
-    let rows: [[String]]
+    let rows: [PartsImportXLSXRow]
+}
+
+private struct PartsImportXLSXRow {
+    let rowNumber: Int
+    let columns: [String]
 }
 
 private struct PartsImportXLSXReader {
+    private static let maxArchiveEntries = 2_048
+    private static let maxEntrySize = 5 * 1024 * 1024
+    private static let maxTotalExtractedSize = 25 * 1024 * 1024
+
     let entries: [String: Data]
 
     init(data: Data) throws {
@@ -54,15 +57,75 @@ private struct PartsImportXLSXReader {
         } catch {
             throw PartsService.PartsError.invalidInput("Unsupported XLSX file: unable to open workbook archive.")
         }
+
+        var extracted = try Self.extractEntries(
+            from: archive,
+            wantedPaths: ["xl/workbook.xml", "xl/_rels/workbook.xml.rels"]
+        )
+        guard let workbookData = extracted["xl/workbook.xml"],
+              let workbookXML = String(data: workbookData, encoding: .utf8) else {
+            throw PartsService.PartsError.invalidInput("Unsupported XLSX file: missing workbook metadata at xl/workbook.xml.")
+        }
+        let firstSheet = workbookXML.xmlElements(named: "sheet").first
+        let relationshipId = firstSheet?.xmlAttribute("r:id") ?? firstSheet?.xmlAttribute("id")
+        let relationshipXML = extracted["xl/_rels/workbook.xml.rels"].flatMap { String(data: $0, encoding: .utf8) }
+        let worksheetPath = Self.resolveWorksheetPath(relationshipId: relationshipId, relationshipsXML: relationshipXML)
+
+        let sheetEntries = try Self.extractEntries(
+            from: archive,
+            wantedPaths: [worksheetPath, "xl/sharedStrings.xml"]
+        )
+        for (path, data) in sheetEntries {
+            extracted[path] = data
+        }
+        self.entries = extracted
+    }
+
+    private static func extractEntries(from archive: Archive, wantedPaths: Set<String>) throws -> [String: Data] {
         var extracted: [String: Data] = [:]
+        var scannedEntryCount = 0
+        var totalExtractedSize = 0
         for entry in archive {
+            scannedEntryCount += 1
+            guard scannedEntryCount <= maxArchiveEntries else {
+                throw PartsService.PartsError.invalidInput("Unsupported XLSX file: workbook archive has too many entries.")
+            }
+            guard wantedPaths.contains(entry.path) else { continue }
+            let advertisedSize = Int(entry.uncompressedSize)
+            guard advertisedSize <= maxEntrySize else {
+                throw PartsService.PartsError.invalidInput("Unsupported XLSX file: entry \(entry.path) is too large.")
+            }
+            totalExtractedSize += advertisedSize
+            guard totalExtractedSize <= maxTotalExtractedSize else {
+                throw PartsService.PartsError.invalidInput("Unsupported XLSX file: extracted workbook data is too large.")
+            }
+
             var entryData = Data()
             _ = try archive.extract(entry) { chunk in
                 entryData.append(chunk)
             }
+            guard entryData.count <= maxEntrySize else {
+                throw PartsService.PartsError.invalidInput("Unsupported XLSX file: entry \(entry.path) is too large.")
+            }
             extracted[entry.path] = entryData
         }
-        self.entries = extracted
+        return extracted
+    }
+
+    private static func resolveWorksheetPath(relationshipId: String?, relationshipsXML: String?) -> String {
+        guard let relationshipId, let relationshipsXML else {
+            return "xl/worksheets/sheet1.xml"
+        }
+        for relationship in relationshipsXML.xmlElements(named: "Relationship") {
+            guard relationship.xmlAttribute("Id") == relationshipId,
+                  var target = relationship.xmlAttribute("Target") else { continue }
+            if target.hasPrefix("/") {
+                target.removeFirst()
+                return target
+            }
+            return "xl/\(target)".replacingOccurrences(of: "//", with: "/")
+        }
+        return "xl/worksheets/sheet1.xml"
     }
 
     func readFirstWorksheet() throws -> PartsImportXLSXWorksheet {
@@ -111,18 +174,25 @@ private struct PartsImportXLSXReader {
         }
     }
 
-    private func parseRows(from worksheetXML: String, sharedStrings: [String]) throws -> [[String]] {
+    private func parseRows(from worksheetXML: String, sharedStrings: [String]) throws -> [PartsImportXLSXRow] {
         let rowElements = worksheetXML.xmlElements(named: "row")
-        return rowElements.compactMap { rowElement in
+        return rowElements.enumerated().compactMap { offset, rowElement in
             var cellsByColumn: [Int: String] = [:]
             var maxColumn = -1
+            var spreadsheetRowNumber = rowElement.xmlAttribute("r").flatMap(Int.init) ?? offset + 1
             for cell in rowElement.xmlElements(named: "c") {
                 guard let reference = cell.xmlAttribute("r"), let column = Self.columnIndex(from: reference) else { continue }
+                if let cellRowNumber = Self.rowNumber(from: reference) {
+                    spreadsheetRowNumber = cellRowNumber
+                }
                 maxColumn = max(maxColumn, column)
                 cellsByColumn[column] = value(for: cell, sharedStrings: sharedStrings)
             }
             guard maxColumn >= 0 else { return nil }
-            return (0...maxColumn).map { cellsByColumn[$0] ?? "" }
+            return PartsImportXLSXRow(
+                rowNumber: spreadsheetRowNumber,
+                columns: (0...maxColumn).map { cellsByColumn[$0] ?? "" }
+            )
         }
     }
 
@@ -154,6 +224,12 @@ private struct PartsImportXLSXReader {
             value = value * 26 + Int(scalar.value - 64)
         }
         return value - 1
+    }
+
+    private static func rowNumber(from cellReference: String) -> Int? {
+        let digits = cellReference.drop { $0.isLetter }
+        guard !digits.isEmpty else { return nil }
+        return Int(digits)
     }
 }
 
@@ -190,14 +266,52 @@ private extension String {
     }
 
     func xmlAttribute(_ name: String) -> String? {
-        let escaped = NSRegularExpression.escapedPattern(for: name)
-        let pattern = #"\b\#(escaped)\s*=\s*(["'])(.*?)\1"#
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return nil }
-        let range = NSRange(startIndex..<endIndex, in: self)
-        guard let match = regex.firstMatch(in: self, options: [], range: range),
-              match.numberOfRanges >= 3,
-              let valueRange = Range(match.range(at: 2), in: self) else { return nil }
-        return String(self[valueRange]).xmlUnescaped
+        let tagEnd = firstIndex(of: ">") ?? endIndex
+        var cursor = startIndex
+
+        func advancePastWhitespace() {
+            while cursor < tagEnd, self[cursor].isWhitespace {
+                cursor = index(after: cursor)
+            }
+        }
+
+        while cursor < tagEnd {
+            advancePastWhitespace()
+            guard cursor < tagEnd else { break }
+            if self[cursor] == "<" || self[cursor] == "/" {
+                cursor = index(after: cursor)
+                continue
+            }
+
+            let keyStart = cursor
+            while cursor < tagEnd,
+                  !self[cursor].isWhitespace,
+                  self[cursor] != "=",
+                  self[cursor] != "/",
+                  self[cursor] != ">" {
+                cursor = index(after: cursor)
+            }
+            let key = String(self[keyStart..<cursor])
+            advancePastWhitespace()
+            guard cursor < tagEnd, self[cursor] == "=" else { continue }
+            cursor = index(after: cursor)
+            advancePastWhitespace()
+            guard cursor < tagEnd, self[cursor] == "\"" || self[cursor] == "'" else { continue }
+
+            let quote = self[cursor]
+            let valueStart = index(after: cursor)
+            cursor = valueStart
+            while cursor < tagEnd, self[cursor] != quote {
+                cursor = index(after: cursor)
+            }
+            guard cursor < tagEnd else { break }
+            let value = String(self[valueStart..<cursor])
+            cursor = index(after: cursor)
+            if key == name {
+                return value.xmlUnescaped
+            }
+        }
+        return nil
     }
 
     func xmlInnerText() -> String {

--- a/core/Sources/WiredPartCore/Services/PartsService+XLSXImport.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService+XLSXImport.swift
@@ -1,0 +1,217 @@
+import Foundation
+import ZIPFoundation
+
+extension PartsService {
+    /// Parse and validate the first worksheet of an XLSX workbook without changing database state.
+    ///
+    /// XLSX rows are normalized into the same draft row path used by CSV import so duplicate
+    /// detection, validation, conflict generation, and atomic commit behavior stay shared.
+    public func previewPartsImportXLSX(_ data: Data) throws -> PartsImportPreview {
+        let workbook = try PartsImportXLSXReader(data: data).readFirstWorksheet()
+        guard workbook.rows.count > 1 else {
+            throw PartsError.invalidInput("XLSX sheet '\(workbook.sheetName)' is empty or has no data rows.")
+        }
+
+        let csv = workbook.rows
+            .map { row in row.map(Self.escapeImportCSVField).joined(separator: ",") }
+            .joined(separator: "\n")
+        var preview: PartsImportPreview
+        do {
+            preview = try previewPartsImportCSV(csv)
+        } catch PartsError.invalidInput(let message) {
+            throw PartsError.invalidInput("XLSX sheet '\(workbook.sheetName)' row 1: \(message)")
+        }
+
+        preview.errors = preview.errors.map { error in
+            PartsImportError(
+                rowNumber: error.rowNumber,
+                message: "XLSX sheet '\(workbook.sheetName)' row \(error.rowNumber): \(error.message)"
+            )
+        }
+        return preview
+    }
+
+    private static func escapeImportCSVField(_ field: String) -> String {
+        if field.contains(",") || field.contains("\"") || field.contains("\n") || field.contains("\r") {
+            return "\"\(field.replacingOccurrences(of: "\"", with: "\"\""))\""
+        }
+        return field
+    }
+}
+
+private struct PartsImportXLSXWorksheet {
+    let sheetName: String
+    let rows: [[String]]
+}
+
+private struct PartsImportXLSXReader {
+    let entries: [String: Data]
+
+    init(data: Data) throws {
+        let archive: Archive
+        do {
+            archive = try Archive(data: data, accessMode: .read)
+        } catch {
+            throw PartsService.PartsError.invalidInput("Unsupported XLSX file: unable to open workbook archive.")
+        }
+        var extracted: [String: Data] = [:]
+        for entry in archive {
+            var entryData = Data()
+            _ = try archive.extract(entry) { chunk in
+                entryData.append(chunk)
+            }
+            extracted[entry.path] = entryData
+        }
+        self.entries = extracted
+    }
+
+    func readFirstWorksheet() throws -> PartsImportXLSXWorksheet {
+        let workbookXML = try stringEntry("xl/workbook.xml", description: "workbook metadata")
+        let sheets = workbookXML.xmlElements(named: "sheet")
+        guard let firstSheet = sheets.first else {
+            throw PartsService.PartsError.invalidInput("Unsupported XLSX file: workbook has no worksheets.")
+        }
+
+        let sheetName = firstSheet.xmlAttribute("name") ?? "Sheet1"
+        let relationshipId = firstSheet.xmlAttribute("r:id") ?? firstSheet.xmlAttribute("id")
+        let worksheetPath = try resolveWorksheetPath(relationshipId: relationshipId)
+        let worksheetXML = try stringEntry(worksheetPath, description: "first worksheet")
+        let sharedStrings = try readSharedStrings()
+        let rows = try parseRows(from: worksheetXML, sharedStrings: sharedStrings)
+        guard !rows.isEmpty else {
+            throw PartsService.PartsError.invalidInput("Unsupported XLSX sheet '\(sheetName)': no readable rows found.")
+        }
+        return PartsImportXLSXWorksheet(sheetName: sheetName, rows: rows)
+    }
+
+    private func resolveWorksheetPath(relationshipId: String?) throws -> String {
+        guard let relationshipId,
+              let relsXML = try? stringEntry("xl/_rels/workbook.xml.rels", description: "workbook relationships") else {
+            return "xl/worksheets/sheet1.xml"
+        }
+
+        for relationship in relsXML.xmlElements(named: "Relationship") {
+            guard relationship.xmlAttribute("Id") == relationshipId,
+                  var target = relationship.xmlAttribute("Target") else { continue }
+            if target.hasPrefix("/") {
+                target.removeFirst()
+                return target
+            }
+            return "xl/\(target)".replacingOccurrences(of: "//", with: "/")
+        }
+        return "xl/worksheets/sheet1.xml"
+    }
+
+    private func readSharedStrings() throws -> [String] {
+        guard let sharedXML = try? stringEntry("xl/sharedStrings.xml", description: "shared strings") else { return [] }
+        return sharedXML.xmlElements(named: "si").map { item in
+            let textRuns = item.xmlElements(named: "t")
+            if textRuns.isEmpty { return "" }
+            return textRuns.map { $0.xmlInnerText().xmlUnescaped }.joined()
+        }
+    }
+
+    private func parseRows(from worksheetXML: String, sharedStrings: [String]) throws -> [[String]] {
+        let rowElements = worksheetXML.xmlElements(named: "row")
+        return rowElements.compactMap { rowElement in
+            var cellsByColumn: [Int: String] = [:]
+            var maxColumn = -1
+            for cell in rowElement.xmlElements(named: "c") {
+                guard let reference = cell.xmlAttribute("r"), let column = Self.columnIndex(from: reference) else { continue }
+                maxColumn = max(maxColumn, column)
+                cellsByColumn[column] = value(for: cell, sharedStrings: sharedStrings)
+            }
+            guard maxColumn >= 0 else { return nil }
+            return (0...maxColumn).map { cellsByColumn[$0] ?? "" }
+        }
+    }
+
+    private func value(for cell: String, sharedStrings: [String]) -> String {
+        let type = cell.xmlAttribute("t")
+        if type == "inlineStr" {
+            return cell.xmlElements(named: "t").map { $0.xmlInnerText().xmlUnescaped }.joined()
+        }
+        let rawValue = cell.xmlFirstElement(named: "v")?.xmlInnerText().xmlUnescaped ?? ""
+        if type == "s", let index = Int(rawValue), sharedStrings.indices.contains(index) {
+            return sharedStrings[index]
+        }
+        return rawValue
+    }
+
+    private func stringEntry(_ path: String, description: String) throws -> String {
+        guard let data = entries[path], let string = String(data: data, encoding: .utf8) else {
+            throw PartsService.PartsError.invalidInput("Unsupported XLSX file: missing \(description) at \(path).")
+        }
+        return string
+    }
+
+    private static func columnIndex(from cellReference: String) -> Int? {
+        let letters = cellReference.prefix { $0.isLetter }
+        guard !letters.isEmpty else { return nil }
+        var value = 0
+        for scalar in String(letters).uppercased().unicodeScalars {
+            guard scalar.value >= 65 && scalar.value <= 90 else { return nil }
+            value = value * 26 + Int(scalar.value - 64)
+        }
+        return value - 1
+    }
+}
+
+private extension String {
+    func xmlElements(named name: String) -> [String] {
+        var results: [String] = []
+        var searchStart = startIndex
+        let openingPrefix = "<\(name)"
+        let closingTag = "</\(name)>"
+
+        while let openRange = range(of: openingPrefix, range: searchStart..<endIndex) {
+            let afterName = index(openRange.lowerBound, offsetBy: openingPrefix.count)
+            guard afterName == endIndex || self[afterName].isWhitespace || self[afterName] == ">" || self[afterName] == "/" else {
+                searchStart = afterName
+                continue
+            }
+            guard let openEnd = range(of: ">", range: openRange.lowerBound..<endIndex)?.upperBound else { break }
+            let tagEnd = index(before: openEnd)
+            if tagEnd > openRange.lowerBound && self[index(before: tagEnd)] == "/" {
+                results.append(String(self[openRange.lowerBound..<openEnd]))
+                searchStart = openEnd
+                continue
+            }
+            guard let closeRange = range(of: closingTag, range: openEnd..<endIndex) else { break }
+            results.append(String(self[openRange.lowerBound..<closeRange.upperBound]))
+            searchStart = closeRange.upperBound
+        }
+
+        return results
+    }
+
+    func xmlFirstElement(named name: String) -> String? {
+        xmlElements(named: name).first
+    }
+
+    func xmlAttribute(_ name: String) -> String? {
+        let escaped = NSRegularExpression.escapedPattern(for: name)
+        let pattern = #"\b\#(escaped)\s*=\s*(["'])(.*?)\1"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return nil }
+        let range = NSRange(startIndex..<endIndex, in: self)
+        guard let match = regex.firstMatch(in: self, options: [], range: range),
+              match.numberOfRanges >= 3,
+              let valueRange = Range(match.range(at: 2), in: self) else { return nil }
+        return String(self[valueRange]).xmlUnescaped
+    }
+
+    func xmlInnerText() -> String {
+        guard let openEnd = firstIndex(of: ">") else { return "" }
+        if self[index(before: openEnd)] == "/" { return "" }
+        guard let closeStart = range(of: "</", options: .backwards)?.lowerBound else { return "" }
+        return String(self[index(after: openEnd)..<closeStart])
+    }
+
+    var xmlUnescaped: String {
+        replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&apos;", with: "'")
+            .replacingOccurrences(of: "&amp;", with: "&")
+    }
+}

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -5986,15 +5986,31 @@ public final class PartsService: Sendable {
     /// Optional columns: `code`, `brand`, `cost_price`, `markup_percent`,
     /// `description`, `unit_of_measure`, `shelf_location`, `bin_location`,
     /// `part_type`.
+    struct PartsImportTabularRow {
+        let rowNumber: Int
+        let columns: [String]
+    }
+
     public func previewPartsImportCSV(_ csv: String) throws -> PartsImportPreview {
-        let lines = csv.components(separatedBy: .newlines)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        guard lines.count > 1 else {
-            throw PartsError.invalidInput("CSV file is empty or has no data rows.")
+        let rows = csv.components(separatedBy: .newlines)
+            .enumerated()
+            .compactMap { offset, line -> PartsImportTabularRow? in
+                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return nil }
+                return PartsImportTabularRow(
+                    rowNumber: offset + 1,
+                    columns: parseImportCSVLine(trimmed)
+                )
+            }
+        return try previewPartsImportRows(rows, emptyDescription: "CSV file is empty or has no data rows.")
+    }
+
+    func previewPartsImportRows(_ rows: [PartsImportTabularRow], emptyDescription: String) throws -> PartsImportPreview {
+        guard rows.count > 1 else {
+            throw PartsError.invalidInput(emptyDescription)
         }
 
-        let headers = parseImportCSVLine(lines[0]).map { $0.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) }
+        let headers = rows[0].columns.map { $0.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) }
         guard let nameIdx = headers.firstIndex(of: "name") else {
             throw PartsError.invalidInput("CSV must have a 'name' column.")
         }
@@ -6004,10 +6020,10 @@ public final class PartsService: Sendable {
         let codeIdx = headers.firstIndex(of: "code")
         let brandIdx = headers.firstIndex(of: "brand")
 
-        var preview = PartsImportPreview(totalRows: lines.count - 1)
-        for lineIdx in 1..<lines.count {
-            let rowNumber = lineIdx + 1
-            let columns = parseImportCSVLine(lines[lineIdx])
+        var preview = PartsImportPreview(totalRows: rows.count - 1)
+        for row in rows.dropFirst() {
+            let rowNumber = row.rowNumber
+            let columns = row.columns
             func value(at index: Int?) -> String? {
                 guard let index, index < columns.count else { return nil }
                 let trimmed = columns[index].trimmingCharacters(in: .whitespacesAndNewlines)

--- a/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
@@ -23,6 +23,87 @@ private func insertPoweredVote(
     }
 }
 
+// MARK: - Helper: Build a minimal XLSX workbook for import tests
+
+private func makeMinimalXLSX(sheetName: String, rows: [[String]]) throws -> Data {
+    func escapeXML(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
+    }
+
+    func columnName(_ index: Int) -> String {
+        var number = index + 1
+        var result = ""
+        while number > 0 {
+            let remainder = (number - 1) % 26
+            result.insert(Character(UnicodeScalar(65 + remainder)!), at: result.startIndex)
+            number = (number - 1) / 26
+        }
+        return result
+    }
+
+    let temporaryDirectory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("xlsx-test-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+    let xlDirectory = temporaryDirectory.appendingPathComponent("xl", isDirectory: true)
+    let worksheetsDirectory = xlDirectory.appendingPathComponent("worksheets", isDirectory: true)
+    let relationshipsDirectory = xlDirectory.appendingPathComponent("_rels", isDirectory: true)
+    try FileManager.default.createDirectory(at: worksheetsDirectory, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: relationshipsDirectory, withIntermediateDirectories: true)
+
+    try """
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      <Default Extension="xml" ContentType="application/xml"/>
+      <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+      <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+    </Types>
+    """.write(to: temporaryDirectory.appendingPathComponent("[Content_Types].xml"), atomically: true, encoding: .utf8)
+
+    try """
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <sheets><sheet name="\(escapeXML(sheetName))" sheetId="1" r:id="rId1"/></sheets>
+    </workbook>
+    """.write(to: xlDirectory.appendingPathComponent("workbook.xml"), atomically: true, encoding: .utf8)
+
+    try """
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+    </Relationships>
+    """.write(to: relationshipsDirectory.appendingPathComponent("workbook.xml.rels"), atomically: true, encoding: .utf8)
+
+    let rowXML: String = rows.enumerated().map { rowIndex, values in
+        let cells: String = values.enumerated().map { columnIndex, value in
+            "<c r=\"\(columnName(columnIndex))\(rowIndex + 1)\" t=\"inlineStr\"><is><t>\(escapeXML(value))</t></is></c>"
+        }.joined()
+        return "<row r=\"\(rowIndex + 1)\">\(cells)</row>"
+    }.joined()
+    try """
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      <sheetData>\(rowXML)</sheetData>
+    </worksheet>
+    """.write(to: worksheetsDirectory.appendingPathComponent("sheet1.xml"), atomically: true, encoding: .utf8)
+
+    let zipURL = temporaryDirectory.appendingPathComponent("workbook.xlsx")
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+    process.arguments = ["-q", "-r", zipURL.path, "[Content_Types].xml", "xl"]
+    process.currentDirectoryURL = temporaryDirectory
+    try process.run()
+    process.waitUntilExit()
+    #expect(process.terminationStatus == 0)
+    return try Data(contentsOf: zipURL)
+}
+
 // MARK: - Helper: Seed a qualified co_occurrence_pairs row
 
 private func seedCoOccurrencePair(
@@ -243,6 +324,69 @@ struct PartsServiceAdvancedTests {
         let updated = try #require(try env.parts.findPartByCode("EX-002"))
         #expect(updated.id == existingId)
         #expect(updated.name == "Updated Name")
+    }
+
+    @Test("previewPartsImportXLSX parses first worksheet through shared import pipeline")
+    func testPreviewPartsImportXLSXClassifiesRows() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "Existing Category")
+        _ = try env.parts.createPart(categoryId: catId, name: "Existing Part", code: "XLS-EX-001")
+
+        let xlsx = try makeMinimalXLSX(sheetName: "Import Sheet", rows: [
+            ["name", "code", "category", "brand", "cost_price", "markup_percent", "description", "unit_of_measure", "shelf_location", "bin_location", "part_type"],
+            ["XLSX New Part", "XLS-N-001", "XLS Category", "XLS Brand", "12.50", "25", "xlsx description", "each", "S1", "B1", "material"],
+            ["Existing Replacement", "XLS-EX-001", "Existing Category", "XLS Brand", "9", "10", "", "box", "S2", "B2", "tool"]
+        ])
+
+        var preview = try env.parts.previewPartsImportXLSX(xlsx)
+        #expect(preview.totalRows == 2)
+        #expect(preview.newParts.count == 1)
+        #expect(preview.newParts.first?.name == "XLSX New Part")
+        #expect(preview.newParts.first?.fields["description"] == "xlsx description")
+        #expect(preview.newParts.first?.fields["unit_of_measure"] == "each")
+        #expect(preview.conflicts.count == 1)
+        #expect(preview.conflicts.first?.existingPartCode == "XLS-EX-001")
+        preview.conflicts = preview.conflicts.map { conflict in
+            var editable = conflict
+            editable.resolution = .update
+            return editable
+        }
+
+        let result = try env.parts.commitPartsImportCSV(preview)
+        #expect(result.created == 1)
+        #expect(result.updated == 1)
+        #expect(try env.parts.findPartByCode("XLS-N-001")?.name == "XLSX New Part")
+    }
+
+    @Test("previewPartsImportXLSX reports sheet and spreadsheet row evidence for invalid cells")
+    func testPreviewPartsImportXLSXReportsSheetRowErrors() throws {
+        let env = try E2ETestHelpers.setUp()
+        let xlsx = try makeMinimalXLSX(sheetName: "Bad Numbers", rows: [
+            ["name", "code", "category", "cost_price"],
+            ["Bad Cost", "BC-XLS", "XLS Category", "not-a-number"]
+        ])
+
+        let preview = try env.parts.previewPartsImportXLSX(xlsx)
+
+        #expect(preview.errors.count == 1)
+        #expect(preview.errors.first?.rowNumber == 2)
+        #expect(preview.errors.first?.message.contains("Bad Numbers") == true)
+        #expect(preview.errors.first?.message.contains("row 2") == true)
+        #expect(preview.errors.first?.message.contains("Invalid number for cost_price") == true)
+    }
+
+    @Test("previewPartsImportXLSX rejects missing required headers before writes")
+    func testPreviewPartsImportXLSXRejectsMissingHeaders() throws {
+        let env = try E2ETestHelpers.setUp()
+        let xlsx = try makeMinimalXLSX(sheetName: "Missing Headers", rows: [
+            ["code", "category"],
+            ["NO-NAME", "XLS Category"]
+        ])
+
+        #expect(throws: (any Error).self) {
+            _ = try env.parts.previewPartsImportXLSX(xlsx)
+        }
+        #expect(try env.parts.findPartByCode("NO-NAME") == nil)
     }
 
     // MARK: - approveScheduledDeletion

--- a/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import GRDB
+import ZIPFoundation
 @testable import WiredPartCore
 
 // MARK: - Helper: Insert a powered vote directly (bypassing hat-permission check)
@@ -25,7 +26,7 @@ private func insertPoweredVote(
 
 // MARK: - Helper: Build a minimal XLSX workbook for import tests
 
-private func makeMinimalXLSX(sheetName: String, rows: [[String]]) throws -> Data {
+private func makeMinimalXLSX(sheetName: String, rows: [[String]], rowNumbers: [Int]? = nil) throws -> Data {
     func escapeXML(_ value: String) -> String {
         value
             .replacingOccurrences(of: "&", with: "&amp;")
@@ -46,17 +47,7 @@ private func makeMinimalXLSX(sheetName: String, rows: [[String]]) throws -> Data
         return result
     }
 
-    let temporaryDirectory = FileManager.default.temporaryDirectory
-        .appendingPathComponent("xlsx-test-\(UUID().uuidString)", isDirectory: true)
-    defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
-
-    let xlDirectory = temporaryDirectory.appendingPathComponent("xl", isDirectory: true)
-    let worksheetsDirectory = xlDirectory.appendingPathComponent("worksheets", isDirectory: true)
-    let relationshipsDirectory = xlDirectory.appendingPathComponent("_rels", isDirectory: true)
-    try FileManager.default.createDirectory(at: worksheetsDirectory, withIntermediateDirectories: true)
-    try FileManager.default.createDirectory(at: relationshipsDirectory, withIntermediateDirectories: true)
-
-    try """
+    let contentTypesXML = """
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
       <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
@@ -64,44 +55,53 @@ private func makeMinimalXLSX(sheetName: String, rows: [[String]]) throws -> Data
       <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
       <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
     </Types>
-    """.write(to: temporaryDirectory.appendingPathComponent("[Content_Types].xml"), atomically: true, encoding: .utf8)
+    """
 
-    try """
+    let workbookXML = """
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
       <sheets><sheet name="\(escapeXML(sheetName))" sheetId="1" r:id="rId1"/></sheets>
     </workbook>
-    """.write(to: xlDirectory.appendingPathComponent("workbook.xml"), atomically: true, encoding: .utf8)
+    """
 
-    try """
+    let workbookRelationshipsXML = """
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
       <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
     </Relationships>
-    """.write(to: relationshipsDirectory.appendingPathComponent("workbook.xml.rels"), atomically: true, encoding: .utf8)
+    """
 
     let rowXML: String = rows.enumerated().map { rowIndex, values in
+        let spreadsheetRow = rowNumbers?[rowIndex] ?? rowIndex + 1
         let cells: String = values.enumerated().map { columnIndex, value in
-            "<c r=\"\(columnName(columnIndex))\(rowIndex + 1)\" t=\"inlineStr\"><is><t>\(escapeXML(value))</t></is></c>"
+            "<c r=\"\(columnName(columnIndex))\(spreadsheetRow)\" t=\"inlineStr\"><is><t>\(escapeXML(value))</t></is></c>"
         }.joined()
-        return "<row r=\"\(rowIndex + 1)\">\(cells)</row>"
+        return "<row r=\"\(spreadsheetRow)\">\(cells)</row>"
     }.joined()
-    try """
+    let worksheetXML = """
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
       <sheetData>\(rowXML)</sheetData>
     </worksheet>
-    """.write(to: worksheetsDirectory.appendingPathComponent("sheet1.xml"), atomically: true, encoding: .utf8)
+    """
 
-    let zipURL = temporaryDirectory.appendingPathComponent("workbook.xlsx")
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
-    process.arguments = ["-q", "-r", zipURL.path, "[Content_Types].xml", "xl"]
-    process.currentDirectoryURL = temporaryDirectory
-    try process.run()
-    process.waitUntilExit()
-    #expect(process.terminationStatus == 0)
-    return try Data(contentsOf: zipURL)
+    let temporaryURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("xlsx-test-\(UUID().uuidString).xlsx")
+    defer { try? FileManager.default.removeItem(at: temporaryURL) }
+
+    let archive = try Archive(url: temporaryURL, accessMode: .create)
+    let entries: [(String, Data)] = [
+        ("[Content_Types].xml", Data(contentTypesXML.utf8)),
+        ("xl/workbook.xml", Data(workbookXML.utf8)),
+        ("xl/_rels/workbook.xml.rels", Data(workbookRelationshipsXML.utf8)),
+        ("xl/worksheets/sheet1.xml", Data(worksheetXML.utf8))
+    ]
+    for (path, data) in entries {
+        try archive.addEntry(with: path, type: .file, uncompressedSize: Int64(data.count)) { position, size in
+            data.subdata(in: Int(position)..<Int(position) + size)
+        }
+    }
+    return try Data(contentsOf: temporaryURL)
 }
 
 // MARK: - Helper: Seed a qualified co_occurrence_pairs row
@@ -373,6 +373,38 @@ struct PartsServiceAdvancedTests {
         #expect(preview.errors.first?.message.contains("Bad Numbers") == true)
         #expect(preview.errors.first?.message.contains("row 2") == true)
         #expect(preview.errors.first?.message.contains("Invalid number for cost_price") == true)
+    }
+
+
+
+    @Test("previewPartsImportXLSX preserves spreadsheet row numbers across blank rows")
+    func testPreviewPartsImportXLSXPreservesSparseSpreadsheetRowNumbers() throws {
+        let env = try E2ETestHelpers.setUp()
+        let xlsx = try makeMinimalXLSX(sheetName: "Sparse Rows", rows: [
+            ["name", "code", "category", "cost_price"],
+            ["Bad Sparse Cost", "BSC-XLS", "XLS Category", "not-a-number"]
+        ], rowNumbers: [1, 5])
+
+        let preview = try env.parts.previewPartsImportXLSX(xlsx)
+
+        #expect(preview.errors.count == 1)
+        #expect(preview.errors.first?.rowNumber == 5)
+        #expect(preview.errors.first?.message.contains("row 5") == true)
+    }
+
+    @Test("previewPartsImportXLSX imports quote-heavy cells without CSV escaping loss")
+    func testPreviewPartsImportXLSXPreservesQuotedCellText() throws {
+        let env = try E2ETestHelpers.setUp()
+        let xlsx = try makeMinimalXLSX(sheetName: "Quotes", rows: [
+            ["name", "code", "category", "description"],
+            ["Quoted XLSX Part", "Q-XLS", "XLS Category", "has, comma and \"quoted\" text"]
+        ])
+
+        let preview = try env.parts.previewPartsImportXLSX(xlsx)
+
+        #expect(preview.errors.isEmpty)
+        #expect(preview.newParts.count == 1)
+        #expect(preview.newParts.first?.fields["description"] == "has, comma and \"quoted\" text")
     }
 
     @Test("previewPartsImportXLSX rejects missing required headers before writes")


### PR DESCRIPTION
## Summary
- Add XLSX workbook preview support for first worksheet using ZIPFoundation and shared CSV import preview/commit pipeline
- Preserve sheet name and spreadsheet row number in XLSX validation errors
- Cover happy path, conflict detection, invalid numeric cells, missing headers, and no-partial-write behavior through import tests

## Test Plan
- swift test --filter PartsServiceAdvancedTests/testPreviewPartsImportXLSX
- swift test --filter PartsServiceAdvancedTests/testPreviewPartsImportCSVClassifiesRows
- swift test --filter PartsServiceAdvancedTests/testCommitPartsImportCSV

Notes: swift test --filter PartsServiceAdvancedTests currently has two unrelated approveScheduledDeletion permission failures in existing tests.