### PR TITLE
WEI-2494 preserve staging-box delivery state work

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSStagingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSStagingPage.swift
@@ -19,6 +19,7 @@ struct IOSStagingPage: View {
 
     @State private var stagedItems: [WarehouseService.StagedItem] = []
     @State private var stagingBoxes: [WarehouseService.StagingBox] = []
+    @State private var boxContents: [Int64: [WarehouseService.StagingBoxContent]] = [:]
     @State private var jobs: [JobsService.JobListItem] = []
     @State private var isLoading = true
     @State private var searchText = ""
@@ -434,9 +435,30 @@ struct IOSStagingPage: View {
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                 }
+                assignBoxMenu(for: item)
             }
         }
         .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func assignBoxMenu(for item: WarehouseService.StagedItem) -> some View {
+        let boxes = eligibleBoxes(for: item)
+        if !boxes.isEmpty {
+            Menu {
+                ForEach(boxes, id: \.id) { box in
+                    Button {
+                        assign(item: item, to: box)
+                    } label: {
+                        Label(box.labelText, systemImage: "shippingbox")
+                    }
+                }
+            } label: {
+                Image(systemName: "shippingbox.and.arrow.backward")
+                    .foregroundStyle(.blue)
+            }
+            .accessibilityLabel("Assign \(item.partName) to box")
+        }
     }
 
     // MARK: - Boxes Content
