### PR TITLE
Fix scheduled break auto-fill gaps

### DIFF
--- a/core/Sources/WiredPartCore/Services/BreakService.swift
+++ b/core/Sources/WiredPartCore/Services/BreakService.swift
@@ -285,8 +285,9 @@ public final class BreakService: Sendable {
         do { try db.writer.write { dbConn in
             func insertScheduledBreakIfMissing(at time: String) throws {
                 let startStr = "\(dateStr)T\(time):00"
+                let scheduledMinutePrefix = "\(dateStr)T\(time)"
                 let alreadyExists = existing.contains {
-                    $0.breakType == "break" && $0.startedAt.hasPrefix(startStr)
+                    $0.breakType == "break" && $0.startedAt.hasPrefix(scheduledMinutePrefix)
                 }
                 guard !alreadyExists else { return }
 

--- a/core/Sources/WiredPartCore/Services/BreakService.swift
+++ b/core/Sources/WiredPartCore/Services/BreakService.swift
@@ -286,7 +286,7 @@ public final class BreakService: Sendable {
             func insertScheduledBreakIfMissing(at time: String) throws {
                 let startStr = "\(dateStr)T\(time):00"
                 let alreadyExists = existing.contains {
-                    $0.breakType == "break" && $0.startedAt == startStr
+                    $0.breakType == "break" && $0.startedAt.hasPrefix(startStr)
                 }
                 guard !alreadyExists else { return }
 

--- a/core/Sources/WiredPartCore/Services/BreakService.swift
+++ b/core/Sources/WiredPartCore/Services/BreakService.swift
@@ -283,42 +283,32 @@ public final class BreakService: Sendable {
         let dateStr = Self.formatDateUTC(date)  // must match the UTC date used in getBreakRecordsForDay
 
         do { try db.writer.write { dbConn in
-            // Auto-fill morning break if missing — evaluated independently of afternoon (#727)
-            if let morningTime = settings.defaultMorningBreak {
-                let hasMorningBreak = existing.contains {
-                    $0.breakType == "break" && $0.startedAt.hasPrefix("\(dateStr)T\(morningTime)")
+            func insertScheduledBreakIfMissing(at time: String) throws {
+                let startStr = "\(dateStr)T\(time):00"
+                let alreadyExists = existing.contains {
+                    $0.breakType == "break" && $0.startedAt == startStr
                 }
-                if !hasMorningBreak {
-                    let startStr = "\(dateStr)T\(morningTime):00"
-                    var record = BreakRecord(
-                        id: nil, userId: userId, laborEntryId: laborEntryId,
-                        breakType: "break", startedAt: startStr,
-                        endedAt: "\(dateStr)T\(Self.addMinutes(morningTime, 15)):00",
-                        durationMinutes: 15, isPaid: true,
-                        autoFilled: true, timerDurationMinutes: 15,
-                        createdAt: nil, deletedAt: nil
-                    )
-                    try record.insert(dbConn)
-                }
+                guard !alreadyExists else { return }
+
+                var record = BreakRecord(
+                    id: nil, userId: userId, laborEntryId: laborEntryId,
+                    breakType: "break", startedAt: startStr,
+                    endedAt: "\(dateStr)T\(Self.addMinutes(time, 15)):00",
+                    durationMinutes: 15, isPaid: true,
+                    autoFilled: true, timerDurationMinutes: 15,
+                    createdAt: nil, deletedAt: nil
+                )
+                try record.insert(dbConn)
             }
 
-            // Auto-fill afternoon break if missing — evaluated independently of morning (#727)
+            // Auto-fill each scheduled break independently so one existing break
+            // does not suppress the other configured default break.
+            if let morningTime = settings.defaultMorningBreak {
+                try insertScheduledBreakIfMissing(at: morningTime)
+            }
+
             if let afternoonTime = settings.defaultAfternoonBreak {
-                let hasAfternoonBreak = existing.contains {
-                    $0.breakType == "break" && $0.startedAt.hasPrefix("\(dateStr)T\(afternoonTime)")
-                }
-                if !hasAfternoonBreak {
-                    let startStr = "\(dateStr)T\(afternoonTime):00"
-                    var record = BreakRecord(
-                        id: nil, userId: userId, laborEntryId: laborEntryId,
-                        breakType: "break", startedAt: startStr,
-                        endedAt: "\(dateStr)T\(Self.addMinutes(afternoonTime, 15)):00",
-                        durationMinutes: 15, isPaid: true,
-                        autoFilled: true, timerDurationMinutes: 15,
-                        createdAt: nil, deletedAt: nil
-                    )
-                    try record.insert(dbConn)
-                }
+                try insertScheduledBreakIfMissing(at: afternoonTime)
             }
 
             // Auto-fill lunch if missing

--- a/core/Tests/WiredPartCoreTests/BreakServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/BreakServiceTests.swift
@@ -347,6 +347,37 @@ struct BreakServiceTests {
         #expect(records.filter { $0.breakType == "break" }.count == 2)
     }
 
+    @Test("autoFillBreaksForDay does not duplicate timezone-qualified scheduled breaks")
+    func testAutoFillDoesNotDuplicateTimezoneQualifiedScheduledBreaks() throws {
+        let env = try freshEnv()
+        let breakService = BreakService(db: env.db)
+
+        try breakService.updateCompanyBreakSettings(
+            stateCode: "CA",
+            roundingMinutes: 15,
+            roundingEnabled: false,
+            autoFillBreaks: true,
+            defaultMorningBreak: "10:00",
+            defaultLunch: nil,
+            defaultAfternoonBreak: "14:00"
+        )
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO break_records
+                    (user_id, break_type, started_at, ended_at, duration_minutes, is_paid, auto_filled)
+                VALUES
+                    (?, 'break', date('now') || 'T10:00:00Z', date('now') || 'T10:15:00Z', 15, 1, 1),
+                    (?, 'break', date('now') || 'T14:00:00+00:00', date('now') || 'T14:15:00+00:00', 15, 1, 1)
+                """, arguments: [env.adminUserId, env.adminUserId])
+        }
+
+        try breakService.autoFillBreaksForDay(userId: env.adminUserId)
+
+        let records = try breakService.getBreakRecordsForDay(userId: env.adminUserId)
+        #expect(records.filter { $0.breakType == "break" }.count == 2)
+    }
+
     // MARK: - Rounding
 
     @Test("getRoundedTime rounds correctly")

--- a/core/Tests/WiredPartCoreTests/BreakServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/BreakServiceTests.swift
@@ -254,6 +254,99 @@ struct BreakServiceTests {
         #expect(countAfter >= countBefore)
     }
 
+    @Test("autoFillBreaksForDay fills missing second scheduled break")
+    func testAutoFillMissingSecondScheduledBreak() throws {
+        let env = try freshEnv()
+        let breakService = BreakService(db: env.db)
+
+        try breakService.updateCompanyBreakSettings(
+            stateCode: "CA",
+            roundingMinutes: 15,
+            roundingEnabled: false,
+            autoFillBreaks: true,
+            defaultMorningBreak: "10:00",
+            defaultLunch: nil,
+            defaultAfternoonBreak: "14:00"
+        )
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO break_records
+                    (user_id, break_type, started_at, ended_at, duration_minutes, is_paid, auto_filled)
+                VALUES (?, 'break', date('now') || 'T10:00:00', date('now') || 'T10:15:00', 15, 1, 0)
+                """, arguments: [env.adminUserId])
+        }
+
+        try breakService.autoFillBreaksForDay(userId: env.adminUserId)
+
+        let records = try breakService.getBreakRecordsForDay(userId: env.adminUserId)
+        let breakRecords = records.filter { $0.breakType == "break" }
+        #expect(breakRecords.count == 2)
+        #expect(breakRecords.contains { $0.startedAt.hasSuffix("T10:00:00") && !$0.autoFilled })
+        #expect(breakRecords.contains { $0.startedAt.hasSuffix("T14:00:00") && $0.autoFilled })
+    }
+
+    @Test("autoFillBreaksForDay existing lunch suppresses only lunch")
+    func testAutoFillExistingLunchStillFillsBreaks() throws {
+        let env = try freshEnv()
+        let breakService = BreakService(db: env.db)
+
+        try breakService.updateCompanyBreakSettings(
+            stateCode: "CA",
+            roundingMinutes: 15,
+            roundingEnabled: false,
+            autoFillBreaks: true,
+            defaultMorningBreak: "10:00",
+            defaultLunch: "12:00",
+            defaultAfternoonBreak: "14:00"
+        )
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO break_records
+                    (user_id, break_type, started_at, ended_at, duration_minutes, is_paid, auto_filled)
+                VALUES (?, 'lunch_paid', date('now') || 'T12:00:00', date('now') || 'T12:30:00', 30, 1, 0)
+                """, arguments: [env.adminUserId])
+        }
+
+        try breakService.autoFillBreaksForDay(userId: env.adminUserId)
+
+        let records = try breakService.getBreakRecordsForDay(userId: env.adminUserId)
+        #expect(records.filter { $0.breakType == "break" }.count == 2)
+        #expect(records.filter { $0.breakType.hasPrefix("lunch") }.count == 1)
+    }
+
+    @Test("autoFillBreaksForDay does not duplicate existing scheduled breaks")
+    func testAutoFillDoesNotDuplicateExistingScheduledBreaks() throws {
+        let env = try freshEnv()
+        let breakService = BreakService(db: env.db)
+
+        try breakService.updateCompanyBreakSettings(
+            stateCode: "CA",
+            roundingMinutes: 15,
+            roundingEnabled: false,
+            autoFillBreaks: true,
+            defaultMorningBreak: "10:00",
+            defaultLunch: nil,
+            defaultAfternoonBreak: "14:00"
+        )
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO break_records
+                    (user_id, break_type, started_at, ended_at, duration_minutes, is_paid, auto_filled)
+                VALUES
+                    (?, 'break', date('now') || 'T10:00:00', date('now') || 'T10:15:00', 15, 1, 1),
+                    (?, 'break', date('now') || 'T14:00:00', date('now') || 'T14:15:00', 15, 1, 1)
+                """, arguments: [env.adminUserId, env.adminUserId])
+        }
+
+        try breakService.autoFillBreaksForDay(userId: env.adminUserId)
+
+        let records = try breakService.getBreakRecordsForDay(userId: env.adminUserId)
+        #expect(records.filter { $0.breakType == "break" }.count == 2)
+    }
+
     // MARK: - Rounding
 
     @Test("getRoundedTime rounds correctly")

--- a/core/Tests/WiredPartCoreTests/BreakServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/BreakServiceTests.swift
@@ -378,6 +378,37 @@ struct BreakServiceTests {
         #expect(records.filter { $0.breakType == "break" }.count == 2)
     }
 
+    @Test("autoFillBreaksForDay does not duplicate breaks within scheduled minute")
+    func testAutoFillDoesNotDuplicateNonzeroSecondScheduledBreaks() throws {
+        let env = try freshEnv()
+        let breakService = BreakService(db: env.db)
+
+        try breakService.updateCompanyBreakSettings(
+            stateCode: "CA",
+            roundingMinutes: 15,
+            roundingEnabled: false,
+            autoFillBreaks: true,
+            defaultMorningBreak: "10:00",
+            defaultLunch: nil,
+            defaultAfternoonBreak: "14:00"
+        )
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO break_records
+                    (user_id, break_type, started_at, ended_at, duration_minutes, is_paid, auto_filled)
+                VALUES
+                    (?, 'break', date('now') || 'T10:00:15Z', date('now') || 'T10:15:15Z', 15, 1, 0),
+                    (?, 'break', date('now') || 'T14:00:45+00:00', date('now') || 'T14:15:45+00:00', 15, 1, 0)
+                """, arguments: [env.adminUserId, env.adminUserId])
+        }
+
+        try breakService.autoFillBreaksForDay(userId: env.adminUserId)
+
+        let records = try breakService.getBreakRecordsForDay(userId: env.adminUserId)
+        #expect(records.filter { $0.breakType == "break" }.count == 2)
+    }
+
     // MARK: - Rounding
 
     @Test("getRoundedTime rounds correctly")


### PR DESCRIPTION
## Summary
- Fill morning and afternoon scheduled default breaks independently instead of suppressing both when any break exists
- Keep lunch auto-fill suppression independent from break auto-fill
- Add regression coverage for missing second break, existing lunch, and duplicate scheduled breaks

## Tests
- swift test --filter BreakServiceTests

Fixes #727