### PR TITLE
docs: document GitHub account and org migration plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,10 @@ Errors are learning opportunities. When something breaks:
 
 **GitHub Issues is the single source of truth** for all bugs, features, and improvements. Every unfixed problem MUST have a GitHub issue. Every fix should reference and close its issue.
 
+## GitHub Account Context
+
+This repo is currently under the user's personal GitHub account (`xXKillerNoobYT`), not a GitHub organization. Do not assume organization teams, organization policy pages, organization-level settings, or organization Copilot controls exist. Verify the repo owner before applying GitHub admin instructions. If a requested control is organization-only, document it as not applicable unless/until the user transfers the repo to an organization; use repo-level or user-account-level settings where available. See `docs/github-account-context.md`.
+
 **Rules:**
 
 1. **Find something broken? File it.** Every bug, gap, or missing feature gets a GitHub issue with: title prefix `[Area][Type]`, description of what's wrong, impact, and fix approach.

--- a/docs/auto-go-memory.md
+++ b/docs/auto-go-memory.md
@@ -22,6 +22,7 @@ Memory is organized by topic, not chronologically. Each entry includes when it w
 - **Hardcoded user ID `1` is an anti-pattern** (see `feedback_hardcoded_user_ids.md`). Always flow real `userId` from session for `created_by`/`updated_by`/`started_by`.
 - **Plans are the source of truth for design** (`docs/plans/`). If code diverges from plan, plan wins — unless I file a Q&A and the user decides otherwise.
 - **GitHub issues are the single source of truth for unfixed problems** (per CLAUDE.md). Anything unfixable gets filed.
+- **GitHub repos are personal-account owned for now** (`xXKillerNoobYT`), not organization-owned. Verify repo owner context before applying GitHub admin instructions; treat org-only settings as not applicable unless the user moves repos to an organization. See `docs/github-account-context.md`.
 
 ## Things I know about the user's working style
 

--- a/docs/github-account-context.md
+++ b/docs/github-account-context.md
@@ -1,0 +1,35 @@
+# GitHub Account Context
+
+This project currently lives under the user's personal GitHub account, not a GitHub organization.
+
+Current verified repo context:
+
+- Repository: `xXKillerNoobYT/Weird-Part-Run-2`
+- Remote: `https://github.com/xXKillerNoobYT/Weird-Part-Run-2.git`
+- Owner account: `xXKillerNoobYT`
+- Visibility at last verification: public
+- Viewer permission at last verification: admin
+
+Verification command:
+
+```bash
+gh repo view xXKillerNoobYT/Weird-Part-Run-2 \
+  --json nameWithOwner,owner,visibility,isPrivate,url,viewerPermission
+```
+
+## Operating rule for agents
+
+Do not assume GitHub organization features, organization teams, organization policy pages, or organization-level settings exist for this repo.
+
+When a workflow asks for GitHub owner/org settings:
+
+1. First inspect the actual repo owner from `git remote get-url origin` or `gh repo view`.
+2. If the owner is a personal account, use repo-level or user-account-level GitHub settings only.
+3. If a requested control only exists for organizations, document that it is not applicable until the repo is transferred to a GitHub organization.
+4. Do not block implementation work waiting for org-only settings unless the user explicitly decides to create or move to a GitHub organization.
+
+## Practical impact
+
+- Branch protection, required checks, auto-merge, issues, PRs, and repo secrets are repo-level and still apply.
+- Organization teams, organization rulesets, organization member permissions, and organization Copilot policy screens may not apply.
+- Any Paperclip task created from an "org settings" assumption should be re-scoped to the equivalent repo/user-account setting or marked not applicable with evidence.

