### PR TITLE
[Warehouse][iOS] Guard zone resize placement

### DIFF
--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -2998,6 +2998,15 @@ public final class WarehouseService: Sendable {
             throw WarehouseError.invalidDimension
         }
         return try db.writer.write { dbConn in
+            try Self.validateZonePlacement(
+                floorPlanId: floorPlanId,
+                excludingZoneId: nil,
+                gridX: gridX,
+                gridY: gridY,
+                gridWidth: gridWidth,
+                gridHeight: gridHeight,
+                dbConn: dbConn
+            )
             var zone = WarehouseZone(
                 floorPlanId: floorPlanId,
                 zoneType: zoneType,
@@ -3037,16 +3046,85 @@ public final class WarehouseService: Sendable {
         if let gridHeight, gridHeight <= 0 { throw WarehouseError.invalidDimension }
         try db.writer.write { dbConn in
             guard var zone = try WarehouseZone.fetchOne(dbConn, key: id) else { return }
+            let nextGridX = gridX ?? zone.gridX
+            let nextGridY = gridY ?? zone.gridY
+            let nextGridWidth = gridWidth ?? zone.gridWidth
+            let nextGridHeight = gridHeight ?? zone.gridHeight
+            try Self.validateZonePlacement(
+                floorPlanId: zone.floorPlanId,
+                excludingZoneId: id,
+                gridX: nextGridX,
+                gridY: nextGridY,
+                gridWidth: nextGridWidth,
+                gridHeight: nextGridHeight,
+                dbConn: dbConn
+            )
             if let v = zoneType { zone.zoneType = v }
             if let v = label { zone.label = v }
             if let v = colorHex { zone.colorHex = v }
-            if let v = gridX { zone.gridX = v }
-            if let v = gridY { zone.gridY = v }
-            if let v = gridWidth { zone.gridWidth = v }
-            if let v = gridHeight { zone.gridHeight = v }
+            zone.gridX = nextGridX
+            zone.gridY = nextGridY
+            zone.gridWidth = nextGridWidth
+            zone.gridHeight = nextGridHeight
             if let v = rotation { zone.rotation = v }
             if let v = zoneOrder { zone.zoneOrder = v }
             try zone.update(dbConn)
+        }
+    }
+
+    private static func validateZonePlacement(
+        floorPlanId: Int64,
+        excludingZoneId: Int64?,
+        gridX: Int,
+        gridY: Int,
+        gridWidth: Int,
+        gridHeight: Int,
+        dbConn: Database
+    ) throws {
+        guard gridX >= 0, gridY >= 0, gridWidth > 0, gridHeight > 0 else {
+            throw WarehouseError.invalidDimension
+        }
+        guard let floorPlan = try WarehouseFloorPlan
+            .filter(Column("id") == floorPlanId && Column("deleted_at") == nil)
+            .fetchOne(dbConn)
+        else {
+            throw WarehouseError.invalidDimension
+        }
+        if let rows = floorPlan.gridRows, let cols = floorPlan.gridCols {
+            guard gridY + gridHeight <= rows, gridX + gridWidth <= cols else {
+                throw WarehouseError.invalidDimension
+            }
+        }
+
+        var query = WarehouseZone
+            .filter(Column("floor_plan_id") == floorPlanId && Column("deleted_at") == nil)
+        if let excludingZoneId {
+            query = query.filter(Column("id") != excludingZoneId)
+        }
+        let zones = try query.fetchAll(dbConn)
+        let candidate = ZoneGridRect(x: gridX, y: gridY, width: gridWidth, height: gridHeight)
+        let hasOverlap = zones.contains { zone in
+            candidate.intersects(ZoneGridRect(
+                x: zone.gridX,
+                y: zone.gridY,
+                width: zone.gridWidth,
+                height: zone.gridHeight
+            ))
+        }
+        guard !hasOverlap else { throw WarehouseError.invalidDimension }
+    }
+
+    private struct ZoneGridRect {
+        let x: Int
+        let y: Int
+        let width: Int
+        let height: Int
+
+        func intersects(_ other: ZoneGridRect) -> Bool {
+            x < other.x + other.width &&
+                x + width > other.x &&
+                y < other.y + other.height &&
+                y + height > other.y
         }
     }
 

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -720,6 +720,81 @@ struct WarehouseServiceExtTests {
         }
     }
 
+    @Test("updateZone keeps adjacent zone visible when resize remains non-overlapping")
+    func updateZone_preservesAdjacentZoneWhenResizeIsValid() throws {
+        let env = try E2ETestHelpers.setUp()
+        let floorPlan = try env.warehouse.createFloorPlan(name: "Two Zone Resize", widthInches: 480, lengthInches: 360)
+        let floorPlanId = floorPlan.id!
+        try env.warehouse.updateFloorPlanGrid(floorPlanId: floorPlanId, rows: 4, cols: 4)
+        let storage = try env.warehouse.addZone(
+            floorPlanId: floorPlanId,
+            zoneType: "storage",
+            label: "Storage",
+            gridX: 0,
+            gridY: 0,
+            gridWidth: 1,
+            gridHeight: 1
+        )
+        let receiving = try env.warehouse.addZone(
+            floorPlanId: floorPlanId,
+            zoneType: "receiving",
+            label: "Receiving",
+            gridX: 2,
+            gridY: 0,
+            gridWidth: 1,
+            gridHeight: 1
+        )
+
+        try env.warehouse.updateZone(id: storage.id!, gridWidth: 2, gridHeight: 2)
+
+        let zones = try env.warehouse.listZones(floorPlanId: floorPlanId)
+        let updatedStorage = try #require(zones.first { $0.id == storage.id })
+        let unchangedReceiving = try #require(zones.first { $0.id == receiving.id })
+        #expect(updatedStorage.gridX == 0)
+        #expect(updatedStorage.gridY == 0)
+        #expect(updatedStorage.gridWidth == 2)
+        #expect(updatedStorage.gridHeight == 2)
+        #expect(unchangedReceiving.gridX == 2)
+        #expect(unchangedReceiving.gridY == 0)
+        #expect(zones.count == 2)
+    }
+
+    @Test("updateZone rejects overlap and leaves original placement unchanged")
+    func updateZone_rejectsOverlapAndPreservesOriginalPlacement() throws {
+        let env = try E2ETestHelpers.setUp()
+        let floorPlan = try env.warehouse.createFloorPlan(name: "Overlap Rejection", widthInches: 480, lengthInches: 360)
+        let floorPlanId = floorPlan.id!
+        try env.warehouse.updateFloorPlanGrid(floorPlanId: floorPlanId, rows: 4, cols: 4)
+        let storage = try env.warehouse.addZone(
+            floorPlanId: floorPlanId,
+            zoneType: "storage",
+            label: "Storage",
+            gridX: 0,
+            gridY: 0,
+            gridWidth: 1,
+            gridHeight: 1
+        )
+        _ = try env.warehouse.addZone(
+            floorPlanId: floorPlanId,
+            zoneType: "receiving",
+            label: "Receiving",
+            gridX: 2,
+            gridY: 0,
+            gridWidth: 1,
+            gridHeight: 1
+        )
+
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            try env.warehouse.updateZone(id: storage.id!, gridWidth: 3, gridHeight: 1)
+        }
+
+        let zones = try env.warehouse.listZones(floorPlanId: floorPlanId)
+        let unchangedStorage = try #require(zones.first { $0.id == storage.id })
+        #expect(unchangedStorage.gridWidth == 1)
+        #expect(unchangedStorage.gridHeight == 1)
+        #expect(zones.count == 2)
+    }
+
     // MARK: - getPartName / getPartCode
 
     @Test("getPartName returns part name for existing part")


### PR DESCRIPTION
## Summary
- add service-level zone placement validation for add/update paths
- keep the Storage R1C1 + Receiving R1C3 resize case non-destructive
- add regression coverage for valid adjacent resize and rejected overlap preservation

## Verification
- swift test --package-path core --filter WarehouseServiceExtTests/updateZone_preservesAdjacentZoneWhenResizeIsValid
- swift test --package-path core --filter WarehouseServiceExtTests/updateZone_rejectsOverlapAndPreservesOriginalPlacement
- git diff --check

## Validation gap
- xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme WiredPart-iOS -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build was attempted twice in the clean worktree but local xcodebuild exited with ** BUILD INTERRUPTED ** before a compiler result.
- WEI-1182 breakpoint screenshot pass for phone 375, tablet 768 portrait, and wide iPad Pro landscape still needs to run against this PR branch.