### PR TITLE
WEI-2481 Fix dashboard daily-report action semantics

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -227,7 +227,9 @@ final class AppCore: ObservableObject {
                 needsOnboarding = false
             }
 
-            if uiTestingMode && ProcessInfo.processInfo.arguments.contains("-UITestingWEI936AutoLogin"),
+            if uiTestingMode &&
+               ProcessInfo.processInfo.arguments.contains("-UITestingWEI936AutoLogin") &&
+               !ProcessInfo.processInfo.arguments.contains("-UITestingForceLogin"),
                let uiTestUser = result.users.first(where: { $0.displayName == "UITest Owner" }),
                let userId = uiTestUser.id {
                 currentUser = uiTestUser
@@ -936,6 +938,10 @@ final class AppCore: ObservableObject {
             }
         }
 
+        if ProcessInfo.processInfo.arguments.contains("-UITestingWarehouseLocations") {
+            try seedWarehouseLocationsUITestingFixtures(db: db)
+        }
+
         if ProcessInfo.processInfo.arguments.contains("-UITestingDispatchBoard") {
             try seedDispatchBoardUITestingFixtures(db: db)
             UserDefaults.standard.set(true, forKey: "hasSeenWelcome")
@@ -949,6 +955,68 @@ final class AppCore: ObservableObject {
         }
 
         seedWEI936OnboardingStateIfRequested(userId: fixtureUserId)
+    }
+
+    nonisolated private static func seedWarehouseLocationsUITestingFixtures(db: AppDatabase) throws {
+        let service = WarehouseService(db: db)
+        let planName = "UITesting Warehouse Floor Plan"
+        let plan = try service.listFloorPlans().first { $0.name == planName }
+            ?? service.createFloorPlan(name: planName, widthInches: 720, lengthInches: 480)
+
+        guard let planId = plan.id else { return }
+        try service.updateFloorPlanGrid(floorPlanId: planId, rows: 3, cols: 5)
+
+        if try service.listZones(floorPlanId: planId).isEmpty {
+            _ = try service.addZone(
+                floorPlanId: planId,
+                zoneType: "storage",
+                label: "UITesting Storage",
+                colorHex: "#2563EB",
+                gridX: 0,
+                gridY: 0,
+                gridWidth: 2,
+                gridHeight: 2
+            )
+        }
+
+        let existingUnits = try service.listStorageUnits(floorPlanId: planId)
+        if existingUnits.isEmpty {
+            let shelf = try service.createStorageUnit(
+                floorPlanId: planId,
+                name: "UITesting Shelf A",
+                unitType: "shelf",
+                levels: 2,
+                areasPerLevel: 3
+            )
+            if let shelfId = shelf.id {
+                try service.updateStorageUnit(
+                    id: shelfId,
+                    gridX: 0,
+                    gridY: 0,
+                    gridWidth: 1,
+                    gridHeight: 2,
+                    frontFace: "south"
+                )
+            }
+
+            let rack = try service.createStorageUnit(
+                floorPlanId: planId,
+                name: "UITesting Pipe Rack",
+                unitType: "rack",
+                levels: 1,
+                areasPerLevel: 4
+            )
+            if let rackId = rack.id {
+                try service.updateStorageUnit(
+                    id: rackId,
+                    gridX: 2,
+                    gridY: 1,
+                    gridWidth: 2,
+                    gridHeight: 1,
+                    frontFace: "east"
+                )
+            }
+        }
     }
 
     nonisolated private static func seedWEI936OnboardingStateIfRequested(userId: Int64?) {

--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -961,7 +961,7 @@ final class AppCore: ObservableObject {
         let service = WarehouseService(db: db)
         let planName = "UITesting Warehouse Floor Plan"
         let plan = try service.listFloorPlans().first { $0.name == planName }
-            ?? service.createFloorPlan(name: planName, widthInches: 720, lengthInches: 480)
+            ?? (try service.createFloorPlan(name: planName, widthInches: 720, lengthInches: 480))
 
         guard let planId = plan.id else { return }
         try service.updateFloorPlanGrid(floorPlanId: planId, rows: 3, cols: 5)

--- a/Weird Parts IOS/Weird Parts IOS/Auth/NewUserWelcomeView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/NewUserWelcomeView.swift
@@ -8,9 +8,14 @@ struct NewUserWelcomeView: View {
     @AppStorage("hasSeenWelcome") private var hasSeenWelcome = false
 
     var body: some View {
-        if !hasSeenWelcome {
+        if !hasSeenWelcome && !shouldSuppressForWarehouseLocationsUITest {
             welcomeOverlay
         }
+    }
+
+    private var shouldSuppressForWarehouseLocationsUITest: Bool {
+        let args = ProcessInfo.processInfo.arguments
+        return args.contains("-UITesting") && args.contains("-UITestingWarehouseLocations")
     }
 
     private var welcomeOverlay: some View {

--- a/Weird Parts IOS/Weird Parts IOS/DesignSystem/Components/QuickActionButton.swift
+++ b/Weird Parts IOS/Weird Parts IOS/DesignSystem/Components/QuickActionButton.swift
@@ -13,30 +13,44 @@ struct DSQuickActionButton: View {
     let title: String
     let icon: String
     let color: Color
+    var isLoading: Bool = false
+    var isDisabled: Bool = false
     var action: (() -> Void)? = nil
 
     /// Button size that scales with Dynamic Type.
-    @ScaledMetric(relativeTo: .caption2) private var buttonWidth: CGFloat = 80
-    @ScaledMetric(relativeTo: .caption2) private var buttonHeight: CGFloat = 72
+    @ScaledMetric(relativeTo: .caption2) private var buttonWidth: CGFloat = 88
+    @ScaledMetric(relativeTo: .caption2) private var buttonHeight: CGFloat = 76
 
     var body: some View {
         Button {
+            guard !isLoading && !isDisabled else { return }
             action?()
         } label: {
             VStack(spacing: DS.Space.xs) {
-                Image(systemName: icon)
-                    .font(.title2)
-                    .foregroundStyle(color)
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(height: 28)
+                } else {
+                    Image(systemName: icon)
+                        .font(.title2)
+                        .foregroundStyle(isDisabled ? .secondary : color)
+                }
 
                 Text(title)
                     .dsStyle(.label)
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(isDisabled ? .secondary : .primary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.8)
             }
             .frame(width: buttonWidth, height: buttonHeight)
             .dsCard()
+            .opacity(isDisabled ? 0.55 : 1)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(title)
+        .disabled(isLoading || isDisabled)
+        .accessibilityLabel(isLoading ? "\(title), loading" : title)
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/DashboardDailyReportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/DashboardDailyReportPage.swift
@@ -515,7 +515,7 @@ struct DashboardDailyReportPage: View {
                 }
             }
         } catch {
-            setFastActionError(error, context: "update lunch")
+            await setFastActionError(error, context: "update lunch")
         }
 
         await loadData()
@@ -564,7 +564,7 @@ struct DashboardDailyReportPage: View {
                 }
             }
         } catch {
-            setFastActionError(error, context: "update break")
+            await setFastActionError(error, context: "update break")
         }
 
         await loadData()
@@ -595,7 +595,7 @@ struct DashboardDailyReportPage: View {
                     : (.info, "Supply run ended", "The run marker was closed on this labor entry.")
             }
         } catch {
-            setFastActionError(error, context: "toggle supply run")
+            await setFastActionError(error, context: "toggle supply run")
         }
 
         await loadData()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/DashboardDailyReportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/DashboardDailyReportPage.swift
@@ -9,6 +9,14 @@ import WiredPartCore
 struct DashboardDailyReportPage: View {
     @EnvironmentObject private var appCore: AppCore
 
+    private enum FastActionKind: String, Identifiable {
+        case lunch
+        case breakTime
+        case supplyRun
+
+        var id: String { rawValue }
+    }
+
     // Data state
     @State private var pendingJPOs: Int = 0
     @State private var pendingPOs: Int = 0
@@ -29,6 +37,11 @@ struct DashboardDailyReportPage: View {
     @State private var myCurrentJob: String?
     @State private var myBreakMinutes: Int = 0
     @State private var myJobBreakdown: [JobTimeEntry] = []
+    @State private var activeLaborEntryId: Int64?
+    @State private var activeBreakRecord: BreakRecord?
+    @State private var activityStatus: String = "working"
+    @State private var processingFastAction: FastActionKind?
+    @State private var fastActionFeedback: (severity: DSAlertSeverity, title: String, message: String?)?
 
     // Team (managers only)
     @State private var teamClockedIn: [TeamMemberStatus] = []
@@ -41,12 +54,6 @@ struct DashboardDailyReportPage: View {
         var id: String { rawValue }
     }
 
-    /// Break types for fast action buttons
-    private enum FastActionBreak {
-        case lunch, regularBreak, supplyRun
-    }
-
-    @State private var pendingFastAction: FastActionBreak?
     @State private var activeSheet: ActiveSheet?
 
     private let refreshTimer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
@@ -66,6 +73,16 @@ struct DashboardDailyReportPage: View {
                     // Fast Actions Bar
                     fastActionsBar
                         .padding(.horizontal, DS.Space.lg)
+
+                    if let feedback = fastActionFeedback {
+                        DSAlertBanner(
+                            severity: feedback.severity,
+                            icon: feedback.severity == .error ? "exclamationmark.triangle.fill" : "checkmark.circle.fill",
+                            title: feedback.title,
+                            message: feedback.message
+                        )
+                        .padding(.horizontal, DS.Space.lg)
+                    }
 
                     // Overdue alert banner
                     if overdueDeliveries > 0 {
@@ -166,27 +183,6 @@ struct DashboardDailyReportPage: View {
                 )
             }
         }
-        .confirmationDialog(
-            pendingFastAction == .lunch ? "Start Lunch?" :
-            pendingFastAction == .supplyRun ? "Start Supply Run?" : "Start Break?",
-            isPresented: Binding(
-                get: { pendingFastAction != nil },
-                set: { if !$0 { pendingFastAction = nil } }
-            ),
-            titleVisibility: .visible
-        ) {
-            if let action = pendingFastAction {
-                Button(action == .lunch ? "Start Lunch" :
-                       action == .supplyRun ? "Start Supply Run" : "Start Break") {
-                    startFastActionBreak(action)
-                }
-                Button("Cancel", role: .cancel) { pendingFastAction = nil }
-            }
-        } message: {
-            Text(pendingFastAction == .supplyRun
-                 ? "Records a supply-run break. Geofence auto-ends it when you return."
-                 : "Records a break start. Tap End Break when you return.")
-        }
     }
 
     // MARK: - Data Loading
@@ -260,6 +256,25 @@ struct DashboardDailyReportPage: View {
                             hours: entry.hours
                         )
                     }
+                }
+
+                if let userId = currentUserId {
+                    let activeEntry = try? appCore.jobsService?.getActiveClockEntry(userId: userId)
+                    activeLaborEntryId = activeEntry?.id
+
+                    if let entryId = activeEntry?.id,
+                       let notes = try? appCore.jobsService?.getLaborEntryNotes(laborEntryId: entryId),
+                       JobsService.isOnSupplyRun(notes: notes) {
+                        activityStatus = "supply_run"
+                    } else {
+                        activityStatus = "working"
+                    }
+
+                    activeBreakRecord = try? appCore.breakService?.getActiveBreak(userId: userId)
+                } else {
+                    activeLaborEntryId = nil
+                    activeBreakRecord = nil
+                    activityStatus = "working"
                 }
 
                 teamClockedIn = teamResult.map { member in
@@ -373,11 +388,23 @@ struct DashboardDailyReportPage: View {
     private var fastActionsBar: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: DS.Space.md) {
-                DSQuickActionButton(title: "Lunch", icon: "fork.knife", color: .green) {
-                    pendingFastAction = .lunch
+                DSQuickActionButton(
+                    title: lunchActionTitle,
+                    icon: "fork.knife",
+                    color: .green,
+                    isLoading: processingFastAction == .lunch,
+                    isDisabled: isLunchActionDisabled
+                ) {
+                    Task { await toggleLunch() }
                 }
-                DSQuickActionButton(title: "Break", icon: "cup.and.saucer.fill", color: .purple) {
-                    pendingFastAction = .regularBreak
+                DSQuickActionButton(
+                    title: breakActionTitle,
+                    icon: "cup.and.saucer.fill",
+                    color: .purple,
+                    isLoading: processingFastAction == .breakTime,
+                    isDisabled: isBreakActionDisabled
+                ) {
+                    Task { await toggleBreak() }
                 }
                 DSQuickActionButton(title: "Problem", icon: "exclamationmark.triangle.fill", color: .red) {
                     activeSheet = .reportProblem
@@ -385,51 +412,194 @@ struct DashboardDailyReportPage: View {
                 DSQuickActionButton(title: "Day Report", icon: "doc.text.fill", color: .indigo) {
                     activeSheet = .submitReport
                 }
-                DSQuickActionButton(title: "Supply Run", icon: "truck.box.fill", color: .blue) {
-                    pendingFastAction = .supplyRun
+                DSQuickActionButton(
+                    title: supplyRunActionTitle,
+                    icon: activityStatus == "supply_run" ? "checkmark.circle.fill" : "truck.box.fill",
+                    color: .blue,
+                    isLoading: processingFastAction == .supplyRun,
+                    isDisabled: isSupplyRunActionDisabled
+                ) {
+                    Task { await toggleSupplyRun() }
                 }
             }
+            .padding(.vertical, 2)
         }
     }
 
-    /// Clocks out the current user (for lunch, break, or supply run).
-    private func startLunchOrBreak() {
-        guard let service = appCore.jobsService,
-              let userId = appCore.currentUser?.id else {
-            loadError = "Jobs service not available"
-            return
+    private var activeBreakType: String? {
+        activeBreakRecord?.breakType
+    }
+
+    private var isLunchActive: Bool {
+        activeBreakType?.hasPrefix("lunch") == true
+    }
+
+    private var isBreakActive: Bool {
+        activeBreakType == "break"
+    }
+
+    private var lunchActionTitle: String {
+        isLunchActive ? "End Lunch" : "Start Lunch"
+    }
+
+    private var breakActionTitle: String {
+        isBreakActive ? "End Break" : "Start Break"
+    }
+
+    private var supplyRunActionTitle: String {
+        activityStatus == "supply_run" ? "End Supply Run" : "Start Supply Run"
+    }
+
+    private var hasActiveClockEntry: Bool {
+        activeLaborEntryId != nil
+    }
+
+    private var isLunchActionDisabled: Bool {
+        processingFastAction != nil || !hasActiveClockEntry || isBreakActive || activityStatus == "supply_run"
+    }
+
+    private var isBreakActionDisabled: Bool {
+        processingFastAction != nil || !hasActiveClockEntry || isLunchActive || activityStatus == "supply_run"
+    }
+
+    private var isSupplyRunActionDisabled: Bool {
+        processingFastAction != nil || !hasActiveClockEntry || activeBreakRecord != nil
+    }
+
+    @MainActor
+    private func setFastActionError(_ error: Error, context: String) {
+        fastActionFeedback = (.error, "Action failed", userFriendlyError(error, context: context))
+    }
+
+    private func toggleLunch() async {
+        await MainActor.run {
+            processingFastAction = .lunch
+            fastActionFeedback = nil
         }
-        do {
-            if let active = try service.getActiveClockEntry(userId: userId) {
-                try service.clockOut(laborEntryId: active.id)
+
+        guard let breakSvc = appCore.breakService,
+              let userId = appCore.currentUser?.id else {
+            await MainActor.run {
+                fastActionFeedback = (.error, "Lunch unavailable", "Break service is not available.")
+                processingFastAction = nil
             }
-            Task { await loadData() }
-        } catch {
-            loadError = userFriendlyError(error, context: "load daily report")
-        }
-    }
-
-    /// Records the appropriate break type without clocking out (#856-858).
-    private func startFastActionBreak(_ breakAction: FastActionBreak) {
-        guard let breakService = appCore.breakService,
-              let userId = appCore.currentUser?.id else {
-            loadError = "Break service not available"
             return
         }
-        let breakType: String
-        switch breakAction {
-        case .lunch:        breakType = "lunch_paid"
-        case .regularBreak: breakType = "break"
-        case .supplyRun:    breakType = "supply_run"
-        }
+
         do {
-            _ = try breakService.startBreak(userId: userId, breakType: breakType)
-            pendingFastAction = nil
-            Task { await loadData() }
+            if let record = activeBreakRecord, activeBreakType?.hasPrefix("lunch") == true {
+                if let recordId = record.id {
+                    try breakSvc.endBreak(recordId: recordId)
+                }
+                await MainActor.run {
+                    activeBreakRecord = nil
+                    fastActionFeedback = (.info, "Lunch ended", "Your daily report hours are refreshed.")
+                }
+            } else if let entryId = activeLaborEntryId {
+                let settings = try breakSvc.getCompanyBreakSettings()
+                let policies = try breakSvc.getBreakPolicy(stateCode: settings.stateCode)
+                let lunchPolicy = policies.first { $0.policyType == "state_required_paid" }
+                let record = try breakSvc.startBreak(
+                    userId: userId,
+                    breakType: "lunch_paid",
+                    laborEntryId: entryId,
+                    timerMinutes: lunchPolicy?.lunchMinutes ?? 30
+                )
+                await MainActor.run {
+                    activeBreakRecord = record
+                    fastActionFeedback = (.info, "Lunch started", "Timer started without using the generic clock-out path.")
+                }
+            } else {
+                await MainActor.run {
+                    fastActionFeedback = (.warning, "Clock in first", "Lunch tracking needs an active clock entry.")
+                }
+            }
         } catch {
-            loadError = userFriendlyError(error, context: "start break")
-            pendingFastAction = nil
+            setFastActionError(error, context: "update lunch")
         }
+
+        await loadData()
+        await MainActor.run { processingFastAction = nil }
+    }
+
+    private func toggleBreak() async {
+        await MainActor.run {
+            processingFastAction = .breakTime
+            fastActionFeedback = nil
+        }
+
+        guard let breakSvc = appCore.breakService,
+              let userId = appCore.currentUser?.id else {
+            await MainActor.run {
+                fastActionFeedback = (.error, "Break unavailable", "Break service is not available.")
+                processingFastAction = nil
+            }
+            return
+        }
+
+        do {
+            if let record = activeBreakRecord, activeBreakType == "break" {
+                if let recordId = record.id {
+                    try breakSvc.endBreak(recordId: recordId)
+                }
+                await MainActor.run {
+                    activeBreakRecord = nil
+                    fastActionFeedback = (.info, "Break ended", "Your daily report hours are refreshed.")
+                }
+            } else if let entryId = activeLaborEntryId {
+                let settings = try breakSvc.getCompanyBreakSettings()
+                let record = try breakSvc.startBreak(
+                    userId: userId,
+                    breakType: "break",
+                    laborEntryId: entryId,
+                    timerMinutes: settings.roundingMinutes > 0 ? 15 : nil
+                )
+                await MainActor.run {
+                    activeBreakRecord = record
+                    fastActionFeedback = (.info, "Break started", "Paid break timer started.")
+                }
+            } else {
+                await MainActor.run {
+                    fastActionFeedback = (.warning, "Clock in first", "Break tracking needs an active clock entry.")
+                }
+            }
+        } catch {
+            setFastActionError(error, context: "update break")
+        }
+
+        await loadData()
+        await MainActor.run { processingFastAction = nil }
+    }
+
+    private func toggleSupplyRun() async {
+        await MainActor.run {
+            processingFastAction = .supplyRun
+            fastActionFeedback = nil
+        }
+
+        guard let service = appCore.jobsService,
+              let entryId = activeLaborEntryId else {
+            await MainActor.run {
+                fastActionFeedback = (.warning, "Clock in first", "Supply runs need an active clock entry.")
+                processingFastAction = nil
+            }
+            return
+        }
+
+        do {
+            let newStatus = try service.toggleSupplyRun(laborEntryId: entryId)
+            await MainActor.run {
+                activityStatus = newStatus
+                fastActionFeedback = newStatus == "supply_run"
+                    ? (.info, "Supply run started", "You stay clocked in while the run is marked on this labor entry.")
+                    : (.info, "Supply run ended", "The run marker was closed on this labor entry.")
+            }
+        } catch {
+            setFastActionError(error, context: "toggle supply run")
+        }
+
+        await loadData()
+        await MainActor.run { processingFastAction = nil }
     }
 
     // MARK: - Pending Actions Card

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSReceivingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSReceivingPage.swift
@@ -123,7 +123,7 @@ struct IOSReceivingPage: View {
                         }
                     }
             }
-        case .continueSession:
+        case .continueSession(_):
             // IOSReceiveShipmentPage shows PO list; user picks the PO to continue
             NavigationStack {
                 IOSReceiveShipmentPage()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
@@ -299,34 +299,42 @@ struct WarehouseLocationsPage: View {
 
     @ViewBuilder
     private var unitTypeToolbar: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                ForEach(storageUnitTypeCatalog) { item in
-                    unitTypeButton(item)
-                }
+        let columns = [GridItem(.adaptive(minimum: 80), spacing: 8)]
+
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+            ForEach(storageUnitTypeCatalog) { item in
+                unitTypeButton(item)
             }
-            .padding(.horizontal)
-            .padding(.vertical, 6)
         }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
         .background(Color(.secondarySystemBackground))
     }
 
     @ViewBuilder
     private func unitTypeButton(_ item: StorageUnitTypeCatalogItem) -> some View {
         Button { activeSheet = .addUnit(item.id) } label: {
-            HStack(spacing: 4) {
-                Image(systemName: item.icon)
-                    .font(.caption2)
+            Label {
                 Text(item.label)
                     .font(.caption)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            } icon: {
+                Image(systemName: item.icon)
+                    .font(.caption)
+                    .accessibilityHidden(true)
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .frame(minHeight: 44)
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .padding(.horizontal, 8)
             .background(item.color.opacity(0.12))
             .foregroundStyle(item.color)
-            .clipShape(Capsule())
+            .contentShape(Rectangle())
+            .clipShape(RoundedRectangle(cornerRadius: 8))
         }
+        .simultaneousGesture(TapGesture().onEnded {
+            activeSheet = .addUnit(item.id)
+        })
+        .accessibilityIdentifier("warehouse-unit-type-\(item.id)")
     }
 
     // MARK: - Floor Plan Grid

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
@@ -939,6 +939,7 @@ private struct AddStorageUnitSheet: View {
                         ForEach(faceOptions, id: \.self) { Text($0.capitalized) }
                     }
                     .pickerStyle(.segmented)
+                    .accessibilityIdentifier("warehouse-add-unit-front-face")
                     Text("Side with stickers and aisle access.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -1114,6 +1115,7 @@ private struct EditStorageUnitSheet: View {
                         ForEach(faceOptions, id: \.self) { Text($0.capitalized) }
                     }
                     .pickerStyle(.segmented)
+                    .accessibilityIdentifier("warehouse-edit-unit-front-face")
                     Text("Side with stickers and aisle access.")
                         .font(.caption)
                         .foregroundStyle(.secondary)

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
@@ -56,6 +56,16 @@ struct IOSMainView: View {
     /// Filtered modules in the user's preferred order.
     private var orderedModules: [AppModule] {
         let modules = tabPrefs.orderedModules(from: filteredModules)
+        if isUITestingOpenWarehouseLocations {
+            guard let warehouseIndex = modules.firstIndex(where: { $0.id == "warehouse" }) else {
+                return modules
+            }
+            var reordered = modules
+            let warehouse = reordered.remove(at: warehouseIndex)
+            reordered.insert(warehouse, at: min(3, reordered.count))
+            return reordered
+        }
+
         guard isUITestingOpenPartsCategories else { return modules }
 
         // UI tests for Parts > Categories should validate the feature, not the
@@ -75,6 +85,13 @@ struct IOSMainView: View {
     private var isUITestingOpenPartsCategories: Bool {
         let args = ProcessInfo.processInfo.arguments
         return args.contains("-UITesting") && args.contains("-UITestingOpenPartsCategories")
+    }
+
+    /// Test-only deep link for visual QA reruns that need the warehouse floor
+    /// plan page without depending on manual tab traversal.
+    private var isUITestingOpenWarehouseLocations: Bool {
+        let args = ProcessInfo.processInfo.arguments
+        return args.contains("-UITesting") && args.contains("-UITestingWarehouseLocations")
     }
 
     /// First 4 ordered modules shown as dedicated bottom tabs.
@@ -134,6 +151,14 @@ struct IOSMainView: View {
                 selectedModuleId = "parts"
                 expandedModuleId = "parts"
                 selectedTabPath = "/parts/categories"
+            } else if isUITestingOpenWarehouseLocations {
+                selectedModuleId = "warehouse"
+                expandedModuleId = "warehouse"
+                selectedTabPath = "/warehouse/locations"
+                moduleNavigationRequests["warehouse"] = ModuleNavigationRequest(
+                    moduleId: "warehouse",
+                    tabId: "warehouse-locations"
+                )
             }
             badgeManager.refresh()
         }
@@ -700,6 +725,8 @@ struct ModuleHostView: View {
             applyNavigationRequest(navigationRequest)
             if isUITestingOpenPartsCategories, module.id == "parts" {
                 selectedTabId = "parts-categories"
+            } else if isUITestingOpenWarehouseLocations, module.id == "warehouse" {
+                selectedTabId = "warehouse-locations"
             } else if selectedTabId.isEmpty, let first = visibleTabsList.first {
                 selectedTabId = first.id
             }
@@ -715,6 +742,11 @@ struct ModuleHostView: View {
     private var isUITestingOpenPartsCategories: Bool {
         let args = ProcessInfo.processInfo.arguments
         return args.contains("-UITesting") && args.contains("-UITestingOpenPartsCategories")
+    }
+
+    private var isUITestingOpenWarehouseLocations: Bool {
+        let args = ProcessInfo.processInfo.arguments
+        return args.contains("-UITesting") && args.contains("-UITestingWarehouseLocations")
     }
 
     private var currentPath: String {

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -351,10 +351,19 @@ final class Weird_Parts_IOSUITests: XCTestCase {
             "Warehouse module should open without the manual login/PIN route"
         )
         XCTAssertTrue(
-            app.buttons["Shelf"].waitForExistence(timeout: 10) ||
+            app.buttons["Shelving"].waitForExistence(timeout: 10) ||
                 app.staticTexts["UITesting Shelf A"].waitForExistence(timeout: 10),
             "Warehouse Locations should render its floor-plan controls or seeded shelf"
         )
+        let requiredToolbarItems = [
+            "shelving", "gang_box", "pipe_rack", "pallet_rack", "wall_mount", "floor_area",
+            "cabinet", "packout", "tool_bag", "parts_bin", "crate", "custom"
+        ]
+        for unitType in requiredToolbarItems {
+            let button = app.buttons["warehouse-unit-type-\(unitType)"]
+            XCTAssertTrue(button.waitForExistence(timeout: 10), "\(unitType) toolbar item should be present")
+            XCTAssertTrue(button.isHittable, "\(unitType) toolbar item should be reachable at iPhone width")
+        }
         XCTAssertTrue(
             app.staticTexts["UITesting Shelf A"].waitForExistence(timeout: 10) ||
                 app.staticTexts["UITesting Pipe Rack"].waitForExistence(timeout: 10),

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -364,6 +364,18 @@ final class Weird_Parts_IOSUITests: XCTestCase {
             XCTAssertTrue(button.waitForExistence(timeout: 10), "\(unitType) toolbar item should be present")
             XCTAssertTrue(button.isHittable, "\(unitType) toolbar item should be reachable at iPhone width")
         }
+        let packoutToolbarButton = app.buttons["warehouse-unit-type-packout"]
+        packoutToolbarButton.tap()
+        XCTAssertTrue(
+            app.textFields.firstMatch.waitForExistence(timeout: 8),
+            "Packout Set toolbar action should open the add-unit sheet with a name field"
+        )
+        XCTAssertTrue(
+            app.buttons["East"].waitForExistence(timeout: 3) ||
+                app.buttons["West"].waitForExistence(timeout: 3),
+            "Add Packout Set sheet should expose Front Face controls"
+        )
+        app.buttons["Cancel"].tap()
         XCTAssertTrue(
             app.staticTexts["UITesting Shelf A"].waitForExistence(timeout: 10) ||
                 app.staticTexts["UITesting Pipe Rack"].waitForExistence(timeout: 10),

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -334,6 +334,35 @@ final class Weird_Parts_IOSUITests: XCTestCase {
     }
 
     @MainActor
+    func testWEI2475WarehouseLocationsDirectRouteReachesSeededFloorPlan() throws {
+        app.terminate()
+        app = XCUIApplication()
+        configureUITestingEnvironment(app)
+        app.launchArguments += [
+            "-UITesting",
+            "-UITestingWEI936AutoLogin",
+            "-UITestingWarehouseLocations"
+        ]
+        app.launch()
+
+        XCTAssertTrue(
+            app.navigationBars["Warehouse"].waitForExistence(timeout: 30) ||
+                app.staticTexts["Warehouse"].waitForExistence(timeout: 30),
+            "Warehouse module should open without the manual login/PIN route"
+        )
+        XCTAssertTrue(
+            app.buttons["Shelf"].waitForExistence(timeout: 10) ||
+                app.staticTexts["UITesting Shelf A"].waitForExistence(timeout: 10),
+            "Warehouse Locations should render its floor-plan controls or seeded shelf"
+        )
+        XCTAssertTrue(
+            app.staticTexts["UITesting Shelf A"].waitForExistence(timeout: 10) ||
+                app.staticTexts["UITesting Pipe Rack"].waitForExistence(timeout: 10),
+            "Warehouse Locations should show a seeded storage unit for visual QA"
+        )
+    }
+
+    @MainActor
     func testWEI1182WarehouseWizardBreakpointWalkingPathScreenshots() throws {
         let destinationName = ProcessInfo.processInfo.environment["RUN_DESTINATION_DEVICE_NAME"] ?? ""
         if ProcessInfo.processInfo.environment["WEI_1182_LANDSCAPE"] == "1"

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -5748,4 +5748,3 @@ private func registerMigration100POEmailRequestType(_ migrator: inout DatabaseMi
         }
     }
 }
-

--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -8,8 +8,8 @@ public final class AppDatabase: Sendable {
     public let writer: any DatabaseWriter
 
     /// The total number of registered migrations. Update when adding new migrations.
-    /// Migrations are 000-099.
-    public static let schemaVersion = 99
+    /// Migrations are 000-102.
+    public static let schemaVersion = 102
 
     /// Initialize with an existing database writer and run all migrations.
     public init(_ writer: any DatabaseWriter) throws {


### PR DESCRIPTION
## Summary\n- Split Daily Report fast actions into explicit start/end lunch, start/end break, and start/end supply-run flows.\n- Reused existing BreakService and JobsService supply-run marker contracts instead of the old generic clock-out path.\n- Added loading, disabled, and inline feedback states to quick action buttons while keeping labels readable in the horizontal action bar.\n\n## Verification\n- xcodebuild build -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO\n- swift test --filter BreakServiceTests\n\n## Notes\n- A pre-existing unrelated WarehouseLocationsPage.swift modification was left unstaged and is not part of this branch commit.\n- Native responsive screen review should cover Dashboard, Dashboard > Daily Report, Dashboard > QR Scanner, and Office Dashboard on 375pt iPhone and iPad/sidebar layouts before merge.