### PR TITLE
WEI-2466 Wire Job Return Sorting/Receiving flow

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -65,6 +65,14 @@ struct IOSReceiveShipmentPage: View {
                 "Damaged - returning"
             case .wrongPart:
                 "Wrong part"
+            case .jobReturnHolding:
+                "Job return held"
+            case .jobReturnDamagedReview:
+                "Job return damaged review"
+            case .jobReturnSupplierReview:
+                "Job return supplier review"
+            case .jobReturnWrongPartReview:
+                "Job return wrong part review"
             }
         }
         var icon: String {
@@ -75,6 +83,10 @@ struct IOSReceiveShipmentPage: View {
             case .usedWriteOff: "xmark.bin.fill"
             case .damagedReturn: "exclamationmark.triangle.fill"
             case .wrongPart: "questionmark.circle.fill"
+            case .jobReturnHolding: "tray.full.fill"
+            case .jobReturnDamagedReview: "exclamationmark.triangle.fill"
+            case .jobReturnSupplierReview: "arrow.uturn.backward.circle.fill"
+            case .jobReturnWrongPartReview: "questionmark.circle.fill"
             }
         }
         var color: Color {
@@ -87,6 +99,10 @@ struct IOSReceiveShipmentPage: View {
             case .usedWriteOff: .orange
             case .damagedReturn: .red
             case .wrongPart: .red
+            case .jobReturnHolding: .blue
+            case .jobReturnDamagedReview: .red
+            case .jobReturnSupplierReview: .orange
+            case .jobReturnWrongPartReview: .red
             }
         }
     }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -177,7 +177,7 @@ struct IOSReceiveShipmentPage: View {
                     } label: {
                         Image(systemName: "qrcode.viewfinder")
                     }
