### PR TITLE
fix(orders): simplify stable id payload for CodeQL Swift build

### DIFF
--- a/core/Sources/WiredPartCore/Services/OrdersService.swift
+++ b/core/Sources/WiredPartCore/Services/OrdersService.swift
@@ -205,17 +205,30 @@ public final class OrdersService: Sendable {
             wishlistItemIds: [Int64],
             forecastTargetIds: [Int64]
         ) -> String {
-            let payload = [
+            let sourceIdComponent = String(sourceId ?? 0)
+            let quantityComponent = String(quantity)
+            let jobIdComponent = String(jobId ?? 0)
+            let lockedSupplierIdComponent = String(lockedSupplierId ?? 0)
+            let lineIdsComponent = joinedIDComponent(lineIds)
+            let wishlistItemIdsComponent = joinedIDComponent(wishlistItemIds)
+            let forecastTargetIdsComponent = joinedIDComponent(forecastTargetIds)
+
+            let payloadComponents: [String] = [
                 sourceType,
-                String(sourceId ?? 0),
-                String(quantity),
-                String(jobId ?? 0),
-                String(lockedSupplierId ?? 0),
-                lineIds.map(String.init).joined(separator: ","),
-                wishlistItemIds.map(String.init).joined(separator: ","),
-                forecastTargetIds.map(String.init).joined(separator: ",")
-            ].joined(separator: "|")
-            return "src-\(sourceType)-\(sourceId ?? 0)-\(stableHash(payload))"
+                sourceIdComponent,
+                quantityComponent,
+                jobIdComponent,
+                lockedSupplierIdComponent,
+                lineIdsComponent,
+                wishlistItemIdsComponent,
+                forecastTargetIdsComponent
+            ]
+            let payload = payloadComponents.joined(separator: "|")
+            return "src-\(sourceType)-\(sourceIdComponent)-\(stableHash(payload))"
+        }
+
+        private static func joinedIDComponent(_ ids: [Int64]) -> String {
+            ids.map { String($0) }.joined(separator: ",")
         }
 
         private static func stableHash(_ text: String) -> String {


### PR DESCRIPTION
## Summary
- Break the procurement stable-id payload construction into explicitly typed String components.
- Add a small helper for joined Int64 ID lists so Swift does not have to infer the whole heterogeneous expression at once.
- Preserve the existing payload ordering and stable hash input/output format.

## Test Plan
- swift build --package-path core --scratch-path /tmp/wiredpart-swiftpm-build-wei-2139
- swift test --package-path core --scratch-path /tmp/wiredpart-swiftpm-test-wei-2139 --filter OrdersServiceTests

Fixes Paperclip WEI-2139.