### PR TITLE
Respect auto sync opt-in on app launch

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -251,7 +251,7 @@ final class AppCore: ObservableObject {
                 syncManager.setupAppLifecycleSync()
 
                 // Auto-sync on launch if configured
-                if syncManager.isSyncAvailable {
+                if syncManager.isSyncAvailable && syncManager.isAutoSyncEnabled {
                     Task { [syncManager] in
                         await syncManager.syncNow()
                         syncManager.startPeerDiscovery()

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -60,6 +60,11 @@ final class IOSSyncManager {
         return hasServer || btEnabled
     }
 
+    /// Whether automatic launch/foreground sync is enabled by settings.
+    var isAutoSyncEnabled: Bool {
+        (try? settingsService?.isAutoSyncEnabled()) ?? true
+    }
+
     /// The configured shop server address from settings, or nil.
     private var serverAddress: String? {
         guard let service = settingsService else { return nil }
@@ -494,7 +499,7 @@ final class IOSSyncManager {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
-                guard let self, self.isSyncAvailable else { return }
+                guard let self, self.isSyncAvailable, self.isAutoSyncEnabled else { return }
                 await self.syncNow()
             }
         }

--- a/core/Sources/WiredPartCore/Services/SettingsService.swift
+++ b/core/Sources/WiredPartCore/Services/SettingsService.swift
@@ -152,6 +152,15 @@ public final class SettingsService: Sendable {
         }
     }
 
+    /// Whether automatic background/launch sync is enabled.
+    ///
+    /// Missing settings default to enabled so existing configured sync installs
+    /// keep their prior behavior; only an explicit "false" opts out.
+    public func isAutoSyncEnabled() throws -> Bool {
+        let value = try getSettingsByCategory("sync")["auto_sync"]
+        return value != "false"
+    }
+
     /// Bulk upsert a dictionary of key->value pairs under one category.
     ///
     /// This must be a single database write transaction so a mid-map failure cannot

--- a/core/Tests/WiredPartCoreTests/SettingsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SettingsServiceTests.swift
@@ -117,6 +117,34 @@ struct SettingsServiceTests {
         #expect(!syncable.contains { $0.key == "last_backup_time" })
     }
 
+    @Test("isAutoSyncEnabled defaults to true")
+    func testAutoSyncDefaultsEnabled() throws {
+        let db = try freshDB()
+        let svc = SettingsService(db: db)
+
+        #expect(try svc.isAutoSyncEnabled() == true)
+    }
+
+    @Test("isAutoSyncEnabled respects explicit false")
+    func testAutoSyncExplicitFalse() throws {
+        let db = try freshDB()
+        let svc = SettingsService(db: db)
+
+        try svc.upsertSetting(key: "auto_sync", value: "false", category: "sync")
+
+        #expect(try svc.isAutoSyncEnabled() == false)
+    }
+
+    @Test("isAutoSyncEnabled treats explicit true as enabled")
+    func testAutoSyncExplicitTrue() throws {
+        let db = try freshDB()
+        let svc = SettingsService(db: db)
+
+        try svc.upsertSetting(key: "auto_sync", value: "true", category: "sync")
+
+        #expect(try svc.isAutoSyncEnabled() == true)
+    }
+
     // MARK: - Theme
 
     @Test("getTheme returns defaults when no settings exist")


### PR DESCRIPTION
## Summary
- Gate iOS launch sync, peer discovery, and foreground auto-sync on the persisted sync auto_sync setting
- Add a SettingsService helper for the auto-sync opt-in with regression coverage
- Keep manual Sync Now and explicit peer discovery paths unchanged

## Verification
- swift test --filter SettingsServiceTests
- xcodebuild -workspace 'Wierd Parts.xcworkspace' -scheme 'WiredPart-iOS' -destination 'generic/platform=iOS Simulator' -quiet build CODE_SIGNING_ALLOWED=NO (passed in the issue workspace; clean temp worktree retry was interrupted twice after compiling touched files, no compiler error emitted)

GitHub sync: tracker #372 synced before work; branch pushed to GitHub.