@@ -540,67 +562,97 @@ struct IOSStagingPage: View {
     }
 
     private func boxRow(_ box: WarehouseService.StagingBox) -> some View {
-        HStack(spacing: 12) {
-            // Status icon: checkmark for full, half-circle for open
-            ZStack {
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(box.isFull ? Color.green.opacity(0.15) : Color.orange.opacity(0.15))
-                    .frame(width: 40, height: 40)
-                Image(systemName: box.isFull ? "checkmark.circle.fill" : "circle.bottomhalf.filled")
-                    .font(.title3)
-                    .foregroundStyle(box.isFull ? .green : .orange)
-                    .accessibilityLabel(box.isFull ? "Status: Full" : "Status: Open")
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                // Label guidance — the text to write on the box
-                Text(box.labelText)
-                    .font(.system(.headline, design: .monospaced))
-                    .fontWeight(.bold)
-                    .foregroundStyle(box.isFull ? .secondary : .primary)
-
-                HStack(spacing: 8) {
-                    // Size badge
-                    boxSizeBadge(box.boxSize)
-
-                    Text(box.isFull ? "FULL" : "OPEN")
-                        .font(.caption2)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(box.isFull ? .green : .orange)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(
-                            Capsule()
-                                .fill(box.isFull ? Color.green.opacity(0.12) : Color.orange.opacity(0.12))
-                        )
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(boxStatusColor(box).opacity(0.15))
+                        .frame(width: 40, height: 40)
+                    Image(systemName: boxStatusIcon(box))
+                        .font(.title3)
+                        .foregroundStyle(boxStatusColor(box))
                 }
 
-                if let created = box.createdAt {
-                    Text("Created \(formatDate(created))")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(box.labelText)
+                        .font(.system(.headline, design: .monospaced))
+                        .fontWeight(.bold)
+                        .foregroundStyle(box.isFull ? .secondary : .primary)
+
+                    HStack(spacing: 8) {
+                        boxSizeBadge(box.boxSize)
+                        statusBadge(box.status)
+                        Text("\(box.contentCount) item\(box.contentCount == 1 ? "" : "s")")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if let created = box.createdAt {
+                        Text("Created \(formatDate(created))")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
                 }
+
+                Spacer()
+
+                Menu {
+                    Button {
+                        if box.isFull { reopenBox(boxId: box.id) } else { markFull(boxId: box.id) }
+                    } label: {
+                        Label(box.isFull ? "Reopen" : "Mark Full", systemImage: box.isFull ? "arrow.uturn.backward" : "checkmark.circle")
+                    }
+                    Button { updateBox(boxId: box.id, status: "staged") } label: {
+                        Label("Staged", systemImage: "tray.2")
+                    }
+                    Button { updateBox(boxId: box.id, status: "loaded") } label: {
+                        Label("Loaded", systemImage: "truck.box")
+                    }
+                    Button { updateBox(boxId: box.id, status: "delivered") } label: {
+                        Label("Delivered", systemImage: "checkmark.seal")
+                    }
+                    Button { updateBox(boxId: box.id, status: "returned_cancelled") } label: {
+                        Label("Returned/Cancelled", systemImage: "arrow.uturn.left")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityLabel("Box actions")
             }
 
-            Spacer()
-
-            // Quick full/open toggle
-            Button {
-                if box.isFull {
-                    reopenBox(boxId: box.id)
-                } else {
-                    markFull(boxId: box.id)
+            let contents = boxContents[box.id] ?? []
+            if !contents.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(contents, id: \.id) { content in
+                        HStack(spacing: 8) {
+                            Image(systemName: "cube.box")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(content.partName)
+                                .font(.caption)
+                                .lineLimit(1)
+                            Spacer()
+                            Text("x\(content.qty)")
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                            Button {
+                                remove(content: content, from: box)
+                            } label: {
+                                Image(systemName: "xmark.circle")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Remove \(content.partName) from box")
+                        }
+                    }
                 }
-            } label: {
-                Image(systemName: box.isFull ? "arrow.uturn.backward.circle" : "checkmark.circle")
-                    .font(.title2)
-                    .foregroundStyle(box.isFull ? .orange : .green)
+                .padding(.leading, 52)
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel(box.isFull ? "Reopen box" : "Mark box full")
         }
         .padding(.vertical, 4)
-        .opacity(box.isFull ? 0.7 : 1.0)
+        .opacity(box.status == "delivered" ? 0.7 : 1.0)
     }
 
     private func boxSizeBadge(_ size: String) -> some View {
@@ -625,6 +677,16 @@ struct IOSStagingPage: View {
                 .font(.caption2)
         }
         .foregroundStyle(color)
+    }
+
+    private func statusBadge(_ status: String) -> some View {
+        Text(statusLabel(status).uppercased())
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundStyle(statusColor(status))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(statusColor(status).opacity(0.12)))
     }
 
     // MARK: - Create Box Sheet
@@ -748,6 +810,51 @@ struct IOSStagingPage: View {
         return label.uppercased()
     }
 
+    private func eligibleBoxes(for item: WarehouseService.StagedItem) -> [WarehouseService.StagingBox] {
+        stagingBoxes.filter { box in
+            box.status == "staged" &&
+            !box.isFull &&
+            !isItem(item.id, assignedTo: box.id) &&
+            (item.destinationType != "job" || item.destinationId == nil || item.destinationId == box.jobId)
+        }
+    }
+
+    private func isItem(_ itemId: Int64, assignedTo boxId: Int64) -> Bool {
+        boxContents[boxId, default: []].contains { $0.stagingTagId == itemId }
+    }
+
+    private func statusLabel(_ status: String) -> String {
+        switch status {
+        case "loaded": return "Loaded"
+        case "delivered": return "Delivered"
+        case "returned_cancelled": return "Returned/Cancelled"
+        default: return "Staged"
+        }
+    }
+
+    private func statusColor(_ status: String) -> Color {
+        switch status {
+        case "loaded": return .blue
+        case "delivered": return .green
+        case "returned_cancelled": return .orange
+        default: return .purple
+        }
+    }
+
+    private func boxStatusColor(_ box: WarehouseService.StagingBox) -> Color {
+        box.isFull && box.status == "staged" ? .green : statusColor(box.status)
+    }
+
+    private func boxStatusIcon(_ box: WarehouseService.StagingBox) -> String {
+        if box.isFull && box.status == "staged" { return "checkmark.circle.fill" }
+        switch box.status {
+        case "loaded": return "truck.box.fill"
+        case "delivered": return "checkmark.seal.fill"
+        case "returned_cancelled": return "arrow.uturn.left.circle.fill"
+        default: return "shippingbox.fill"
+        }
+    }
+
     // MARK: - Actions
 
     private func clearItem(id: Int64) {
@@ -798,6 +905,45 @@ struct IOSStagingPage: View {
             loadData()
         } catch {
             actionError = userFriendlyError(error, context: "update staging")
+        }
+    }
+
+    private func assign(item: WarehouseService.StagedItem, to box: WarehouseService.StagingBox) {
+        guard let service = appCore.warehouseService else {
+            actionError = "Service not available"
+            return
+        }
+        do {
+            _ = try service.assignStagedItemToBox(stagingTagId: item.id, boxId: box.id)
+            loadData()
+        } catch {
+            actionError = userFriendlyError(error, context: "assign item to box")
+        }
+    }
+
+    private func remove(content: WarehouseService.StagingBoxContent, from box: WarehouseService.StagingBox) {
+        guard let service = appCore.warehouseService else {
+            actionError = "Service not available"
+            return
+        }
+        do {
+            try service.removeStagedItemFromBox(stagingTagId: content.stagingTagId, boxId: box.id)
+            loadData()
+        } catch {
+            actionError = userFriendlyError(error, context: "remove item from box")
+        }
+    }
+
+    private func updateBox(boxId: Int64, status: String) {
+        guard let service = appCore.warehouseService else {
+            actionError = "Service not available"
+            return
+        }
+        do {
+            try service.updateStagingBoxDeliveryState(boxId: boxId, status: status)
+            loadData()
+        } catch {
+            actionError = userFriendlyError(error, context: "update box state")
         }
     }
 
@@ -853,6 +999,7 @@ struct IOSStagingPage: View {
         do {
             stagedItems = try service.getStagedItems()
             stagingBoxes = try service.listStagingBoxes()
+            boxContents = Dictionary(grouping: try service.listStagingBoxContents(), by: { $0.boxId })
             if let jobsService = appCore.jobsService {
                 jobs = try jobsService.listJobs(status: "active", limit: 200)
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
@@ -13,6 +13,126 @@ private struct DraggableUnit: Codable, Transferable {
     }
 }
 
+private struct StorageUnitTypeCatalogItem: Identifiable {
+    let id: String
+    let label: String
+    let icon: String
+    let color: Color
+    let defaultGridWidth: Int
+    let defaultGridHeight: Int
+    let defaultWidthInches: Int
+    let defaultDepthInches: Int
+    let defaultHeightInches: Int
+    let defaultLevelCount: Int
+    let defaultAreasPerLevel: Int
+    let defaultMovable: Bool
+    let defaultJobReady: Bool
+    let hierarchySummary: String
+}
+
+private let storageUnitTypeCatalog: [StorageUnitTypeCatalogItem] = [
+    StorageUnitTypeCatalogItem(
+        id: "shelving", label: "Shelving", icon: "cabinet.fill", color: .blue,
+        defaultGridWidth: 2, defaultGridHeight: 1,
+        defaultWidthInches: 48, defaultDepthInches: 24, defaultHeightInches: 72,
+        defaultLevelCount: 4, defaultAreasPerLevel: 4,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "Levels + areas"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "gang_box", label: "Gang Box", icon: "shippingbox.fill", color: .green,
+        defaultGridWidth: 2, defaultGridHeight: 1,
+        defaultWidthInches: 48, defaultDepthInches: 24, defaultHeightInches: 36,
+        defaultLevelCount: 2, defaultAreasPerLevel: 3,
+        defaultMovable: true, defaultJobReady: false,
+        hierarchySummary: "Trays + boxes"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "pipe_rack", label: "Pipe Rack", icon: "lines.measurement.horizontal", color: .orange,
+        defaultGridWidth: 3, defaultGridHeight: 1,
+        defaultWidthInches: 96, defaultDepthInches: 24, defaultHeightInches: 60,
+        defaultLevelCount: 3, defaultAreasPerLevel: 3,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "Tiers + areas"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "pallet_rack", label: "Pallet Rack", icon: "square.stack.3d.up.fill", color: .purple,
+        defaultGridWidth: 3, defaultGridHeight: 2,
+        defaultWidthInches: 96, defaultDepthInches: 48, defaultHeightInches: 144,
+        defaultLevelCount: 3, defaultAreasPerLevel: 4,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "Levels + areas"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "wall_mount", label: "Wall Mount", icon: "rectangle.portrait.and.arrow.right", color: .teal,
+        defaultGridWidth: 1, defaultGridHeight: 2,
+        defaultWidthInches: 36, defaultDepthInches: 6, defaultHeightInches: 48,
+        defaultLevelCount: 2, defaultAreasPerLevel: 4,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "Sections + areas"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "floor_area", label: "Floor Area", icon: "square.dashed", color: .brown,
+        defaultGridWidth: 3, defaultGridHeight: 2,
+        defaultWidthInches: 72, defaultDepthInches: 48, defaultHeightInches: 12,
+        defaultLevelCount: 1, defaultAreasPerLevel: 4,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "Zones + areas"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "cabinet", label: "Cabinet", icon: "cabinet.fill", color: .indigo,
+        defaultGridWidth: 1, defaultGridHeight: 1,
+        defaultWidthInches: 36, defaultDepthInches: 24, defaultHeightInches: 72,
+        defaultLevelCount: 4, defaultAreasPerLevel: 2,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "Drawers + areas"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "packout", label: "Packout Set", icon: "archivebox.fill", color: .red,
+        defaultGridWidth: 1, defaultGridHeight: 1,
+        defaultWidthInches: 24, defaultDepthInches: 18, defaultHeightInches: 24,
+        defaultLevelCount: 3, defaultAreasPerLevel: 4,
+        defaultMovable: true, defaultJobReady: true,
+        hierarchySummary: "Modules + compartments"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "tool_bag", label: "Tool Bag", icon: "bag.fill", color: .mint,
+        defaultGridWidth: 1, defaultGridHeight: 1,
+        defaultWidthInches: 18, defaultDepthInches: 12, defaultHeightInches: 18,
+        defaultLevelCount: 1, defaultAreasPerLevel: 6,
+        defaultMovable: true, defaultJobReady: false,
+        hierarchySummary: "Compartments"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "parts_bin", label: "Parts Bin", icon: "tray.full.fill", color: .cyan,
+        defaultGridWidth: 1, defaultGridHeight: 1,
+        defaultWidthInches: 18, defaultDepthInches: 12, defaultHeightInches: 12,
+        defaultLevelCount: 1, defaultAreasPerLevel: 8,
+        defaultMovable: true, defaultJobReady: false,
+        hierarchySummary: "Compartments"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "crate", label: "Crate/Tote", icon: "shippingbox", color: .pink,
+        defaultGridWidth: 1, defaultGridHeight: 1,
+        defaultWidthInches: 24, defaultDepthInches: 18, defaultHeightInches: 16,
+        defaultLevelCount: 1, defaultAreasPerLevel: 1,
+        defaultMovable: true, defaultJobReady: false,
+        hierarchySummary: "Single open container"
+    ),
+    StorageUnitTypeCatalogItem(
+        id: "custom", label: "Custom", icon: "plus.square", color: .gray,
+        defaultGridWidth: 1, defaultGridHeight: 1,
+        defaultWidthInches: 48, defaultDepthInches: 24, defaultHeightInches: 72,
+        defaultLevelCount: 4, defaultAreasPerLevel: 4,
+        defaultMovable: false, defaultJobReady: false,
+        hierarchySummary: "User-selected"
+    )
+]
+
+private func storageUnitCatalogItem(for type: String) -> StorageUnitTypeCatalogItem {
+    storageUnitTypeCatalog.first { $0.id == type } ?? storageUnitTypeCatalog.last!
+}
+
 /// Warehouse Locations — floor plan grid editor + storage hierarchy drill-down.
 ///
 /// Top level: Floor plan selector + grid view of storage units and features.
@@ -181,14 +301,9 @@ struct WarehouseLocationsPage: View {
     private var unitTypeToolbar: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                unitTypeButton("Shelf", type: "shelving", icon: "cabinet.fill")
-                unitTypeButton("Pipe Rack", type: "pipe_rack", icon: "lines.measurement.horizontal")
-                unitTypeButton("Gang Box", type: "gang_box", icon: "shippingbox.fill")
-                unitTypeButton("Wall Mount", type: "wall_mount", icon: "rectangle.portrait.and.arrow.right")
-                unitTypeButton("Cabinet", type: "cabinet", icon: "cabinet.fill")
-                unitTypeButton("Pallet Rack", type: "pallet_rack", icon: "square.stack.3d.up.fill")
-                unitTypeButton("Floor Area", type: "floor_area", icon: "square.dashed")
-                unitTypeButton("Custom", type: "custom", icon: "plus.square")
+                ForEach(storageUnitTypeCatalog) { item in
+                    unitTypeButton(item)
+                }
             }
             .padding(.horizontal)
             .padding(.vertical, 6)
@@ -197,18 +312,19 @@ struct WarehouseLocationsPage: View {
     }
 
     @ViewBuilder
-    private func unitTypeButton(_ label: String, type: String, icon: String) -> some View {
-        Button { activeSheet = .addUnit(type) } label: {
+    private func unitTypeButton(_ item: StorageUnitTypeCatalogItem) -> some View {
+        Button { activeSheet = .addUnit(item.id) } label: {
             HStack(spacing: 4) {
-                Image(systemName: icon)
+                Image(systemName: item.icon)
                     .font(.caption2)
-                Text(label)
+                Text(item.label)
                     .font(.caption)
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
-            .background(Color.blue.opacity(0.1))
-            .foregroundStyle(.blue)
+            .frame(minHeight: 44)
+            .background(item.color.opacity(0.12))
+            .foregroundStyle(item.color)
             .clipShape(Capsule())
         }
     }
@@ -320,6 +436,9 @@ struct WarehouseLocationsPage: View {
         RoundedRectangle(cornerRadius: 4)
             .fill(unitColor(unit.unitType))
             .overlay(
+                frontFaceMarker(unit.frontFace, width: w - 2, height: h - 2)
+            )
+            .overlay(
                 RoundedRectangle(cornerRadius: 4)
                     .strokeBorder(.white.opacity(0.3), lineWidth: 1)
             )
@@ -356,6 +475,40 @@ struct WarehouseLocationsPage: View {
                     Label("Remove", systemImage: "trash")
                 }
             }
+    }
+
+    @ViewBuilder
+    private func frontFaceMarker(_ frontFace: String?, width: CGFloat, height: CGFloat) -> some View {
+        let face = (frontFace ?? "south").lowercased()
+        let markerColor = Color.yellow.opacity(0.95)
+        let markerThickness: CGFloat = 5
+        let markerLength = max(14, min(width, height) * 0.55)
+
+        ZStack(alignment: .topLeading) {
+            switch face {
+            case "north":
+                Rectangle()
+                    .fill(markerColor)
+                    .frame(width: markerLength, height: markerThickness)
+                    .offset(x: max(0, (width - markerLength) / 2), y: 0)
+            case "east":
+                Rectangle()
+                    .fill(markerColor)
+                    .frame(width: markerThickness, height: markerLength)
+                    .offset(x: max(0, width - markerThickness), y: max(0, (height - markerLength) / 2))
+            case "west":
+                Rectangle()
+                    .fill(markerColor)
+                    .frame(width: markerThickness, height: markerLength)
+                    .offset(x: 0, y: max(0, (height - markerLength) / 2))
+            default:
+                Rectangle()
+                    .fill(markerColor)
+                    .frame(width: markerLength, height: markerThickness)
+                    .offset(x: max(0, (width - markerLength) / 2), y: max(0, height - markerThickness))
+            }
+        }
+        .frame(width: width, height: height)
     }
 
     // MARK: - Movable Storage Section
@@ -600,48 +753,15 @@ struct WarehouseLocationsPage: View {
     // MARK: - Helpers
 
     private func unitColor(_ type: String) -> Color {
-        switch type {
-        case "shelving": .blue
-        case "pipe_rack": .orange
-        case "gang_box": .green
-        case "pallet_rack": .purple
-        case "wall_mount": .teal
-        case "cabinet": .indigo
-        case "floor_area": .brown
-        default: .gray
-        }
+        storageUnitCatalogItem(for: type).color
     }
 
     private func unitIcon(_ type: String) -> String {
-        switch type {
-        case "shelving": "cabinet.fill"
-        case "pipe_rack": "lines.measurement.horizontal"
-        case "gang_box": "shippingbox.fill"
-        case "pallet_rack": "square.stack.3d.up.fill"
-        case "wall_mount": "rectangle.portrait.and.arrow.right"
-        case "cabinet": "cabinet.fill"
-        case "floor_area": "square.dashed"
-        case "tool_bag": "bag.fill"
-        case "packout": "archivebox.fill"
-        default: "square.fill"
-        }
+        storageUnitCatalogItem(for: type).icon
     }
 
     private func unitTypeLabel(_ type: String) -> String {
-        switch type {
-        case "shelving": "Shelf"
-        case "pipe_rack": "Pipe Rack"
-        case "gang_box": "Gang Box"
-        case "pallet_rack": "Pallet Rack"
-        case "wall_mount": "Wall Mount"
-        case "cabinet": "Cabinet"
-        case "floor_area": "Floor Area"
-        case "packout": "Packout"
-        case "tool_bag": "Tool Bag"
-        case "parts_bin": "Parts Bin"
-        case "crate": "Crate"
-        default: type.replacingOccurrences(of: "_", with: " ").capitalized
-        }
+        storageUnitCatalogItem(for: type).label
     }
 
     private func featureColor(_ type: String) -> Color {
@@ -760,6 +880,25 @@ private struct AddStorageUnitSheet: View {
     @State private var error: String?
 
     private let faceOptions = ["north", "south", "east", "west"]
+    private var catalogItem: StorageUnitTypeCatalogItem {
+        storageUnitCatalogItem(for: unitType)
+    }
+
+    init(floorPlanId: Int64, unitType: String, onCreated: @escaping () -> Void) {
+        let defaults = storageUnitCatalogItem(for: unitType)
+        self.floorPlanId = floorPlanId
+        self.unitType = unitType
+        self.onCreated = onCreated
+        _widthInches = State(initialValue: defaults.defaultWidthInches)
+        _depthInches = State(initialValue: defaults.defaultDepthInches)
+        _heightInches = State(initialValue: defaults.defaultHeightInches)
+        _levelCount = State(initialValue: defaults.defaultLevelCount)
+        _areasPerLevel = State(initialValue: defaults.defaultAreasPerLevel)
+        _gridWidth = State(initialValue: defaults.defaultGridWidth)
+        _gridHeight = State(initialValue: defaults.defaultGridHeight)
+        _isMovable = State(initialValue: defaults.defaultMovable)
+        _isJobReady = State(initialValue: defaults.defaultJobReady)
+    }
 
     var body: some View {
         NavigationStack {
@@ -768,6 +907,10 @@ private struct AddStorageUnitSheet: View {
                     TextField("Name", text: $name)
                     TextField("Row (e.g. R01)", text: $rowNumber)
                     TextField("Unit (e.g. U01)", text: $unitNumber)
+                }
+
+                Section("Type") {
+                    typeSummaryRow(catalogItem)
                 }
 
                 Section("Dimensions") {
@@ -783,12 +926,21 @@ private struct AddStorageUnitSheet: View {
                     Stepper("Height: \(gridHeight) cells", value: $gridHeight, in: 1...10)
                 }
 
-                Section("Configuration") {
-                    Stepper("Levels: \(levelCount)", value: $levelCount, in: 1...20)
-                    Stepper("Areas/Level: \(areasPerLevel)", value: $areasPerLevel, in: 1...24)
+                Section {
                     Picker("Front Face", selection: $frontFace) {
                         ForEach(faceOptions, id: \.self) { Text($0.capitalized) }
                     }
+                    .pickerStyle(.segmented)
+                    Text("Side with stickers and aisle access.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    Text("Orientation")
+                }
+
+                Section("Structure") {
+                    Stepper("Levels: \(levelCount)", value: $levelCount, in: 1...20)
+                    Stepper("Areas/Level: \(areasPerLevel)", value: $areasPerLevel, in: 1...24)
                 }
 
                 Section("Options") {
@@ -801,7 +953,7 @@ private struct AddStorageUnitSheet: View {
                 }
             }
             .scrollDismissesKeyboard(.interactively)
-            .navigationTitle("Add \(unitType.replacingOccurrences(of: "_", with: " ").capitalized)")
+            .navigationTitle("Add \(catalogItem.label)")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -813,6 +965,24 @@ private struct AddStorageUnitSheet: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func typeSummaryRow(_ item: StorageUnitTypeCatalogItem) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: item.icon)
+                .foregroundStyle(item.color)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.label)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Text(item.hierarchySummary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
     }
 
     private func create() {
@@ -894,6 +1064,9 @@ private struct EditStorageUnitSheet: View {
     @State private var error: String?
 
     private let faceOptions = ["north", "south", "east", "west"]
+    private var catalogItem: StorageUnitTypeCatalogItem {
+        storageUnitCatalogItem(for: unit.unitType)
+    }
 
     init(unit: WarehouseStorageUnit, onUpdated: @escaping () -> Void) {
         self.unit = unit
@@ -917,6 +1090,10 @@ private struct EditStorageUnitSheet: View {
                     TextField("Unit (e.g. U01)", text: $unitNumber)
                 }
 
+                Section("Type") {
+                    typeSummaryRow(catalogItem)
+                }
+
                 Section("Grid Placement") {
                     Stepper("X: \(gridX)", value: $gridX, in: 0...100)
                     Stepper("Y: \(gridY)", value: $gridY, in: 0...100)
@@ -924,10 +1101,16 @@ private struct EditStorageUnitSheet: View {
                     Stepper("Height: \(gridHeight) cells", value: $gridHeight, in: 1...10)
                 }
 
-                Section("Orientation") {
+                Section {
                     Picker("Front Face", selection: $frontFace) {
                         ForEach(faceOptions, id: \.self) { Text($0.capitalized) }
                     }
+                    .pickerStyle(.segmented)
+                    Text("Side with stickers and aisle access.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    Text("Orientation")
                 }
 
                 if let error {
@@ -946,6 +1129,24 @@ private struct EditStorageUnitSheet: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func typeSummaryRow(_ item: StorageUnitTypeCatalogItem) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: item.icon)
+                .foregroundStyle(item.color)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.label)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Text(item.hierarchySummary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
     }
 
     private func save() {
@@ -990,7 +1191,7 @@ private struct StorageUnitDetailSheet: View {
         NavigationStack {
             List {
                 Section {
-                    LabeledContent("Type", value: unit.unitType.replacingOccurrences(of: "_", with: " ").capitalized)
+                    LabeledContent("Type", value: storageUnitCatalogItem(for: unit.unitType).label)
                     if let row = unit.rowNumber { LabeledContent("Row", value: row) }
                     if let un = unit.unitNumber { LabeledContent("Unit", value: un) }
                     if unit.isMovable {
@@ -1007,7 +1208,7 @@ private struct StorageUnitDetailSheet: View {
                         directionRow(
                             step: unit.rowNumber != nil ? 3 : 2,
                             icon: "cabinet.fill",
-                            text: "\(unit.name) — \(unit.unitType.replacingOccurrences(of: "_", with: " ").capitalized)"
+                            text: "\(unit.name) — \(storageUnitCatalogItem(for: unit.unitType).label)"
                         )
                         if let x = unit.gridX, let y = unit.gridY {
                             directionRow(

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -136,6 +136,7 @@ extension AppDatabase {
         registerMigration097PartImportAuditSessions(&migrator)
         registerMigration098JobReturnIntakeHolding(&migrator)
         registerMigration099ReceivingItemRoutingDisposition(&migrator)
+        registerMigration100StagingBoxContentsAndDeliveryState(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -5658,6 +5659,40 @@ extension AppDatabase {
             try db.create(index: "idx_receiving_items_routing_disposition",
                           on: "receiving_session_items",
                           columns: ["session_id", "routing_disposition"])
+        }
+    }
+
+    private static func registerMigration100StagingBoxContentsAndDeliveryState(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("100_staging_box_contents_delivery_state") { db in
+            try addColumnIfMissing(db, table: "staging_boxes", column: "status", type: .text, defaultValue: "staged")
+            try addColumnIfMissing(db, table: "staging_boxes", column: "loaded_at", type: .text)
+            try addColumnIfMissing(db, table: "staging_boxes", column: "delivered_at", type: .text)
+            try addColumnIfMissing(db, table: "staging_boxes", column: "returned_cancelled_at", type: .text)
+            try db.execute(sql: "UPDATE staging_boxes SET status = 'staged' WHERE status IS NULL OR status = ''")
+
+            try db.create(table: "staging_box_contents", ifNotExists: true) { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("box_id", .integer).notNull()
+                    .references("staging_boxes", onDelete: .cascade)
+                t.column("staging_tag_id", .integer).notNull()
+                    .references("pulled_staging_tags", onDelete: .cascade)
+                t.column("status", .text).notNull()
+                    .defaults(to: "staged")
+                t.column("assigned_at", .text).notNull()
+                    .defaults(sql: "(datetime('now'))")
+                t.column("removed_at", .text)
+                t.column("loaded_at", .text)
+                t.column("delivered_at", .text)
+                t.column("returned_cancelled_at", .text)
+                t.column("deleted_at", .text)
+            }
+
+            try db.create(index: "idx_staging_box_contents_box",
+                          on: "staging_box_contents",
+                          columns: ["box_id"])
+            try db.create(index: "idx_staging_box_contents_tag",
+                          on: "staging_box_contents",
+                          columns: ["staging_tag_id"])
         }
     }
 }

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -38,6 +38,8 @@ public final class WarehouseService: Sendable {
         case sessionItemNotFound(Int64)
         case jobReturnIntakeNotFound(Int64)
         case jobReturnItemNotFound(Int64)
+        case stagingBoxNotFound(Int64)
+        case stagingTagNotFound(Int64)
     }
 
     // =========================================================================
@@ -2574,8 +2576,32 @@ public final class WarehouseService: Sendable {
         public let boxSize: String         // small / normal / large
         public let labelText: String       // e.g. "SMITH RES 0412-01"
         public let isFull: Bool
+        public let status: String          // staged / loaded / delivered / returned_cancelled
         public let areaId: Int64?
         public let createdAt: String?
+        public let loadedAt: String?
+        public let deliveredAt: String?
+        public let returnedCancelledAt: String?
+        public let contentCount: Int
+    }
+
+    /// A staged item assigned to a physical box. Rows are retained across
+    /// delivery transitions so loaded/delivered boxes still show historical
+    /// contents even after the active staging tags are resolved.
+    public struct StagingBoxContent: Sendable, Identifiable {
+        public let id: Int64
+        public let boxId: Int64
+        public let stagingTagId: Int64
+        public let status: String
+        public let assignedAt: String?
+        public let removedAt: String?
+        public let partId: Int64
+        public let partName: String
+        public let partCode: String?
+        public let qty: Int
+        public let destinationType: String?
+        public let destinationId: Int64?
+        public let destinationLabel: String?
     }
 
     /// Create a new staging box for a job, auto-generating box_number and label_text.
@@ -2643,8 +2669,13 @@ public final class WarehouseService: Sendable {
                 boxSize: size,
                 labelText: labelText,
                 isFull: false,
+                status: "staged",
                 areaId: areaId,
-                createdAt: nil
+                createdAt: nil,
+                loadedAt: nil,
+                deliveredAt: nil,
+                returnedCancelledAt: nil,
+                contentCount: 0
             )
         }
     }
@@ -2663,7 +2694,12 @@ public final class WarehouseService: Sendable {
 
                 let sql = """
                     SELECT sb.*,
-                           j.job_name, j.job_number
+                           j.job_name, j.job_number,
+                           (
+                               SELECT COUNT(*)
+                               FROM staging_box_contents sbc
+                               WHERE sbc.box_id = sb.id AND sbc.deleted_at IS NULL
+                           ) AS content_count
                     FROM staging_boxes sb
                     LEFT JOIN jobs j ON j.id = sb.job_id AND j.deleted_at IS NULL
                     WHERE \(whereClauses.joined(separator: " AND "))
@@ -2681,8 +2717,13 @@ public final class WarehouseService: Sendable {
                         boxSize: row["box_size"] ?? "normal",
                         labelText: row["label_text"] ?? "",
                         isFull: (row["is_full"] as Int?) == 1,
+                        status: row["status"] ?? "staged",
                         areaId: row["area_id"] as Int64?,
-                        createdAt: row["created_at"] as String?
+                        createdAt: row["created_at"] as String?,
+                        loadedAt: row["loaded_at"] as String?,
+                        deliveredAt: row["delivered_at"] as String?,
+                        returnedCancelledAt: row["returned_cancelled_at"] as String?,
+                        contentCount: row["content_count"] ?? 0
                     )
                 }
             }
@@ -2763,9 +2804,190 @@ public final class WarehouseService: Sendable {
                 boxSize: size,
                 labelText: labelText,
                 isFull: false,
+                status: "staged",
                 areaId: areaId,
-                createdAt: nil
+                createdAt: nil,
+                loadedAt: nil,
+                deliveredAt: nil,
+                returnedCancelledAt: nil,
+                contentCount: 0
             )
+        }
+    }
+
+    @discardableResult
+    public func assignStagedItemToBox(stagingTagId: Int64, boxId: Int64) throws -> Int64 {
+        try db.writer.write { dbConn in
+            guard try stagingBoxExists(boxId, dbConn: dbConn) else {
+                throw WarehouseError.stagingBoxNotFound(boxId)
+            }
+            guard try activeStagingTagExists(stagingTagId, dbConn: dbConn) else {
+                throw WarehouseError.stagingTagNotFound(stagingTagId)
+            }
+
+            if let existingId = try Int64.fetchOne(
+                dbConn,
+                sql: "SELECT id FROM staging_box_contents WHERE staging_tag_id = ? LIMIT 1",
+                arguments: [stagingTagId]
+            ) {
+                try dbConn.execute(
+                    sql: """
+                        UPDATE staging_box_contents
+                        SET box_id = ?, status = 'staged', removed_at = NULL, deleted_at = NULL,
+                            loaded_at = NULL, delivered_at = NULL, returned_cancelled_at = NULL
+                        WHERE id = ?
+                        """,
+                    arguments: [boxId, existingId]
+                )
+                return existingId
+            }
+
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO staging_box_contents (box_id, staging_tag_id, status, assigned_at)
+                    VALUES (?, ?, 'staged', datetime('now'))
+                    """,
+                arguments: [boxId, stagingTagId]
+            )
+            return dbConn.lastInsertedRowID
+        }
+    }
+
+    public func removeStagedItemFromBox(stagingTagId: Int64, boxId: Int64) throws {
+        try db.writer.write { dbConn in
+            try dbConn.execute(
+                sql: """
+                    UPDATE staging_box_contents
+                    SET deleted_at = datetime('now'), removed_at = datetime('now')
+                    WHERE box_id = ? AND staging_tag_id = ? AND deleted_at IS NULL
+                    """,
+                arguments: [boxId, stagingTagId]
+            )
+        }
+    }
+
+    public func listStagingBoxContents(boxId: Int64? = nil) throws -> [StagingBoxContent] {
+        do {
+            return try db.writer.read { dbConn -> [StagingBoxContent] in
+                var whereClauses = ["sbc.deleted_at IS NULL"]
+                var args: [DatabaseValueConvertible?] = []
+                if let boxId {
+                    whereClauses.append("sbc.box_id = ?")
+                    args.append(boxId)
+                }
+
+                let rows = try Row.fetchAll(
+                    dbConn,
+                    sql: """
+                        SELECT sbc.id, sbc.box_id, sbc.staging_tag_id, sbc.status,
+                               sbc.assigned_at, sbc.removed_at,
+                               s.part_id, s.qty,
+                               p.name AS part_name, p.code AS part_code,
+                               pst.destination_type, pst.destination_id, pst.destination_label
+                        FROM staging_box_contents sbc
+                        JOIN pulled_staging_tags pst ON pst.id = sbc.staging_tag_id
+                        JOIN stock s ON s.id = pst.stock_id
+                        LEFT JOIN parts p ON p.id = s.part_id AND p.deleted_at IS NULL
+                        WHERE \(whereClauses.joined(separator: " AND "))
+                        ORDER BY sbc.assigned_at, sbc.id
+                        """,
+                    arguments: StatementArguments(args)
+                )
+
+                return rows.map { row in
+                    StagingBoxContent(
+                        id: row["id"] ?? 0,
+                        boxId: row["box_id"] ?? 0,
+                        stagingTagId: row["staging_tag_id"] ?? 0,
+                        status: row["status"] ?? "staged",
+                        assignedAt: row["assigned_at"] as String?,
+                        removedAt: row["removed_at"] as String?,
+                        partId: row["part_id"] ?? 0,
+                        partName: row["part_name"] ?? "Unknown Part",
+                        partCode: row["part_code"] as String?,
+                        qty: row["qty"] ?? 0,
+                        destinationType: row["destination_type"] as String?,
+                        destinationId: row["destination_id"] as Int64?,
+                        destinationLabel: row["destination_label"] as String?
+                    )
+                }
+            }
+        } catch {
+            if isTableNotFoundError(error) { return [] }
+            throw error
+        }
+    }
+
+    public func updateStagingBoxDeliveryState(boxId: Int64, status: String) throws {
+        let normalized = status.replacingOccurrences(of: "-", with: "_").lowercased()
+        guard ["staged", "loaded", "delivered", "returned_cancelled"].contains(normalized) else {
+            throw WarehouseError.requiredFieldEmpty
+        }
+
+        try db.writer.write { dbConn in
+            guard try stagingBoxExists(boxId, dbConn: dbConn) else {
+                throw WarehouseError.stagingBoxNotFound(boxId)
+            }
+
+            let timestampColumn: String?
+            switch normalized {
+            case "loaded": timestampColumn = "loaded_at"
+            case "delivered": timestampColumn = "delivered_at"
+            case "returned_cancelled": timestampColumn = "returned_cancelled_at"
+            default: timestampColumn = nil
+            }
+
+            if let timestampColumn {
+                try dbConn.execute(
+                    sql: "UPDATE staging_boxes SET status = ?, \(timestampColumn) = COALESCE(\(timestampColumn), datetime('now')) WHERE id = ? AND deleted_at IS NULL",
+                    arguments: [normalized, boxId]
+                )
+            } else {
+                try dbConn.execute(
+                    sql: "UPDATE staging_boxes SET status = ? WHERE id = ? AND deleted_at IS NULL",
+                    arguments: [normalized, boxId]
+                )
+            }
+
+            try dbConn.execute(
+                sql: """
+                    UPDATE staging_box_contents
+                    SET status = ?,
+                        loaded_at = CASE WHEN ? = 'loaded' THEN COALESCE(loaded_at, datetime('now')) ELSE loaded_at END,
+                        delivered_at = CASE WHEN ? = 'delivered' THEN COALESCE(delivered_at, datetime('now')) ELSE delivered_at END,
+                        returned_cancelled_at = CASE WHEN ? = 'returned_cancelled' THEN COALESCE(returned_cancelled_at, datetime('now')) ELSE returned_cancelled_at END
+                    WHERE box_id = ? AND deleted_at IS NULL
+                    """,
+                arguments: [normalized, normalized, normalized, normalized, boxId]
+            )
+
+            if normalized == "loaded" || normalized == "delivered" {
+                try dbConn.execute(
+                    sql: """
+                        UPDATE pulled_staging_tags
+                        SET deleted_at = COALESCE(deleted_at, datetime('now'))
+                        WHERE id IN (
+                            SELECT staging_tag_id
+                            FROM staging_box_contents
+                            WHERE box_id = ? AND deleted_at IS NULL
+                        )
+                        """,
+                    arguments: [boxId]
+                )
+            } else if normalized == "staged" || normalized == "returned_cancelled" {
+                try dbConn.execute(
+                    sql: """
+                        UPDATE pulled_staging_tags
+                        SET deleted_at = NULL
+                        WHERE id IN (
+                            SELECT staging_tag_id
+                            FROM staging_box_contents
+                            WHERE box_id = ? AND deleted_at IS NULL
+                        )
+                        """,
+                    arguments: [boxId]
+                )
+            }
         }
     }
 
@@ -2779,11 +3001,35 @@ public final class WarehouseService: Sendable {
         }
     }
 
+    private func stagingBoxExists(_ boxId: Int64, dbConn: Database) throws -> Bool {
+        (try Int.fetchOne(
+            dbConn,
+            sql: "SELECT COUNT(*) FROM staging_boxes WHERE id = ? AND deleted_at IS NULL",
+            arguments: [boxId]
+        ) ?? 0) > 0
+    }
+
+    private func activeStagingTagExists(_ stagingTagId: Int64, dbConn: Database) throws -> Bool {
+        (try Int.fetchOne(
+            dbConn,
+            sql: "SELECT COUNT(*) FROM pulled_staging_tags WHERE id = ? AND deleted_at IS NULL",
+            arguments: [stagingTagId]
+        ) ?? 0) > 0
+    }
+
     /// Soft-delete a staging box.
     public func deleteStagingBox(boxId: Int64) throws {
         try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: "UPDATE staging_boxes SET deleted_at = datetime('now') WHERE id = ?",
+                arguments: [boxId]
+            )
+            try dbConn.execute(
+                sql: """
+                    UPDATE staging_box_contents
+                    SET deleted_at = datetime('now'), removed_at = COALESCE(removed_at, datetime('now'))
+                    WHERE box_id = ? AND deleted_at IS NULL
+                    """,
                 arguments: [boxId]
             )
         }

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -1448,6 +1448,82 @@ struct WarehouseServiceExtTests {
         #expect(nextBox.jobId == jobId)
     }
 
+    @Test("staging boxes assign and remove staged items without clearing the tag")
+    func testStagingBoxContentsAssignAndRemove() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-BOX-01", name: "Box Job")
+        let tagId = try seedStagingTag(env, jobId: jobId, partName: "Boxed EMT")
+        let box = try env.warehouse.createStagingBox(jobId: jobId, size: "normal")
+
+        let contentId = try env.warehouse.assignStagedItemToBox(stagingTagId: tagId, boxId: box.id)
+        #expect(contentId > 0)
+
+        let contents = try env.warehouse.listStagingBoxContents(boxId: box.id)
+        #expect(contents.count == 1)
+        #expect(contents.first?.stagingTagId == tagId)
+        #expect(contents.first?.partName == "Boxed EMT")
+        #expect(try env.warehouse.getStagedItems().contains { $0.id == tagId })
+
+        try env.warehouse.removeStagedItemFromBox(stagingTagId: tagId, boxId: box.id)
+        #expect(try env.warehouse.listStagingBoxContents(boxId: box.id).isEmpty)
+        #expect(try env.warehouse.getStagedItems().contains { $0.id == tagId })
+    }
+
+    @Test("loaded and delivered boxes resolve staged items while preserving content history")
+    func testStagingBoxDeliveryTransitionsResolveStagedItems() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-BOX-02", name: "Delivery Job")
+        let tagId = try seedStagingTag(env, jobId: jobId, partName: "Delivery Wire")
+        let box = try env.warehouse.createStagingBox(jobId: jobId, size: "large")
+        _ = try env.warehouse.assignStagedItemToBox(stagingTagId: tagId, boxId: box.id)
+
+        try env.warehouse.updateStagingBoxDeliveryState(boxId: box.id, status: "loaded")
+        #expect(!(try env.warehouse.getStagedItems()).contains { $0.id == tagId })
+        #expect(try env.warehouse.listStagingBoxContents(boxId: box.id).first?.status == "loaded")
+
+        try env.warehouse.updateStagingBoxDeliveryState(boxId: box.id, status: "delivered")
+        let deliveredBox = try env.warehouse.listStagingBoxes(jobId: jobId).first
+        #expect(deliveredBox?.status == "delivered")
+        #expect(deliveredBox?.contentCount == 1)
+        #expect(try env.warehouse.listStagingBoxContents(boxId: box.id).first?.status == "delivered")
+        #expect(!(try env.warehouse.getStagedItems()).contains { $0.id == tagId })
+    }
+
+    @Test("returned-cancelled box restores staged items for resolution")
+    func testReturnedCancelledBoxRestoresStagedItems() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-BOX-03", name: "Return Job")
+        let tagId = try seedStagingTag(env, jobId: jobId, partName: "Return Conduit")
+        let box = try env.warehouse.createStagingBox(jobId: jobId, size: "small")
+        _ = try env.warehouse.assignStagedItemToBox(stagingTagId: tagId, boxId: box.id)
+
+        try env.warehouse.updateStagingBoxDeliveryState(boxId: box.id, status: "loaded")
+        #expect(!(try env.warehouse.getStagedItems()).contains { $0.id == tagId })
+
+        try env.warehouse.updateStagingBoxDeliveryState(boxId: box.id, status: "returned_cancelled")
+        #expect(try env.warehouse.getStagedItems().contains { $0.id == tagId })
+        #expect(try env.warehouse.listStagingBoxContents(boxId: box.id).first?.status == "returned_cancelled")
+    }
+
+    @Test("staging box delivery migration exposes status columns and contents table")
+    func testStagingBoxDeliveryMigrationShape() throws {
+        let env = try E2ETestHelpers.setUp()
+        let columns = try env.db.writer.read { db in
+            try db.columns(in: "staging_boxes").map(\.name)
+        }
+        #expect(columns.contains("status"))
+        #expect(columns.contains("loaded_at"))
+        #expect(columns.contains("delivered_at"))
+        #expect(columns.contains("returned_cancelled_at"))
+
+        let contentColumns = try env.db.writer.read { db in
+            try db.columns(in: "staging_box_contents").map(\.name)
+        }
+        #expect(contentColumns.contains("box_id"))
+        #expect(contentColumns.contains("staging_tag_id"))
+        #expect(contentColumns.contains("status"))
+    }
+
     // MARK: - Quantity validation guards (iter 72)
 
     @Test("updateSessionItem throws invalidQuantity for negative receivedQty")
@@ -1456,6 +1532,23 @@ struct WarehouseServiceExtTests {
         #expect(throws: WarehouseService.WarehouseError.invalidQuantity) {
             try env.warehouse.updateSessionItem(itemId: 1, receivedQty: -1)
         }
+    }
+
+    private func seedStagingTag(_ env: E2ETestHelpers.TestEnvironment, jobId: Int64, partName: String) throws -> Int64 {
+        let catId = try E2ETestHelpers.seedCategory(env, name: "Box Test \(UUID().uuidString.prefix(6))")
+        let partId = try E2ETestHelpers.seedPart(env, name: partName, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 4)
+        guard let stockId = try env.parts.getPartStock(partId: partId).first?["id"] as Int64? else {
+            Issue.record("No stock row found for staging box test")
+            throw WarehouseService.WarehouseError.partNotFound(partId)
+        }
+        return try env.warehouse.createStagingTag(
+            stockId: stockId,
+            destinationType: "job",
+            destinationId: jobId,
+            destinationLabel: "Job \(jobId)",
+            taggedBy: env.adminUserId
+        )
     }
 
     @Test("recordScan throws invalidQuantity for zero qty")


### PR DESCRIPTION
## Summary
- Preserves the dirty warehouse staging-box delivery-state work found on the unrelated dashboard PR checkout.
- Adds staging box contents, delivery-state timestamps/statuses, assignment/removal service APIs, and UI controls for box assignment/state transitions.
- Includes warehouse service coverage for assignment, delivered/returned-cancelled transitions, and migration shape.

## Routing
- Linked GitHub issue: #869
- Based on `WEI-2466-job-return-sorting-ui` so review shows only the staging-box delta and keeps the dashboard PR dirty checkout cleanup separate.

## Verification
- `git diff --check`
- `swift test --filter WarehouseServiceExtTests` built successfully, then the Swift test runner produced no test output and was terminated after hanging post-build.