### PR TITLE
fix(scanning): surface QR scanner startup failures

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Scanning/IOSQRScanner.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Scanning/IOSQRScanner.swift
@@ -98,7 +98,7 @@ struct IOSQRScannerView: UIViewControllerRepresentable {
     final class Coordinator: NSObject {
         var onEvent: (QRScanEvent) -> Void
         weak var scanner: DataScannerViewController?
-        var delegate: ScannerDelegate?
+        fileprivate var delegate: ScannerDelegate?
         var isScanning = false
 
         init(onEvent: @escaping (QRScanEvent) -> Void) {
@@ -168,13 +168,35 @@ final class IOSQRScanner: QRScannerAdapter {
 
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let rootVC = windowScene.windows.first?.rootViewController else {
-            continuation?.yield(.error("Unable to present scanner"))
+            finishPresentedScanner(scanner, errorMessage: "Unable to present scanner")
             return
         }
 
-        rootVC.present(scanner, animated: true) {
-            try? scanner.startScanning()
+        rootVC.present(scanner, animated: true) { [weak self, weak scanner] in
+            guard let self, let scanner else { return }
+
+            do {
+                try scanner.startScanning()
+            } catch {
+                self.finishPresentedScanner(
+                    scanner,
+                    errorMessage: userFriendlyError(error, context: "scan item")
+                )
+            }
         }
+    }
+
+    private func finishPresentedScanner(_ scanner: DataScannerViewController, errorMessage: String) {
+        let activeContinuation = continuation
+        activeContinuation?.yield(.error(errorMessage))
+
+        scanner.stopScanning()
+        scanner.dismiss(animated: true)
+
+        scannerVC = nil
+        delegate = nil
+        continuation = nil
+        activeContinuation?.finish()
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -182,6 +182,21 @@ struct Weird_Parts_IOSTests {
         #expect(!sheetSource.contains("\"cancelled\""), "Editing status to cancelled leaves deleted_at NULL; cancellation must use the explicit soft-delete action")
     }
 
+    @Test func qrScannerStartFailureIsSurfacedAndStreamFinished() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let scannerURL = repoRoot
+            .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Scanning/IOSQRScanner.swift")
+        let scannerSource = try String(contentsOf: scannerURL, encoding: .utf8)
+
+        #expect(!scannerSource.contains("try? scanner.startScanning()"), "Startup failures from DataScannerViewController must not be swallowed")
+        #expect(scannerSource.contains("catch {"), "The modal scanner start path needs explicit do/catch error handling")
+        #expect(scannerSource.contains("activeContinuation?.yield(.error(errorMessage))"), "Startup failures should emit an actionable QRScanEvent error")
+        #expect(scannerSource.contains("activeContinuation?.finish()"), "Startup failures should finish the scan stream instead of leaving a dead sheet")
+    }
+
     @Test func uiTestingFixturesSeedJPOFlowDataForQASmoke() throws {
         let db = try AppDatabase.openInMemoryDatabase()
         let auth = AuthService(db: db)


### PR DESCRIPTION
## Summary
- Fixes #696
- Replaces the modal QR scanner `try? scanner.startScanning()` path with explicit do/catch handling.
- Emits an actionable `.error(...)`, dismisses/cleans scanner state, and finishes the stream when startup fails.
- Adds a focused source seam regression test for startup failure propagation and stream completion.

## Test Plan
- [x] `python3` source assertions for QR scanner startup failure handling
- [x] `xcodebuild build -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "platform=iOS Simulator,name=iPhone 17,OS=26.4.1"` (fails before completing due unrelated existing duplicate declarations in `IOSJobDetailTabView.swift`: `isLoadingJobNotebook` and `createMissingJobNotebook(for:)`; no remaining errors from `IOSQRScanner.swift`)
