### PR TITLE
fix(scheduling): soft-delete subcontractor cancellations

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateSubcontractorScheduleSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateSubcontractorScheduleSheet.swift
@@ -26,7 +26,7 @@ struct CreateSubcontractorScheduleSheet: View {
     @State private var isSaving = false
     @State private var saveError: String?
 
-    private let statuses = ["scheduled", "confirmed", "completed", "cancelled"]
+    private let statuses = ["scheduled", "confirmed", "completed"]
 
     init(
         initialDate: Date,

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSSubSchedulePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSSubSchedulePage.swift
@@ -17,6 +17,8 @@ struct IOSSubSchedulePage: View {
     @State private var selectedDate = Date()
     @State private var searchText = ""
     @State private var activeSheet: ActiveSheet?
+    @State private var rowPendingCancellation: SchedulingService.SubScheduleRow?
+    @State private var isCancelling = false
 
     private enum ActiveSheet: Identifiable {
         case create
@@ -79,6 +81,12 @@ struct IOSSubSchedulePage: View {
         }
         .refreshable { loadData() }
         .task { loadData() }
+        .alert("Cancel Schedule?", isPresented: cancellationAlertBinding, presenting: rowPendingCancellation) { row in
+            Button("Cancel Schedule", role: .destructive) { cancelSubSchedule(row) }
+            Button("Keep Schedule", role: .cancel) { rowPendingCancellation = nil }
+        } message: { row in
+            Text("This removes \(row.subName) from \(formatDate(row.scheduleDate)) and frees the job/sub/date slot for rescheduling.")
+        }
     }
 
     // MARK: - Date Navigator
@@ -142,6 +150,8 @@ struct IOSSubSchedulePage: View {
                     .contentShape(Rectangle())
                     .onTapGesture { activeSheet = .edit(row) }
                     .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button("Cancel Schedule", role: .destructive) { rowPendingCancellation = row }
+                            .disabled(isCancelling)
                         Button("Edit") { activeSheet = .edit(row) }
                             .tint(.blue)
                     }
@@ -220,6 +230,15 @@ struct IOSSubSchedulePage: View {
 
     // MARK: - Helpers
 
+    private var cancellationAlertBinding: Binding<Bool> {
+        Binding(
+            get: { rowPendingCancellation != nil },
+            set: { isPresented in
+                if !isPresented { rowPendingCancellation = nil }
+            }
+        )
+    }
+
     private func formatDate(_ dateString: String) -> String {
         guard let date = Formatters.localDateFormatter.date(from: String(dateString.prefix(10))) else {
             return String(dateString.prefix(10))
@@ -252,5 +271,25 @@ struct IOSSubSchedulePage: View {
             loadError = userFriendlyError(error, context: "load sub schedule")
         }
         isLoading = false
+    }
+
+    private func cancelSubSchedule(_ row: SchedulingService.SubScheduleRow) {
+        guard let service = appCore.schedulingService else {
+            loadError = "Service not available"
+            rowPendingCancellation = nil
+            return
+        }
+
+        isCancelling = true
+        loadError = nil
+        do {
+            try service.cancelSubcontractorSchedule(id: row.id)
+            rowPendingCancellation = nil
+            loadData()
+        } catch {
+            loadError = userFriendlyError(error, context: "cancel sub schedule")
+            rowPendingCancellation = nil
+        }
+        isCancelling = false
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -5,6 +5,7 @@
 //  Created by Isaac Aznoe on 3/15/26.
 //
 
+import Foundation
 import Testing
 import WiredPartCore
 @testable import Weird_Parts
@@ -162,6 +163,23 @@ struct Weird_Parts_IOSTests {
     @Test func receivingRoutingShowsActionableErrorForUnknownPartRoutes() throws {
         #expect(ReceivingRoutingValidation.missingLinkedPartError(partId: nil) == "This receiving item is no longer linked to an active part. Mark it as a wrong part or fix the PO line before routing damaged or used inventory.")
         #expect(ReceivingRoutingValidation.missingLinkedPartError(partId: 6) == nil)
+    }
+
+    @Test func subSchedulePageExposesExplicitSoftDeleteCancellationAction() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let pageURL = repoRoot
+            .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSSubSchedulePage.swift")
+        let sheetURL = repoRoot
+            .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateSubcontractorScheduleSheet.swift")
+        let pageSource = try String(contentsOf: pageURL, encoding: .utf8)
+        let sheetSource = try String(contentsOf: sheetURL, encoding: .utf8)
+
+        #expect(pageSource.contains("cancelSubcontractorSchedule"), "Sub schedule rows need an explicit cancel action wired to the service soft-delete API")
+        #expect(pageSource.contains("Cancel Schedule"), "The destructive UI should be labelled as cancellation, not hidden behind edit/status changes")
+        #expect(!sheetSource.contains("\"cancelled\""), "Editing status to cancelled leaves deleted_at NULL; cancellation must use the explicit soft-delete action")
     }
 
     @Test func uiTestingFixturesSeedJPOFlowDataForQASmoke() throws {

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -132,6 +132,7 @@ extension AppDatabase {
         registerMigration093DailyReportClockOutQuestion(&migrator)
         registerMigration094ShortTermPipelineCategoryOverride(&migrator)
         registerMigration095JobStageTemplates(&migrator)
+        registerMigration096SubcontractorScheduleSoftDeleteUniqueness(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -1838,8 +1839,12 @@ extension AppDatabase {
                 t.column("deleted_at", .text)
                 t.column("created_at", .text).defaults(sql: "(datetime('now'))")
                 t.column("updated_at", .text).defaults(sql: "(datetime('now'))")
-                t.uniqueKey(["job_id", "gc_id", "scheduled_date"])
             }
+            try db.execute(sql: """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_subcontractor_schedules_active_slot
+                ON subcontractor_schedules(job_id, gc_id, scheduled_date)
+                WHERE deleted_at IS NULL
+                """)
         }
     }
 }
@@ -5507,6 +5512,51 @@ extension AppDatabase {
                 ON job_stage_category_map(template_id, category_id)
                 """)
             try db.execute(sql: "CREATE INDEX idx_jscm_template ON job_stage_category_map(template_id)")
+        }
+    }
+
+    // MARK: - Migration 096: Subcontractor schedule active-slot uniqueness
+
+    private static func registerMigration096SubcontractorScheduleSoftDeleteUniqueness(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("096_subcontractor_schedule_soft_delete_uniqueness") { db in
+            // GH #612: cancelled subcontractor schedules are soft-deleted and must
+            // not keep blocking the same job/sub/date from being scheduled again.
+            // The original table-level UNIQUE(job_id, gc_id, scheduled_date) still
+            // applied to deleted rows, so rebuild the table without that constraint
+            // and replace it with a partial unique index on active rows only.
+            try db.execute(sql: "DROP INDEX IF EXISTS idx_subcontractor_schedules_active_slot")
+            try db.execute(sql: "ALTER TABLE subcontractor_schedules RENAME TO subcontractor_schedules_old")
+            try db.create(table: "subcontractor_schedules") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("job_id", .integer).notNull()
+                    .references("jobs", onDelete: .cascade)
+                t.column("gc_id", .integer).notNull()
+                    .references("general_contractors", onDelete: .cascade)
+                t.column("scheduled_date", .text).notNull()
+                t.column("arrival_time", .text)
+                t.column("departure_time", .text)
+                t.column("scope_of_work", .text)
+                t.column("status", .text).defaults(to: "scheduled")
+                t.column("notes", .text)
+                t.column("created_by", .integer).references("users")
+                t.column("deleted_at", .text)
+                t.column("created_at", .text).defaults(sql: "(datetime('now'))")
+                t.column("updated_at", .text).defaults(sql: "(datetime('now'))")
+            }
+            try db.execute(sql: """
+                INSERT INTO subcontractor_schedules
+                    (id, job_id, gc_id, scheduled_date, arrival_time, departure_time,
+                     scope_of_work, status, notes, created_by, deleted_at, created_at, updated_at)
+                SELECT id, job_id, gc_id, scheduled_date, arrival_time, departure_time,
+                       scope_of_work, status, notes, created_by, deleted_at, created_at, updated_at
+                FROM subcontractor_schedules_old
+                """)
+            try db.drop(table: "subcontractor_schedules_old")
+            try db.execute(sql: """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_subcontractor_schedules_active_slot
+                ON subcontractor_schedules(job_id, gc_id, scheduled_date)
+                WHERE deleted_at IS NULL
+                """)
         }
     }
 }

--- a/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
@@ -1599,6 +1599,43 @@ struct SchedulingServiceTests {
         #expect(deletedAt != nil)
     }
 
+    @Test("cancelSubcontractorSchedule frees the job, subcontractor, and date for rescheduling")
+    func testCancelSubcontractorScheduleAllowsRescheduleSameSlot() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let gcId = try seedSchedulingContractor(env, contactName: "Reusable Sub", companyName: "Reusable Co")
+        let cancelledScheduleId = try env.scheduling.createSubcontractorSchedule(
+            jobId: jobId,
+            gcId: gcId,
+            scheduledDate: "2026-09-15",
+            arrivalTime: nil,
+            departureTime: nil,
+            scopeOfWork: nil,
+            status: "scheduled",
+            notes: nil,
+            createdBy: nil
+        )
+
+        try env.scheduling.cancelSubcontractorSchedule(id: cancelledScheduleId)
+
+        let newScheduleId = try env.scheduling.createSubcontractorSchedule(
+            jobId: jobId,
+            gcId: gcId,
+            scheduledDate: "2026-09-15",
+            arrivalTime: "10:00",
+            departureTime: nil,
+            scopeOfWork: "Rescheduled work",
+            status: "scheduled",
+            notes: nil,
+            createdBy: env.adminUserId
+        )
+
+        #expect(newScheduleId != cancelledScheduleId)
+        let visibleRows = try env.scheduling.getSubSchedule(date: "2026-09-15")
+        #expect(visibleRows.map(\.id) == [newScheduleId])
+        #expect(visibleRows[0].arrivalTime == "10:00")
+    }
+
     private func seedSchedulingContractor(_ env: E2ETestHelpers.TestEnvironment, contactName: String, companyName: String) throws -> Int64 {
         try env.db.writer.write { db -> Int64 in
             try db.execute(sql: """


### PR DESCRIPTION
## Summary
- Rebuilds subcontractor_schedules with active-slot uniqueness scoped to non-deleted rows
- Keeps cancelled subcontractor schedules as soft-deleted audit history while freeing the same job/sub/date for rescheduling
- Adds iOS/service regression coverage for cancelled rows being hidden and rescheduling after cancel
- Rebased the migration on top of current main as migration 096 so it coexists with job stage templates migration 095

## Test Plan
- [x] swift test --filter SchedulingServiceTests

Refs #612