### PR TITLE
[WEI-2124] Audit parts import sessions

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -133,6 +133,7 @@ extension AppDatabase {
         registerMigration094ShortTermPipelineCategoryOverride(&migrator)
         registerMigration095JobStageTemplates(&migrator)
         registerMigration096SubcontractorScheduleSoftDeleteUniqueness(&migrator)
+        registerMigration097PartImportAuditSessions(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -5512,6 +5513,47 @@ extension AppDatabase {
                 ON job_stage_category_map(template_id, category_id)
                 """)
             try db.execute(sql: "CREATE INDEX idx_jscm_template ON job_stage_category_map(template_id)")
+        }
+    }
+
+
+    // MARK: - Migration 097: Part import audit sessions
+
+    private static func registerMigration097PartImportAuditSessions(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("097_part_import_audit_sessions") { db in
+            try db.create(table: "part_import_sessions", ifNotExists: true) { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("source_kind", .text).notNull()
+                t.column("filename", .text)
+                t.column("source_hash", .text)
+                t.column("user_id", .integer).references("users")
+                t.column("status", .text).notNull().defaults(to: "pending")
+                t.column("total_rows", .integer).notNull().defaults(to: 0)
+                t.column("created_count", .integer).notNull().defaults(to: 0)
+                t.column("updated_count", .integer).notNull().defaults(to: 0)
+                t.column("skipped_count", .integer).notNull().defaults(to: 0)
+                t.column("error_message", .text)
+                t.column("started_at", .text).notNull().defaults(sql: "(datetime('now'))")
+                t.column("committed_at", .text)
+                t.column("failed_at", .text)
+            }
+            try db.create(table: "part_import_row_evidence", ifNotExists: true) { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("session_id", .integer).notNull()
+                    .references("part_import_sessions", onDelete: .cascade)
+                t.column("row_number", .integer).notNull()
+                t.column("action", .text).notNull()
+                t.column("part_id", .integer).references("parts")
+                t.column("source_name", .text).notNull()
+                t.column("source_code", .text)
+                t.column("source_category", .text).notNull()
+                t.column("source_brand", .text)
+                t.column("row_payload_json", .text).notNull()
+                t.column("created_at", .text).notNull().defaults(sql: "(datetime('now'))")
+            }
+            try db.create(index: "idx_part_import_sessions_source_hash", on: "part_import_sessions", columns: ["source_hash"])
+            try db.create(index: "idx_part_import_sessions_started", on: "part_import_sessions", columns: ["started_at"])
+            try db.create(index: "idx_part_import_row_evidence_session", on: "part_import_row_evidence", columns: ["session_id", "row_number"])
         }
     }
 

--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -8,8 +8,8 @@ public final class AppDatabase: Sendable {
     public let writer: any DatabaseWriter
 
     /// The total number of registered migrations. Update when adding new migrations.
-    /// Migrations are 000-095.
-    public static let schemaVersion = 95
+    /// Migrations are 000-097.
+    public static let schemaVersion = 97
 
     /// Initialize with an existing database writer and run all migrations.
     public init(_ writer: any DatabaseWriter) throws {

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -5965,12 +5965,28 @@ public final class PartsService: Sendable {
         public var resolution: PartsImportConflictResolution = .ask
     }
 
+    /// Metadata that ties an import preview/commit to a durable source artifact.
+    public struct PartsImportSourceMetadata: Sendable {
+        public var sourceKind: String
+        public var filename: String?
+        public var sourceHash: String?
+        public var userId: Int64?
+
+        public init(sourceKind: String, filename: String? = nil, sourceHash: String? = nil, userId: Int64? = nil) {
+            self.sourceKind = sourceKind
+            self.filename = filename
+            self.sourceHash = sourceHash
+            self.userId = userId
+        }
+    }
+
     /// Preview generated before any import writes occur.
     public struct PartsImportPreview: Sendable {
         public var newParts: [PartsImportParsedRow] = []
         public var conflicts: [PartsImportConflict] = []
         public var errors: [PartsImportError] = []
         public var totalRows: Int = 0
+        public var source: PartsImportSourceMetadata?
     }
 
     /// Result of an atomic import commit.
@@ -5978,6 +5994,7 @@ public final class PartsService: Sendable {
         public let created: Int
         public let updated: Int
         public let skipped: Int
+        public let importSessionId: Int64?
     }
 
     /// Parse and validate a parts CSV without changing database state.
@@ -6096,121 +6113,199 @@ public final class PartsService: Sendable {
     /// errors, no writes are attempted. If any database write fails mid-import,
     /// GRDB rolls back the entire transaction, preventing partial bad state.
     public func commitPartsImportCSV(_ preview: PartsImportPreview) throws -> PartsImportCommitResult {
-        guard preview.errors.isEmpty else {
-            let first = preview.errors[0]
-            throw PartsError.invalidInput("Import has validation errors; first error row \(first.rowNumber): \(first.message)")
+        let importSessionId = try createImportSessionIfNeeded(for: preview)
+        do {
+            guard preview.errors.isEmpty else {
+                let first = preview.errors[0]
+                throw PartsError.invalidInput("Import has validation errors; first error row \(first.rowNumber): \(first.message)")
+            }
+
+            var created = 0
+            var updated = 0
+            var skipped = 0
+
+            try db.writer.write { dbConn in
+                func findOrCreateCategoryInTransaction(_ name: String) throws -> Int64 {
+                    if let existing = try Row.fetchOne(dbConn, sql: "SELECT id FROM part_categories WHERE name = ? AND deleted_at IS NULL", arguments: [name]) {
+                        return existing["id"]
+                    }
+                    try Validators.requireName(name, field: "Category name")
+                    try dbConn.execute(sql: """
+                        INSERT INTO part_categories (name, sort_order, is_active, created_at, updated_at)
+                        VALUES (?, 0, 1, datetime('now'), datetime('now'))
+                        """, arguments: [name])
+                    return dbConn.lastInsertedRowID
+                }
+
+                func findOrCreateBrandInTransaction(_ name: String?) throws -> Int64? {
+                    guard let name, !name.isEmpty else { return nil }
+                    if let existing = try Row.fetchOne(dbConn, sql: "SELECT id FROM brands WHERE name = ? AND deleted_at IS NULL", arguments: [name]) {
+                        return existing["id"]
+                    }
+                    try Validators.requireName(name, field: "Brand name")
+                    try dbConn.execute(sql: """
+                        INSERT INTO brands (name, is_active, created_at, updated_at)
+                        VALUES (?, 1, datetime('now'), datetime('now'))
+                        """, arguments: [name])
+                    return dbConn.lastInsertedRowID
+                }
+
+                func create(_ row: PartsImportParsedRow) throws -> Int64 {
+                    let categoryId = try findOrCreateCategoryInTransaction(row.category)
+                    let brandId = try findOrCreateBrandInTransaction(row.brand)
+                    let cost = row.fields["cost_price"].flatMap(Double.init) ?? 0
+                    let markup = row.fields["markup_percent"].flatMap(Double.init) ?? 0
+                    let partType = row.fields["part_type"] ?? "general"
+
+                    try Validators.requireName(row.name, field: "Part name")
+                    try Validators.requireText(row.code, field: "Part code", limit: Validators.Limits.code)
+                    try Validators.requireNonNegative(cost, field: "Cost price")
+                    try Validators.requireNonNegative(markup, field: "Markup percent")
+
+                    try dbConn.execute(sql: """
+                        INSERT INTO parts (
+                            category_id, brand_id, part_type, code, name, description,
+                            unit_of_measure, company_cost_price, weighted_avg_cost,
+                            company_markup_percent, shelf_location, bin_location,
+                            auto_add_to_wishlist_when_low, is_deprecated, is_qr_tagged,
+                            is_active, created_at, updated_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 1, datetime('now'), datetime('now'))
+                        """, arguments: [
+                            categoryId,
+                            brandId,
+                            partType,
+                            row.code,
+                            row.name,
+                            row.fields["description"],
+                            row.fields["unit_of_measure"],
+                            cost,
+                            cost,
+                            markup,
+                            row.fields["shelf_location"],
+                            row.fields["bin_location"]
+                        ])
+                    return dbConn.lastInsertedRowID
+                }
+
+                func update(_ conflict: PartsImportConflict) throws {
+                    let row = conflict.parsedRow
+                    let categoryId = try findOrCreateCategoryInTransaction(row.category)
+                    let brandId = try findOrCreateBrandInTransaction(row.brand)
+                    let cost = row.fields["cost_price"].flatMap(Double.init)
+                    let markup = row.fields["markup_percent"].flatMap(Double.init)
+
+                    var clauses = [
+                        "name = ?",
+                        "code = ?",
+                        "category_id = ?",
+                        "brand_id = ?"
+                    ]
+                    var args: [DatabaseValueConvertible?] = [row.name, row.code, categoryId, brandId]
+
+                    if let partType = row.fields["part_type"] { clauses.append("part_type = ?"); args.append(partType) }
+                    if let description = row.fields["description"] { clauses.append("description = ?"); args.append(description) }
+                    if let unit = row.fields["unit_of_measure"] { clauses.append("unit_of_measure = ?"); args.append(unit) }
+                    if let cost { clauses.append("company_cost_price = ?"); args.append(cost); clauses.append("weighted_avg_cost = ?"); args.append(cost) }
+                    if let markup { clauses.append("company_markup_percent = ?"); args.append(markup) }
+                    if let shelf = row.fields["shelf_location"] { clauses.append("shelf_location = ?"); args.append(shelf) }
+                    if let bin = row.fields["bin_location"] { clauses.append("bin_location = ?"); args.append(bin) }
+                    clauses.append("updated_at = datetime('now')")
+                    args.append(conflict.existingPartId)
+
+                    try dbConn.execute(sql: "UPDATE parts SET \(clauses.joined(separator: ", ")) WHERE id = ? AND deleted_at IS NULL", arguments: StatementArguments(args))
+                }
+
+                for row in preview.newParts {
+                    let partId = try create(row)
+                    try recordImportRowEvidence(dbConn, sessionId: importSessionId, row: row, action: "created", partId: partId)
+                    created += 1
+                }
+                for conflict in preview.conflicts {
+                    switch conflict.resolution {
+                    case .update:
+                        try update(conflict)
+                        try recordImportRowEvidence(dbConn, sessionId: importSessionId, row: conflict.parsedRow, action: "updated", partId: conflict.existingPartId)
+                        updated += 1
+                    case .skip, .ask:
+                        skipped += 1
+                    }
+                }
+            }
+
+            try finishImportSessionIfNeeded(id: importSessionId, status: "committed", created: created, updated: updated, skipped: skipped, error: nil)
+            return PartsImportCommitResult(created: created, updated: updated, skipped: skipped, importSessionId: importSessionId)
+        } catch {
+            try? finishImportSessionIfNeeded(id: importSessionId, status: "failed", created: 0, updated: 0, skipped: 0, error: String(describing: error))
+            throw error
         }
+    }
 
-        var created = 0
-        var updated = 0
-        var skipped = 0
+    private func createImportSessionIfNeeded(for preview: PartsImportPreview) throws -> Int64? {
+        guard let source = preview.source else { return nil }
+        return try db.writer.write { dbConn in
+            try dbConn.execute(sql: """
+                INSERT INTO part_import_sessions (
+                    source_kind, filename, source_hash, user_id, status, total_rows, started_at
+                ) VALUES (?, ?, ?, ?, 'pending', ?, datetime('now'))
+                """, arguments: [source.sourceKind, source.filename, source.sourceHash, source.userId, preview.totalRows])
+            return dbConn.lastInsertedRowID
+        }
+    }
 
+    private func finishImportSessionIfNeeded(id: Int64?, status: String, created: Int, updated: Int, skipped: Int, error: String?) throws {
+        guard let id else { return }
         try db.writer.write { dbConn in
-            func findOrCreateCategoryInTransaction(_ name: String) throws -> Int64 {
-                if let existing = try Row.fetchOne(dbConn, sql: "SELECT id FROM part_categories WHERE name = ? AND deleted_at IS NULL", arguments: [name]) {
-                    return existing["id"]
-                }
-                try Validators.requireName(name, field: "Category name")
+            if status == "committed" {
                 try dbConn.execute(sql: """
-                    INSERT INTO part_categories (name, sort_order, is_active, created_at, updated_at)
-                    VALUES (?, 0, 1, datetime('now'), datetime('now'))
-                    """, arguments: [name])
-                return dbConn.lastInsertedRowID
-            }
-
-            func findOrCreateBrandInTransaction(_ name: String?) throws -> Int64? {
-                guard let name, !name.isEmpty else { return nil }
-                if let existing = try Row.fetchOne(dbConn, sql: "SELECT id FROM brands WHERE name = ? AND deleted_at IS NULL", arguments: [name]) {
-                    return existing["id"]
-                }
-                try Validators.requireName(name, field: "Brand name")
+                    UPDATE part_import_sessions
+                    SET status = ?, created_count = ?, updated_count = ?, skipped_count = ?, committed_at = datetime('now'), error_message = NULL
+                    WHERE id = ?
+                    """, arguments: [status, created, updated, skipped, id])
+            } else {
                 try dbConn.execute(sql: """
-                    INSERT INTO brands (name, is_active, created_at, updated_at)
-                    VALUES (?, 1, datetime('now'), datetime('now'))
-                    """, arguments: [name])
-                return dbConn.lastInsertedRowID
-            }
-
-            func create(_ row: PartsImportParsedRow) throws {
-                let categoryId = try findOrCreateCategoryInTransaction(row.category)
-                let brandId = try findOrCreateBrandInTransaction(row.brand)
-                let cost = row.fields["cost_price"].flatMap(Double.init) ?? 0
-                let markup = row.fields["markup_percent"].flatMap(Double.init) ?? 0
-                let partType = row.fields["part_type"] ?? "general"
-
-                try Validators.requireName(row.name, field: "Part name")
-                try Validators.requireText(row.code, field: "Part code", limit: Validators.Limits.code)
-                try Validators.requireNonNegative(cost, field: "Cost price")
-                try Validators.requireNonNegative(markup, field: "Markup percent")
-
-                try dbConn.execute(sql: """
-                    INSERT INTO parts (
-                        category_id, brand_id, part_type, code, name, description,
-                        unit_of_measure, company_cost_price, weighted_avg_cost,
-                        company_markup_percent, shelf_location, bin_location,
-                        auto_add_to_wishlist_when_low, is_deprecated, is_qr_tagged,
-                        is_active, created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 1, datetime('now'), datetime('now'))
-                    """, arguments: [
-                        categoryId,
-                        brandId,
-                        partType,
-                        row.code,
-                        row.name,
-                        row.fields["description"],
-                        row.fields["unit_of_measure"],
-                        cost,
-                        cost,
-                        markup,
-                        row.fields["shelf_location"],
-                        row.fields["bin_location"]
-                    ])
-            }
-
-            func update(_ conflict: PartsImportConflict) throws {
-                let row = conflict.parsedRow
-                let categoryId = try findOrCreateCategoryInTransaction(row.category)
-                let brandId = try findOrCreateBrandInTransaction(row.brand)
-                let cost = row.fields["cost_price"].flatMap(Double.init)
-                let markup = row.fields["markup_percent"].flatMap(Double.init)
-
-                var clauses = [
-                    "name = ?",
-                    "code = ?",
-                    "category_id = ?",
-                    "brand_id = ?"
-                ]
-                var args: [DatabaseValueConvertible?] = [row.name, row.code, categoryId, brandId]
-
-                if let partType = row.fields["part_type"] { clauses.append("part_type = ?"); args.append(partType) }
-                if let description = row.fields["description"] { clauses.append("description = ?"); args.append(description) }
-                if let unit = row.fields["unit_of_measure"] { clauses.append("unit_of_measure = ?"); args.append(unit) }
-                if let cost { clauses.append("company_cost_price = ?"); args.append(cost); clauses.append("weighted_avg_cost = ?"); args.append(cost) }
-                if let markup { clauses.append("company_markup_percent = ?"); args.append(markup) }
-                if let shelf = row.fields["shelf_location"] { clauses.append("shelf_location = ?"); args.append(shelf) }
-                if let bin = row.fields["bin_location"] { clauses.append("bin_location = ?"); args.append(bin) }
-                clauses.append("updated_at = datetime('now')")
-                args.append(conflict.existingPartId)
-
-                try dbConn.execute(sql: "UPDATE parts SET \(clauses.joined(separator: ", ")) WHERE id = ? AND deleted_at IS NULL", arguments: StatementArguments(args))
-            }
-
-            for row in preview.newParts {
-                try create(row)
-                created += 1
-            }
-            for conflict in preview.conflicts {
-                switch conflict.resolution {
-                case .update:
-                    try update(conflict)
-                    updated += 1
-                case .skip, .ask:
-                    skipped += 1
-                }
+                    UPDATE part_import_sessions
+                    SET status = ?, created_count = ?, updated_count = ?, skipped_count = ?, failed_at = datetime('now'), error_message = ?
+                    WHERE id = ?
+                    """, arguments: [status, created, updated, skipped, error, id])
             }
         }
+    }
 
-        return PartsImportCommitResult(created: created, updated: updated, skipped: skipped)
+    private func recordImportRowEvidence(_ dbConn: Database, sessionId: Int64?, row: PartsImportParsedRow, action: String, partId: Int64) throws {
+        guard let sessionId else { return }
+        try dbConn.execute(sql: """
+            INSERT INTO part_import_row_evidence (
+                session_id, row_number, action, part_id, source_name, source_code,
+                source_category, source_brand, row_payload_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+            """, arguments: [
+                sessionId,
+                row.rowNumber,
+                action,
+                partId,
+                row.name,
+                row.code,
+                row.category,
+                row.brand,
+                importRowPayloadJSON(row)
+            ])
+    }
+
+    private func importRowPayloadJSON(_ row: PartsImportParsedRow) -> String {
+        let payload: [String: Any] = [
+            "rowNumber": row.rowNumber,
+            "name": row.name,
+            "code": row.code as Any,
+            "category": row.category,
+            "brand": row.brand as Any,
+            "fields": row.fields
+        ]
+        guard JSONSerialization.isValidJSONObject(payload),
+              let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]),
+              let json = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return json
     }
 
     private func parseImportCSVLine(_ line: String) -> [String] {

--- a/core/Tests/WiredPartCoreTests/DatabaseTests.swift
+++ b/core/Tests/WiredPartCoreTests/DatabaseTests.swift
@@ -97,9 +97,19 @@ struct DatabaseTests {
         }
     }
 
-    @Test("Schema version is 95")
+
+    @Test("Migration 097 creates part import audit session tables")
+    func testMigration097CreatesPartImportAuditTables() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        let tables = try db.writer.read { db in
+            try String.fetchAll(db, sql: "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('part_import_sessions', 'part_import_row_evidence') ORDER BY name")
+        }
+        #expect(tables == ["part_import_row_evidence", "part_import_sessions"])
+    }
+
+    @Test("Schema version is 97")
     func testSchemaVersion() throws {
-        #expect(AppDatabase.schemaVersion == 95)
+        #expect(AppDatabase.schemaVersion == 97)
     }
 
     @Test("Migration 095 normalizes duplicate legacy stage sort orders and category maps")

--- a/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
@@ -297,6 +297,90 @@ struct PartsServiceAdvancedTests {
         }
     }
 
+
+
+    @Test("commitPartsImportCSV records durable import session and accepted row evidence")
+    func testCommitPartsImportCSVRecordsAuditSessionEvidence() throws {
+        let env = try E2ETestHelpers.setUp()
+        var preview = try env.parts.previewPartsImportCSV("""
+        name,code,category,brand,cost_price
+        Audited Part,AUD-001,Audit Category,Audit Brand,12.25
+        """)
+        preview.source = PartsService.PartsImportSourceMetadata(
+            sourceKind: "csv",
+            filename: "parts.csv",
+            sourceHash: "sha256:testhash",
+            userId: env.adminUserId
+        )
+
+        let result = try env.parts.commitPartsImportCSV(preview)
+
+        let sessionId = try #require(result.importSessionId)
+        let session = try #require(try env.db.writer.read { db in
+            try Row.fetchOne(db, sql: "SELECT * FROM part_import_sessions WHERE id = ?", arguments: [sessionId])
+        })
+        #expect(session["source_kind"] as String == "csv")
+        #expect(session["filename"] as String? == "parts.csv")
+        #expect(session["source_hash"] as String? == "sha256:testhash")
+        #expect(session["user_id"] as Int64? == env.adminUserId)
+        #expect(session["status"] as String == "committed")
+        #expect(session["total_rows"] as Int == 1)
+        #expect(session["created_count"] as Int == 1)
+        #expect(session["updated_count"] as Int == 0)
+        #expect(session["skipped_count"] as Int == 0)
+        #expect(session["committed_at"] as String? != nil)
+
+        let evidence = try env.db.writer.read { db in
+            try Row.fetchAll(db, sql: "SELECT * FROM part_import_row_evidence WHERE session_id = ? ORDER BY row_number", arguments: [sessionId])
+        }
+        #expect(evidence.count == 1)
+        let firstEvidence = try #require(evidence.first)
+        #expect(firstEvidence["row_number"] as Int == 2)
+        #expect(firstEvidence["action"] as String == "created")
+        #expect(firstEvidence["source_code"] as String? == "AUD-001")
+        #expect(firstEvidence["source_name"] as String == "Audited Part")
+        #expect(firstEvidence["part_id"] as Int64? != nil)
+        #expect((firstEvidence["row_payload_json"] as String?)?.contains("Audit Category") == true)
+    }
+
+    @Test("commitPartsImportCSV records failed import session while rolling back partial writes")
+    func testCommitPartsImportCSVRecordsRollbackFailureWithoutPartialWrites() throws {
+        let env = try E2ETestHelpers.setUp()
+        let before = try env.parts.getImportExportStats()
+        var preview = try env.parts.previewPartsImportCSV("""
+        name,code,category,brand,cost_price
+        Duplicate One,DUP-AUD-001,Rollback Audit Category,Rollback Audit Brand,5
+        Duplicate Two,DUP-AUD-001,Rollback Audit Category,Rollback Audit Brand,6
+        """)
+        preview.source = PartsService.PartsImportSourceMetadata(
+            sourceKind: "csv",
+            filename: "duplicate.csv",
+            sourceHash: "sha256:duplicate",
+            userId: env.adminUserId
+        )
+
+        do {
+            _ = try env.parts.commitPartsImportCSV(preview)
+            Issue.record("duplicate part code should fail during atomic import commit")
+        } catch {
+            let after = try env.parts.getImportExportStats()
+            #expect(after.totalParts == before.totalParts)
+            #expect(after.totalCategories == before.totalCategories)
+            #expect(try env.parts.findPartByCode("DUP-AUD-001") == nil)
+
+            let session = try #require(try env.db.writer.read { db in
+                try Row.fetchOne(db, sql: "SELECT * FROM part_import_sessions WHERE source_hash = ?", arguments: ["sha256:duplicate"])
+            })
+            #expect(session["status"] as String == "failed")
+            #expect(session["error_message"] as String? != nil)
+            #expect(session["created_count"] as Int == 0)
+            let evidenceCount = try env.db.writer.read { db in
+                try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM part_import_row_evidence WHERE session_id = ?", arguments: [session["id"] as Int64]) ?? -1
+            }
+            #expect(evidenceCount == 0)
+        }
+    }
+
     @Test("commitPartsImportCSV creates and updates rows atomically from a clean preview")
     func testCommitPartsImportCSVCreatesAndUpdates() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- add migration 097 for part import sessions and row-level import evidence
- attach optional source metadata (kind, filename, hash, user id) to import previews and commit results
- persist committed counts/evidence on success and failed session metadata on rollback errors

## Tests
- swift test --filter 'PartsServiceAdvancedTests/testCommitPartsImportCSVRecords|Database Migration Tests/testMigration097|Database Migration Tests/testSchemaVersion'
- swift test --filter DatabaseTests
- swift test --filter PartsServiceAdvancedTests (fails existing approveScheduledDeletion permission tests; new import audit tests pass)