### PR TITLE
feat(parts): add OCR import preview prototype

### DIFF
--- a/core/Sources/WiredPartCore/Services/PartsService+OCRImportPreview.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService+OCRImportPreview.swift
@@ -141,12 +141,12 @@ extension PartsService {
             let lines = normalizedOCRLines(page.text)
             guard !lines.isEmpty else { continue }
 
+            var chunkNumber = 1
             var startIndex = 0
             while startIndex < lines.count {
                 let endIndex = min(startIndex + chunkLineLimit, lines.count)
                 let chunkLines = Array(lines[startIndex..<endIndex])
                 let text = chunkLines.joined(separator: "\n")
-                let chunkNumber = chunks.filter { $0.pageNumber == page.pageNumber }.count + 1
                 let id = "p\(page.pageNumber)-c\(chunkNumber)"
                 chunks.append(PartsOCRImportChunk(
                     id: id,
@@ -154,6 +154,7 @@ extension PartsService {
                     text: text,
                     snippet: makeOCRSnippet(from: text)
                 ))
+                chunkNumber += 1
                 startIndex = endIndex
             }
         }
@@ -166,9 +167,14 @@ extension PartsService {
         var candidates: [PartsOCRImportCandidate] = []
         var errors: [PartsOCRImportError] = []
         var activeHeader: OCRPartsHeader?
+        var activePageNumber: Int?
         var rowNumber = 1
 
         for chunk in chunks {
+            if activePageNumber != chunk.pageNumber {
+                activePageNumber = chunk.pageNumber
+                activeHeader = nil
+            }
             for line in normalizedOCRLines(chunk.text) {
                 let cells = splitOCRTableLine(line)
                 guard cells.count >= 2 else { continue }
@@ -190,8 +196,14 @@ extension PartsService {
                     rowErrors.append("Missing required category")
                 }
                 for numericHeader in ["cost_price", "markup_percent"] {
-                    if let raw = normalized.fields[numericHeader], Double(raw) == nil {
-                        rowErrors.append("Invalid number for \(numericHeader): \(raw)")
+                    if let raw = normalized.fields[numericHeader] {
+                        guard let value = Double(raw) else {
+                            rowErrors.append("Invalid number for \(numericHeader): \(raw)")
+                            continue
+                        }
+                        if value < 0 {
+                            rowErrors.append("\(numericHeader) cannot be negative")
+                        }
                     }
                 }
 

--- a/core/Sources/WiredPartCore/Services/PartsService+OCRImportPreview.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService+OCRImportPreview.swift
@@ -1,0 +1,355 @@
+import Foundation
+
+// MARK: - PDF/OCR Import Preview Prototype
+
+extension PartsService {
+    /// One page of text extracted from a PDF/image OCR pass.
+    ///
+    /// Platform UI/adapters can use Apple Vision/VisionKit to produce these pages;
+    /// the core importer stays deterministic so chunking and row normalization are
+    /// testable without image fixtures or device-only frameworks.
+    public struct PartsOCRTextPage: Sendable {
+        public let pageNumber: Int
+        public let text: String
+
+        public init(pageNumber: Int, text: String) {
+            self.pageNumber = pageNumber
+            self.text = text
+        }
+    }
+
+    /// Small evidence chunk from extracted OCR text.
+    public struct PartsOCRImportChunk: Sendable, Identifiable {
+        public let id: String
+        public let pageNumber: Int
+        public let text: String
+        public let snippet: String
+
+        public init(id: String, pageNumber: Int, text: String, snippet: String) {
+            self.id = id
+            self.pageNumber = pageNumber
+            self.text = text
+            self.snippet = snippet
+        }
+    }
+
+    /// Proposed import row detected from OCR text. It is intentionally not a
+    /// commit-ready CSV row: every field carries source evidence for human/AI review.
+    public struct PartsOCRImportCandidate: Sendable {
+        public let rowNumber: Int
+        public let chunkId: String
+        public let pageNumber: Int
+        public let sourceSnippet: String
+        public let confidence: Double
+        public let name: String
+        public let code: String?
+        public let category: String
+        public let brand: String?
+        public let fields: [String: String]
+
+        public init(
+            rowNumber: Int,
+            chunkId: String,
+            pageNumber: Int,
+            sourceSnippet: String,
+            confidence: Double,
+            name: String,
+            code: String?,
+            category: String,
+            brand: String?,
+            fields: [String: String]
+        ) {
+            self.rowNumber = rowNumber
+            self.chunkId = chunkId
+            self.pageNumber = pageNumber
+            self.sourceSnippet = sourceSnippet
+            self.confidence = confidence
+            self.name = name
+            self.code = code
+            self.category = category
+            self.brand = brand
+            self.fields = fields
+        }
+    }
+
+    /// Validation issue surfaced while normalizing an OCR candidate row.
+    public struct PartsOCRImportError: Error, Sendable {
+        public let pageNumber: Int
+        public let sourceSnippet: String
+        public let message: String
+
+        public init(pageNumber: Int, sourceSnippet: String, message: String) {
+            self.pageNumber = pageNumber
+            self.sourceSnippet = sourceSnippet
+            self.message = message
+        }
+    }
+
+    /// Preview-only result for OCR/PDF imports. No commit entry point consumes this
+    /// type yet; `isCommitAllowed` remains false until evidence review UX/rules are approved.
+    public struct PartsOCRImportPreview: Sendable {
+        public let chunks: [PartsOCRImportChunk]
+        public let candidates: [PartsOCRImportCandidate]
+        public let errors: [PartsOCRImportError]
+        public let isCommitAllowed: Bool
+
+        public init(
+            chunks: [PartsOCRImportChunk],
+            candidates: [PartsOCRImportCandidate],
+            errors: [PartsOCRImportError],
+            isCommitAllowed: Bool = false
+        ) {
+            self.chunks = chunks
+            self.candidates = candidates
+            self.errors = errors
+            self.isCommitAllowed = isCommitAllowed
+        }
+    }
+
+    /// Deterministically chunk OCR text and detect likely parts table rows.
+    ///
+    /// This is a preview-only prototype: it normalizes likely rows and evidence,
+    /// but does not write to the database and deliberately does not expose a commit flow.
+    public func previewPartsImportOCR(
+        pages: [PartsOCRTextPage],
+        chunkLineLimit: Int = 8
+    ) throws -> PartsOCRImportPreview {
+        let cleanedPages = pages
+            .filter { !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .sorted { $0.pageNumber < $1.pageNumber }
+        guard !cleanedPages.isEmpty else {
+            throw PartsError.invalidInput("OCR import preview requires at least one page of extracted text.")
+        }
+
+        let safeChunkLineLimit = max(1, chunkLineLimit)
+        let chunks = makeOCRImportChunks(pages: cleanedPages, chunkLineLimit: safeChunkLineLimit)
+        let parsed = detectOCRImportRows(in: chunks)
+        return PartsOCRImportPreview(
+            chunks: chunks,
+            candidates: parsed.candidates,
+            errors: parsed.errors,
+            isCommitAllowed: false
+        )
+    }
+
+    private func makeOCRImportChunks(
+        pages: [PartsOCRTextPage],
+        chunkLineLimit: Int
+    ) -> [PartsOCRImportChunk] {
+        var chunks: [PartsOCRImportChunk] = []
+        for page in pages {
+            let lines = normalizedOCRLines(page.text)
+            guard !lines.isEmpty else { continue }
+
+            var startIndex = 0
+            while startIndex < lines.count {
+                let endIndex = min(startIndex + chunkLineLimit, lines.count)
+                let chunkLines = Array(lines[startIndex..<endIndex])
+                let text = chunkLines.joined(separator: "\n")
+                let chunkNumber = chunks.filter { $0.pageNumber == page.pageNumber }.count + 1
+                let id = "p\(page.pageNumber)-c\(chunkNumber)"
+                chunks.append(PartsOCRImportChunk(
+                    id: id,
+                    pageNumber: page.pageNumber,
+                    text: text,
+                    snippet: makeOCRSnippet(from: text)
+                ))
+                startIndex = endIndex
+            }
+        }
+        return chunks
+    }
+
+    private func detectOCRImportRows(
+        in chunks: [PartsOCRImportChunk]
+    ) -> (candidates: [PartsOCRImportCandidate], errors: [PartsOCRImportError]) {
+        var candidates: [PartsOCRImportCandidate] = []
+        var errors: [PartsOCRImportError] = []
+        var activeHeader: OCRPartsHeader?
+        var rowNumber = 1
+
+        for chunk in chunks {
+            for line in normalizedOCRLines(chunk.text) {
+                let cells = splitOCRTableLine(line)
+                guard cells.count >= 2 else { continue }
+
+                if let header = parseOCRPartsHeader(cells) {
+                    activeHeader = header
+                    continue
+                }
+                guard let header = activeHeader else { continue }
+                guard cells.count >= min(2, header.headers.count) else { continue }
+
+                let normalized = normalizeOCRCandidate(cells: cells, header: header)
+                let sourceSnippet = makeOCRSnippet(from: line)
+                var rowErrors: [String] = []
+                if normalized.name == nil || normalized.name?.isEmpty == true {
+                    rowErrors.append("Missing required name")
+                }
+                if normalized.category == nil || normalized.category?.isEmpty == true {
+                    rowErrors.append("Missing required category")
+                }
+                for numericHeader in ["cost_price", "markup_percent"] {
+                    if let raw = normalized.fields[numericHeader], Double(raw) == nil {
+                        rowErrors.append("Invalid number for \(numericHeader): \(raw)")
+                    }
+                }
+
+                if !rowErrors.isEmpty {
+                    for message in rowErrors {
+                        errors.append(PartsOCRImportError(
+                            pageNumber: chunk.pageNumber,
+                            sourceSnippet: sourceSnippet,
+                            message: message
+                        ))
+                    }
+                    continue
+                }
+
+                guard let name = normalized.name, let category = normalized.category else { continue }
+                let recognizedFieldCount = 2
+                    + (normalized.code == nil ? 0 : 1)
+                    + (normalized.brand == nil ? 0 : 1)
+                    + normalized.fields.count
+                let confidence = min(0.98, 0.70 + (Double(recognizedFieldCount) * 0.04))
+                candidates.append(PartsOCRImportCandidate(
+                    rowNumber: rowNumber,
+                    chunkId: chunk.id,
+                    pageNumber: chunk.pageNumber,
+                    sourceSnippet: sourceSnippet,
+                    confidence: confidence,
+                    name: name,
+                    code: normalized.code,
+                    category: category,
+                    brand: normalized.brand,
+                    fields: normalized.fields
+                ))
+                rowNumber += 1
+            }
+        }
+        return (candidates, errors)
+    }
+
+    private struct OCRPartsHeader {
+        let headers: [String]
+    }
+
+    private func parseOCRPartsHeader(_ cells: [String]) -> OCRPartsHeader? {
+        let headers = cells.map(normalizeOCRHeader)
+        let hasName = headers.contains("name")
+        let hasCategory = headers.contains("category")
+        let hasCode = headers.contains("code") || headers.contains("part_number")
+        guard hasName && (hasCategory || hasCode) else { return nil }
+        return OCRPartsHeader(headers: headers)
+    }
+
+    private func normalizeOCRCandidate(
+        cells: [String],
+        header: OCRPartsHeader
+    ) -> (name: String?, code: String?, category: String?, brand: String?, fields: [String: String]) {
+        var name: String?
+        var code: String?
+        var category: String?
+        var brand: String?
+        var fields: [String: String] = [:]
+
+        for (index, headerName) in header.headers.enumerated() {
+            guard index < cells.count else { continue }
+            let value = cells[index].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty else { continue }
+
+            switch headerName {
+            case "name": name = value
+            case "code", "part_number": code = value
+            case "category": category = value
+            case "brand": brand = value
+            case "cost", "cost_price", "price": fields["cost_price"] = value
+            case "markup", "markup_percent": fields["markup_percent"] = value
+            case "unit", "unit_of_measure", "uom": fields["unit_of_measure"] = value
+            case "description": fields["description"] = value
+            case "shelf", "shelf_location": fields["shelf_location"] = value
+            case "bin", "bin_location": fields["bin_location"] = value
+            case "part_type": fields["part_type"] = value
+            default: break
+            }
+        }
+        return (name, code, category, brand, fields)
+    }
+
+    private func normalizedOCRLines(_ text: String) -> [String] {
+        text.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private func splitOCRTableLine(_ line: String) -> [String] {
+        if line.contains("|") {
+            return line.components(separatedBy: "|").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        }
+        if line.contains("\t") {
+            return line.components(separatedBy: "\t").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        }
+        return splitOnRepeatedSpaces(line)
+    }
+
+    private func splitOnRepeatedSpaces(_ line: String) -> [String] {
+        var cells: [String] = []
+        var current = ""
+        var spaceRun = 0
+        for char in line {
+            if char == " " {
+                spaceRun += 1
+                if spaceRun < 2 {
+                    current.append(char)
+                }
+            } else {
+                if spaceRun >= 2 {
+                    let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty { cells.append(trimmed) }
+                    current = ""
+                }
+                spaceRun = 0
+                current.append(char)
+            }
+        }
+        let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { cells.append(trimmed) }
+        return cells
+    }
+
+    private func normalizeOCRHeader(_ raw: String) -> String {
+        let lowered = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "#", with: " number ")
+            .replacingOccurrences(of: "%", with: " percent ")
+        let tokens = lowered
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+        let joined = tokens.joined(separator: "_")
+
+        switch joined {
+        case "part", "part_name", "item", "item_name", "description_name": return "name"
+        case "sku", "part_no", "part_number", "part_num", "item_no", "item_number": return "part_number"
+        case "code", "part_code", "item_code": return "code"
+        case "cat", "category", "class": return "category"
+        case "brand", "manufacturer", "mfr": return "brand"
+        case "cost", "unit_cost", "price", "unit_price": return "cost_price"
+        case "markup", "markup_percent", "margin": return "markup_percent"
+        case "unit", "uom", "unit_of_measure": return "unit_of_measure"
+        case "desc", "description", "notes": return "description"
+        case "shelf", "shelf_location": return "shelf_location"
+        case "bin", "bin_location": return "bin_location"
+        case "type", "part_type": return "part_type"
+        default: return joined
+        }
+    }
+
+    private func makeOCRSnippet(from text: String, limit: Int = 160) -> String {
+        let singleLine = text
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard singleLine.count > limit else { return singleLine }
+        return String(singleLine.prefix(limit)).trimmingCharacters(in: .whitespacesAndNewlines) + "…"
+    }
+}

--- a/core/Tests/WiredPartCoreTests/PartsOCRImportPreviewTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsOCRImportPreviewTests.swift
@@ -91,4 +91,39 @@ struct PartsOCRImportPreviewTests {
         #expect(preview.errors.contains { $0.message.contains("category") })
         #expect(preview.errors.contains { $0.message.contains("cost_price") })
     }
+
+    @Test("previewPartsImportOCR does not carry headers between pages")
+    func previewPartsImportOCRDoesNotCarryHeadersAcrossPages() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        let preview = try env.parts.previewPartsImportOCR(pages: [
+            .init(pageNumber: 1, text: """
+            Code | Name | Category
+            A-1 | First Page Row | Wire
+            """),
+            .init(pageNumber: 2, text: """
+            B-2 | Second Page Without Header | Conduit
+            """)
+        ])
+
+        #expect(preview.candidates.count == 1)
+        #expect(preview.candidates.first?.code == "A-1")
+    }
+
+    @Test("previewPartsImportOCR rejects negative cost and markup values")
+    func previewPartsImportOCRRejectsNegativeNumericValues() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        let preview = try env.parts.previewPartsImportOCR(pages: [
+            .init(pageNumber: 5, text: """
+            Code | Name | Category | Cost | Markup
+            NEG-1 | Negative Cost | Wire | -1 | 10
+            NEG-2 | Negative Markup | Wire | 5 | -10
+            """)
+        ])
+
+        #expect(preview.candidates.isEmpty)
+        #expect(preview.errors.contains { $0.message == "cost_price cannot be negative" })
+        #expect(preview.errors.contains { $0.message == "markup_percent cannot be negative" })
+    }
 }

--- a/core/Tests/WiredPartCoreTests/PartsOCRImportPreviewTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsOCRImportPreviewTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import WiredPartCore
+
+@Suite("Parts PDF/OCR import preview tests")
+struct PartsOCRImportPreviewTests {
+    @Test("previewPartsImportOCR chunks extracted page text with page evidence")
+    func previewPartsImportOCRChunksExtractedPageTextWithEvidence() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        let preview = try env.parts.previewPartsImportOCR(pages: [
+            .init(pageNumber: 1, text: """
+            Vendor Quote
+            Code | Name | Category | Cost
+            W-14 | 14 AWG THHN Wire | Wire | 31.50
+            """),
+            .init(pageNumber: 2, text: """
+            Continuation
+            Code | Name | Category | Unit
+            EMT-2 | 2 inch EMT Conduit | Conduit | each
+            """)
+        ], chunkLineLimit: 2)
+
+        #expect(preview.chunks.count >= 2)
+        #expect(preview.chunks.map(\.pageNumber).contains(1))
+        #expect(preview.chunks.map(\.pageNumber).contains(2))
+        #expect(preview.chunks.allSatisfy { !$0.snippet.isEmpty })
+        #expect(preview.chunks.contains { $0.snippet.contains("14 AWG THHN Wire") })
+    }
+
+    @Test("previewPartsImportOCR detects table rows as proposed import rows with source evidence")
+    func previewPartsImportOCRDetectsRowsWithConfidenceAndEvidence() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        let preview = try env.parts.previewPartsImportOCR(pages: [
+            .init(pageNumber: 3, text: """
+            Parts List
+            Code | Name | Category | Brand | Cost | Markup | Unit
+            W-14 | 14 AWG THHN Wire | Wire | Southwire | 31.50 | 20 | roll
+            EMT-2 | 2 inch EMT Conduit | Conduit | Allied | 12.25 | 15 | each
+            """)
+        ])
+
+        #expect(preview.candidates.count == 2)
+        let wire = try #require(preview.candidates.first { $0.code == "W-14" })
+        #expect(wire.name == "14 AWG THHN Wire")
+        #expect(wire.category == "Wire")
+        #expect(wire.brand == "Southwire")
+        #expect(wire.fields["cost_price"] == "31.50")
+        #expect(wire.fields["markup_percent"] == "20")
+        #expect(wire.fields["unit_of_measure"] == "roll")
+        #expect(wire.pageNumber == 3)
+        #expect(wire.confidence >= 0.85)
+        #expect(wire.sourceSnippet.contains("14 AWG THHN Wire"))
+    }
+
+    @Test("previewPartsImportOCR is preview-only and does not write parts")
+    func previewPartsImportOCRIsPreviewOnlyAndDoesNotWriteParts() throws {
+        let env = try E2ETestHelpers.setUp()
+        let before = try env.parts.getImportExportStats()
+
+        let preview = try env.parts.previewPartsImportOCR(pages: [
+            .init(pageNumber: 1, text: """
+            Code | Name | Category
+            X-100 | Preview Only Breaker | Electrical
+            """)
+        ])
+
+        let after = try env.parts.getImportExportStats()
+        #expect(preview.isCommitAllowed == false)
+        #expect(preview.candidates.count == 1)
+        #expect(after.totalParts == before.totalParts)
+        #expect(try env.parts.findPartByCode("X-100") == nil)
+    }
+
+    @Test("previewPartsImportOCR surfaces row errors with page and snippet evidence")
+    func previewPartsImportOCRSurfacesRowErrorsWithEvidence() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        let preview = try env.parts.previewPartsImportOCR(pages: [
+            .init(pageNumber: 4, text: """
+            Code | Name | Category | Cost
+            BAD-1 | Missing Category |  | 5.00
+            BAD-2 | Bad Cost | Wire | not-money
+            """)
+        ])
+
+        #expect(preview.candidates.isEmpty)
+        #expect(preview.errors.count == 2)
+        #expect(preview.errors.allSatisfy { $0.pageNumber == 4 && !$0.sourceSnippet.isEmpty })
+        #expect(preview.errors.contains { $0.message.contains("category") })
+        #expect(preview.errors.contains { $0.message.contains("cost_price") })
+    }
+}


### PR DESCRIPTION
## Summary
- add a deterministic preview-only OCR/PDF parts import path that consumes extracted page text
- split OCR text into page/chunk evidence and normalize likely table rows into proposed import candidates
- keep the OCR path explicitly preview-only with no database writes or commit flow until review UX/rules are approved

## Test Plan
- swift test --filter PartsOCRImportPreviewTests
- swift test --filter previewPartsImport
- swift test --filter PartsServiceAdvancedTests (known unrelated failures: approveScheduledDeletion permission tests)
- swift test (timed out after 600s while the large suite was still running)

Refs #597