-                    .accessibilityLabel("Scan QR code")
+                    .accessibilityLabel("Scan PO")
                 }
             }
             ToolbarItem(placement: .primaryAction) {
@@ -1031,6 +1031,7 @@ struct IOSReceiveShipmentPage: View {
                 let returnCount = routingResults.values.filter { result in
                     switch result.route {
                     case .recommendReturn, .returnOverstock, .damagedReturn: return true
+                    case .jobReturnDamagedReview, .jobReturnSupplierReview: return true
                     default: return false
                     }
                 }.count

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
@@ -1780,12 +1780,13 @@ private struct MisplacedPartSheet: View {
             let parts = try service.searchParts(query: query, limit: 15)
             partResults = parts.compactMap { part in
                 guard let id = part.id, id > 0, part.deletedAt == nil else { return nil }
+                let stock = (try? service.getPartStockSummary(partId: id).total)
                 return MisplacedLookupPart(
                     id: id,
                     name: part.name,
                     code: part.code,
                     detail: part.manufacturerPartNumber,
-                    totalStock: nil
+                    totalStock: stock
                 )
             }
             partLookupMessage = partResults.isEmpty

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSReceivingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSReceivingPage.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 import WiredPartCore
 
-/// Receiving incoming shipments page for iOS.
+/// Sorting/Receiving incoming shipments and job returns page for iOS.
 ///
-/// Shows active and recent receiving sessions for purchase orders.
+/// Shows active and recent sorting sessions for purchase orders and job returns.
 /// Displays PO ID, started-by name, mode, status, and item count.
 /// Supports pull-to-refresh, smart card filters by status,
 /// start new session, and continue active sessions.
@@ -18,9 +18,12 @@ struct IOSReceivingPage: View {
     @State private var loadError: String?
     @State private var activeSheet: ActiveSheet?
     @State private var selectedFilter: StatusFilter?
+    @State private var jobReturnItems: [WarehouseService.JobReturnHoldingItem] = []
 
     private enum ActiveSheet: Identifiable {
-        case startReceiving
+        case chooseEntry
+        case poIncoming
+        case jobReturn
         case continueSession(Int64)
         case help
 
@@ -45,23 +48,25 @@ struct IOSReceivingPage: View {
         VStack(spacing: 0) {
             OnboardingBanner(pageId: "warehouse-receiving")
 
+            entryActions
+
             // Smart card filters
-            if !sessions.isEmpty {
+            if !sessions.isEmpty || !jobReturnGroups.isEmpty {
                 smartCardFilters
             }
 
             sessionList
         }
         .task { appCore.onboardingManager?.markCompleted("wh-receiving-view") }
-        .navigationTitle("Receiving")
-        .searchable(text: $searchText, prompt: "Search receiving sessions...")
+        .navigationTitle("Sorting/Receiving")
+        .searchable(text: $searchText, prompt: "Search sorting sessions...")
         .refreshable { loadData() }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-                Button { activeSheet = .startReceiving } label: {
+                Button { activeSheet = .chooseEntry } label: {
                     Image(systemName: "plus")
                 }
-                .accessibilityLabel("Start receiving session")
+                .accessibilityLabel("Start sorting or receiving session")
             }
             ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .help } label: {
@@ -87,9 +92,30 @@ struct IOSReceivingPage: View {
     @ViewBuilder
     private func sheetContent(for sheet: ActiveSheet) -> some View {
         switch sheet {
-        case .startReceiving:
+        case .chooseEntry:
+            NavigationStack {
+                entryChoiceSheet
+                    .navigationTitle("New Sorting/Receiving")
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Close") { activeSheet = nil }
+                        }
+                    }
+            }
+        case .poIncoming:
             NavigationStack {
                 IOSReceiveShipmentPage()
+                    .environmentObject(appCore)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Close") { activeSheet = nil }
+                        }
+                    }
+            }
+        case .jobReturn:
+            NavigationStack {
+                IOSJobReturnSortingPage()
                     .environmentObject(appCore)
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
@@ -110,14 +136,76 @@ struct IOSReceivingPage: View {
             }
         case .help:
             PageHelpSheet(
-                title: "Receiving Help",
+                title: "Sorting/Receiving Help",
                 sections: [
-                    ("Overview", "Track incoming shipments from suppliers. Each receiving session records what was ordered vs. what actually arrived."),
-                    ("Starting a Session", "Tap + to start receiving against a purchase order. Scan or manually enter received quantities."),
-                    ("Status Filters", "Use the smart cards to filter by active, completed, or cancelled sessions. Pull down to refresh.")
+                    ("Overview", "Use PO Incoming for supplier shipments and Job Return for material coming back from jobs."),
+                    ("PO Incoming", "PO Incoming keeps the purchase order receiving checklist, including quantity checks and visible price verification."),
+                    ("Job Return", "Job Return records the job, source, returned-by user, notes, parts, quantities, and sorting outcome without PO price verification.")
                 ]
             )
         }
+    }
+
+    private var entryActions: some View {
+        HStack(spacing: 12) {
+            Button { activeSheet = .poIncoming } label: {
+                Label("PO Incoming", systemImage: "shippingbox.and.arrow.backward")
+                    .font(.subheadline.weight(.semibold))
+                    .frame(maxWidth: .infinity, minHeight: 44)
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityLabel("Scan PO")
+
+            Button { activeSheet = .jobReturn } label: {
+                Label("Job Return", systemImage: "arrow.uturn.backward.circle")
+                    .font(.subheadline.weight(.semibold))
+                    .frame(maxWidth: .infinity, minHeight: 44)
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+    }
+
+    private var entryChoiceSheet: some View {
+        List {
+            Section {
+                Button { activeSheet = .poIncoming } label: {
+                    entryChoiceRow(
+                        icon: "shippingbox.and.arrow.backward.fill",
+                        title: "PO Incoming",
+                        subtitle: "Receive supplier shipments against purchase orders and verify receipt prices."
+                    )
+                }
+                .accessibilityLabel("Scan PO")
+
+                Button { activeSheet = .jobReturn } label: {
+                    entryChoiceRow(
+                        icon: "arrow.uturn.backward.circle.fill",
+                        title: "Job Return",
+                        subtitle: "Sort parts returned from a job into holding, shelf, staging, write-off, or review."
+                    )
+                }
+            }
+        }
+    }
+
+    private func entryChoiceRow(icon: String, title: String, subtitle: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.title2)
+                .frame(width: 36, height: 36)
+                .foregroundStyle(.blue)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.headline)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.vertical, 6)
     }
 
     // MARK: - Smart Card Filters
@@ -136,9 +224,11 @@ struct IOSReceivingPage: View {
     }
 
     private func countForFilter(_ filter: StatusFilter) -> Int {
-        sessions.filter { session in
+        let poCount = sessions.filter { session in
             filter.matchStatuses.contains(session.status)
         }.count
+        let jobReturnCount = filter == .active ? jobReturnGroups.filter { $0.totalQty > 0 }.count : 0
+        return poCount + jobReturnCount
     }
 
     private func smartCard(filter: StatusFilter, count: Int) -> some View {
@@ -197,16 +287,16 @@ struct IOSReceivingPage: View {
     @ViewBuilder
     private var sessionList: some View {
         if isLoading {
-            ProgressView("Loading receiving sessions...")
+            ProgressView("Loading sorting sessions...")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
-        } else if filteredSessions.isEmpty {
+        } else if filteredSessions.isEmpty && filteredJobReturnGroups.isEmpty {
             if searchText.isEmpty && selectedFilter == nil {
                 EmptyStateView(
                     icon: "shippingbox.and.arrow.backward",
-                    title: "No Receiving Sessions",
-                    message: "No active receiving sessions found. Tap + to start receiving a shipment."
+                    title: "No Sorting Sessions",
+                    message: "Start with PO Incoming for purchase orders or Job Return for material coming back from a job."
                 )
             } else {
                 EmptyStateView(
@@ -216,22 +306,120 @@ struct IOSReceivingPage: View {
                 )
             }
         } else {
-            List(filteredSessions, id: \.id) { session in
-                let isActive = session.status == "in_progress" || session.status == "active"
-                if isActive {
-                    Button {
-                        activeSheet = .continueSession(session.id)
-                    } label: {
-                        sessionRow(session)
+            List {
+                if !filteredSessions.isEmpty {
+                    Section("PO Incoming") {
+                        ForEach(filteredSessions, id: \.id) { session in
+                            let isActive = session.status == "in_progress" || session.status == "active"
+                            if isActive {
+                                Button {
+                                    activeSheet = .continueSession(session.id)
+                                } label: {
+                                    sessionRow(session)
+                                }
+                                .buttonStyle(.plain)
+                            } else {
+                                sessionRow(session)
+                            }
+                        }
                     }
-                    .buttonStyle(.plain)
-                } else {
-                    sessionRow(session)
+                }
+
+                if !filteredJobReturnGroups.isEmpty {
+                    Section("Job Return") {
+                        ForEach(filteredJobReturnGroups) { group in
+                            jobReturnGroupRow(group)
+                        }
+                    }
                 }
             }
             .listStyle(.insetGrouped)
             .scrollDismissesKeyboard(.interactively)
         }
+    }
+
+    private struct JobReturnGroup: Identifiable {
+        let id: Int64
+        let sourceJobName: String
+        let itemCount: Int
+        let totalQty: Int
+        let statuses: [String]
+        let createdAt: String
+    }
+
+    private var jobReturnGroups: [JobReturnGroup] {
+        Dictionary(grouping: jobReturnItems, by: \.intakeId)
+            .map { intakeId, items in
+                let first = items.first
+                return JobReturnGroup(
+                    id: intakeId,
+                    sourceJobName: first?.sourceJobName ?? "Unknown Job",
+                    itemCount: items.count,
+                    totalQty: items.reduce(0) { $0 + $1.qtyRemaining },
+                    statuses: Array(Set(items.map(\.status))).sorted(),
+                    createdAt: first?.createdAt ?? ""
+                )
+            }
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
+    private var filteredJobReturnGroups: [JobReturnGroup] {
+        var result = jobReturnGroups
+
+        if let filter = selectedFilter {
+            result = result.filter { group in
+                filter.matchStatuses.contains("in_progress") && group.totalQty > 0
+            }
+        }
+
+        if !searchText.isEmpty {
+            let query = searchText.lowercased()
+            result = result.filter {
+                $0.sourceJobName.lowercased().contains(query) ||
+                $0.statuses.joined(separator: " ").lowercased().contains(query)
+            }
+        }
+
+        return result
+    }
+
+    private func jobReturnGroupRow(_ group: JobReturnGroup) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "arrow.uturn.backward.circle.fill")
+                .font(.title3)
+                .foregroundStyle(.orange)
+                .frame(width: 32, height: 32)
+                .background(Color.orange.opacity(0.12))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text("Job Return")
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                    sourceBadge("Job Return")
+                }
+                Text(group.sourceJobName)
+                    .fontWeight(.medium)
+                    .lineLimit(1)
+                Text(formatDate(group.createdAt))
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 4) {
+                statusBadge("in_progress")
+                Label("\(group.itemCount) items", systemImage: "cube.box")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("\(group.totalQty) in holding/review")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+        }
+        .padding(.vertical, 4)
     }
 
     private var filteredSessions: [WarehouseService.ReceivingSessionInfo] {
@@ -272,6 +460,7 @@ struct IOSReceivingPage: View {
                     Text("PO #\(session.poId)")
                         .font(.system(.caption, design: .monospaced))
                         .foregroundStyle(.secondary)
+                    sourceBadge("PO Incoming")
                     modeBadge(session.mode)
                 }
                 Text("Started by \(session.startedByName)")
@@ -330,6 +519,15 @@ struct IOSReceivingPage: View {
             .foregroundStyle(.purple)
     }
 
+    private func sourceBadge(_ source: String) -> some View {
+        Text(source)
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(Color.blue.opacity(0.12)))
+            .foregroundStyle(.blue)
+    }
+
     // MARK: - Helpers
 
     private func formatDate(_ dateStr: String) -> String {
@@ -349,9 +547,10 @@ struct IOSReceivingPage: View {
         loadError = nil
         do {
             sessions = try service.getActiveSessions()
+            jobReturnItems = try service.getJobReturnHoldingItems(includeRouted: false)
             postAIContext()
         } catch {
-            loadError = userFriendlyError(error, context: "load receiving data")
+            loadError = userFriendlyError(error, context: "load sorting data")
         }
         isLoading = false
     }
@@ -362,15 +561,584 @@ struct IOSReceivingPage: View {
             .sorted()
             .joined(separator: ", ")
         let context = """
-        Warehouse Receiving page. Read-only context.
-        Loaded sessions: \(sessions.count), visible after filters: \(filteredSessions.count), selected filter: \(selectedFilter?.rawValue ?? "none"), search active: \(!searchText.isEmpty).
+        Warehouse Sorting/Receiving page. Read-only context.
+        Loaded PO incoming sessions: \(sessions.count), active Job Return groups: \(jobReturnGroups.count), visible after filters: \(filteredSessions.count + filteredJobReturnGroups.count), selected filter: \(selectedFilter?.rawValue ?? "none"), search active: \(!searchText.isEmpty).
         Session statuses: \(statusCounts.isEmpty ? "none" : statusCounts).
-        Available read-only guidance: explain active/completed/cancelled session filters, search, continuing active sessions, and start receiving entry point. Do not start or continue a session directly.
+        Available read-only guidance: explain PO Incoming vs Job Return entry points, active/completed/cancelled filters, search, continuing active sessions, and source badges. Do not start or continue a session directly.
         """
         NotificationCenter.default.post(
             name: .warehouseReceivingPageActive,
             object: nil,
             userInfo: ["context": context]
         )
+    }
+}
+
+// MARK: - Job Return Sorting
+
+private struct IOSJobReturnSortingPage: View {
+    @EnvironmentObject private var appCore: AppCore
+
+    @State private var jobs: [JobsService.JobListItem] = []
+    @State private var selectedJob: JobsService.JobListItem?
+    @State private var jobSearchText = ""
+    @State private var returnSource = "Crew truck"
+    @State private var notes = ""
+    @State private var partSearchText = ""
+    @State private var partResults: [Part] = []
+    @State private var lines: [JobReturnDraftLine] = []
+    @State private var loadError: String?
+    @State private var actionError: String?
+    @State private var completionMessage: String?
+    @State private var isLoading = true
+    @State private var isSubmitting = false
+    @State private var activeSheet: ActiveSheet?
+
+    private enum ActiveSheet: Identifiable {
+        case partScanner
+        case help
+        var id: String { String(describing: self) }
+    }
+
+    private enum ReturnCondition: String, CaseIterable, Identifiable {
+        case usable = "Usable"
+        case damaged = "Damaged"
+        case wrongPart = "Wrong Part"
+
+        var id: String { rawValue }
+        var serviceValue: String {
+            switch self {
+            case .usable: "usable"
+            case .damaged: "damaged"
+            case .wrongPart: "wrong_part"
+            }
+        }
+    }
+
+    private enum SortAction: String, CaseIterable, Identifiable {
+        case holding = "Holding"
+        case shelf = "Shelf"
+        case stage = "Stage"
+        case writeOff = "Write-off"
+        case supplierReview = "Supplier/Damage Review"
+        case wrongPart = "Wrong Part"
+
+        var id: String { rawValue }
+    }
+
+    private struct JobReturnDraftLine: Identifiable, Equatable {
+        let id = UUID()
+        let partId: Int64
+        let partName: String
+        let partCode: String?
+        var qty: Int = 1
+        var condition: ReturnCondition = .usable
+        var sortAction: SortAction = .holding
+        var notes: String = ""
+    }
+
+    var body: some View {
+        List {
+            if let error = loadError {
+                Section {
+                    ErrorStateView(message: error) { loadData() }
+                }
+            }
+
+            Section("Return Details") {
+                jobPicker
+
+                Picker("Return Source", selection: $returnSource) {
+                    Text("Crew truck").tag("Crew truck")
+                    Text("Job box").tag("Job box")
+                    Text("Customer site").tag("Customer site")
+                    Text("Other").tag("Other")
+                }
+
+                HStack {
+                    Text("Returned By")
+                    Spacer()
+                    Text(appCore.currentUser?.displayName ?? "Current user")
+                        .foregroundStyle(.secondary)
+                }
+
+                TextField("Notes", text: $notes, axis: .vertical)
+                    .lineLimit(2...4)
+            }
+
+            Section("Add Returned Parts") {
+                HStack {
+                    TextField("Search parts", text: $partSearchText)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .onSubmit { searchParts() }
+                    Button { searchParts() } label: {
+                        Image(systemName: "magnifyingglass")
+                    }
+                    .accessibilityLabel("Search returned parts")
+                    Button { activeSheet = .partScanner } label: {
+                        Image(systemName: "barcode.viewfinder")
+                    }
+                    .accessibilityLabel("Scan returned part")
+                }
+
+                ForEach(partResults.prefix(8), id: \.id) { part in
+                    Button { addPart(part) } label: {
+                        partResultRow(part)
+                    }
+                }
+            }
+
+            if !lines.isEmpty {
+                Section("Returned Lines") {
+                    ForEach($lines) { $line in
+                        draftLineRow($line)
+                    }
+                    .onDelete { offsets in
+                        lines.remove(atOffsets: offsets)
+                    }
+                }
+
+                Section("Completion Preview") {
+                    completionPreview
+                }
+            }
+
+            Section {
+                Button {
+                    Task { await submitJobReturn() }
+                } label: {
+                    HStack {
+                        Spacer()
+                        if isSubmitting {
+                            ProgressView()
+                        } else {
+                            Label("Complete Job Return", systemImage: "checkmark.circle.fill")
+                                .fontWeight(.semibold)
+                        }
+                        Spacer()
+                    }
+                }
+                .frame(minHeight: 44)
+                .disabled(!canSubmit || isSubmitting)
+            }
+
+            if let error = actionError {
+                Section {
+                    Label(error, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .navigationTitle("Job Return")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { loadData() }
+        .onChange(of: jobSearchText) { _, _ in filterSelectedJobIfNeeded() }
+        .onChange(of: partSearchText) { _, newValue in
+            if newValue.trimmingCharacters(in: .whitespacesAndNewlines).count >= 2 {
+                searchParts()
+            }
+        }
+        .alert("Job Return Complete", isPresented: Binding(
+            get: { completionMessage != nil },
+            set: { if !$0 { completionMessage = nil } }
+        )) {
+            Button("OK") {
+                completionMessage = nil
+                resetForm()
+            }
+        } message: {
+            Text(completionMessage ?? "")
+        }
+        .sheet(item: $activeSheet) { sheet in
+            switch sheet {
+            case .partScanner:
+                QRScanSheet(expectedType: .part) { result in
+                    handleScannedPart(code: result.code)
+                }
+                .environmentObject(appCore)
+            case .help:
+                PageHelpSheet(
+                    title: "Job Return Help",
+                    sections: [
+                        ("Sorting", "Choose Holding when the item should stay out of shelf inventory until later review."),
+                        ("Shelf", "Shelf adds usable returned material back to warehouse inventory."),
+                        ("Review", "Damaged, supplier review, and wrong part outcomes keep the material out of shelf stock.")
+                    ]
+                )
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button { activeSheet = .help } label: {
+                    Image(systemName: "questionmark.circle")
+                }
+                .accessibilityLabel("Help")
+            }
+        }
+    }
+
+    private var canSubmit: Bool {
+        selectedJob != nil &&
+        appCore.currentUser?.id != nil &&
+        !returnSource.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        lines.contains { $0.qty > 0 }
+    }
+
+    private var filteredJobs: [JobsService.JobListItem] {
+        let query = jobSearchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return jobs }
+        return jobs.filter {
+            $0.jobName.lowercased().contains(query) ||
+            $0.jobNumber.lowercased().contains(query) ||
+            ($0.customerName ?? "").lowercased().contains(query)
+        }
+    }
+
+    private var jobPicker: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            TextField("Search jobs", text: $jobSearchText)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+
+            Picker("Job", selection: Binding(
+                get: { selectedJob?.id },
+                set: { id in selectedJob = jobs.first { $0.id == id } }
+            )) {
+                Text("Select a job").tag(Int64?.none)
+                ForEach(filteredJobs.prefix(50), id: \.id) { job in
+                    Text("\(job.jobNumber) - \(job.jobName)").tag(Optional(job.id))
+                }
+            }
+        }
+    }
+
+    private func partResultRow(_ part: Part) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(part.name)
+                    .foregroundStyle(.primary)
+                if let code = part.code {
+                    Text(code)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            Image(systemName: "plus.circle.fill")
+                .foregroundStyle(.blue)
+        }
+    }
+
+    private func draftLineRow(_ line: Binding<JobReturnDraftLine>) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(line.wrappedValue.partName)
+                        .font(.headline)
+                    if let code = line.wrappedValue.partCode {
+                        Text(code)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+                quantityStepper(line)
+            }
+
+            Picker("Condition", selection: line.condition) {
+                ForEach(ReturnCondition.allCases) { condition in
+                    Text(condition.rawValue).tag(condition)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Picker("Sort Action", selection: line.sortAction) {
+                ForEach(SortAction.allCases) { action in
+                    Text(action.rawValue).tag(action)
+                }
+            }
+
+            Text(routingCopy(for: line.wrappedValue.sortAction))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            TextField("Line notes", text: line.notes, axis: .vertical)
+                .lineLimit(1...3)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func quantityStepper(_ line: Binding<JobReturnDraftLine>) -> some View {
+        HStack(spacing: 12) {
+            Button {
+                line.qty.wrappedValue = max(1, line.qty.wrappedValue - 1)
+            } label: {
+                Image(systemName: "minus.circle.fill")
+                    .font(.title3)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Decrease returned quantity")
+
+            Text("\(line.qty.wrappedValue)")
+                .font(.title3.weight(.semibold))
+                .frame(minWidth: 44)
+                .multilineTextAlignment(.center)
+
+            Button {
+                line.qty.wrappedValue += 1
+            } label: {
+                Image(systemName: "plus.circle.fill")
+                    .font(.title3)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Increase returned quantity")
+        }
+        .frame(minHeight: 44)
+    }
+
+    private var completionPreview: some View {
+        let groups = completionGroups(for: lines)
+        return VStack(alignment: .leading, spacing: 8) {
+            ForEach(["Shelved", "Staged", "Write-off", "Supplier/Damage Review", "Wrong Part", "Holding"], id: \.self) { label in
+                HStack {
+                    Text(label)
+                    Spacer()
+                    Text("\(groups[label, default: 0])")
+                        .fontWeight(.semibold)
+                }
+                .font(.subheadline)
+            }
+            if groups["Holding", default: 0] > 0 {
+                Label("Unsorted Job Return items stay in holding and do not count as shelf inventory.", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func routingCopy(for action: SortAction) -> String {
+        switch action {
+        case .holding:
+            "Hold for later sorting. This does not add shelf inventory."
+        case .shelf:
+            "Return usable material to shelf inventory."
+        case .stage:
+            "Stage the returned item back to the selected job without changing shelf stock."
+        case .writeOff:
+            "Write off unusable returned material with audit history."
+        case .supplierReview:
+            "Keep damaged or supplier-returnable material out of shelf stock for review."
+        case .wrongPart:
+            "Flag as wrong part and keep it out of shelf inventory."
+        }
+    }
+
+    private func completionGroups(for lines: [JobReturnDraftLine]) -> [String: Int] {
+        var groups: [String: Int] = [:]
+        for line in lines where line.qty > 0 {
+            switch line.sortAction {
+            case .shelf:
+                groups["Shelved", default: 0] += line.qty
+            case .stage:
+                groups["Staged", default: 0] += line.qty
+            case .writeOff:
+                groups["Write-off", default: 0] += line.qty
+            case .supplierReview:
+                groups["Supplier/Damage Review", default: 0] += line.qty
+            case .wrongPart:
+                groups["Wrong Part", default: 0] += line.qty
+            case .holding:
+                groups["Holding", default: 0] += line.qty
+            }
+        }
+        return groups
+    }
+
+    private func loadData() {
+        isLoading = true
+        loadError = nil
+        do {
+            guard let jobsService = appCore.jobsService else {
+                loadError = "Jobs service not available"
+                isLoading = false
+                return
+            }
+            jobs = try jobsService.listJobs(status: "active", limit: 200)
+            if selectedJob == nil {
+                selectedJob = jobs.first
+            }
+        } catch {
+            loadError = userFriendlyError(error, context: "load active jobs")
+        }
+        isLoading = false
+    }
+
+    private func searchParts() {
+        guard let service = appCore.partsService else {
+            actionError = "Parts service not available"
+            return
+        }
+        let query = partSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard query.count >= 2 else {
+            partResults = []
+            return
+        }
+        do {
+            partResults = try service.searchParts(query: query, limit: 12)
+        } catch {
+            actionError = userFriendlyError(error, context: "search parts")
+        }
+    }
+
+    private func addPart(_ part: Part) {
+        guard let partId = part.id else { return }
+        if let index = lines.firstIndex(where: { $0.partId == partId }) {
+            lines[index].qty += 1
+        } else {
+            lines.append(JobReturnDraftLine(partId: partId, partName: part.name, partCode: part.code))
+        }
+        partSearchText = ""
+        partResults = []
+    }
+
+    private func handleScannedPart(code: String) {
+        partSearchText = code
+        searchParts()
+        if partResults.count == 1, let part = partResults.first {
+            addPart(part)
+        }
+    }
+
+    private func filterSelectedJobIfNeeded() {
+        if let selectedJob, !filteredJobs.contains(where: { $0.id == selectedJob.id }) {
+            self.selectedJob = filteredJobs.first
+        }
+    }
+
+    private func submitJobReturn() async {
+        guard let warehouseService = appCore.warehouseService else {
+            actionError = "Warehouse service not available"
+            return
+        }
+        guard let job = selectedJob else {
+            actionError = "Select a job before completing the return."
+            return
+        }
+        guard let userId = appCore.currentUser?.id else {
+            actionError = "Not logged in. Please log in and try again."
+            return
+        }
+
+        isSubmitting = true
+        actionError = nil
+
+        do {
+            let lineInputs = lines.filter { $0.qty > 0 }.map { line in
+                WarehouseService.JobReturnLineInput(
+                    partId: line.partId,
+                    qty: line.qty,
+                    condition: conditionForSubmit(line),
+                    notes: line.notes.isEmpty ? nil : line.notes
+                )
+            }
+            let intakeId = try warehouseService.createJobReturnIntake(
+                sourceJobId: job.id,
+                returnSource: returnSource,
+                returnedBy: userId,
+                lines: lineInputs,
+                notes: notes.isEmpty ? nil : notes
+            )
+
+            let holdingItems = try warehouseService.getJobReturnHoldingItems(jobId: job.id, includeRouted: false)
+                .filter { $0.intakeId == intakeId }
+            try applyImmediateRoutes(holdingItems: holdingItems, userId: userId, jobId: job.id)
+
+            await MainActor.run {
+                completionMessage = completionSummary()
+                isSubmitting = false
+            }
+        } catch {
+            await MainActor.run {
+                actionError = userFriendlyError(error, context: "complete job return")
+                isSubmitting = false
+            }
+        }
+    }
+
+    private func conditionForSubmit(_ line: JobReturnDraftLine) -> String {
+        switch line.sortAction {
+        case .supplierReview:
+            "damaged"
+        case .wrongPart:
+            "wrong_part"
+        default:
+            line.condition.serviceValue
+        }
+    }
+
+    private func applyImmediateRoutes(
+        holdingItems: [WarehouseService.JobReturnHoldingItem],
+        userId: Int64,
+        jobId: Int64
+    ) throws {
+        guard let warehouseService = appCore.warehouseService else { return }
+        var remainingItems = holdingItems
+        for line in lines where line.qty > 0 {
+            guard let itemIndex = remainingItems.firstIndex(where: { $0.partId == line.partId }) else { continue }
+            let item = remainingItems.remove(at: itemIndex)
+            switch line.sortAction {
+            case .shelf:
+                try warehouseService.confirmJobReturnShelfRoute(
+                    intakeItemId: item.id,
+                    qty: line.qty,
+                    performedBy: userId,
+                    notes: line.notes.isEmpty ? nil : line.notes
+                )
+            case .stage:
+                try warehouseService.confirmJobReturnStagingRoute(
+                    intakeItemId: item.id,
+                    qty: line.qty,
+                    jobId: jobId,
+                    performedBy: userId,
+                    notes: line.notes.isEmpty ? nil : line.notes
+                )
+            case .writeOff:
+                try warehouseService.writeOffJobReturnItem(
+                    intakeItemId: item.id,
+                    qty: line.qty,
+                    reason: "Job return write-off",
+                    performedBy: userId,
+                    notes: line.notes.isEmpty ? nil : line.notes
+                )
+            case .holding, .supplierReview, .wrongPart:
+                break
+            }
+        }
+    }
+
+    private func completionSummary() -> String {
+        let groups = completionGroups(for: lines)
+        var parts: [String] = []
+        if groups["Shelved", default: 0] > 0 { parts.append("\(groups["Shelved", default: 0]) shelved") }
+        if groups["Staged", default: 0] > 0 { parts.append("\(groups["Staged", default: 0]) staged") }
+        if groups["Write-off", default: 0] > 0 { parts.append("\(groups["Write-off", default: 0]) written off") }
+        if groups["Supplier/Damage Review", default: 0] > 0 { parts.append("\(groups["Supplier/Damage Review", default: 0]) in supplier/damage review") }
+        if groups["Wrong Part", default: 0] > 0 { parts.append("\(groups["Wrong Part", default: 0]) wrong part") }
+        if groups["Holding", default: 0] > 0 { parts.append("\(groups["Holding", default: 0]) holding") }
+        let base = parts.isEmpty ? "Job Return complete." : "Job Return complete: \(parts.joined(separator: ", "))."
+        if groups["Holding", default: 0] > 0 {
+            return "\(base) Holding items do not count as shelf inventory until sorted."
+        }
+        return base
+    }
+
+    private func resetForm() {
+        lines = []
+        notes = ""
+        partSearchText = ""
+        partResults = []
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSReceivingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSReceivingPage.swift
@@ -592,6 +592,7 @@ private struct IOSJobReturnSortingPage: View {
     @State private var completionMessage: String?
     @State private var isLoading = true
     @State private var isSubmitting = false
+    @State private var isShowingCompletionReview = false
     @State private var activeSheet: ActiveSheet?
 
     private enum ActiveSheet: Identifiable {
@@ -706,14 +707,14 @@ private struct IOSJobReturnSortingPage: View {
 
             Section {
                 Button {
-                    Task { await submitJobReturn() }
+                    isShowingCompletionReview = true
                 } label: {
                     HStack {
                         Spacer()
                         if isSubmitting {
                             ProgressView()
                         } else {
-                            Label("Complete Job Return", systemImage: "checkmark.circle.fill")
+                            Label("Review Job Return", systemImage: "checkmark.circle.fill")
                                 .fontWeight(.semibold)
                         }
                         Spacer()
@@ -750,6 +751,15 @@ private struct IOSJobReturnSortingPage: View {
         } message: {
             Text(completionMessage ?? "")
         }
+        .alert("Complete Job Return?", isPresented: $isShowingCompletionReview) {
+            Button("Cancel", role: .cancel) {}
+            Button("Complete Job Return") {
+                Task { await submitJobReturn() }
+            }
+            .disabled(isSubmitting)
+        } message: {
+            Text(completionReviewMessage)
+        }
         .sheet(item: $activeSheet) { sheet in
             switch sheet {
             case .partScanner:
@@ -783,6 +793,25 @@ private struct IOSJobReturnSortingPage: View {
         appCore.currentUser?.id != nil &&
         !returnSource.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         lines.contains { $0.qty > 0 }
+    }
+
+    private var completionReviewMessage: String {
+        let groups = completionGroups(for: lines)
+        let routedSummary = ["Shelved", "Staged", "Write-off", "Supplier/Damage Review", "Wrong Part", "Holding"]
+            .compactMap { label -> String? in
+                let qty = groups[label, default: 0]
+                return qty > 0 ? "\(label): \(qty)" : nil
+            }
+            .joined(separator: "\n")
+        let jobName = selectedJob?.jobName ?? "selected job"
+        let base = routedSummary.isEmpty ? "No return lines are ready." : routedSummary
+        return """
+        Review the sorting outcomes for \(jobName) before committing this return.
+
+        \(base)
+
+        Holding, review, staged, and write-off items stay out of shelf inventory unless explicitly shelved.
+        """
     }
 
     private var filteredJobs: [JobsService.JobListItem] {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSStagingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSStagingPage.swift
@@ -19,6 +19,7 @@ struct IOSStagingPage: View {
 
     @State private var stagedItems: [WarehouseService.StagedItem] = []
     @State private var stagingBoxes: [WarehouseService.StagingBox] = []
+    @State private var boxContents: [Int64: [WarehouseService.StagingBoxContent]] = [:]
     @State private var jobs: [JobsService.JobListItem] = []
     @State private var isLoading = true
     @State private var searchText = ""
@@ -434,9 +435,30 @@ struct IOSStagingPage: View {
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                 }
+                assignBoxMenu(for: item)
             }
         }
         .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func assignBoxMenu(for item: WarehouseService.StagedItem) -> some View {
+        let boxes = eligibleBoxes(for: item)
+        if !boxes.isEmpty {
+            Menu {
+                ForEach(boxes, id: \.id) { box in
+                    Button {
+                        assign(item: item, to: box)
+                    } label: {
+                        Label(box.labelText, systemImage: "shippingbox")
+                    }
+                }
+            } label: {
+                Image(systemName: "shippingbox.and.arrow.backward")
+                    .foregroundStyle(.blue)
+            }
+            .accessibilityLabel("Assign \(item.partName) to box")
+        }
     }
 
     // MARK: - Boxes Content
@@ -540,67 +562,97 @@ struct IOSStagingPage: View {
     }
 
     private func boxRow(_ box: WarehouseService.StagingBox) -> some View {
-        HStack(spacing: 12) {
-            // Status icon: checkmark for full, half-circle for open
-            ZStack {
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(box.isFull ? Color.green.opacity(0.15) : Color.orange.opacity(0.15))
-                    .frame(width: 40, height: 40)
-                Image(systemName: box.isFull ? "checkmark.circle.fill" : "circle.bottomhalf.filled")
-                    .font(.title3)
-                    .foregroundStyle(box.isFull ? .green : .orange)
-                    .accessibilityLabel(box.isFull ? "Status: Full" : "Status: Open")
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                // Label guidance — the text to write on the box
-                Text(box.labelText)
-                    .font(.system(.headline, design: .monospaced))
-                    .fontWeight(.bold)
-                    .foregroundStyle(box.isFull ? .secondary : .primary)
-
-                HStack(spacing: 8) {
-                    // Size badge
-                    boxSizeBadge(box.boxSize)
-
-                    Text(box.isFull ? "FULL" : "OPEN")
-                        .font(.caption2)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(box.isFull ? .green : .orange)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(
-                            Capsule()
-                                .fill(box.isFull ? Color.green.opacity(0.12) : Color.orange.opacity(0.12))
-                        )
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(boxStatusColor(box).opacity(0.15))
+                        .frame(width: 40, height: 40)
+                    Image(systemName: boxStatusIcon(box))
+                        .font(.title3)
+                        .foregroundStyle(boxStatusColor(box))
                 }
 
-                if let created = box.createdAt {
-                    Text("Created \(formatDate(created))")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(box.labelText)
+                        .font(.system(.headline, design: .monospaced))
+                        .fontWeight(.bold)
+                        .foregroundStyle(box.isFull ? .secondary : .primary)
+
+                    HStack(spacing: 8) {
+                        boxSizeBadge(box.boxSize)
+                        statusBadge(box.status)
+                        Text("\(box.contentCount) item\(box.contentCount == 1 ? "" : "s")")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if let created = box.createdAt {
+                        Text("Created \(formatDate(created))")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
                 }
+
+                Spacer()
+
+                Menu {
+                    Button {
+                        if box.isFull { reopenBox(boxId: box.id) } else { markFull(boxId: box.id) }
+                    } label: {
+                        Label(box.isFull ? "Reopen" : "Mark Full", systemImage: box.isFull ? "arrow.uturn.backward" : "checkmark.circle")
+                    }
+                    Button { updateBox(boxId: box.id, status: "staged") } label: {
+                        Label("Staged", systemImage: "tray.2")
+                    }
+                    Button { updateBox(boxId: box.id, status: "loaded") } label: {
+                        Label("Loaded", systemImage: "truck.box")
+                    }
+                    Button { updateBox(boxId: box.id, status: "delivered") } label: {
+                        Label("Delivered", systemImage: "checkmark.seal")
+                    }
+                    Button { updateBox(boxId: box.id, status: "returned_cancelled") } label: {
+                        Label("Returned/Cancelled", systemImage: "arrow.uturn.left")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityLabel("Box actions")
             }
 
-            Spacer()
-
-            // Quick full/open toggle
-            Button {
-                if box.isFull {
-                    reopenBox(boxId: box.id)
-                } else {
-                    markFull(boxId: box.id)
+            let contents = boxContents[box.id] ?? []
+            if !contents.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(contents, id: \.id) { content in
+                        HStack(spacing: 8) {
+                            Image(systemName: "cube.box")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(content.partName)
+                                .font(.caption)
+                                .lineLimit(1)
+                            Spacer()
+                            Text("x\(content.qty)")
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                            Button {
+                                remove(content: content, from: box)
+                            } label: {
+                                Image(systemName: "xmark.circle")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Remove \(content.partName) from box")
+                        }
+                    }
                 }
-            } label: {
-                Image(systemName: box.isFull ? "arrow.uturn.backward.circle" : "checkmark.circle")
-                    .font(.title2)
-                    .foregroundStyle(box.isFull ? .orange : .green)
+                .padding(.leading, 52)
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel(box.isFull ? "Reopen box" : "Mark box full")
         }
         .padding(.vertical, 4)
-        .opacity(box.isFull ? 0.7 : 1.0)
+        .opacity(box.status == "delivered" ? 0.7 : 1.0)
     }
 
     private func boxSizeBadge(_ size: String) -> some View {
@@ -625,6 +677,16 @@ struct IOSStagingPage: View {
                 .font(.caption2)
         }
         .foregroundStyle(color)
+    }
+
+    private func statusBadge(_ status: String) -> some View {
+        Text(statusLabel(status).uppercased())
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundStyle(statusColor(status))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(statusColor(status).opacity(0.12)))
     }
 
     // MARK: - Create Box Sheet
@@ -748,6 +810,51 @@ struct IOSStagingPage: View {
         return label.uppercased()
     }
 
+    private func eligibleBoxes(for item: WarehouseService.StagedItem) -> [WarehouseService.StagingBox] {
+        stagingBoxes.filter { box in
+            box.status == "staged" &&
+            !box.isFull &&
+            !isItem(item.id, assignedTo: box.id) &&
+            (item.destinationType != "job" || item.destinationId == nil || item.destinationId == box.jobId)
+        }
+    }
+
+    private func isItem(_ itemId: Int64, assignedTo boxId: Int64) -> Bool {
+        boxContents[boxId, default: []].contains { $0.stagingTagId == itemId }
+    }
+
+    private func statusLabel(_ status: String) -> String {
+        switch status {
+        case "loaded": return "Loaded"
+        case "delivered": return "Delivered"
+        case "returned_cancelled": return "Returned/Cancelled"
+        default: return "Staged"
+        }
+    }
+
+    private func statusColor(_ status: String) -> Color {
+        switch status {
+        case "loaded": return .blue
+        case "delivered": return .green
+        case "returned_cancelled": return .orange
+        default: return .purple
+        }
+    }
+
+    private func boxStatusColor(_ box: WarehouseService.StagingBox) -> Color {
+        box.isFull && box.status == "staged" ? .green : statusColor(box.status)
+    }
+
+    private func boxStatusIcon(_ box: WarehouseService.StagingBox) -> String {
+        if box.isFull && box.status == "staged" { return "checkmark.circle.fill" }
+        switch box.status {
+        case "loaded": return "truck.box.fill"
+        case "delivered": return "checkmark.seal.fill"
+        case "returned_cancelled": return "arrow.uturn.left.circle.fill"
+        default: return "shippingbox.fill"
+        }
+    }
+
     // MARK: - Actions
 
     private func clearItem(id: Int64) {
@@ -798,6 +905,45 @@ struct IOSStagingPage: View {
             loadData()
         } catch {
             actionError = userFriendlyError(error, context: "update staging")
+        }
+    }
+
+    private func assign(item: WarehouseService.StagedItem, to box: WarehouseService.StagingBox) {
+        guard let service = appCore.warehouseService else {
+            actionError = "Service not available"
+            return
+        }
+        do {
+            _ = try service.assignStagedItemToBox(stagingTagId: item.id, boxId: box.id)
+            loadData()
+        } catch {
+            actionError = userFriendlyError(error, context: "assign item to box")
+        }
+    }
+
+    private func remove(content: WarehouseService.StagingBoxContent, from box: WarehouseService.StagingBox) {
+        guard let service = appCore.warehouseService else {
+            actionError = "Service not available"
+            return
+        }
+        do {
+            try service.removeStagedItemFromBox(stagingTagId: content.stagingTagId, boxId: box.id)
+            loadData()
+        } catch {
+            actionError = userFriendlyError(error, context: "remove item from box")
+        }
+    }
+
+    private func updateBox(boxId: Int64, status: String) {
+        guard let service = appCore.warehouseService else {
+            actionError = "Service not available"
+            return
+        }
+        do {
+            try service.updateStagingBoxDeliveryState(boxId: boxId, status: status)
+            loadData()
+        } catch {
+            actionError = userFriendlyError(error, context: "update box state")
         }
     }
 
@@ -853,6 +999,7 @@ struct IOSStagingPage: View {
         do {
             stagedItems = try service.getStagedItems()
             stagingBoxes = try service.listStagingBoxes()
+            boxContents = Dictionary(grouping: try service.listStagingBoxContents(), by: { $0.boxId })
             if let jobsService = appCore.jobsService {
                 jobs = try jobsService.listJobs(status: "active", limit: 200)
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ReceivingRoutingFlow.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ReceivingRoutingFlow.swift
@@ -1085,6 +1085,12 @@ struct ReceivingRoutingFlow: View {
                 performedBy: userId,
                 notes: "Received via PO, staged for \(link.jobName)"
             )
+            try service.markReceivingSessionItemRouted(
+                itemId: item.id,
+                disposition: .staged,
+                routedQty: receivedQty,
+                routedBy: userId
+            )
             isProcessing = false
             withAnimation { currentStep = .routeConfirmed }
             onRouteComplete(.stageForJob(jobId: link.jobId, jobName: link.jobName, jpoId: link.jpoId))
@@ -1118,6 +1124,12 @@ struct ReceivingRoutingFlow: View {
                 jobId: demand.jobId,
                 performedBy: userId,
                 notes: "Cross-job staging from receiving for \(demand.jobName)"
+            )
+            try service.markReceivingSessionItemRouted(
+                itemId: item.id,
+                disposition: .staged,
+                routedQty: qtyToStage,
+                routedBy: userId
             )
             isProcessing = false
             withAnimation { currentStep = .routeConfirmed }
@@ -1153,6 +1165,12 @@ struct ReceivingRoutingFlow: View {
                 performedBy: userId,
                 notes: "Damaged on arrival, requesting \(action.rawValue.lowercased())"
             )
+            try service.markReceivingSessionItemRouted(
+                itemId: item.id,
+                disposition: .supplierReturn,
+                routedQty: receivedQty,
+                routedBy: userId
+            )
             isProcessing = false
             withAnimation { currentStep = .routeConfirmed }
             onRouteComplete(.damagedReturn)
@@ -1185,6 +1203,12 @@ struct ReceivingRoutingFlow: View {
                 reason: "Used part, stock at target",
                 performedBy: userId,
                 notes: "Used part received, not needed for stock"
+            )
+            try service.markReceivingSessionItemRouted(
+                itemId: item.id,
+                disposition: .writeOff,
+                routedQty: receivedQty,
+                routedBy: userId
             )
             isProcessing = false
             withAnimation { currentStep = .routeConfirmed }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
@@ -13,6 +13,126 @@ private struct DraggableUnit: Codable, Transferable {
     }
 }
 
+private struct StorageUnitTypeCatalogItem: Identifiable {
+    let id: String
+    let label: String
+    let icon: String
+    let color: Color
+    let defaultGridWidth: Int
+    let defaultGridHeight: Int
+    let defaultWidthInches: Int
+    let defaultDepthInches: Int
+    let defaultHeightInches: Int
+    let defaultLevelCount: Int
+    let defaultAreasPerLevel: Int
+    let defaultMovable: Bool
+    let defaultJobReady: Bool
+    let hierarchySummary: String
+}
+
+private let storageUnitTypeCatalog: [StorageUnitTypeCatalogItem] = [
+    StorageUnitTypeCatalogItem(
+        id: "shelving", label: "Shelving", icon: "cabinet.fill", color: .blue,
+        defaultGridWidth: 2, defaultGridHeight: 1,
+        defaultWidthInches: 48, defaultDepthInches: 24, defaultHeightInches: 72,
+        defaultLevelCount: 4, defaultAreasPerLevel: 4,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "Levels + areas"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "gang_box", label: "Gang Box", icon: "shippingbox.fill", color: .green,
+        defaultGridWidth: 2, defaultGridHeight: 1,
+        defaultWidthInches: 48, defaultDepthInches: 24, defaultHeightInches: 36,
+        defaultLevelCount: 2, defaultAreasPerLevel: 3,
+        defaultMovable: true, defaultJobReady: false,
+        hierarchySummary: "Trays + boxes"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "pipe_rack", label: "Pipe Rack", icon: "lines.measurement.horizontal", color: .orange,
+        defaultGridWidth: 3, defaultGridHeight: 1,
+        defaultWidthInches: 96, defaultDepthInches: 24, defaultHeightInches: 60,
+        defaultLevelCount: 3, defaultAreasPerLevel: 3,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "Tiers + areas"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "pallet_rack", label: "Pallet Rack", icon: "square.stack.3d.up.fill", color: .purple,
+        defaultGridWidth: 3, defaultGridHeight: 2,
+        defaultWidthInches: 96, defaultDepthInches: 48, defaultHeightInches: 144,
+        defaultLevelCount: 3, defaultAreasPerLevel: 4,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "Levels + areas"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "wall_mount", label: "Wall Mount", icon: "rectangle.portrait.and.arrow.right", color: .teal,
+        defaultGridWidth: 1, defaultGridHeight: 2,
+        defaultWidthInches: 36, defaultDepthInches: 6, defaultHeightInches: 48,
+        defaultLevelCount: 2, defaultAreasPerLevel: 4,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "Sections + areas"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "floor_area", label: "Floor Area", icon: "square.dashed", color: .brown,
+        defaultGridWidth: 3, defaultGridHeight: 2,
+        defaultWidthInches: 72, defaultDepthInches: 48, defaultHeightInches: 12,
+        defaultLevelCount: 1, defaultAreasPerLevel: 4,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "Zones + areas"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "cabinet", label: "Cabinet", icon: "cabinet.fill", color: .indigo,
+        defaultGridWidth: 1, defaultGridHeight: 1,
+        defaultWidthInches: 36, defaultDepthInches: 24, defaultHeightInches: 72,
+        defaultLevelCount: 4, defaultAreasPerLevel: 2,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "Drawers + areas"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "packout", label: "Packout Set", icon: "archivebox.fill", color: .red,
+        defaultGridWidth: 1, defaultGridHeight: 1,
+        defaultWidthInches: 24, defaultDepthInches: 18, defaultHeightInches: 24,
+        defaultLevelCount: 3, defaultAreasPerLevel: 4,
+        defaultMovable: true, defaultJobReady: true,
+        hierarchySummary: "Modules + compartments"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "tool_bag", label: "Tool Bag", icon: "bag.fill", color: .mint,
+        defaultGridWidth: 1, defaultGridHeight: 1,
+        defaultWidthInches: 18, defaultDepthInches: 12, defaultHeightInches: 18,
+        defaultLevelCount: 1, defaultAreasPerLevel: 6,
+        defaultMovable: true, defaultJobReady: false,
+        hierarchySummary: "Compartments"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "parts_bin", label: "Parts Bin", icon: "tray.full.fill", color: .cyan,
+        defaultGridWidth: 1, defaultGridHeight: 1,
+        defaultWidthInches: 18, defaultDepthInches: 12, defaultHeightInches: 12,
+        defaultLevelCount: 1, defaultAreasPerLevel: 8,
+        defaultMovable: true, defaultJobReady: false,
+        hierarchySummary: "Compartments"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "crate", label: "Crate/Tote", icon: "shippingbox", color: .pink,
+        defaultGridWidth: 1, defaultGridHeight: 1,
+        defaultWidthInches: 24, defaultDepthInches: 18, defaultHeightInches: 16,
+        defaultLevelCount: 1, defaultAreasPerLevel: 1,
+        defaultMovable: true, defaultJobReady: false,
+        hierarchySummary: "Single open container"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "custom", label: "Custom", icon: "plus.square", color: .gray,
+        defaultGridWidth: 1, defaultGridHeight: 1,
+        defaultWidthInches: 48, defaultDepthInches: 24, defaultHeightInches: 72,
+        defaultLevelCount: 4, defaultAreasPerLevel: 4,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "User-selected"
+    )
+]
+
+private func storageUnitCatalogItem(for type: String) -> StorageUnitTypeCatalogItem {
+    storageUnitTypeCatalog.first { $0.id == type } ?? storageUnitTypeCatalog.last!
+}
+
 /// Warehouse Locations — floor plan grid editor + storage hierarchy drill-down.
 ///
 /// Top level: Floor plan selector + grid view of storage units and features.
@@ -181,14 +301,9 @@ struct WarehouseLocationsPage: View {
     private var unitTypeToolbar: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                unitTypeButton("Shelf", type: "shelving", icon: "cabinet.fill")
-                unitTypeButton("Pipe Rack", type: "pipe_rack", icon: "lines.measurement.horizontal")
-                unitTypeButton("Gang Box", type: "gang_box", icon: "shippingbox.fill")
-                unitTypeButton("Wall Mount", type: "wall_mount", icon: "rectangle.portrait.and.arrow.right")
-                unitTypeButton("Cabinet", type: "cabinet", icon: "cabinet.fill")
-                unitTypeButton("Pallet Rack", type: "pallet_rack", icon: "square.stack.3d.up.fill")
-                unitTypeButton("Floor Area", type: "floor_area", icon: "square.dashed")
-                unitTypeButton("Custom", type: "custom", icon: "plus.square")
+                ForEach(storageUnitTypeCatalog) { item in
+                    unitTypeButton(item)
+                }
             }
             .padding(.horizontal)
             .padding(.vertical, 6)
@@ -197,18 +312,19 @@ struct WarehouseLocationsPage: View {
     }
 
     @ViewBuilder
-    private func unitTypeButton(_ label: String, type: String, icon: String) -> some View {
-        Button { activeSheet = .addUnit(type) } label: {
+    private func unitTypeButton(_ item: StorageUnitTypeCatalogItem) -> some View {
+        Button { activeSheet = .addUnit(item.id) } label: {
             HStack(spacing: 4) {
-                Image(systemName: icon)
+                Image(systemName: item.icon)
                     .font(.caption2)
-                Text(label)
+                Text(item.label)
                     .font(.caption)
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
-            .background(Color.blue.opacity(0.1))
-            .foregroundStyle(.blue)
+            .frame(minHeight: 44)
+            .background(item.color.opacity(0.12))
+            .foregroundStyle(item.color)
             .clipShape(Capsule())
         }
     }
@@ -320,6 +436,9 @@ struct WarehouseLocationsPage: View {
         RoundedRectangle(cornerRadius: 4)
             .fill(unitColor(unit.unitType))
             .overlay(
+                frontFaceMarker(unit.frontFace, width: w - 2, height: h - 2)
+            )
+            .overlay(
                 RoundedRectangle(cornerRadius: 4)
                     .strokeBorder(.white.opacity(0.3), lineWidth: 1)
             )
@@ -356,6 +475,40 @@ struct WarehouseLocationsPage: View {
                     Label("Remove", systemImage: "trash")
                 }
             }
+    }
+
+    @ViewBuilder
+    private func frontFaceMarker(_ frontFace: String?, width: CGFloat, height: CGFloat) -> some View {
+        let face = (frontFace ?? "south").lowercased()
+        let markerColor = Color.yellow.opacity(0.95)
+        let markerThickness: CGFloat = 5
+        let markerLength = max(14, min(width, height) * 0.55)
+
+        ZStack(alignment: .topLeading) {
+            switch face {
+            case "north":
+                Rectangle()
+                    .fill(markerColor)
+                    .frame(width: markerLength, height: markerThickness)
+                    .offset(x: max(0, (width - markerLength) / 2), y: 0)
+            case "east":
+                Rectangle()
+                    .fill(markerColor)
+                    .frame(width: markerThickness, height: markerLength)
+                    .offset(x: max(0, width - markerThickness), y: max(0, (height - markerLength) / 2))
+            case "west":
+                Rectangle()
+                    .fill(markerColor)
+                    .frame(width: markerThickness, height: markerLength)
+                    .offset(x: 0, y: max(0, (height - markerLength) / 2))
+            default:
+                Rectangle()
+                    .fill(markerColor)
+                    .frame(width: markerLength, height: markerThickness)
+                    .offset(x: max(0, (width - markerLength) / 2), y: max(0, height - markerThickness))
+            }
+        }
+        .frame(width: width, height: height)
     }
 
     // MARK: - Movable Storage Section
@@ -600,48 +753,15 @@ struct WarehouseLocationsPage: View {
     // MARK: - Helpers
 
     private func unitColor(_ type: String) -> Color {
-        switch type {
-        case "shelving": .blue
-        case "pipe_rack": .orange
-        case "gang_box": .green
-        case "pallet_rack": .purple
-        case "wall_mount": .teal
-        case "cabinet": .indigo
-        case "floor_area": .brown
-        default: .gray
-        }
+        storageUnitCatalogItem(for: type).color
     }
 
     private func unitIcon(_ type: String) -> String {
-        switch type {
-        case "shelving": "cabinet.fill"
-        case "pipe_rack": "lines.measurement.horizontal"
-        case "gang_box": "shippingbox.fill"
-        case "pallet_rack": "square.stack.3d.up.fill"
-        case "wall_mount": "rectangle.portrait.and.arrow.right"
-        case "cabinet": "cabinet.fill"
-        case "floor_area": "square.dashed"
-        case "tool_bag": "bag.fill"
-        case "packout": "archivebox.fill"
-        default: "square.fill"
-        }
+        storageUnitCatalogItem(for: type).icon
     }
 
     private func unitTypeLabel(_ type: String) -> String {
-        switch type {
-        case "shelving": "Shelf"
-        case "pipe_rack": "Pipe Rack"
-        case "gang_box": "Gang Box"
-        case "pallet_rack": "Pallet Rack"
-        case "wall_mount": "Wall Mount"
-        case "cabinet": "Cabinet"
-        case "floor_area": "Floor Area"
-        case "packout": "Packout"
-        case "tool_bag": "Tool Bag"
-        case "parts_bin": "Parts Bin"
-        case "crate": "Crate"
-        default: type.replacingOccurrences(of: "_", with: " ").capitalized
-        }
+        storageUnitCatalogItem(for: type).label
     }
 
     private func featureColor(_ type: String) -> Color {
@@ -760,6 +880,25 @@ private struct AddStorageUnitSheet: View {
     @State private var error: String?
 
     private let faceOptions = ["north", "south", "east", "west"]
+    private var catalogItem: StorageUnitTypeCatalogItem {
+        storageUnitCatalogItem(for: unitType)
+    }
+
+    init(floorPlanId: Int64, unitType: String, onCreated: @escaping () -> Void) {
+        let defaults = storageUnitCatalogItem(for: unitType)
+        self.floorPlanId = floorPlanId
+        self.unitType = unitType
+        self.onCreated = onCreated
+        _widthInches = State(initialValue: defaults.defaultWidthInches)
+        _depthInches = State(initialValue: defaults.defaultDepthInches)
+        _heightInches = State(initialValue: defaults.defaultHeightInches)
+        _levelCount = State(initialValue: defaults.defaultLevelCount)
+        _areasPerLevel = State(initialValue: defaults.defaultAreasPerLevel)
+        _gridWidth = State(initialValue: defaults.defaultGridWidth)
+        _gridHeight = State(initialValue: defaults.defaultGridHeight)
+        _isMovable = State(initialValue: defaults.defaultMovable)
+        _isJobReady = State(initialValue: defaults.defaultJobReady)
+    }
 
     var body: some View {
         NavigationStack {
@@ -768,6 +907,10 @@ private struct AddStorageUnitSheet: View {
                     TextField("Name", text: $name)
                     TextField("Row (e.g. R01)", text: $rowNumber)
                     TextField("Unit (e.g. U01)", text: $unitNumber)
+                }
+
+                Section("Type") {
+                    typeSummaryRow(catalogItem)
                 }
 
                 Section("Dimensions") {
@@ -783,12 +926,21 @@ private struct AddStorageUnitSheet: View {
                     Stepper("Height: \(gridHeight) cells", value: $gridHeight, in: 1...10)
                 }
 
-                Section("Configuration") {
-                    Stepper("Levels: \(levelCount)", value: $levelCount, in: 1...20)
-                    Stepper("Areas/Level: \(areasPerLevel)", value: $areasPerLevel, in: 1...24)
+                Section {
                     Picker("Front Face", selection: $frontFace) {
                         ForEach(faceOptions, id: \.self) { Text($0.capitalized) }
                     }
+                    .pickerStyle(.segmented)
+                    Text("Side with stickers and aisle access.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    Text("Orientation")
+                }
+
+                Section("Structure") {
+                    Stepper("Levels: \(levelCount)", value: $levelCount, in: 1...20)
+                    Stepper("Areas/Level: \(areasPerLevel)", value: $areasPerLevel, in: 1...24)
                 }
 
                 Section("Options") {
@@ -801,7 +953,7 @@ private struct AddStorageUnitSheet: View {
                 }
             }
             .scrollDismissesKeyboard(.interactively)
-            .navigationTitle("Add \(unitType.replacingOccurrences(of: "_", with: " ").capitalized)")
+            .navigationTitle("Add \(catalogItem.label)")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -813,6 +965,24 @@ private struct AddStorageUnitSheet: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func typeSummaryRow(_ item: StorageUnitTypeCatalogItem) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: item.icon)
+                .foregroundStyle(item.color)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.label)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Text(item.hierarchySummary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
     }
 
     private func create() {
@@ -894,6 +1064,9 @@ private struct EditStorageUnitSheet: View {
     @State private var error: String?
 
     private let faceOptions = ["north", "south", "east", "west"]
+    private var catalogItem: StorageUnitTypeCatalogItem {
+        storageUnitCatalogItem(for: unit.unitType)
+    }
 
     init(unit: WarehouseStorageUnit, onUpdated: @escaping () -> Void) {
         self.unit = unit
@@ -917,6 +1090,10 @@ private struct EditStorageUnitSheet: View {
                     TextField("Unit (e.g. U01)", text: $unitNumber)
                 }
 
+                Section("Type") {
+                    typeSummaryRow(catalogItem)
+                }
+
                 Section("Grid Placement") {
                     Stepper("X: \(gridX)", value: $gridX, in: 0...100)
                     Stepper("Y: \(gridY)", value: $gridY, in: 0...100)
@@ -924,10 +1101,16 @@ private struct EditStorageUnitSheet: View {
                     Stepper("Height: \(gridHeight) cells", value: $gridHeight, in: 1...10)
                 }
 
-                Section("Orientation") {
+                Section {
                     Picker("Front Face", selection: $frontFace) {
                         ForEach(faceOptions, id: \.self) { Text($0.capitalized) }
                     }
+                    .pickerStyle(.segmented)
+                    Text("Side with stickers and aisle access.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    Text("Orientation")
                 }
 
                 if let error {
@@ -946,6 +1129,24 @@ private struct EditStorageUnitSheet: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func typeSummaryRow(_ item: StorageUnitTypeCatalogItem) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: item.icon)
+                .foregroundStyle(item.color)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.label)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Text(item.hierarchySummary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
     }
 
     private func save() {
@@ -990,7 +1191,7 @@ private struct StorageUnitDetailSheet: View {
         NavigationStack {
             List {
                 Section {
-                    LabeledContent("Type", value: unit.unitType.replacingOccurrences(of: "_", with: " ").capitalized)
+                    LabeledContent("Type", value: storageUnitCatalogItem(for: unit.unitType).label)
                     if let row = unit.rowNumber { LabeledContent("Row", value: row) }
                     if let un = unit.unitNumber { LabeledContent("Unit", value: un) }
                     if unit.isMovable {
@@ -1007,7 +1208,7 @@ private struct StorageUnitDetailSheet: View {
                         directionRow(
                             step: unit.rowNumber != nil ? 3 : 2,
                             icon: "cabinet.fill",
-                            text: "\(unit.name) — \(unit.unitType.replacingOccurrences(of: "_", with: " ").capitalized)"
+                            text: "\(unit.name) — \(storageUnitCatalogItem(for: unit.unitType).label)"
                         )
                         if let x = unit.gridX, let y = unit.gridY {
                             directionRow(

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -139,6 +139,7 @@ extension AppDatabase {
         registerMigration099POSupplierTransmission(&migrator)
         registerMigration099ReceivingItemRoutingDisposition(&migrator)
         registerMigration100POEmailRequestType(&migrator)
+        registerMigration100StagingBoxContentsAndDeliveryState(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -5692,6 +5693,40 @@ extension AppDatabase {
             try db.create(index: "idx_receiving_items_routing_disposition",
                           on: "receiving_session_items",
                           columns: ["session_id", "routing_disposition"])
+        }
+    }
+
+    private static func registerMigration100StagingBoxContentsAndDeliveryState(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("100_staging_box_contents_delivery_state") { db in
+            try addColumnIfMissing(db, table: "staging_boxes", column: "status", type: .text, defaultValue: "staged")
+            try addColumnIfMissing(db, table: "staging_boxes", column: "loaded_at", type: .text)
+            try addColumnIfMissing(db, table: "staging_boxes", column: "delivered_at", type: .text)
+            try addColumnIfMissing(db, table: "staging_boxes", column: "returned_cancelled_at", type: .text)
+            try db.execute(sql: "UPDATE staging_boxes SET status = 'staged' WHERE status IS NULL OR status = ''")
+
+            try db.create(table: "staging_box_contents", ifNotExists: true) { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("box_id", .integer).notNull()
+                    .references("staging_boxes", onDelete: .cascade)
+                t.column("staging_tag_id", .integer).notNull()
+                    .references("pulled_staging_tags", onDelete: .cascade)
+                t.column("status", .text).notNull()
+                    .defaults(to: "staged")
+                t.column("assigned_at", .text).notNull()
+                    .defaults(sql: "(datetime('now'))")
+                t.column("removed_at", .text)
+                t.column("loaded_at", .text)
+                t.column("delivered_at", .text)
+                t.column("returned_cancelled_at", .text)
+                t.column("deleted_at", .text)
+            }
+
+            try db.create(index: "idx_staging_box_contents_box",
+                          on: "staging_box_contents",
+                          columns: ["box_id"])
+            try db.create(index: "idx_staging_box_contents_tag",
+                          on: "staging_box_contents",
+                          columns: ["staging_tag_id"])
         }
     }
 }

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -137,6 +137,7 @@ extension AppDatabase {
         registerMigration098JobReturnIntakeHolding(&migrator)
         registerMigration098NotebookEntryEditLocks(&migrator)
         registerMigration099POSupplierTransmission(&migrator)
+        registerMigration099ReceivingItemRoutingDisposition(&migrator)
         registerMigration100POEmailRequestType(&migrator)
     }
 
@@ -5678,6 +5679,19 @@ extension AppDatabase {
             try db.create(index: "idx_job_return_intakes_job", on: "job_return_intakes", columns: ["source_job_id", "status"])
             try db.create(index: "idx_job_return_items_intake", on: "job_return_intake_items", columns: ["intake_id", "status"])
             try db.create(index: "idx_job_return_items_part", on: "job_return_intake_items", columns: ["part_id", "status"])
+        }
+    }
+
+    private static func registerMigration099ReceivingItemRoutingDisposition(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("099_receiving_item_routing_disposition") { db in
+            try addColumnIfMissing(db, table: "receiving_session_items", column: "routing_disposition", type: .text)
+            try addColumnIfMissing(db, table: "receiving_session_items", column: "routed_qty", type: .integer, defaultValue: 0)
+            try addColumnIfMissing(db, table: "receiving_session_items", column: "routed_by", type: .integer)
+            try addColumnIfMissing(db, table: "receiving_session_items", column: "routed_at", type: .text)
+
+            try db.create(index: "idx_receiving_items_routing_disposition",
+                          on: "receiving_session_items",
+                          columns: ["session_id", "routing_disposition"])
         }
     }
 }

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -134,6 +134,7 @@ extension AppDatabase {
         registerMigration095JobStageTemplates(&migrator)
         registerMigration096SubcontractorScheduleSoftDeleteUniqueness(&migrator)
         registerMigration097PartImportAuditSessions(&migrator)
+        registerMigration098JobReturnIntakeHolding(&migrator)
         registerMigration098NotebookEntryEditLocks(&migrator)
         registerMigration099POSupplierTransmission(&migrator)
         registerMigration100POEmailRequestType(&migrator)
@@ -5633,6 +5634,50 @@ extension AppDatabase {
                 t.add(column: "sent_by_user_id",           .integer) // FK to users
                 t.add(column: "supplier_confirmation_num", .text)    // Optional PO# / reference from supplier
             }
+        }
+    }
+
+    // MARK: - Migration 098: Job return intake holding
+
+    private static func registerMigration098JobReturnIntakeHolding(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("098_job_return_intake_holding") { db in
+            try db.create(table: "job_return_intakes", ifNotExists: true) { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("source_job_id", .integer).notNull().references("jobs")
+                t.column("return_source", .text).notNull().defaults(to: "job")
+                t.column("returned_by", .integer).notNull().references("users")
+                t.column("status", .text).notNull().defaults(to: "holding")
+                t.column("notes", .text)
+                t.column("completed_at", .text)
+                t.column("deleted_at", .text)
+                t.column("created_at", .text).notNull().defaults(sql: "(datetime('now'))")
+                t.column("updated_at", .text).notNull().defaults(sql: "(datetime('now'))")
+            }
+
+            try db.create(table: "job_return_intake_items", ifNotExists: true) { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("intake_id", .integer).notNull()
+                    .references("job_return_intakes", onDelete: .cascade)
+                t.column("part_id", .integer).notNull().references("parts")
+                t.column("source_job_part_id", .integer).references("job_parts")
+                t.column("supplier_id", .integer).references("suppliers")
+                t.column("po_line_id", .integer).references("po_line_items")
+                t.column("qty_returned", .integer).notNull()
+                t.column("qty_remaining", .integer).notNull()
+                t.column("condition", .text).notNull().defaults(to: "usable")
+                t.column("status", .text).notNull().defaults(to: "holding")
+                t.column("notes", .text)
+                t.column("routed_by", .integer).references("users")
+                t.column("routed_at", .text)
+                t.column("deleted_at", .text)
+                t.column("created_at", .text).notNull().defaults(sql: "(datetime('now'))")
+                t.check(sql: "qty_returned > 0")
+                t.check(sql: "qty_remaining >= 0")
+            }
+
+            try db.create(index: "idx_job_return_intakes_job", on: "job_return_intakes", columns: ["source_job_id", "status"])
+            try db.create(index: "idx_job_return_items_intake", on: "job_return_intake_items", columns: ["intake_id", "status"])
+            try db.create(index: "idx_job_return_items_part", on: "job_return_intake_items", columns: ["part_id", "status"])
         }
     }
 }

--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -8,8 +8,8 @@ public final class AppDatabase: Sendable {
     public let writer: any DatabaseWriter
 
     /// The total number of registered migrations. Update when adding new migrations.
-    /// Migrations are 000-098.
-    public static let schemaVersion = 98
+    /// Migrations are 000-099.
+    public static let schemaVersion = 99
 
     /// Initialize with an existing database writer and run all migrations.
     public init(_ writer: any DatabaseWriter) throws {

--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -8,8 +8,8 @@ public final class AppDatabase: Sendable {
     public let writer: any DatabaseWriter
 
     /// The total number of registered migrations. Update when adding new migrations.
-    /// Migrations are 000-097.
-    public static let schemaVersion = 97
+    /// Migrations are 000-098.
+    public static let schemaVersion = 98
 
     /// Initialize with an existing database writer and run all migrations.
     public init(_ writer: any DatabaseWriter) throws {

--- a/core/Sources/WiredPartCore/Services/DashboardService.swift
+++ b/core/Sources/WiredPartCore/Services/DashboardService.swift
@@ -641,27 +641,23 @@ public final class DashboardService: Sendable {
                     )
                 }
 
-                // Break minutes (gaps between consecutive entries)
+                // Break minutes are sourced from the Clock page break/lunch records.
                 let breakMinutes = try Int.fetchOne(conn, sql: """
-                    SELECT COALESCE(SUM(gap_minutes), 0) FROM (
-                        SELECT CAST((julianday(le2.clock_in) - julianday(le1.clock_out)) * 1440 AS INTEGER) AS gap_minutes
-                        FROM labor_entries le1
-                        JOIN labor_entries le2
-                            ON le2.user_id = le1.user_id
-                            AND le2.clock_in > le1.clock_out
-                            AND le2.deleted_at IS NULL
-                            AND date(le2.clock_in) = date('now')
-                        WHERE le1.user_id = ? AND le1.clock_out IS NOT NULL AND le1.deleted_at IS NULL
-                            AND date(le1.clock_in) = date('now')
-                            AND NOT EXISTS (
-                                SELECT 1 FROM labor_entries le3
-                                WHERE le3.user_id = le1.user_id
-                                    AND le3.clock_in > le1.clock_out
-                                    AND le3.clock_in < le2.clock_in
-                                    AND le3.deleted_at IS NULL
-                                    AND date(le3.clock_in) = date('now')
-                            )
-                    )
+                    SELECT COALESCE(SUM(
+                        CASE
+                            WHEN ended_at IS NOT NULL THEN
+                                COALESCE(
+                                    duration_minutes,
+                                    CAST((julianday(ended_at) - julianday(started_at)) * 1440 AS INTEGER)
+                                )
+                            ELSE
+                                CAST((julianday('now') - julianday(started_at)) * 1440 AS INTEGER)
+                        END
+                    ), 0)
+                    FROM break_records
+                    WHERE user_id = ?
+                      AND date(started_at) = date('now')
+                      AND deleted_at IS NULL
                     """, arguments: [userId]) ?? 0
 
                 return MyHoursToday(

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -35,6 +35,8 @@ public final class WarehouseService: Sendable {
         case areaNotFound(Int64)
         case unitNotFound(Int64)
         case levelNotFound(Int64)
+        case jobReturnIntakeNotFound(Int64)
+        case jobReturnItemNotFound(Int64)
     }
 
     // =========================================================================
@@ -1312,6 +1314,77 @@ public final class WarehouseService: Sendable {
         public let notes: String?
     }
 
+    /// Explicit source for receiving/routing work. Job returns are intentionally
+    /// modeled without a PO line so callers never need fake PO identifiers.
+    public enum ReceivingSource: Sendable, Equatable {
+        case poIncoming(poLineId: Int64)
+        case jobReturn(intakeItemId: Int64)
+    }
+
+    public struct JobReturnLineInput: Sendable, Equatable {
+        public let partId: Int64
+        public let qty: Int
+        public let condition: String
+        public let sourceJobPartId: Int64?
+        public let supplierId: Int64?
+        public let poLineId: Int64?
+        public let notes: String?
+
+        public init(
+            partId: Int64,
+            qty: Int,
+            condition: String = "usable",
+            sourceJobPartId: Int64? = nil,
+            supplierId: Int64? = nil,
+            poLineId: Int64? = nil,
+            notes: String? = nil
+        ) {
+            self.partId = partId
+            self.qty = qty
+            self.condition = condition
+            self.sourceJobPartId = sourceJobPartId
+            self.supplierId = supplierId
+            self.poLineId = poLineId
+            self.notes = notes
+        }
+    }
+
+    public struct JobReturnIntakeInfo: Sendable, Identifiable, Equatable {
+        public let id: Int64
+        public let sourceJobId: Int64
+        public let sourceJobName: String
+        public let returnSource: String
+        public let returnedBy: Int64
+        public let returnedByName: String
+        public let status: String
+        public let notes: String?
+        public let itemCount: Int
+        public let createdAt: String
+    }
+
+    public struct JobReturnHoldingItem: Sendable, Identifiable, Equatable {
+        public let id: Int64
+        public let intakeId: Int64
+        public let sourceJobId: Int64
+        public let sourceJobName: String
+        public let partId: Int64
+        public let partName: String
+        public let partCode: String?
+        public let sourceJobPartId: Int64?
+        public let supplierId: Int64?
+        public let poLineId: Int64?
+        public let qtyReturned: Int
+        public let qtyRemaining: Int
+        public let condition: String
+        public let status: String
+        public let notes: String?
+        public let createdAt: String
+
+        public var hasSupplierReturnData: Bool {
+            supplierId != nil || poLineId != nil
+        }
+    }
+
     /// Start a new receiving session for a PO.
     @discardableResult
     public func startReceivingSession(
@@ -1597,6 +1670,263 @@ public final class WarehouseService: Sendable {
                     """,
                 arguments: [sessionId]
             )
+        }
+    }
+
+    /// Create a non-PO Job Return intake. Items start in holding/review tables
+    /// and do not touch `stock` until an explicit shelf route is confirmed.
+    @discardableResult
+    public func createJobReturnIntake(
+        sourceJobId: Int64,
+        returnSource: String,
+        returnedBy: Int64,
+        lines: [JobReturnLineInput],
+        notes: String? = nil
+    ) throws -> Int64 {
+        let trimmedSource = returnSource.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedSource.isEmpty else { throw WarehouseError.requiredFieldEmpty }
+        guard !lines.isEmpty else { throw WarehouseError.requiredFieldEmpty }
+        for line in lines {
+            guard line.qty > 0 else { throw WarehouseError.invalidQuantity }
+            guard line.partId > 0 else { throw WarehouseError.partNotFound(line.partId) }
+        }
+
+        return try db.writer.write { dbConn in
+            try Self.requireActiveJob(sourceJobId, dbConn: dbConn)
+            try Self.requireActiveUser(returnedBy, dbConn: dbConn)
+
+            for line in lines {
+                try Self.requireActivePart(line.partId, dbConn: dbConn)
+                if let sourceJobPartId = line.sourceJobPartId {
+                    try Self.requireJobPart(sourceJobPartId, sourceJobId: sourceJobId, partId: line.partId, dbConn: dbConn)
+                }
+            }
+
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO job_return_intakes
+                        (source_job_id, return_source, returned_by, status, notes, created_at, updated_at)
+                    VALUES (?, ?, ?, 'holding', ?, datetime('now'), datetime('now'))
+                    """,
+                arguments: [sourceJobId, trimmedSource, returnedBy, notes]
+            )
+            let intakeId = dbConn.lastInsertedRowID
+
+            for line in lines {
+                let condition = Self.normalizedReturnCondition(line.condition)
+                let status = Self.initialJobReturnStatus(condition: condition, hasSupplierReturnData: line.supplierId != nil || line.poLineId != nil)
+                try dbConn.execute(
+                    sql: """
+                        INSERT INTO job_return_intake_items
+                            (intake_id, part_id, source_job_part_id, supplier_id, po_line_id,
+                             qty_returned, qty_remaining, condition, status, notes, created_at)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                        """,
+                    arguments: [
+                        intakeId, line.partId, line.sourceJobPartId, line.supplierId, line.poLineId,
+                        line.qty, line.qty, condition, status, line.notes,
+                    ]
+                )
+            }
+
+            return intakeId
+        }
+    }
+
+    public func getJobReturnIntake(id: Int64) throws -> JobReturnIntakeInfo? {
+        do {
+            return try db.writer.read { dbConn in
+                guard let row = try Row.fetchOne(dbConn, sql: """
+                    SELECT jri.*,
+                           COALESCE(j.job_name, 'Unknown Job') AS source_job_name,
+                           COALESCE(u.display_name, u.email, 'Unknown') AS returned_by_name,
+                           (SELECT COUNT(*) FROM job_return_intake_items i
+                            WHERE i.intake_id = jri.id AND i.deleted_at IS NULL) AS item_count
+                    FROM job_return_intakes jri
+                    LEFT JOIN jobs j ON j.id = jri.source_job_id AND j.deleted_at IS NULL
+                    LEFT JOIN users u ON u.id = jri.returned_by AND u.deleted_at IS NULL
+                    WHERE jri.id = ? AND jri.deleted_at IS NULL
+                    """, arguments: [id]) else { return nil }
+                return Self.jobReturnIntakeInfo(from: row)
+            }
+        } catch {
+            if isTableNotFoundError(error) { return nil }
+            throw error
+        }
+    }
+
+    public func getJobReturnHoldingItems(jobId: Int64? = nil, includeRouted: Bool = false) throws -> [JobReturnHoldingItem] {
+        do {
+            return try db.writer.read { dbConn in
+                var whereClauses = ["i.deleted_at IS NULL", "jri.deleted_at IS NULL"]
+                var args: [DatabaseValueConvertible?] = []
+                if let jobId {
+                    whereClauses.append("jri.source_job_id = ?")
+                    args.append(jobId)
+                }
+                if !includeRouted {
+                    whereClauses.append("i.qty_remaining > 0")
+                    whereClauses.append("i.status IN ('holding', 'damaged_review', 'wrong_part_review', 'supplier_review')")
+                }
+                let rows = try Row.fetchAll(dbConn, sql: """
+                    SELECT i.*,
+                           jri.source_job_id,
+                           COALESCE(j.job_name, 'Unknown Job') AS source_job_name,
+                           COALESCE(p.name, 'Unknown Part') AS part_name,
+                           p.code AS part_code
+                    FROM job_return_intake_items i
+                    JOIN job_return_intakes jri ON jri.id = i.intake_id
+                    LEFT JOIN jobs j ON j.id = jri.source_job_id AND j.deleted_at IS NULL
+                    LEFT JOIN parts p ON p.id = i.part_id AND p.deleted_at IS NULL
+                    WHERE \(whereClauses.joined(separator: " AND "))
+                    ORDER BY i.created_at DESC, i.id DESC
+                    """, arguments: StatementArguments(args))
+                return rows.map(Self.jobReturnHoldingItem(from:))
+            }
+        } catch {
+            if isTableNotFoundError(error) { return [] }
+            throw error
+        }
+    }
+
+    /// Confirm that a held Job Return item should re-enter shelf inventory.
+    @discardableResult
+    public func confirmJobReturnShelfRoute(
+        intakeItemId: Int64,
+        qty: Int,
+        performedBy: Int64,
+        shelfLocationId: Int64 = 1,
+        notes: String? = nil
+    ) throws -> Int64 {
+        guard qty > 0 else { throw WarehouseError.invalidQuantity }
+        return try db.writer.write { dbConn in
+            try Self.requireActiveUser(performedBy, dbConn: dbConn)
+            guard let item = try Self.fetchJobReturnHoldingItem(id: intakeItemId, dbConn: dbConn) else {
+                throw WarehouseError.jobReturnItemNotFound(intakeItemId)
+            }
+            guard item.qtyRemaining >= qty else {
+                throw WarehouseError.insufficientStock(available: item.qtyRemaining, requested: qty)
+            }
+
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO stock_movements
+                    (part_id, qty, from_location_type, from_location_id, to_location_type, to_location_id,
+                     movement_type, reason, notes, performed_by, job_id, created_at)
+                    VALUES (?, ?, 'job_return_holding', ?, 'warehouse', ?, ?, 'Job return shelved', ?, ?, ?, datetime('now'))
+                    """,
+                arguments: [
+                    item.partId, qty, intakeItemId, shelfLocationId,
+                    StockMovement.MovementType.restockFromShop.rawValue,
+                    notes, performedBy, item.sourceJobId,
+                ]
+            )
+            let movementId = dbConn.lastInsertedRowID
+
+            try dbConn.execute(
+                sql: """
+                    UPDATE stock SET qty = qty + ?, updated_at = datetime('now')
+                    WHERE part_id = ? AND location_type = 'warehouse' AND location_id = ?
+                      AND deleted_at IS NULL
+                    """,
+                arguments: [qty, item.partId, shelfLocationId]
+            )
+            if dbConn.changesCount == 0 {
+                try dbConn.execute(
+                    sql: """
+                        INSERT INTO stock (part_id, location_type, location_id, qty, updated_at)
+                        VALUES (?, 'warehouse', ?, ?, datetime('now'))
+                        """,
+                    arguments: [item.partId, shelfLocationId, qty]
+                )
+            }
+
+            let remaining = item.qtyRemaining - qty
+            try dbConn.execute(
+                sql: """
+                    UPDATE job_return_intake_items
+                    SET qty_remaining = ?,
+                        status = CASE WHEN ? = 0 THEN 'shelved' ELSE status END,
+                        routed_by = ?,
+                        routed_at = datetime('now')
+                    WHERE id = ?
+                    """,
+                arguments: [remaining, remaining, performedBy, intakeItemId]
+            )
+            try Self.refreshJobReturnIntakeStatus(intakeId: item.intakeId, dbConn: dbConn)
+
+            return movementId
+        }
+    }
+
+    /// Confirm that a held Job Return item is staged for a job. This records
+    /// staging stock only; shelf inventory remains unchanged.
+    @discardableResult
+    public func confirmJobReturnStagingRoute(
+        intakeItemId: Int64,
+        qty: Int,
+        jobId: Int64,
+        performedBy: Int64,
+        notes: String? = nil
+    ) throws -> Int64 {
+        try routeJobReturnItemToStockLocation(
+            intakeItemId: intakeItemId,
+            qty: qty,
+            toLocationType: "pulled",
+            toLocationId: jobId,
+            movementType: StockMovement.MovementType.receivingStaged.rawValue,
+            reason: "Job return staged",
+            performedBy: performedBy,
+            jobId: jobId,
+            finalStatus: "staged",
+            notes: notes
+        )
+    }
+
+    /// Write off a held Job Return item. Because the item has never entered
+    /// shelf stock, this records audit history without changing stock.
+    @discardableResult
+    public func writeOffJobReturnItem(
+        intakeItemId: Int64,
+        qty: Int,
+        reason: String,
+        performedBy: Int64,
+        notes: String? = nil
+    ) throws -> Int64 {
+        let trimmedReason = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedReason.isEmpty else { throw WarehouseError.requiredFieldEmpty }
+        guard qty > 0 else { throw WarehouseError.invalidQuantity }
+
+        return try db.writer.write { dbConn in
+            try Self.requireActiveUser(performedBy, dbConn: dbConn)
+            guard let item = try Self.fetchJobReturnHoldingItem(id: intakeItemId, dbConn: dbConn) else {
+                throw WarehouseError.jobReturnItemNotFound(intakeItemId)
+            }
+            guard item.qtyRemaining >= qty else {
+                throw WarehouseError.insufficientStock(available: item.qtyRemaining, requested: qty)
+            }
+
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO stock_movements
+                    (part_id, qty, from_location_type, from_location_id, movement_type,
+                     reason, notes, performed_by, job_id, created_at)
+                    VALUES (?, ?, 'job_return_holding', ?, ?, ?, ?, ?, ?, datetime('now'))
+                    """,
+                arguments: [
+                    item.partId, qty, intakeItemId, StockMovement.MovementType.writeOff.rawValue,
+                    trimmedReason, notes, performedBy, item.sourceJobId,
+                ]
+            )
+            let movementId = dbConn.lastInsertedRowID
+            try Self.applyJobReturnRoutingResult(
+                intakeItem: item,
+                routedQty: qty,
+                finalStatus: "written_off",
+                performedBy: performedBy,
+                dbConn: dbConn
+            )
+            return movementId
         }
     }
 
@@ -2499,6 +2829,14 @@ public final class WarehouseService: Sendable {
         case damagedReturn
         /// Wrong part received.
         case wrongPart
+        /// Returned job material is held until an explicit shelf/review route is confirmed.
+        case jobReturnHolding(intakeItemId: Int64, levels: PartStockLevels)
+        /// Returned job material needs damaged review; it should not affect shelf stock.
+        case jobReturnDamagedReview(intakeItemId: Int64)
+        /// Returned job material can only enter supplier review when supplier return data exists.
+        case jobReturnSupplierReview(intakeItemId: Int64)
+        /// Returned job material was identified as the wrong part and stays out of shelf stock.
+        case jobReturnWrongPartReview(intakeItemId: Int64)
     }
 
     /// Get shelf stock levels for a part (warehouse location_type only).
@@ -2624,6 +2962,47 @@ public final class WarehouseService: Sendable {
         }
     }
 
+    /// Source-aware route suggestion for PO incoming and Job Return items.
+    public func suggestReceivingRoute(
+        partId: Int64,
+        condition: String = "new",
+        source: ReceivingSource
+    ) throws -> ReceivingRoute {
+        switch source {
+        case .poIncoming(let poLineId):
+            if let link = try getJobLinkForPOLine(poLineId: poLineId) {
+                return .stageForJob(jobId: link.jobId, jobName: link.jobName, jpoId: link.jpoId)
+            }
+            let demands = try getActiveJPODemandForPart(partId: partId)
+            if !demands.isEmpty {
+                return .suggestStaging(demands: demands)
+            }
+            let levels = try getPartStockLevels(partId: partId)
+            if levels.isBelowTarget { return .restockShelf(levels: levels) }
+            if levels.isAtOrAboveMax { return .returnOverstock(levels: levels) }
+            return .recommendReturn(levels: levels)
+
+        case .jobReturn(let intakeItemId):
+            guard let item = try db.writer.read({ dbConn in
+                try Self.fetchJobReturnHoldingItem(id: intakeItemId, dbConn: dbConn)
+            }) else {
+                throw WarehouseError.jobReturnItemNotFound(intakeItemId)
+            }
+            let normalizedCondition = Self.normalizedReturnCondition(condition)
+            if normalizedCondition == "wrong_part" {
+                return .jobReturnWrongPartReview(intakeItemId: intakeItemId)
+            }
+            if normalizedCondition == "damaged" {
+                if item.hasSupplierReturnData {
+                    return .jobReturnSupplierReview(intakeItemId: intakeItemId)
+                }
+                return .jobReturnDamagedReview(intakeItemId: intakeItemId)
+            }
+            let levels = try getPartStockLevels(partId: partId)
+            return .jobReturnHolding(intakeItemId: intakeItemId, levels: levels)
+        }
+    }
+
     /// Move received parts to staging for a job (does NOT count toward shelf inventory).
     @discardableResult
     public func stageReceivedPartsForJob(
@@ -2697,6 +3076,215 @@ public final class WarehouseService: Sendable {
     // =========================================================================
     // MARK: - Internal Helpers
     // =========================================================================
+
+    private static func requireActivePart(_ partId: Int64, dbConn: Database) throws {
+        let exists = (try Int.fetchOne(dbConn, sql: """
+            SELECT COUNT(*) FROM parts WHERE id = ? AND deleted_at IS NULL
+            """, arguments: [partId]) ?? 0) > 0
+        guard exists else { throw WarehouseError.partNotFound(partId) }
+    }
+
+    private static func requireActiveJob(_ jobId: Int64, dbConn: Database) throws {
+        let exists = (try Int.fetchOne(dbConn, sql: """
+            SELECT COUNT(*) FROM jobs WHERE id = ? AND deleted_at IS NULL
+            """, arguments: [jobId]) ?? 0) > 0
+        guard exists else { throw WarehouseError.jobNotFound(jobId) }
+    }
+
+    private static func requireActiveUser(_ userId: Int64, dbConn: Database) throws {
+        let exists = (try Int.fetchOne(dbConn, sql: """
+            SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+            """, arguments: [userId]) ?? 0) > 0
+        guard exists else { throw WarehouseError.userNotFound(userId) }
+    }
+
+    private static func requireJobPart(_ jobPartId: Int64, sourceJobId: Int64, partId: Int64, dbConn: Database) throws {
+        let exists = (try Int.fetchOne(dbConn, sql: """
+            SELECT COUNT(*) FROM job_parts
+            WHERE id = ? AND job_id = ? AND part_id = ? AND deleted_at IS NULL
+            """, arguments: [jobPartId, sourceJobId, partId]) ?? 0) > 0
+        guard exists else { throw WarehouseError.requiredFieldEmpty }
+    }
+
+    private static func normalizedReturnCondition(_ condition: String) -> String {
+        let normalized = condition
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: " ", with: "_")
+        return normalized.isEmpty ? "usable" : normalized
+    }
+
+    private static func initialJobReturnStatus(condition: String, hasSupplierReturnData: Bool) -> String {
+        switch condition {
+        case "damaged":
+            return hasSupplierReturnData ? "supplier_review" : "damaged_review"
+        case "wrong_part", "wrong":
+            return "wrong_part_review"
+        default:
+            return "holding"
+        }
+    }
+
+    private static func jobReturnIntakeInfo(from row: Row) -> JobReturnIntakeInfo {
+        JobReturnIntakeInfo(
+            id: row["id"] ?? 0,
+            sourceJobId: row["source_job_id"] ?? 0,
+            sourceJobName: row["source_job_name"] ?? "Unknown Job",
+            returnSource: row["return_source"] ?? "job",
+            returnedBy: row["returned_by"] ?? 0,
+            returnedByName: row["returned_by_name"] ?? "Unknown",
+            status: row["status"] ?? "holding",
+            notes: row["notes"] as String?,
+            itemCount: row["item_count"] ?? 0,
+            createdAt: row["created_at"] ?? ""
+        )
+    }
+
+    private static func jobReturnHoldingItem(from row: Row) -> JobReturnHoldingItem {
+        JobReturnHoldingItem(
+            id: row["id"] ?? 0,
+            intakeId: row["intake_id"] ?? 0,
+            sourceJobId: row["source_job_id"] ?? 0,
+            sourceJobName: row["source_job_name"] ?? "Unknown Job",
+            partId: row["part_id"] ?? 0,
+            partName: row["part_name"] ?? "Unknown Part",
+            partCode: row["part_code"] as String?,
+            sourceJobPartId: row["source_job_part_id"] as Int64?,
+            supplierId: row["supplier_id"] as Int64?,
+            poLineId: row["po_line_id"] as Int64?,
+            qtyReturned: row["qty_returned"] ?? 0,
+            qtyRemaining: row["qty_remaining"] ?? 0,
+            condition: row["condition"] ?? "usable",
+            status: row["status"] ?? "holding",
+            notes: row["notes"] as String?,
+            createdAt: row["created_at"] ?? ""
+        )
+    }
+
+    private static func fetchJobReturnHoldingItem(id: Int64, dbConn: Database) throws -> JobReturnHoldingItem? {
+        guard let row = try Row.fetchOne(dbConn, sql: """
+            SELECT i.*,
+                   jri.source_job_id,
+                   COALESCE(j.job_name, 'Unknown Job') AS source_job_name,
+                   COALESCE(p.name, 'Unknown Part') AS part_name,
+                   p.code AS part_code
+            FROM job_return_intake_items i
+            JOIN job_return_intakes jri ON jri.id = i.intake_id AND jri.deleted_at IS NULL
+            LEFT JOIN jobs j ON j.id = jri.source_job_id AND j.deleted_at IS NULL
+            LEFT JOIN parts p ON p.id = i.part_id AND p.deleted_at IS NULL
+            WHERE i.id = ? AND i.deleted_at IS NULL
+            """, arguments: [id]) else { return nil }
+        return jobReturnHoldingItem(from: row)
+    }
+
+    private static func refreshJobReturnIntakeStatus(intakeId: Int64, dbConn: Database) throws {
+        let activeCount = try Int.fetchOne(dbConn, sql: """
+            SELECT COUNT(*) FROM job_return_intake_items
+            WHERE intake_id = ? AND deleted_at IS NULL AND qty_remaining > 0
+              AND status IN ('holding', 'damaged_review', 'wrong_part_review', 'supplier_review')
+            """, arguments: [intakeId]) ?? 0
+        if activeCount == 0 {
+            try dbConn.execute(sql: """
+                UPDATE job_return_intakes
+                SET status = 'completed', completed_at = datetime('now'), updated_at = datetime('now')
+                WHERE id = ?
+                """, arguments: [intakeId])
+        } else {
+            try dbConn.execute(sql: "UPDATE job_return_intakes SET updated_at = datetime('now') WHERE id = ?", arguments: [intakeId])
+        }
+    }
+
+    @discardableResult
+    private func routeJobReturnItemToStockLocation(
+        intakeItemId: Int64,
+        qty: Int,
+        toLocationType: String,
+        toLocationId: Int64,
+        movementType: String,
+        reason: String,
+        performedBy: Int64,
+        jobId: Int64?,
+        finalStatus: String,
+        notes: String?
+    ) throws -> Int64 {
+        guard qty > 0 else { throw WarehouseError.invalidQuantity }
+        return try db.writer.write { dbConn in
+            try Self.requireActiveUser(performedBy, dbConn: dbConn)
+            if let jobId {
+                try Self.requireActiveJob(jobId, dbConn: dbConn)
+            }
+            guard let item = try Self.fetchJobReturnHoldingItem(id: intakeItemId, dbConn: dbConn) else {
+                throw WarehouseError.jobReturnItemNotFound(intakeItemId)
+            }
+            guard item.qtyRemaining >= qty else {
+                throw WarehouseError.insufficientStock(available: item.qtyRemaining, requested: qty)
+            }
+
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO stock_movements
+                    (part_id, qty, from_location_type, from_location_id, to_location_type, to_location_id,
+                     movement_type, reason, notes, performed_by, job_id, created_at)
+                    VALUES (?, ?, 'job_return_holding', ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                    """,
+                arguments: [
+                    item.partId, qty, intakeItemId, toLocationType, toLocationId,
+                    movementType, reason, notes, performedBy, jobId ?? item.sourceJobId,
+                ]
+            )
+            let movementId = dbConn.lastInsertedRowID
+
+            try dbConn.execute(
+                sql: """
+                    UPDATE stock SET qty = qty + ?, updated_at = datetime('now')
+                    WHERE part_id = ? AND location_type = ? AND location_id = ?
+                      AND deleted_at IS NULL
+                    """,
+                arguments: [qty, item.partId, toLocationType, toLocationId]
+            )
+            if dbConn.changesCount == 0 {
+                try dbConn.execute(
+                    sql: """
+                        INSERT INTO stock (part_id, location_type, location_id, qty, updated_at)
+                        VALUES (?, ?, ?, ?, datetime('now'))
+                        """,
+                    arguments: [item.partId, toLocationType, toLocationId, qty]
+                )
+            }
+
+            try Self.applyJobReturnRoutingResult(
+                intakeItem: item,
+                routedQty: qty,
+                finalStatus: finalStatus,
+                performedBy: performedBy,
+                dbConn: dbConn
+            )
+            return movementId
+        }
+    }
+
+    private static func applyJobReturnRoutingResult(
+        intakeItem: JobReturnHoldingItem,
+        routedQty: Int,
+        finalStatus: String,
+        performedBy: Int64,
+        dbConn: Database
+    ) throws {
+        let remaining = intakeItem.qtyRemaining - routedQty
+        try dbConn.execute(
+            sql: """
+                UPDATE job_return_intake_items
+                SET qty_remaining = ?,
+                    status = CASE WHEN ? = 0 THEN ? ELSE status END,
+                    routed_by = ?,
+                    routed_at = datetime('now')
+                WHERE id = ?
+                """,
+            arguments: [remaining, remaining, finalStatus, performedBy, intakeItem.id]
+        )
+        try refreshJobReturnIntakeStatus(intakeId: intakeItem.intakeId, dbConn: dbConn)
+    }
 
     /// Execute a SELECT COUNT(*) or SELECT COALESCE(SUM(...), 0) query.
     /// Returns 0 if the table does not exist.

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -38,6 +38,8 @@ public final class WarehouseService: Sendable {
         case sessionItemNotFound(Int64)
         case jobReturnIntakeNotFound(Int64)
         case jobReturnItemNotFound(Int64)
+        case stagingBoxNotFound(Int64)
+        case stagingTagNotFound(Int64)
     }
 
     // =========================================================================
@@ -2574,8 +2576,32 @@ public final class WarehouseService: Sendable {
         public let boxSize: String         // small / normal / large
         public let labelText: String       // e.g. "SMITH RES 0412-01"
         public let isFull: Bool
+        public let status: String          // staged / loaded / delivered / returned_cancelled
         public let areaId: Int64?
         public let createdAt: String?
+        public let loadedAt: String?
+        public let deliveredAt: String?
+        public let returnedCancelledAt: String?
+        public let contentCount: Int
+    }
+
+    /// A staged item assigned to a physical box. Rows are retained across
+    /// delivery transitions so loaded/delivered boxes still show historical
+    /// contents even after the active staging tags are resolved.
+    public struct StagingBoxContent: Sendable, Identifiable {
+        public let id: Int64
+        public let boxId: Int64
+        public let stagingTagId: Int64
+        public let status: String
+        public let assignedAt: String?
+        public let removedAt: String?
+        public let partId: Int64
+        public let partName: String
+        public let partCode: String?
+        public let qty: Int
+        public let destinationType: String?
+        public let destinationId: Int64?
+        public let destinationLabel: String?
     }
 
     /// Create a new staging box for a job, auto-generating box_number and label_text.
@@ -2643,8 +2669,13 @@ public final class WarehouseService: Sendable {
                 boxSize: size,
                 labelText: labelText,
                 isFull: false,
+                status: "staged",
                 areaId: areaId,
-                createdAt: nil
+                createdAt: nil,
+                loadedAt: nil,
+                deliveredAt: nil,
+                returnedCancelledAt: nil,
+                contentCount: 0
             )
         }
     }
@@ -2663,7 +2694,12 @@ public final class WarehouseService: Sendable {
 
                 let sql = """
                     SELECT sb.*,
-                           j.job_name, j.job_number
+                           j.job_name, j.job_number,
+                           (
+                               SELECT COUNT(*)
+                               FROM staging_box_contents sbc
+                               WHERE sbc.box_id = sb.id AND sbc.deleted_at IS NULL
+                           ) AS content_count
                     FROM staging_boxes sb
                     LEFT JOIN jobs j ON j.id = sb.job_id AND j.deleted_at IS NULL
                     WHERE \(whereClauses.joined(separator: " AND "))
@@ -2681,8 +2717,13 @@ public final class WarehouseService: Sendable {
                         boxSize: row["box_size"] ?? "normal",
                         labelText: row["label_text"] ?? "",
                         isFull: (row["is_full"] as Int?) == 1,
+                        status: row["status"] ?? "staged",
                         areaId: row["area_id"] as Int64?,
-                        createdAt: row["created_at"] as String?
+                        createdAt: row["created_at"] as String?,
+                        loadedAt: row["loaded_at"] as String?,
+                        deliveredAt: row["delivered_at"] as String?,
+                        returnedCancelledAt: row["returned_cancelled_at"] as String?,
+                        contentCount: row["content_count"] ?? 0
                     )
                 }
             }
@@ -2763,9 +2804,190 @@ public final class WarehouseService: Sendable {
                 boxSize: size,
                 labelText: labelText,
                 isFull: false,
+                status: "staged",
                 areaId: areaId,
-                createdAt: nil
+                createdAt: nil,
+                loadedAt: nil,
+                deliveredAt: nil,
+                returnedCancelledAt: nil,
+                contentCount: 0
             )
+        }
+    }
+
+    @discardableResult
+    public func assignStagedItemToBox(stagingTagId: Int64, boxId: Int64) throws -> Int64 {
+        try db.writer.write { dbConn in
+            guard try stagingBoxExists(boxId, dbConn: dbConn) else {
+                throw WarehouseError.stagingBoxNotFound(boxId)
+            }
+            guard try activeStagingTagExists(stagingTagId, dbConn: dbConn) else {
+                throw WarehouseError.stagingTagNotFound(stagingTagId)
+            }
+
+            if let existingId = try Int64.fetchOne(
+                dbConn,
+                sql: "SELECT id FROM staging_box_contents WHERE staging_tag_id = ? LIMIT 1",
+                arguments: [stagingTagId]
+            ) {
+                try dbConn.execute(
+                    sql: """
+                        UPDATE staging_box_contents
+                        SET box_id = ?, status = 'staged', removed_at = NULL, deleted_at = NULL,
+                            loaded_at = NULL, delivered_at = NULL, returned_cancelled_at = NULL
+                        WHERE id = ?
+                        """,
+                    arguments: [boxId, existingId]
+                )
+                return existingId
+            }
+
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO staging_box_contents (box_id, staging_tag_id, status, assigned_at)
+                    VALUES (?, ?, 'staged', datetime('now'))
+                    """,
+                arguments: [boxId, stagingTagId]
+            )
+            return dbConn.lastInsertedRowID
+        }
+    }
+
+    public func removeStagedItemFromBox(stagingTagId: Int64, boxId: Int64) throws {
+        try db.writer.write { dbConn in
+            try dbConn.execute(
+                sql: """
+                    UPDATE staging_box_contents
+                    SET deleted_at = datetime('now'), removed_at = datetime('now')
+                    WHERE box_id = ? AND staging_tag_id = ? AND deleted_at IS NULL
+                    """,
+                arguments: [boxId, stagingTagId]
+            )
+        }
+    }
+
+    public func listStagingBoxContents(boxId: Int64? = nil) throws -> [StagingBoxContent] {
+        do {
+            return try db.writer.read { dbConn -> [StagingBoxContent] in
+                var whereClauses = ["sbc.deleted_at IS NULL"]
+                var args: [DatabaseValueConvertible?] = []
+                if let boxId {
+                    whereClauses.append("sbc.box_id = ?")
+                    args.append(boxId)
+                }
+
+                let rows = try Row.fetchAll(
+                    dbConn,
+                    sql: """
+                        SELECT sbc.id, sbc.box_id, sbc.staging_tag_id, sbc.status,
+                               sbc.assigned_at, sbc.removed_at,
+                               s.part_id, s.qty,
+                               p.name AS part_name, p.code AS part_code,
+                               pst.destination_type, pst.destination_id, pst.destination_label
+                        FROM staging_box_contents sbc
+                        JOIN pulled_staging_tags pst ON pst.id = sbc.staging_tag_id
+                        JOIN stock s ON s.id = pst.stock_id
+                        LEFT JOIN parts p ON p.id = s.part_id AND p.deleted_at IS NULL
+                        WHERE \(whereClauses.joined(separator: " AND "))
+                        ORDER BY sbc.assigned_at, sbc.id
+                        """,
+                    arguments: StatementArguments(args)
+                )
+
+                return rows.map { row in
+                    StagingBoxContent(
+                        id: row["id"] ?? 0,
+                        boxId: row["box_id"] ?? 0,
+                        stagingTagId: row["staging_tag_id"] ?? 0,
+                        status: row["status"] ?? "staged",
+                        assignedAt: row["assigned_at"] as String?,
+                        removedAt: row["removed_at"] as String?,
+                        partId: row["part_id"] ?? 0,
+                        partName: row["part_name"] ?? "Unknown Part",
+                        partCode: row["part_code"] as String?,
+                        qty: row["qty"] ?? 0,
+                        destinationType: row["destination_type"] as String?,
+                        destinationId: row["destination_id"] as Int64?,
+                        destinationLabel: row["destination_label"] as String?
+                    )
+                }
+            }
+        } catch {
+            if isTableNotFoundError(error) { return [] }
+            throw error
+        }
+    }
+
+    public func updateStagingBoxDeliveryState(boxId: Int64, status: String) throws {
+        let normalized = status.replacingOccurrences(of: "-", with: "_").lowercased()
+        guard ["staged", "loaded", "delivered", "returned_cancelled"].contains(normalized) else {
+            throw WarehouseError.requiredFieldEmpty
+        }
+
+        try db.writer.write { dbConn in
+            guard try stagingBoxExists(boxId, dbConn: dbConn) else {
+                throw WarehouseError.stagingBoxNotFound(boxId)
+            }
+
+            let timestampColumn: String?
+            switch normalized {
+            case "loaded": timestampColumn = "loaded_at"
+            case "delivered": timestampColumn = "delivered_at"
+            case "returned_cancelled": timestampColumn = "returned_cancelled_at"
+            default: timestampColumn = nil
+            }
+
+            if let timestampColumn {
+                try dbConn.execute(
+                    sql: "UPDATE staging_boxes SET status = ?, \(timestampColumn) = COALESCE(\(timestampColumn), datetime('now')) WHERE id = ? AND deleted_at IS NULL",
+                    arguments: [normalized, boxId]
+                )
+            } else {
+                try dbConn.execute(
+                    sql: "UPDATE staging_boxes SET status = ? WHERE id = ? AND deleted_at IS NULL",
+                    arguments: [normalized, boxId]
+                )
+            }
+
+            try dbConn.execute(
+                sql: """
+                    UPDATE staging_box_contents
+                    SET status = ?,
+                        loaded_at = CASE WHEN ? = 'loaded' THEN COALESCE(loaded_at, datetime('now')) ELSE loaded_at END,
+                        delivered_at = CASE WHEN ? = 'delivered' THEN COALESCE(delivered_at, datetime('now')) ELSE delivered_at END,
+                        returned_cancelled_at = CASE WHEN ? = 'returned_cancelled' THEN COALESCE(returned_cancelled_at, datetime('now')) ELSE returned_cancelled_at END
+                    WHERE box_id = ? AND deleted_at IS NULL
+                    """,
+                arguments: [normalized, normalized, normalized, normalized, boxId]
+            )
+
+            if normalized == "loaded" || normalized == "delivered" {
+                try dbConn.execute(
+                    sql: """
+                        UPDATE pulled_staging_tags
+                        SET deleted_at = COALESCE(deleted_at, datetime('now'))
+                        WHERE id IN (
+                            SELECT staging_tag_id
+                            FROM staging_box_contents
+                            WHERE box_id = ? AND deleted_at IS NULL
+                        )
+                        """,
+                    arguments: [boxId]
+                )
+            } else if normalized == "staged" || normalized == "returned_cancelled" {
+                try dbConn.execute(
+                    sql: """
+                        UPDATE pulled_staging_tags
+                        SET deleted_at = NULL
+                        WHERE id IN (
+                            SELECT staging_tag_id
+                            FROM staging_box_contents
+                            WHERE box_id = ? AND deleted_at IS NULL
+                        )
+                        """,
+                    arguments: [boxId]
+                )
+            }
         }
     }
 
@@ -2779,11 +3001,35 @@ public final class WarehouseService: Sendable {
         }
     }
 
+    private func stagingBoxExists(_ boxId: Int64, dbConn: Database) throws -> Bool {
+        (try Int.fetchOne(
+            dbConn,
+            sql: "SELECT COUNT(*) FROM staging_boxes WHERE id = ? AND deleted_at IS NULL",
+            arguments: [boxId]
+        ) ?? 0) > 0
+    }
+
+    private func activeStagingTagExists(_ stagingTagId: Int64, dbConn: Database) throws -> Bool {
+        (try Int.fetchOne(
+            dbConn,
+            sql: "SELECT COUNT(*) FROM pulled_staging_tags WHERE id = ? AND deleted_at IS NULL",
+            arguments: [stagingTagId]
+        ) ?? 0) > 0
+    }
+
     /// Soft-delete a staging box.
     public func deleteStagingBox(boxId: Int64) throws {
         try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: "UPDATE staging_boxes SET deleted_at = datetime('now') WHERE id = ?",
+                arguments: [boxId]
+            )
+            try dbConn.execute(
+                sql: """
+                    UPDATE staging_box_contents
+                    SET deleted_at = datetime('now'), removed_at = COALESCE(removed_at, datetime('now'))
+                    WHERE box_id = ? AND deleted_at IS NULL
+                    """,
                 arguments: [boxId]
             )
         }

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -35,6 +35,7 @@ public final class WarehouseService: Sendable {
         case areaNotFound(Int64)
         case unitNotFound(Int64)
         case levelNotFound(Int64)
+        case sessionItemNotFound(Int64)
         case jobReturnIntakeNotFound(Int64)
         case jobReturnItemNotFound(Int64)
     }
@@ -1321,6 +1322,14 @@ public final class WarehouseService: Sendable {
         case jobReturn(intakeItemId: Int64)
     }
 
+    public enum ReceivingRoutingDisposition: String, Sendable, Equatable {
+        case staged
+        case supplierReturn = "supplier_return"
+        case writeOff = "write_off"
+        case wrongPart = "wrong_part"
+        case review
+    }
+
     public struct JobReturnLineInput: Sendable, Equatable {
         public let partId: Int64
         public let qty: Int
@@ -1572,6 +1581,44 @@ public final class WarehouseService: Sendable {
         }
     }
 
+    public func markReceivingSessionItemRouted(
+        itemId: Int64,
+        disposition: ReceivingRoutingDisposition,
+        routedQty: Int,
+        routedBy: Int64
+    ) throws {
+        guard routedQty > 0 else { throw WarehouseError.invalidQuantity }
+        try db.writer.write { dbConn in
+            try Self.requireActiveUser(routedBy, dbConn: dbConn)
+            guard let row = try Row.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT received_qty FROM receiving_session_items
+                    WHERE id = ? AND deleted_at IS NULL
+                    """,
+                arguments: [itemId]
+            ) else {
+                throw WarehouseError.sessionItemNotFound(itemId)
+            }
+            let receivedQty: Int = row["received_qty"] ?? 0
+            guard receivedQty >= routedQty else {
+                throw WarehouseError.insufficientStock(available: receivedQty, requested: routedQty)
+            }
+
+            try dbConn.execute(
+                sql: """
+                    UPDATE receiving_session_items
+                    SET routing_disposition = ?,
+                        routed_qty = ?,
+                        routed_by = ?,
+                        routed_at = datetime('now')
+                    WHERE id = ? AND deleted_at IS NULL
+                    """,
+                arguments: [disposition.rawValue, routedQty, routedBy, itemId]
+            )
+        }
+    }
+
     /// Complete a receiving session: update status and create stock movements.
     public func completeSession(sessionId: Int64, completedBy: Int64) throws {
         try db.writer.write { dbConn in
@@ -1607,11 +1654,23 @@ public final class WarehouseService: Sendable {
                 arguments: [sessionId]
             )
 
-            // Create stock movements for each received item
+            // Create shelf stock movements for each received item that was not
+            // already routed to staging, return/review, or write-off.
             let items = try Row.fetchAll(
                 dbConn,
                 sql: """
-                    SELECT rsi.received_qty, rsi.actual_cost,
+                    SELECT rsi.received_qty,
+                           CASE
+                               WHEN rsi.routing_disposition IS NOT NULL
+                                    AND rsi.routing_disposition NOT IN ('shelf', 'restock_shelf', 'used_shelf')
+                               THEN CASE
+                                   WHEN rsi.received_qty - COALESCE(rsi.routed_qty, rsi.received_qty) > 0
+                                   THEN rsi.received_qty - COALESCE(rsi.routed_qty, rsi.received_qty)
+                                   ELSE 0
+                               END
+                               ELSE rsi.received_qty
+                           END AS shelf_qty,
+                           rsi.actual_cost,
                            pli.part_id
                     FROM receiving_session_items rsi
                     JOIN po_line_items pli ON pli.id = rsi.po_line_id
@@ -1622,8 +1681,8 @@ public final class WarehouseService: Sendable {
 
             for item in items {
                 let partId: Int64 = item["part_id"] ?? 0
-                let receivedQty: Int = item["received_qty"] ?? 0
-                guard partId > 0, receivedQty > 0 else { continue }
+                let shelfQty: Int = item["shelf_qty"] ?? 0
+                guard partId > 0, shelfQty > 0 else { continue }
                 let unitCost: Double? = item["actual_cost"] as Double?
 
                 // Insert movement
@@ -1634,7 +1693,7 @@ public final class WarehouseService: Sendable {
                          movement_type, reason, performed_by, unit_cost_at_move, created_at)
                         VALUES (?, ?, 'warehouse', 1, '\(StockMovement.MovementType.receiving.rawValue)', 'PO receiving', ?, ?, datetime('now'))
                         """,
-                    arguments: [partId, receivedQty, completedBy, unitCost]
+                    arguments: [partId, shelfQty, completedBy, unitCost]
                 )
 
                 // Add to warehouse stock
@@ -1644,7 +1703,7 @@ public final class WarehouseService: Sendable {
                         WHERE part_id = ? AND location_type = 'warehouse' AND location_id = 1
                           AND deleted_at IS NULL
                         """,
-                    arguments: [receivedQty, partId]
+                    arguments: [shelfQty, partId]
                 )
                 if dbConn.changesCount == 0 {
                     try dbConn.execute(
@@ -1652,7 +1711,7 @@ public final class WarehouseService: Sendable {
                             INSERT INTO stock (part_id, location_type, location_id, qty, updated_at)
                             VALUES (?, 'warehouse', 1, ?, datetime('now'))
                             """,
-                        arguments: [partId, receivedQty]
+                        arguments: [partId, shelfQty]
                     )
                 }
             }

--- a/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
@@ -147,6 +147,47 @@ struct DashboardServiceTests {
         #expect(hours.totalHours >= 0)
     }
 
+    @Test("My hours today reads completed break minutes from break records without labor gaps")
+    func testMyHoursTodayBreakMinutesFromBreakRecords() throws {
+        let (env, dash) = try freshEnv()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-BREAK-01", name: "Break Job")
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO labor_entries (user_id, job_id, clock_in, clock_out, regular_hours, status)
+                VALUES (?, ?, datetime('now','-4 hours'), datetime('now','-1 hour'), 3.0, 'completed')
+                """, arguments: [env.adminUserId, jobId])
+            try db.execute(sql: """
+                INSERT INTO break_records
+                    (user_id, break_type, started_at, ended_at, duration_minutes, is_paid, auto_filled)
+                VALUES
+                    (?, 'break', datetime('now','-3 hours'), datetime('now','-2 hours','-45 minutes'), 15, 1, 0),
+                    (?, 'lunch_unpaid', datetime('now','-2 hours'), datetime('now','-1 hours','-30 minutes'), 30, 0, 0)
+                """, arguments: [env.adminUserId, env.adminUserId])
+        }
+
+        let hours = try dash.getMyHoursToday(userId: env.adminUserId)
+
+        #expect(hours.breakMinutes == 45)
+    }
+
+    @Test("My hours today includes elapsed minutes for active same-day break record")
+    func testMyHoursTodayIncludesActiveBreakElapsedMinutes() throws {
+        let (env, dash) = try freshEnv()
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO break_records
+                    (user_id, break_type, started_at, ended_at, duration_minutes, is_paid, auto_filled)
+                VALUES
+                    (?, 'break', datetime('now','-20 minutes'), NULL, NULL, 1, 0)
+                """, arguments: [env.adminUserId])
+        }
+
+        let hours = try dash.getMyHoursToday(userId: env.adminUserId)
+
+        #expect(hours.breakMinutes >= 19)
+        #expect(hours.breakMinutes <= 21)
+    }
+
     @Test("Team clocked in status reflects active clock entry")
     func testTeamClockedIn() throws {
         let (env, dash) = try freshEnv()

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -1780,6 +1780,53 @@ struct WarehouseServiceExtTests {
         #expect(badMovements == 0)
     }
 
+    @Test("completeSession does not add routed PO incoming items to shelf stock")
+    func testCompleteSession_skipsRoutedPOIncomingShelfStock() throws {
+        let env = try E2ETestHelpers.setUp()
+        let supplierId = try E2ETestHelpers.seedSupplier(env)
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, name: "Routed PO Part", categoryId: catId)
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-PO-STAGE", name: "PO Stage Job")
+        let poId = try env.orders.createPurchaseOrder(poNumber: "PO-ROUTED-STAGE", supplierId: supplierId, notes: nil)
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO po_line_items (po_id, part_id, qty_ordered, unit_cost)
+                VALUES (?, ?, 3, 5.0)
+                """, arguments: [poId, partId])
+        }
+
+        let sessionId = try env.warehouse.startReceivingSession(poId: poId, startedBy: env.adminUserId)
+        let item = try #require(try env.warehouse.getSessionItems(sessionId: sessionId).first)
+        try env.warehouse.updateSessionItem(itemId: item.id, receivedQty: 3)
+        _ = try env.warehouse.stageReceivedPartsForJob(
+            partId: partId,
+            qty: 3,
+            jobId: jobId,
+            performedBy: env.adminUserId,
+            notes: "Regression: staged before PO completion"
+        )
+        try env.warehouse.markReceivingSessionItemRouted(
+            itemId: item.id,
+            disposition: .staged,
+            routedQty: 3,
+            routedBy: env.adminUserId
+        )
+
+        try env.warehouse.completeSession(sessionId: sessionId, completedBy: env.adminUserId)
+
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 0)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "pulled", locationId: jobId) == 3)
+
+        let receivingMovements = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM stock_movements
+                WHERE part_id = ? AND movement_type = 'receiving'
+                """, arguments: [partId]) ?? 0
+        }
+        #expect(receivingMovements == 0)
+    }
+
     // MARK: - Bin/Area assignment + misplaced-parts validation (iter 82)
 
     @Test("assignPartToBin is a no-op on a soft-deleted bin")

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -1051,6 +1051,153 @@ struct WarehouseServiceExtTests {
         #expect(movementId > 0)
     }
 
+    @Test("Job Return intake holds returned items outside shelf stock until confirmed")
+    func testJobReturnIntakeHoldsOutsideShelfStockUntilConfirmed() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        let jobId = try E2ETestHelpers.seedJob(env)
+
+        let intakeId = try env.warehouse.createJobReturnIntake(
+            sourceJobId: jobId,
+            returnSource: "crew_return",
+            returnedBy: env.adminUserId,
+            lines: [
+                .init(partId: partId, qty: 4, condition: "usable", notes: "Unused material from job"),
+            ],
+            notes: "End-of-job cleanup"
+        )
+        #expect(intakeId > 0)
+
+        let holdingItems = try env.warehouse.getJobReturnHoldingItems(jobId: jobId)
+        #expect(holdingItems.count == 1)
+        #expect(holdingItems.first?.qtyRemaining == 4)
+        #expect(holdingItems.first?.poLineId == nil)
+
+        let shelfBefore = try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1)
+        #expect(shelfBefore == 0)
+
+        guard let holdingItem = holdingItems.first else { return }
+        let route = try env.warehouse.suggestReceivingRoute(
+            partId: partId,
+            condition: holdingItem.condition,
+            source: .jobReturn(intakeItemId: holdingItem.id)
+        )
+        if case .jobReturnHolding(let routedItemId, _) = route {
+            #expect(routedItemId == holdingItem.id)
+        } else {
+            #expect(Bool(false), "Usable job returns should stay in return holding before explicit shelf confirmation")
+        }
+
+        _ = try env.warehouse.confirmJobReturnShelfRoute(
+            intakeItemId: holdingItem.id,
+            qty: 4,
+            performedBy: env.adminUserId
+        )
+
+        let shelfAfter = try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1)
+        #expect(shelfAfter == 4)
+
+        let remainingHolding = try env.warehouse.getJobReturnHoldingItems(jobId: jobId)
+        #expect(remainingHolding.isEmpty)
+    }
+
+    @Test("Job Return damaged and wrong-part outcomes stay in review without shelf stock")
+    func testJobReturnReviewOutcomesDoNotAffectShelfStock() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let damagedPartId = try E2ETestHelpers.seedPart(env, name: "Damaged Return Part", categoryId: catId)
+        let wrongPartId = try E2ETestHelpers.seedPart(env, name: "Wrong Return Part", categoryId: catId)
+        let jobId = try E2ETestHelpers.seedJob(env)
+
+        _ = try env.warehouse.createJobReturnIntake(
+            sourceJobId: jobId,
+            returnSource: "truck_cleanout",
+            returnedBy: env.adminUserId,
+            lines: [
+                .init(partId: damagedPartId, qty: 2, condition: "damaged"),
+                .init(partId: wrongPartId, qty: 1, condition: "wrong_part"),
+            ]
+        )
+
+        let holdingItems = try env.warehouse.getJobReturnHoldingItems(jobId: jobId)
+        #expect(Set(holdingItems.map(\.status)) == Set(["damaged_review", "wrong_part_review"]))
+
+        let damaged = holdingItems.first { $0.partId == damagedPartId }
+        let wrong = holdingItems.first { $0.partId == wrongPartId }
+        if let damaged {
+            let route = try env.warehouse.suggestReceivingRoute(
+                partId: damagedPartId,
+                condition: "damaged",
+                source: .jobReturn(intakeItemId: damaged.id)
+            )
+            if case .jobReturnDamagedReview(let itemId) = route {
+                #expect(itemId == damaged.id)
+            } else {
+                #expect(Bool(false), "Damaged job returns without supplier data should use damaged review")
+            }
+        }
+        if let wrong {
+            let route = try env.warehouse.suggestReceivingRoute(
+                partId: wrongPartId,
+                condition: "wrong_part",
+                source: .jobReturn(intakeItemId: wrong.id)
+            )
+            if case .jobReturnWrongPartReview(let itemId) = route {
+                #expect(itemId == wrong.id)
+            } else {
+                #expect(Bool(false), "Wrong job returns should use wrong-part review")
+            }
+        }
+
+        #expect(try env.warehouse.getStockQty(partId: damagedPartId, locationType: "warehouse", locationId: 1) == 0)
+        #expect(try env.warehouse.getStockQty(partId: wrongPartId, locationType: "warehouse", locationId: 1) == 0)
+    }
+
+    @Test("Job Return staging and write-off routes do not affect shelf stock")
+    func testJobReturnStagingAndWriteOffDoNotAffectShelfStock() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let stagedPartId = try E2ETestHelpers.seedPart(env, name: "Returned Stage Part", categoryId: catId)
+        let writeOffPartId = try E2ETestHelpers.seedPart(env, name: "Returned Write-Off Part", categoryId: catId)
+        let jobId = try E2ETestHelpers.seedJob(env)
+
+        _ = try env.warehouse.createJobReturnIntake(
+            sourceJobId: jobId,
+            returnSource: "job_box",
+            returnedBy: env.adminUserId,
+            lines: [
+                .init(partId: stagedPartId, qty: 3),
+                .init(partId: writeOffPartId, qty: 2),
+            ]
+        )
+        let holdingItems = try env.warehouse.getJobReturnHoldingItems(jobId: jobId)
+        guard let staged = holdingItems.first(where: { $0.partId == stagedPartId }),
+              let writeOff = holdingItems.first(where: { $0.partId == writeOffPartId })
+        else { return }
+
+        _ = try env.warehouse.confirmJobReturnStagingRoute(
+            intakeItemId: staged.id,
+            qty: 3,
+            jobId: jobId,
+            performedBy: env.adminUserId
+        )
+        _ = try env.warehouse.writeOffJobReturnItem(
+            intakeItemId: writeOff.id,
+            qty: 2,
+            reason: "Not reusable",
+            performedBy: env.adminUserId
+        )
+
+        #expect(try env.warehouse.getStockQty(partId: stagedPartId, locationType: "warehouse", locationId: 1) == 0)
+        #expect(try env.warehouse.getStockQty(partId: writeOffPartId, locationType: "warehouse", locationId: 1) == 0)
+        #expect(try env.warehouse.getStockQty(partId: stagedPartId, locationType: "pulled", locationId: jobId) == 3)
+
+        let movements = try env.warehouse.listMovements(limit: 20)
+        #expect(movements.contains { $0.partId == stagedPartId && $0.movementType == "receiving_staged" })
+        #expect(movements.contains { $0.partId == writeOffPartId && $0.movementType == "write_off" })
+    }
+
     // MARK: - Storage Hierarchy: createStorageUnit, deleteStorageLevel, deleteStorageArea, assignPartToBin
 
     @Test("createStorageUnit builds full hierarchy with levels and areas")

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -1490,6 +1490,82 @@ struct WarehouseServiceExtTests {
         #expect(nextBox.jobId == jobId)
     }
 
+    @Test("staging boxes assign and remove staged items without clearing the tag")
+    func testStagingBoxContentsAssignAndRemove() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-BOX-01", name: "Box Job")
+        let tagId = try seedStagingTag(env, jobId: jobId, partName: "Boxed EMT")
+        let box = try env.warehouse.createStagingBox(jobId: jobId, size: "normal")
+
+        let contentId = try env.warehouse.assignStagedItemToBox(stagingTagId: tagId, boxId: box.id)
+        #expect(contentId > 0)
+
+        let contents = try env.warehouse.listStagingBoxContents(boxId: box.id)
+        #expect(contents.count == 1)
+        #expect(contents.first?.stagingTagId == tagId)
+        #expect(contents.first?.partName == "Boxed EMT")
+        #expect(try env.warehouse.getStagedItems().contains { $0.id == tagId })
+
+        try env.warehouse.removeStagedItemFromBox(stagingTagId: tagId, boxId: box.id)
+        #expect(try env.warehouse.listStagingBoxContents(boxId: box.id).isEmpty)
+        #expect(try env.warehouse.getStagedItems().contains { $0.id == tagId })
+    }
+
+    @Test("loaded and delivered boxes resolve staged items while preserving content history")
+    func testStagingBoxDeliveryTransitionsResolveStagedItems() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-BOX-02", name: "Delivery Job")
+        let tagId = try seedStagingTag(env, jobId: jobId, partName: "Delivery Wire")
+        let box = try env.warehouse.createStagingBox(jobId: jobId, size: "large")
+        _ = try env.warehouse.assignStagedItemToBox(stagingTagId: tagId, boxId: box.id)
+
+        try env.warehouse.updateStagingBoxDeliveryState(boxId: box.id, status: "loaded")
+        #expect(!(try env.warehouse.getStagedItems()).contains { $0.id == tagId })
+        #expect(try env.warehouse.listStagingBoxContents(boxId: box.id).first?.status == "loaded")
+
+        try env.warehouse.updateStagingBoxDeliveryState(boxId: box.id, status: "delivered")
+        let deliveredBox = try env.warehouse.listStagingBoxes(jobId: jobId).first
+        #expect(deliveredBox?.status == "delivered")
+        #expect(deliveredBox?.contentCount == 1)
+        #expect(try env.warehouse.listStagingBoxContents(boxId: box.id).first?.status == "delivered")
+        #expect(!(try env.warehouse.getStagedItems()).contains { $0.id == tagId })
+    }
+
+    @Test("returned-cancelled box restores staged items for resolution")
+    func testReturnedCancelledBoxRestoresStagedItems() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-BOX-03", name: "Return Job")
+        let tagId = try seedStagingTag(env, jobId: jobId, partName: "Return Conduit")
+        let box = try env.warehouse.createStagingBox(jobId: jobId, size: "small")
+        _ = try env.warehouse.assignStagedItemToBox(stagingTagId: tagId, boxId: box.id)
+
+        try env.warehouse.updateStagingBoxDeliveryState(boxId: box.id, status: "loaded")
+        #expect(!(try env.warehouse.getStagedItems()).contains { $0.id == tagId })
+
+        try env.warehouse.updateStagingBoxDeliveryState(boxId: box.id, status: "returned_cancelled")
+        #expect(try env.warehouse.getStagedItems().contains { $0.id == tagId })
+        #expect(try env.warehouse.listStagingBoxContents(boxId: box.id).first?.status == "returned_cancelled")
+    }
+
+    @Test("staging box delivery migration exposes status columns and contents table")
+    func testStagingBoxDeliveryMigrationShape() throws {
+        let env = try E2ETestHelpers.setUp()
+        let columns = try env.db.writer.read { db in
+            try db.columns(in: "staging_boxes").map(\.name)
+        }
+        #expect(columns.contains("status"))
+        #expect(columns.contains("loaded_at"))
+        #expect(columns.contains("delivered_at"))
+        #expect(columns.contains("returned_cancelled_at"))
+
+        let contentColumns = try env.db.writer.read { db in
+            try db.columns(in: "staging_box_contents").map(\.name)
+        }
+        #expect(contentColumns.contains("box_id"))
+        #expect(contentColumns.contains("staging_tag_id"))
+        #expect(contentColumns.contains("status"))
+    }
+
     // MARK: - Quantity validation guards (iter 72)
 
     @Test("updateSessionItem throws invalidQuantity for negative receivedQty")
@@ -1498,6 +1574,23 @@ struct WarehouseServiceExtTests {
         #expect(throws: WarehouseService.WarehouseError.invalidQuantity) {
             try env.warehouse.updateSessionItem(itemId: 1, receivedQty: -1)
         }
+    }
+
+    private func seedStagingTag(_ env: E2ETestHelpers.TestEnvironment, jobId: Int64, partName: String) throws -> Int64 {
+        let catId = try E2ETestHelpers.seedCategory(env, name: "Box Test \(UUID().uuidString.prefix(6))")
+        let partId = try E2ETestHelpers.seedPart(env, name: partName, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 4)
+        guard let stockId = try env.parts.getPartStock(partId: partId).first?["id"] as Int64? else {
+            Issue.record("No stock row found for staging box test")
+            throw WarehouseService.WarehouseError.partNotFound(partId)
+        }
+        return try env.warehouse.createStagingTag(
+            stockId: stockId,
+            destinationType: "job",
+            destinationId: jobId,
+            destinationLabel: "Job \(jobId)",
+            taggedBy: env.adminUserId
+        )
     }
 
     @Test("recordScan throws invalidQuantity for zero qty")


### PR DESCRIPTION
## Summary
- Renames the warehouse receiving surface to Sorting/Receiving and adds PO Incoming vs Job Return entry paths.
- Adds a Job Return iOS flow with job selection, return source, returned-by display, notes, part search/scan, quantities, per-line sort actions, source badges, and completion grouping.
- Includes the resolved Job Return core intake/holding support needed by the UI branch to build cleanly.

## Verification
- xcodebuild -workspace 'Wierd Parts.xcworkspace' -scheme 'WiredPart-iOS' -destination 'generic/platform=iOS Simulator' build

## Manual verification note
- PO Incoming remains on IOSReceiveShipmentPage with price verification visible and Scan PO accessibility label.
- Job Return path has no PO/cost/price verification controls and warns that holding items do not count as shelf inventory.