--- a/docs/github-organization-migration-plan.md
+++ b/docs/github-organization-migration-plan.md
@@ -1,0 +1,110 @@
+# GitHub Organization Migration Plan
+
+Date: 2026-05-23
+Paperclip issue: WEI-2163
+
+## Why this exists
+
+The current Paperclip company has multiple active project repositories owned by personal GitHub accounts instead of a shared GitHub organization. That makes access control, agent permissions, billing ownership, secrets, and continuity harder to manage as the coding company grows.
+
+This document records the safe migration plan. It intentionally does not transfer any repository by itself; repo transfer changes ownership, permissions, webhooks, secrets, app installs, and clone URLs, so it should be approved and scheduled before execution.
+
+## Current inventory
+
+| Paperclip project | GitHub repo | Current owner type | Visibility | Current permission seen by CTO | Default branch | Recommended target |
+| --- | --- | --- | --- | --- | --- | --- |
+| Mythos Writer | `SkyyPlayz/Mythos-Writer` | User (`SkyyPlayz`) | Private | Write | `main` | `Weirdtoo/Mythos-Writer` |
+| Questing | `SkyyPlayz/Questing` | User (`SkyyPlayz`) | Private | Write | `main` | `Weirdtoo/Questing` |
+| Weird Part's run 2 | `xXKillerNoobYT/Weird-Part-Run-2` | User (`xXKillerNoobYT`) | Public | Admin | `main` | `Weirdtoo/Weird-Part-Run-2` |
+| Coding setup and Policy Senter | `xXKillerNoobYT/paperclip` | User (`xXKillerNoobYT`) | Public | Admin | `master` | `Weirdtoo/paperclip` |
+
+Authenticated GitHub account: `xXKillerNoobYT`.
+Available organization detected: `Weirdtoo`.
+
+## Key risk notes
+
+1. `Weird-Part-Run-2` currently has 68 remote branches. That is above the 20-branch soft cap from the branch hygiene policy, though below the 100-branch hard cap. Do not combine org migration with branch cleanup; migrate ownership first or drain branches first as a separate tracked task.
+2. `Mythos-Writer` and `Questing` are private and currently only show Write permission for the authenticated account. Transfers may require the current owner account (`SkyyPlayz`) or an organization owner to initiate/approve.
+3. GitHub automatically redirects old repo URLs after transfer, but Paperclip project workspace records, local remotes, secrets, deploy keys, GitHub Apps, webhooks, branch protection, and CI assumptions should still be audited and updated explicitly.
+4. The `paperclip` repo uses `master`; the others use `main`. Preserve default branches during transfer unless a separate migration explicitly changes them.
+5. Public/private visibility should be preserved unless the user explicitly approves a visibility change.
+
+## Recommended migration sequence
+
+### Phase 0: Confirm destination policy
+
+- Confirm whether `Weirdtoo` is the intended long-term organization.
+- Confirm whether each repo should keep its current visibility.
+- Confirm desired org teams, for example:
+  - Owners/Admins: user + trusted maintainers.
+  - Agents: Paperclip/Hermes service accounts with least privilege.
+  - Viewers: read-only collaborators if needed.
+
+### Phase 1: Preflight each repo
+
+For each repo:
+
+```bash
+gh repo view OWNER/REPO --json nameWithOwner,isPrivate,visibility,owner,defaultBranchRef,viewerPermission,url
+gh api repos/OWNER/REPO/hooks --jq 'length'
+gh secret list -R OWNER/REPO
+gh variable list -R OWNER/REPO
+gh api repos/OWNER/REPO/environments --jq '.environments | length'
+gh api repos/OWNER/REPO/branches/DEFAULT_BRANCH/protection || true
+gh workflow list -R OWNER/REPO --all
+gh pr list -R OWNER/REPO --state open --limit 100
+```
+
+Record anything that must be recreated or reauthorized after transfer.
+
+### Phase 2: Transfer repositories one at a time
+
+Preferred order:
+
+1. `xXKillerNoobYT/paperclip` because it is public and admin-accessible.
+2. `xXKillerNoobYT/Weird-Part-Run-2` because it is the active beta trunk and admin-accessible.
+3. `SkyyPlayz/Questing` after owner/admin permission is confirmed.
+4. `SkyyPlayz/Mythos-Writer` after owner/admin permission is confirmed.
+
+Use GitHub UI or API. API shape for an admin-authorized transfer:
+
+```bash
+gh api -X POST repos/OWNER/REPO/transfer -f new_owner=Weirdtoo
+```
+
+Do not run this command until the user approves the specific repo transfer window.
+
+### Phase 3: Update local and Paperclip references
+
+After each successful transfer:
+
+```bash
+git remote set-url origin https://github.com/Weirdtoo/REPO.git
+git remote -v
+git fetch origin --prune
+gh repo view Weirdtoo/REPO --json nameWithOwner,visibility,defaultBranchRef
+```
+
+Then update the matching Paperclip project workspace `repoUrl` / codebase metadata if Paperclip does not follow GitHub redirects automatically.
+
+### Phase 4: Post-transfer verification
+
+For each repo:
+
+- Clone/fetch works with the new URL.
+- Existing open PRs and branches are still visible.
+- GitHub Actions workflows still run or are intentionally disabled.
+- Secrets, variables, environments, webhooks, and GitHub Apps are present or recreated.
+- Branch protection/default branch settings are preserved.
+- Paperclip can start a new workspace and push a test branch if needed.
+
+## Paperclip follow-up work items to create
+
+Create one issue per repository so transfer can be approved, executed, and verified independently:
+
+1. `[GitHub][Org Migration] Transfer paperclip repo to Weirdtoo`
+2. `[GitHub][Org Migration] Transfer Weird-Part-Run-2 repo to Weirdtoo`
+3. `[GitHub][Org Migration] Transfer Questing repo to Weirdtoo`
+4. `[GitHub][Org Migration] Transfer Mythos-Writer repo to Weirdtoo`
+
+Each issue should include the preflight checklist, transfer command/UI step, and post-transfer verification checklist above.

