### PR TITLE
fix: pass job due dates to priority colors

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSEscalationTimeline.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSEscalationTimeline.swift
@@ -298,7 +298,10 @@ struct IOSEscalationTimeline: View {
         }
     }
     private func priorityColor(_ priority: String, dueDate: String?) -> Color {
-        return TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
+        if dueDate != nil {
+            return TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
+        }
+        return TimelinePriorityColor.fallbackColor(priority: priority)
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSEscalationTimeline.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSEscalationTimeline.swift
@@ -111,7 +111,7 @@ struct IOSEscalationTimeline: View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 6) {
                 StatusBadge(text: thread.status.capitalized, color: statusColor(thread.status))
-                StatusBadge(text: thread.priority.capitalized, color: priorityColor(thread.priority))
+                StatusBadge(text: thread.priority.capitalized, color: priorityColor(thread.priority, dueDate: thread.dueDate))
             }
 
             Text(thread.question)
@@ -297,10 +297,8 @@ struct IOSEscalationTimeline: View {
         default: return .secondary
         }
     }
-
-    // TODO: When QAThreadRow gains a dueDate field, replace fallback with TimelinePriorityColor.color(priority:dueDateString:)
-    private func priorityColor(_ priority: String) -> Color {
-        return TimelinePriorityColor.fallbackColor(priority: priority)
+    private func priorityColor(_ priority: String, dueDate: String?) -> Color {
+        return TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSQuestionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSQuestionsPage.swift
@@ -217,7 +217,7 @@ struct IOSQuestionsPage: View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
-                    priorityBadge(thread.priority)
+                    priorityBadge(thread.priority, dueDate: thread.dueDate)
                     levelBadge(thread.currentLevel)
                 }
                 Text(thread.question)
@@ -274,9 +274,8 @@ struct IOSQuestionsPage: View {
             .foregroundStyle(color)
     }
 
-    // TODO: When QAThreadRow gains a dueDate field, replace fallback with TimelinePriorityColor.color(priority:dueDateString:)
-    private func priorityBadge(_ priority: String) -> some View {
-        let color = TimelinePriorityColor.fallbackColor(priority: priority)
+    private func priorityBadge(_ priority: String, dueDate: String?) -> some View {
+        let color = TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
         return Text(priority.capitalized)
             .font(.caption2)
             .foregroundStyle(color)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSQuestionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSQuestionsPage.swift
@@ -275,7 +275,9 @@ struct IOSQuestionsPage: View {
     }
 
     private func priorityBadge(_ priority: String, dueDate: String?) -> some View {
-        let color = TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
+        let color: Color = dueDate != nil
+            ? TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
+            : TimelinePriorityColor.fallbackColor(priority: priority)
         return Text(priority.capitalized)
             .font(.caption2)
             .foregroundStyle(color)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSRFIListPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSRFIListPage.swift
@@ -312,7 +312,10 @@ struct IOSRFIListPage: View {
         }
     }
     private func priorityColor(_ priority: String, dueDate: String?) -> Color {
-        return TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
+        if dueDate != nil {
+            return TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
+        }
+        return TimelinePriorityColor.fallbackColor(priority: priority)
     }
 
     // MARK: - Data

--- a/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSRFIListPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSRFIListPage.swift
@@ -269,7 +269,7 @@ struct IOSRFIListPage: View {
                 )
                 StatusBadge(
                     text: thread.priority.capitalized,
-                    color: priorityColor(thread.priority)
+                    color: priorityColor(thread.priority, dueDate: thread.dueDate)
                 )
                 Spacer()
                 Text("Level: \(thread.currentLevel.capitalized)")
@@ -311,10 +311,8 @@ struct IOSRFIListPage: View {
         default: return .secondary
         }
     }
-
-    // TODO: When QAThreadRow gains a dueDate field, replace fallback with TimelinePriorityColor.color(priority:dueDateString:)
-    private func priorityColor(_ priority: String) -> Color {
-        return TimelinePriorityColor.fallbackColor(priority: priority)
+    private func priorityColor(_ priority: String, dueDate: String?) -> Color {
+        return TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
     }
 
     // MARK: - Data

--- a/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSUnifiedApprovalsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSUnifiedApprovalsPage.swift
@@ -379,9 +379,12 @@ struct IOSUnifiedApprovalsPage: View {
                 subtitle: "JPO #\(jpo.id) by \(jpo.requestedByName) - \(jpo.lineCount) lines"
             )
             HStack(spacing: 12) {
+                let priorityColor: Color = jpo.dueDate != nil
+                    ? TimelinePriorityColor.color(priority: jpo.priority, dueDateString: jpo.dueDate)
+                    : TimelinePriorityColor.fallbackColor(priority: jpo.priority)
                 Text("Priority: \(jpo.priority.capitalized)")
                     .font(.caption)
-                    .foregroundStyle(TimelinePriorityColor.color(priority: jpo.priority, dueDateString: jpo.dueDate))
+                    .foregroundStyle(priorityColor)
                 Spacer()
             }
             HStack(spacing: 12) {
@@ -537,16 +540,6 @@ struct IOSUnifiedApprovalsPage: View {
 
     private func statusBadge(_ status: String, color: Color) -> some View {
         Text(status.capitalized)
-            .font(.system(.caption2, weight: .semibold))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(Capsule().fill(color.opacity(0.15)))
-            .foregroundStyle(color)
-    }
-
-    private func priorityBadge(_ priority: String, dueDate: String?) -> some View {
-        let color = TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
-        return Text(priority.capitalized)
             .font(.system(.caption2, weight: .semibold))
             .padding(.horizontal, 6)
             .padding(.vertical, 2)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSUnifiedApprovalsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Office/IOSUnifiedApprovalsPage.swift
@@ -379,6 +379,12 @@ struct IOSUnifiedApprovalsPage: View {
                 subtitle: "JPO #\(jpo.id) by \(jpo.requestedByName) - \(jpo.lineCount) lines"
             )
             HStack(spacing: 12) {
+                Text("Priority: \(jpo.priority.capitalized)")
+                    .font(.caption)
+                    .foregroundStyle(TimelinePriorityColor.color(priority: jpo.priority, dueDateString: jpo.dueDate))
+                Spacer()
+            }
+            HStack(spacing: 12) {
                 actionButton("Approve", icon: "checkmark.circle.fill", color: .green, processingKey: "jpo-\(jpo.id)") {
                     approveJPO(jpo.id)
                 }
@@ -537,6 +543,18 @@ struct IOSUnifiedApprovalsPage: View {
             .background(Capsule().fill(color.opacity(0.15)))
             .foregroundStyle(color)
     }
+
+    private func priorityBadge(_ priority: String, dueDate: String?) -> some View {
+        let color = TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
+        return Text(priority.capitalized)
+            .font(.system(.caption2, weight: .semibold))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(color.opacity(0.15)))
+            .foregroundStyle(color)
+    }
+
+    // MARK: - JPO Actions
 
     private func approveJPO(_ id: Int64) {
         guard let service = appCore.ordersService else {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
@@ -1023,7 +1023,10 @@ struct IOSJPODetailPage: View {
         }
     }
     private func priorityColor(_ priority: String, dueDate: String?) -> Color {
-        return TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
+        if dueDate != nil {
+            return TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
+        }
+        return TimelinePriorityColor.fallbackColor(priority: priority)
     }
 
     private func formatCurrency(_ value: Double) -> String {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
@@ -264,7 +264,7 @@ struct IOSJPODetailPage: View {
                 // Header
                 HStack(spacing: 8) {
                     StatusBadge(text: jpo.status.capitalized, color: statusColor(jpo.status))
-                    StatusBadge(text: jpo.priority.capitalized, color: priorityColor(jpo.priority))
+                    StatusBadge(text: jpo.priority.capitalized, color: priorityColor(jpo.priority, dueDate: jpo.dueDate))
                     Spacer()
                 }
 
@@ -1022,10 +1022,8 @@ struct IOSJPODetailPage: View {
         default: .secondary
         }
     }
-
-    // TODO: When JPODetail gains a dueDate field, replace fallback with TimelinePriorityColor.color(priority:dueDateString:)
-    private func priorityColor(_ priority: String) -> Color {
-        return TimelinePriorityColor.fallbackColor(priority: priority)
+    private func priorityColor(_ priority: String, dueDate: String?) -> Color {
+        return TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
     }
 
     private func formatCurrency(_ value: Double) -> String {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOsPage.swift
@@ -227,7 +227,7 @@ struct IOSJPOsPage: View {
                     Text("JPO #\(jpo.id)")
                         .font(.system(.caption, design: .monospaced))
                         .foregroundStyle(.secondary)
-                    priorityBadge(jpo.priority)
+                    priorityBadge(jpo.priority, dueDate: jpo.dueDate)
                 }
                 Text(jpo.jobName)
                     .fontWeight(.medium)
@@ -278,9 +278,8 @@ struct IOSJPOsPage: View {
             .foregroundStyle(color)
     }
 
-    // TODO: When JPOListItem gains a dueDate field, replace fallback with TimelinePriorityColor.color(priority:dueDateString:)
-    private func priorityBadge(_ priority: String) -> some View {
-        let color = TimelinePriorityColor.fallbackColor(priority: priority)
+    private func priorityBadge(_ priority: String, dueDate: String?) -> some View {
+        let color = TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
         return Text(priority.capitalized)
             .font(.caption2)
             .foregroundStyle(color)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOsPage.swift
@@ -279,7 +279,9 @@ struct IOSJPOsPage: View {
     }
 
     private func priorityBadge(_ priority: String, dueDate: String?) -> some View {
-        let color = TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
+        let color: Color = dueDate != nil
+            ? TimelinePriorityColor.color(priority: priority, dueDateString: dueDate)
+            : TimelinePriorityColor.fallbackColor(priority: priority)
         return Text(priority.capitalized)
             .font(.caption2)
             .foregroundStyle(color)

--- a/core/Sources/WiredPartCore/Services/ChatService.swift
+++ b/core/Sources/WiredPartCore/Services/ChatService.swift
@@ -207,13 +207,14 @@ public final class ChatService: Sendable {
         public let currentLevel: String
         public let status: String
         public let priority: String
+        public let dueDate: String?
         public let answer: String?
         public let answeredByName: String?
 
         public init(
             id: Int64, jobId: Int64 = 0, askedById: Int64? = nil,
             question: String, askedByName: String,
-            currentLevel: String, status: String, priority: String,
+            currentLevel: String, status: String, priority: String, dueDate: String? = nil,
             answer: String?, answeredByName: String?
         ) {
             self.id = id
@@ -224,6 +225,7 @@ public final class ChatService: Sendable {
             self.currentLevel = currentLevel
             self.status = status
             self.priority = priority
+            self.dueDate = dueDate
             self.answer = answer
             self.answeredByName = answeredByName
         }
@@ -410,10 +412,11 @@ public final class ChatService: Sendable {
 
                 let sql = """
                     SELECT qa.id, COALESCE(qa.job_id, 0) AS job_id, qa.asked_by, qa.subject, qa.current_level, qa.status, qa.priority,
-                           qa.answer_text,
+                           qa.answer_text, j.due_date,
                            COALESCE(ua.display_name, ua.email, 'Unknown') AS asked_by_name,
                            COALESCE(ub.display_name, ub.email) AS answered_by_name
                     FROM qa_threads qa
+                    LEFT JOIN jobs j ON j.id = qa.job_id AND j.deleted_at IS NULL
                     LEFT JOIN users ua ON ua.id = qa.asked_by AND ua.deleted_at IS NULL
                     LEFT JOIN users ub ON ub.id = qa.answered_by AND ub.deleted_at IS NULL
                     WHERE \(whereClauses.joined(separator: " AND "))
@@ -431,6 +434,7 @@ public final class ChatService: Sendable {
                         currentLevel: row["current_level"] ?? "field",
                         status: row["status"] ?? "open",
                         priority: row["priority"] ?? "normal",
+                        dueDate: row["due_date"] as String?,
                         answer: row["answer_text"] as String?,
                         answeredByName: row["answered_by_name"] as String?
                     )
@@ -456,10 +460,11 @@ public final class ChatService: Sendable {
 
                 let sql = """
                     SELECT qa.id, COALESCE(qa.job_id, 0) AS job_id, qa.asked_by, qa.subject, qa.current_level, qa.status, qa.priority,
-                           qa.answer_text,
+                           qa.answer_text, j.due_date,
                            COALESCE(ua.display_name, ua.email, 'Unknown') AS asked_by_name,
                            COALESCE(ub.display_name, ub.email) AS answered_by_name
                     FROM qa_threads qa
+                    LEFT JOIN jobs j ON j.id = qa.job_id AND j.deleted_at IS NULL
                     LEFT JOIN users ua ON ua.id = qa.asked_by AND ua.deleted_at IS NULL
                     LEFT JOIN users ub ON ub.id = qa.answered_by AND ub.deleted_at IS NULL
                     WHERE \(whereClauses.joined(separator: " AND "))
@@ -477,6 +482,7 @@ public final class ChatService: Sendable {
                         currentLevel: row["current_level"] ?? "field",
                         status: row["status"] ?? "open",
                         priority: row["priority"] ?? "normal",
+                        dueDate: row["due_date"] as String?,
                         answer: row["answer_text"] as String?,
                         answeredByName: row["answered_by_name"] as String?
                     )

--- a/core/Sources/WiredPartCore/Services/OrdersService.swift
+++ b/core/Sources/WiredPartCore/Services/OrdersService.swift
@@ -137,11 +137,13 @@ public final class OrdersService: Sendable {
         public let priority: String
         public let lineCount: Int
         public let holdCount: Int
+        public let dueDate: String?
         public let createdAt: String?
 
         public init(
             id: Int64, jobId: Int64 = 0, jobName: String, requestedByName: String,
-            status: String, priority: String, lineCount: Int, holdCount: Int = 0, createdAt: String?
+            status: String, priority: String, lineCount: Int, holdCount: Int = 0,
+            dueDate: String? = nil, createdAt: String?
         ) {
             self.id = id
             self.jobId = jobId
@@ -151,6 +153,7 @@ public final class OrdersService: Sendable {
             self.priority = priority
             self.lineCount = lineCount
             self.holdCount = holdCount
+            self.dueDate = dueDate
             self.createdAt = createdAt
         }
     }
@@ -318,6 +321,7 @@ public final class OrdersService: Sendable {
         public let approvedByName: String?
         public let approvedAt: String?
         public let deletedAt: String?
+        public let dueDate: String?
         public let createdAt: String?
         public let updatedAt: String?
         public let deliveryOption: String?
@@ -329,7 +333,7 @@ public final class OrdersService: Sendable {
             requestedBy: Int64, requestedByName: String,
             status: String, priority: String, notes: String?,
             approvedBy: Int64?, approvedByName: String?, approvedAt: String?,
-            deletedAt: String?, createdAt: String?, updatedAt: String?,
+            deletedAt: String?, dueDate: String? = nil, createdAt: String?, updatedAt: String?,
             lines: [JPOLineRow],
             deliveryOption: String? = "partial", deliveryLocked: Bool = false
         ) {
@@ -345,6 +349,7 @@ public final class OrdersService: Sendable {
             self.approvedByName = approvedByName
             self.approvedAt = approvedAt
             self.deletedAt = deletedAt
+            self.dueDate = dueDate
             self.createdAt = createdAt
             self.updatedAt = updatedAt
             self.deliveryOption = deliveryOption
@@ -596,7 +601,7 @@ public final class OrdersService: Sendable {
                 args.append(limit)
 
                 let sql = """
-                    SELECT jp.id, jp.job_id, jp.status, jp.priority, jp.created_at,
+                    SELECT jp.id, jp.job_id, jp.status, jp.priority, jp.created_at, j.due_date,
                            COALESCE(j.job_name, 'Unknown Job') AS job_name,
                            COALESCE(u.display_name, u.email, 'Unknown') AS requested_by_name,
                            COALESCE((SELECT COUNT(*) FROM jpo_line_items jl
@@ -623,6 +628,7 @@ public final class OrdersService: Sendable {
                         priority: row["priority"] ?? "normal",
                         lineCount: row["line_count"] ?? 0,
                         holdCount: row["hold_count"] ?? 0,
+                        dueDate: row["due_date"] as String?,
                         createdAt: row["created_at"] as String?
                     )
                 }
@@ -652,7 +658,7 @@ public final class OrdersService: Sendable {
                 args.append(limit)
 
                 let sql = """
-                    SELECT jp.id, jp.job_id, jp.status, jp.priority, jp.created_at,
+                    SELECT jp.id, jp.job_id, jp.status, jp.priority, jp.created_at, j.due_date,
                            COALESCE(j.job_name, 'Unknown Job') AS job_name,
                            COALESCE(u.display_name, u.email, 'Unknown') AS requested_by_name,
                            COALESCE((SELECT COUNT(*) FROM jpo_line_items jl
@@ -679,6 +685,7 @@ public final class OrdersService: Sendable {
                         priority: row["priority"] ?? "normal",
                         lineCount: row["line_count"] ?? 0,
                         holdCount: row["hold_count"] ?? 0,
+                        dueDate: row["due_date"] as String?,
                         createdAt: row["created_at"] as String?
                     )
                 }
@@ -695,6 +702,7 @@ public final class OrdersService: Sendable {
             let sql = """
                 SELECT jp.*,
                        COALESCE(j.job_name, 'Unknown Job') AS job_name,
+                       j.due_date,
                        COALESCE(u_req.display_name, u_req.email, 'Unknown') AS requested_by_name,
                        COALESCE(u_app.display_name, u_app.email) AS approved_by_name
                 FROM job_parts_orders jp
@@ -751,6 +759,7 @@ public final class OrdersService: Sendable {
                 approvedByName: row["approved_by_name"] as String?,
                 approvedAt: row["approved_at"] as String?,
                 deletedAt: row["deleted_at"] as String?,
+                dueDate: row["due_date"] as String?,
                 createdAt: row["created_at"] as String?,
                 updatedAt: row["updated_at"] as String?,
                 lines: lines,

--- a/core/Tests/WiredPartCoreTests/ChatServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ChatServiceTests.swift
@@ -152,6 +152,32 @@ struct ChatServiceTests {
         #expect(threads.first?.askedById == env.adminUserId)
     }
 
+    @Test("QA thread rows expose backing job due dates for timeline priority color")
+    func testQAThreadRowsExposeJobDueDate() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try env.jobs.createJob(
+            jobNumber: "J-QA-DUE",
+            jobName: "Due Date QA Job",
+            customerName: "Test Customer",
+            status: "active",
+            dueDate: "2026-06-15",
+            createdBy: env.adminUserId
+        )
+
+        let threadId = try env.chat.createQAThread(
+            jobId: jobId,
+            askedBy: env.adminUserId,
+            subject: "Will this badge use the job due date?",
+            priority: "urgent"
+        )
+
+        let allThreads = try env.chat.listQAThreads(status: nil)
+        let jobThreads = try env.chat.listQAThreads(jobId: jobId, status: nil)
+
+        #expect(allThreads.first(where: { $0.id == threadId })?.dueDate == "2026-06-15")
+        #expect(jobThreads.first?.dueDate == "2026-06-15")
+    }
+
     @Test("Filter QA threads by job")
     func testQAThreadsByJob() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
@@ -26,6 +26,28 @@ struct OrdersServiceTests {
         #expect(jpos.count >= 1)
     }
 
+    @Test("JPO list and detail expose backing job due dates for timeline priority color")
+    func testJPORowsExposeJobDueDate() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try env.jobs.createJob(
+            jobNumber: "J-JPO-DUE",
+            jobName: "Due Date JPO Job",
+            customerName: "Test Customer",
+            status: "active",
+            dueDate: "2026-07-20",
+            createdBy: env.adminUserId
+        )
+        let jpoId = try env.orders.createJPO(jobId: jobId, requestedBy: env.adminUserId, notes: nil)
+
+        let listItem = try env.orders.listJPOs().first(where: { $0.id == jpoId })
+        let jobListItem = try env.orders.listJPOs(jobId: jobId).first(where: { $0.id == jpoId })
+        let detail = try env.orders.getJPODetail(id: jpoId)
+
+        #expect(listItem?.dueDate == "2026-07-20")
+        #expect(jobListItem?.dueDate == "2026-07-20")
+        #expect(detail.dueDate == "2026-07-20")
+    }
+
     @Test("JPO detail with line items")
     func testJPODetail() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Pass backing job due dates through QA thread and JPO list/detail service rows.
- Use due-date-aware TimelinePriorityColor calls in Q&A, escalation, RFI, approval, JPO list, and JPO detail priority badges.
- Add service regression coverage proving QA/JPO rows expose job due dates for priority-color consumers.

## Test Plan
- [x] swift test --package-path core --filter 'ChatServiceTests|OrdersServiceTests'
- [x] git diff --check

Fixes #697