### PR TITLE
fix: surface QR scanner start failures

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Scanning/IOSQRScanner.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Scanning/IOSQRScanner.swift
@@ -98,7 +98,7 @@ struct IOSQRScannerView: UIViewControllerRepresentable {
     final class Coordinator: NSObject {
         var onEvent: (QRScanEvent) -> Void
         weak var scanner: DataScannerViewController?
-        var delegate: ScannerDelegate?
+        fileprivate var delegate: ScannerDelegate?
         var isScanning = false
 
         init(onEvent: @escaping (QRScanEvent) -> Void) {
@@ -149,6 +149,7 @@ final class IOSQRScanner: QRScannerAdapter {
 
     func stopScanning() {
         scannerVC?.stopScanning()
+        scannerVC?.delegate = nil
         scannerVC?.dismiss(animated: true)
         scannerVC = nil
         delegate = nil
@@ -168,13 +169,24 @@ final class IOSQRScanner: QRScannerAdapter {
 
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let rootVC = windowScene.windows.first?.rootViewController else {
-            continuation?.yield(.error("Unable to present scanner"))
+            finishScanningWithError("Unable to present scanner")
             return
         }
 
-        rootVC.present(scanner, animated: true) {
-            try? scanner.startScanning()
+        rootVC.present(scanner, animated: true) { [weak self, weak scanner] in
+            guard let self, let scanner else { return }
+
+            do {
+                try scanner.startScanning()
+            } catch {
+                self.finishScanningWithError(userFriendlyError(error, context: "scan item"))
+            }
         }
+    }
+
+    private func finishScanningWithError(_ message: String) {
+        continuation?.yield(.error(message))
+        stopScanning()
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
@@ -235,6 +235,7 @@ struct QRScanSheet: View {
                         await processPayload(payload)
                     case .error(let msg):
                         scanError = msg
+                        isScanning = false
                     case .permissionDenied:
                         scanError = "Camera permission required. Enable in Settings."
                         isScanning = false


### PR DESCRIPTION
## Summary
- Replace swallowed `try? scanner.startScanning()` with explicit `do/catch` so VisionKit startup failures emit a user-friendly QR scan error.
- Clean up scanner delegate/controller state and finish the stream when startup or presentation fails.
- Reset QRScanSheet scanning state when an error event is received so the sheet can recover instead of staying stuck.

Fixes #696

## Test Plan
- [x] `xcodebuild -scheme "Weird Parts" -project "Weird Parts IOS/Weird Parts.xcodeproj" -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1' -skipPackagePluginValidation build` (fails on pre-existing duplicate declarations in `IOSJobDetailTabView.swift`; no remaining `IOSQRScanner.swift` errors after the fix)
- [x] `git diff --check`
- [x] conflict marker / secret diff scan

## Notes
- A direct unit test for `DataScannerViewController.startScanning()` failure is not feasible in the current harness because the code is tied to VisionKit presentation/camera availability. This change adds the explicit seam in the presentation completion handler and verifies through iOS target compilation until the unrelated `IOSJobDetailTabView.swift` blocker.