--- a/docs/paperclip-handoff.md
+++ b/docs/paperclip-handoff.md
@@ -61,6 +61,7 @@ Operational implications:
 - **Reports as dashboards.** Tables, checklists, dashboards. Concrete numbers. Avoid prose walls.
 - **Budget-conscious + time-respectful.** Don't burn tokens on speculative exploration. Be efficient. Cheap models for mechanical work; Opus only for judgment work. (See `docs/auto-go-soul.md` "Opus manages, sub-agents specialize.")
 - **The user is the designer.** When something is ambiguous, the user's intent is authoritative even when expressed imperfectly. Interpret the spirit of the request. When you can't, file a Q&A entry in `docs/dev-qa.md` per the per-POV workflow — don't guess silently.
+- **GitHub is personal-account owned for now.** Current repos are under the user's personal GitHub account, not an organization. Verify owner context before applying GitHub admin instructions; org-only settings should be treated as not applicable unless the user moves repos into an organization. See `docs/github-account-context.md`.
 - **Spelling and shorthand are fine.** The user uses voice-to-text and shorthand sometimes. "approve all", "lests get them aserd", "go" — all valid. Decode and execute.
 - **Owner answers via AskUserQuestion picker.** When there are choices, present them via AskUserQuestion with proposed answers + Keep/Adjust/Different options. Batch by cluster (max 4 per call). (See `feedback_qa_workflow.md`.)
 - **Pin chat reuse.** The user pins chats to come back to. Memory files persist across sessions; lean on them.


### PR DESCRIPTION
## Summary
- Document current personal-account GitHub ownership context for agents
- Add a safe organization migration plan targeting the detected Weirdtoo organization
- Record current Paperclip project repo inventory, visibility, permissions, and transfer risks

## Verification
- Verified Paperclip project repo URLs from the local Paperclip API
- Verified GitHub owner types, org availability, visibility, default branches, and permissions with gh
- Documentation-only change; no repo transfers performed

Paperclip: WEI-2163