### PR TITLE
WEI-1136: Notebook edit locks and AI merge fallback

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -15,6 +15,7 @@ struct IOSNotebookDetailPage: View {
     @State private var loadError: String?
     @State private var actionError: String?
     @State private var activeSheet: ActiveSheet?
+    @State private var activeEditLockEntryId: Int64?
     @State private var expandedGroups: Set<Int64> = []
     @State private var expandedSections: Set<Int64> = []
     @State private var isWarrantyJob = false
@@ -141,7 +142,12 @@ struct IOSNotebookDetailPage: View {
                 .accessibilityLabel("Help")
             }
         }
-        .sheet(item: $activeSheet) { sheet in
+        .sheet(item: $activeSheet, onDismiss: {
+            if let entryId = activeEditLockEntryId {
+                releaseEditLock(entryId: entryId)
+                activeEditLockEntryId = nil
+            }
+        }) { sheet in
             sheetContent(for: sheet)
                 .environmentObject(appCore)
         }
@@ -1209,6 +1215,7 @@ struct IOSNotebookDetailPage: View {
                 editingEntry: entry,
                 onSave: {
                     releaseEditLock(entryId: entry.id)
+                    activeEditLockEntryId = nil
                     loadData()
                 }
             )
@@ -1610,10 +1617,12 @@ struct IOSNotebookDetailPage: View {
         }
         do {
             _ = try service.acquireBlockEditLock(entryId: entry.id, userId: userId)
+            activeEditLockEntryId = entry.id
             activeSheet = .editEntry(entry)
             activeEditLocks = (try? service.activeBlockEditLocks(notebookId: notebookId)) ?? activeEditLocks
         } catch {
             actionError = userFriendlyError(error, context: "start editing")
+            activeEditLockEntryId = entry.id
             activeSheet = .editEntry(entry)
         }
     }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -21,6 +21,7 @@ struct IOSNotebookDetailPage: View {
     @State private var todosNeedingReview: [NotebooksService.NotebookEntryRow] = []
     @State private var panelSchedule = PanelSchedule()
     @State private var blockConflicts: [NotebookBlockConflict] = []
+    @State private var activeEditLocks: [NotebookEntryEditLock] = []
     @State private var pendingDelete: PendingDelete?
     @State private var selectedPageId: Int64?
     @State private var compactPageId: Int64?
@@ -1027,8 +1028,16 @@ struct IOSNotebookDetailPage: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
+            if let lock = activeLock(for: entry.id) {
+                Label(lock.userName, systemImage: "person.crop.circle.badge.clock")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .labelStyle(.iconOnly)
+                    .accessibilityLabel("\(lock.userName) is editing this block")
+            }
+
             Button {
-                activeSheet = .editEntry(entry)
+                beginEditing(entry)
             } label: {
                 Image(systemName: "pencil.circle")
                     .imageScale(.large)
@@ -1039,7 +1048,7 @@ struct IOSNotebookDetailPage: View {
         }
         .contextMenu {
             Button {
-                activeSheet = .editEntry(entry)
+                beginEditing(entry)
             } label: {
                 Label("Edit", systemImage: "pencil")
             }
@@ -1198,7 +1207,10 @@ struct IOSNotebookDetailPage: View {
                 notebookId: notebookId,
                 sectionId: nil,
                 editingEntry: entry,
-                onSave: { loadData() }
+                onSave: {
+                    releaseEditLock(entryId: entry.id)
+                    loadData()
+                }
             )
 
         case .addSection(let groupId):
@@ -1241,6 +1253,9 @@ struct IOSNotebookDetailPage: View {
                 conflicts: blockConflicts,
                 onResolve: { conflictLogId, keepVersion in
                     resolveConflict(conflictLogId: conflictLogId, keepVersion: keepVersion)
+                },
+                onAIMerge: { conflictLogId in
+                    mergeConflictWithAI(conflictLogId: conflictLogId)
                 },
                 onResolveAll: { keepVersion in
                     resolveAllConflicts(keepVersion: keepVersion)
@@ -1353,6 +1368,7 @@ struct IOSNotebookDetailPage: View {
             }
             // Check for sync conflicts on this notebook's entries (62J)
             blockConflicts = (try? service.detectBlockConflicts(notebookId: notebookId)) ?? []
+            activeEditLocks = (try? service.activeBlockEditLocks(notebookId: notebookId)) ?? []
 
             // Load panel schedule from first panel_schedule block entry
             loadPanelScheduleFromEntries(service: service)
@@ -1579,6 +1595,35 @@ struct IOSNotebookDetailPage: View {
         }
     }
 
+    private func activeLock(for entryId: Int64) -> NotebookEntryEditLock? {
+        activeEditLocks.first { $0.entryId == entryId }
+    }
+
+    private func beginEditing(_ entry: NotebooksService.NotebookEntryRow) {
+        guard let service = appCore.notebooksService else {
+            actionError = "Notebooks service unavailable"
+            return
+        }
+        guard let userId = appCore.currentUser?.id else {
+            actionError = "Not logged in. Please log in and try again."
+            return
+        }
+        do {
+            _ = try service.acquireBlockEditLock(entryId: entry.id, userId: userId)
+            activeSheet = .editEntry(entry)
+            activeEditLocks = (try? service.activeBlockEditLocks(notebookId: notebookId)) ?? activeEditLocks
+        } catch {
+            actionError = userFriendlyError(error, context: "start editing")
+            activeSheet = .editEntry(entry)
+        }
+    }
+
+    private func releaseEditLock(entryId: Int64) {
+        guard let service = appCore.notebooksService,
+              let userId = appCore.currentUser?.id else { return }
+        try? service.releaseBlockEditLock(entryId: entryId, userId: userId)
+    }
+
     // MARK: - Conflict Resolution (62J)
 
     private func resolveConflict(conflictLogId: Int64, keepVersion: String) {
@@ -1607,6 +1652,24 @@ struct IOSNotebookDetailPage: View {
             actionError = userFriendlyError(error, context: "complete action")
         }
     }
+
+    private func mergeConflictWithAI(conflictLogId: Int64) {
+        guard let service = appCore.notebooksService else {
+            actionError = "Notebooks service unavailable"
+            return
+        }
+        Task {
+            do {
+                let merged = try await service.resolveBlockConflictWithFoundationModels(conflictLogId: conflictLogId)
+                if !merged {
+                    actionError = "AI merge unavailable. Both versions were preserved for manual resolution."
+                }
+                loadData()
+            } catch {
+                actionError = userFriendlyError(error, context: "merge conflict")
+            }
+        }
+    }
 }
 
 // MARK: - NotebookConflictResolutionSheet (62J)
@@ -1617,6 +1680,7 @@ private struct NotebookConflictResolutionSheet: View {
     @Environment(\.dismiss) private var dismiss
     let conflicts: [NotebookBlockConflict]
     let onResolve: (Int64, String) -> Void      // (conflictLogId, "local" | "remote")
+    let onAIMerge: (Int64) -> Void
     let onResolveAll: (String) -> Void           // "local" | "remote"
 
     var body: some View {
@@ -1740,7 +1804,7 @@ private struct NotebookConflictResolutionSheet: View {
                         }
 
                         // Resolution buttons
-                        HStack(spacing: 12) {
+                        HStack(spacing: 8) {
                             Button {
                                 onResolve(conflict.conflictLogId, "local")
                             } label: {
@@ -1753,6 +1817,19 @@ private struct NotebookConflictResolutionSheet: View {
                             .buttonStyle(.borderedProminent)
                             .tint(.blue)
                             .controlSize(.small)
+
+                            Button {
+                                onAIMerge(conflict.conflictLogId)
+                            } label: {
+                                HStack {
+                                    Image(systemName: "sparkles")
+                                    Text("AI Merge")
+                                }
+                                .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .disabled(!["title", "content", "block_data", "checklist_items"].contains(conflict.fieldName))
 
                             Button {
                                 onResolve(conflict.conflictLogId, "remote")

--- a/core/Sources/WiredPartCore/AI/FoundationModelsService.swift
+++ b/core/Sources/WiredPartCore/AI/FoundationModelsService.swift
@@ -257,6 +257,41 @@ public actor FoundationModelsService {
         return await generate(instructions: instructions, prompt: text)
     }
 
+    // MARK: - Conflict Merge
+
+    /// Attempt to merge two text-compatible conflict versions.
+    public func mergeTextConflict(
+        localText: String,
+        remoteText: String,
+        context: String? = nil
+    ) async -> AIResult {
+        guard !localText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+              !remoteText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .fail("No text to merge")
+        }
+
+        var instructions = domainInstructions + "\n\n"
+        instructions += """
+            Merge two conflicting notebook block versions into one clear version. \
+            Preserve all distinct factual details from both versions. \
+            Do not invent details. If details disagree, include both in a concise \
+            way that signals the discrepancy for manual review. \
+            Only output the merged notebook text.
+            """
+        if let context, !context.isEmpty {
+            instructions += "\nContext: \(context)"
+        }
+
+        let prompt = """
+            Local version:
+            \(localText)
+
+            Remote version:
+            \(remoteText)
+            """
+        return await generate(instructions: instructions, prompt: prompt)
+    }
+
     // MARK: - Pre-Fill Generation
 
     /// Generate draft content for an empty field based on context.

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -134,6 +134,7 @@ extension AppDatabase {
         registerMigration095JobStageTemplates(&migrator)
         registerMigration096SubcontractorScheduleSoftDeleteUniqueness(&migrator)
         registerMigration097PartImportAuditSessions(&migrator)
+        registerMigration098NotebookEntryEditLocks(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -5598,7 +5599,27 @@ extension AppDatabase {
                 CREATE UNIQUE INDEX IF NOT EXISTS idx_subcontractor_schedules_active_slot
                 ON subcontractor_schedules(job_id, gc_id, scheduled_date)
                 WHERE deleted_at IS NULL
-                """)
+            """)
+        }
+    }
+
+    // MARK: - Migration 098: Notebook entry edit locks
+
+    private static func registerMigration098NotebookEntryEditLocks(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("098_notebook_entry_edit_locks") { db in
+            try db.create(table: "notebook_entry_edit_locks", ifNotExists: true) { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("entry_id", .integer).notNull()
+                    .references("notebook_entries", onDelete: .cascade)
+                t.column("user_id", .integer).notNull()
+                    .references("users", onDelete: .cascade)
+                t.column("device_id", .text).notNull()
+                t.column("locked_at", .text).notNull()
+                t.column("expires_at", .text).notNull()
+            }
+            try db.create(index: "idx_notebook_entry_edit_locks_entry", on: "notebook_entry_edit_locks", columns: ["entry_id"], ifNotExists: true)
+            try db.create(index: "idx_notebook_entry_edit_locks_expiry", on: "notebook_entry_edit_locks", columns: ["expires_at"], ifNotExists: true)
+            try db.create(index: "idx_notebook_entry_edit_locks_owner", on: "notebook_entry_edit_locks", columns: ["entry_id", "user_id", "device_id"], unique: true, ifNotExists: true)
         }
     }
 }

--- a/core/Sources/WiredPartCore/Models/Notebooks/NotebooksModels.swift
+++ b/core/Sources/WiredPartCore/Models/Notebooks/NotebooksModels.swift
@@ -367,6 +367,37 @@ public struct NotebookBlockConflict: Identifiable, Sendable {
     }
 }
 
+// MARK: - NotebookEntryEditLock
+
+/// Advisory lock for a notebook block currently being edited on a device.
+public struct NotebookEntryEditLock: Identifiable, Sendable {
+    public let id: Int64
+    public let entryId: Int64
+    public let userId: Int64
+    public let userName: String
+    public let deviceId: String
+    public let lockedAt: String
+    public let expiresAt: String
+
+    public init(
+        id: Int64,
+        entryId: Int64,
+        userId: Int64,
+        userName: String,
+        deviceId: String,
+        lockedAt: String,
+        expiresAt: String
+    ) {
+        self.id = id
+        self.entryId = entryId
+        self.userId = userId
+        self.userName = userName
+        self.deviceId = deviceId
+        self.lockedAt = lockedAt
+        self.expiresAt = expiresAt
+    }
+}
+
 // MARK: - TaskOrderLink
 
 public struct TaskOrderLink: Codable, FetchableRecord, MutablePersistableRecord, Sendable {

--- a/core/Sources/WiredPartCore/Services/NotebooksService.swift
+++ b/core/Sources/WiredPartCore/Services/NotebooksService.swift
@@ -1052,6 +1052,74 @@ public final class NotebooksService: Sendable {
         }
     }
 
+    // MARK: - Advisory Block Edit Locks
+
+    @discardableResult
+    public func acquireBlockEditLock(
+        entryId: Int64,
+        userId: Int64,
+        deviceId: String = DeviceIdentity.current,
+        now: Date = Date(),
+        ttlSeconds: TimeInterval = 300
+    ) throws -> NotebookEntryEditLock {
+        try db.writer.write { dbConn in
+            try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "manage_notebooks")
+            try purgeExpiredBlockEditLocks(dbConn, now: now)
+
+            let lockedAt = Self.lockTimestamp(now)
+            let expiresAt = Self.lockTimestamp(now.addingTimeInterval(ttlSeconds))
+            try dbConn.execute(sql: """
+                INSERT INTO notebook_entry_edit_locks (entry_id, user_id, device_id, locked_at, expires_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(entry_id, user_id, device_id) DO UPDATE SET
+                    locked_at = excluded.locked_at,
+                    expires_at = excluded.expires_at
+                """, arguments: [entryId, userId, deviceId, lockedAt, expiresAt])
+
+            guard let lock = try fetchBlockEditLock(dbConn: dbConn, entryId: entryId, userId: userId, deviceId: deviceId) else {
+                throw NotebooksError.invalidData("Unable to acquire notebook edit lock")
+            }
+            return lock
+        }
+    }
+
+    public func releaseBlockEditLock(
+        entryId: Int64,
+        userId: Int64,
+        deviceId: String = DeviceIdentity.current
+    ) throws {
+        try db.writer.write { dbConn in
+            try dbConn.execute(sql: """
+                DELETE FROM notebook_entry_edit_locks
+                WHERE entry_id = ? AND user_id = ? AND device_id = ?
+                """, arguments: [entryId, userId, deviceId])
+        }
+    }
+
+    public func activeBlockEditLocks(notebookId: Int64, now: Date = Date()) throws -> [NotebookEntryEditLock] {
+        do {
+            return try db.writer.write { dbConn in
+                try purgeExpiredBlockEditLocks(dbConn, now: now)
+                let nowString = Self.lockTimestamp(now)
+                let rows = try Row.fetchAll(dbConn, sql: """
+                    SELECT l.id, l.entry_id, l.user_id, l.device_id, l.locked_at, l.expires_at,
+                           COALESCE(u.display_name, u.email, 'Unknown') AS user_name
+                    FROM notebook_entry_edit_locks l
+                    INNER JOIN notebook_entries ne ON ne.id = l.entry_id
+                    LEFT JOIN users u ON u.id = l.user_id AND u.deleted_at IS NULL
+                    WHERE ne.notebook_id = ?
+                      AND ne.deleted_at IS NULL
+                      AND l.expires_at > ?
+                    ORDER BY l.locked_at DESC
+                    """, arguments: [notebookId, nowString])
+                return rows.map(Self.makeEditLock)
+            }
+        } catch {
+            if isTableNotFoundError(error) { return [] }
+            throw error
+        }
+    }
+
     /// Soft-delete a block entry.
     public func deleteBlockEntry(entryId: Int64) throws {
         try db.writer.write { dbConn in
@@ -1791,6 +1859,65 @@ public final class NotebooksService: Sendable {
         }
     }
 
+    @discardableResult
+    public func resolveBlockConflictWithFoundationModels(
+        conflictLogId: Int64,
+        mergeText: @escaping @Sendable (_ localText: String, _ remoteText: String, _ context: String?) async -> String? = { localText, remoteText, context in
+            let result = await FoundationModelsService().mergeTextConflict(
+                localText: localText,
+                remoteText: remoteText,
+                context: context
+            )
+            return result.success ? result.text : nil
+        }
+    ) async throws -> Bool {
+        let pending = try await db.writer.read { dbConn -> (recordId: String, fieldName: String, local: String, remote: String, context: String?)? in
+            guard let row = try Row.fetchOne(dbConn, sql: """
+                SELECT cl.record_id, cl.field_name, cl.local_value, cl.remote_value,
+                       ne.title AS entry_title, ne.block_type
+                FROM _conflict_log cl
+                LEFT JOIN notebook_entries ne ON CAST(cl.record_id AS INTEGER) = ne.id
+                WHERE cl.id = ? AND cl.reviewed = 0
+                """, arguments: [conflictLogId]) else {
+                return nil
+            }
+
+            let fieldName: String = row["field_name"] ?? ""
+            guard Self.foundationMergeFields.contains(fieldName) else { return nil }
+            let local = row["local_value"] as String? ?? ""
+            let remote = row["remote_value"] as String? ?? ""
+            let context = [
+                row["entry_title"] as String?,
+                row["block_type"] as String?
+            ].compactMap { $0 }.joined(separator: " / ")
+            return (
+                recordId: row["record_id"] ?? "0",
+                fieldName: fieldName,
+                local: local,
+                remote: remote,
+                context: context.isEmpty ? nil : context
+            )
+        }
+
+        guard let pending else { return false }
+        guard let merged = await mergeText(pending.local, pending.remote, pending.context),
+              !merged.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
+
+        try await db.writer.write { dbConn in
+            try dbConn.execute(
+                sql: "UPDATE notebook_entries SET \"\(pending.fieldName)\" = ?, updated_at = datetime('now') WHERE id = ? AND deleted_at IS NULL",
+                arguments: [merged, pending.recordId]
+            )
+            try dbConn.execute(
+                sql: "UPDATE _conflict_log SET winner = 'ai_merge', reviewed = 1 WHERE id = ?",
+                arguments: [conflictLogId]
+            )
+        }
+        return true
+    }
+
     /// Bulk-resolve all unreviewed conflicts for a notebook, keeping the specified version.
     ///
     /// Convenience method for "Keep All Local" or "Keep All Remote" actions.
@@ -1809,5 +1936,44 @@ public final class NotebooksService: Sendable {
     private func isTableNotFoundError(_ error: Error) -> Bool {
         let message = String(describing: error)
         return message.contains("no such table") || message.contains("no such column")
+    }
+
+    private static let foundationMergeFields: Set<String> = ["title", "content", "block_data", "checklist_items"]
+
+    private static func lockTimestamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+
+    private static func makeEditLock(row: Row) -> NotebookEntryEditLock {
+        NotebookEntryEditLock(
+            id: row["id"] ?? 0,
+            entryId: row["entry_id"] ?? 0,
+            userId: row["user_id"] ?? 0,
+            userName: row["user_name"] ?? "Unknown",
+            deviceId: row["device_id"] ?? "",
+            lockedAt: row["locked_at"] ?? "",
+            expiresAt: row["expires_at"] ?? ""
+        )
+    }
+
+    private func fetchBlockEditLock(dbConn: Database, entryId: Int64, userId: Int64, deviceId: String) throws -> NotebookEntryEditLock? {
+        let row = try Row.fetchOne(dbConn, sql: """
+            SELECT l.id, l.entry_id, l.user_id, l.device_id, l.locked_at, l.expires_at,
+                   COALESCE(u.display_name, u.email, 'Unknown') AS user_name
+            FROM notebook_entry_edit_locks l
+            LEFT JOIN users u ON u.id = l.user_id AND u.deleted_at IS NULL
+            WHERE l.entry_id = ? AND l.user_id = ? AND l.device_id = ?
+            """, arguments: [entryId, userId, deviceId])
+        return row.map(Self.makeEditLock)
+    }
+
+    private func purgeExpiredBlockEditLocks(_ dbConn: Database, now: Date) throws {
+        let nowString = Self.lockTimestamp(now)
+        try dbConn.execute(
+            sql: "DELETE FROM notebook_entry_edit_locks WHERE expires_at <= ?",
+            arguments: [nowString]
+        )
     }
 }

--- a/core/Sources/WiredPartCore/Services/NotebooksService.swift
+++ b/core/Sources/WiredPartCore/Services/NotebooksService.swift
@@ -1871,10 +1871,10 @@ public final class NotebooksService: Sendable {
             return result.success ? result.text : nil
         }
     ) async throws -> Bool {
-        let pending = try await db.writer.read { dbConn -> (recordId: String, fieldName: String, local: String, remote: String, context: String?)? in
+        let pending = try await db.writer.read { dbConn -> (recordId: Int64, fieldName: String, local: String, remote: String, context: String?, entryUpdatedAt: String?)? in
             guard let row = try Row.fetchOne(dbConn, sql: """
                 SELECT cl.record_id, cl.field_name, cl.local_value, cl.remote_value,
-                       ne.title AS entry_title, ne.block_type
+                       ne.title AS entry_title, ne.block_type, ne.updated_at AS entry_updated_at
                 FROM _conflict_log cl
                 LEFT JOIN notebook_entries ne ON CAST(cl.record_id AS INTEGER) = ne.id
                 WHERE cl.id = ? AND cl.reviewed = 0
@@ -1884,6 +1884,7 @@ public final class NotebooksService: Sendable {
 
             let fieldName: String = row["field_name"] ?? ""
             guard Self.foundationMergeFields.contains(fieldName) else { return nil }
+            guard let recordId = Int64(row["record_id"] as String? ?? "") else { return nil }
             let local = row["local_value"] as String? ?? ""
             let remote = row["remote_value"] as String? ?? ""
             let context = [
@@ -1891,11 +1892,12 @@ public final class NotebooksService: Sendable {
                 row["block_type"] as String?
             ].compactMap { $0 }.joined(separator: " / ")
             return (
-                recordId: row["record_id"] ?? "0",
+                recordId: recordId,
                 fieldName: fieldName,
                 local: local,
                 remote: remote,
-                context: context.isEmpty ? nil : context
+                context: context.isEmpty ? nil : context,
+                entryUpdatedAt: row["entry_updated_at"]
             )
         }
 
@@ -1905,17 +1907,25 @@ public final class NotebooksService: Sendable {
             return false
         }
 
-        try await db.writer.write { dbConn in
+        let applied = try await db.writer.write { dbConn -> Bool in
             try dbConn.execute(
-                sql: "UPDATE notebook_entries SET \"\(pending.fieldName)\" = ?, updated_at = datetime('now') WHERE id = ? AND deleted_at IS NULL",
-                arguments: [merged, pending.recordId]
+                sql: """
+                    UPDATE notebook_entries
+                    SET "\(pending.fieldName)" = ?, updated_at = datetime('now')
+                    WHERE id = ?
+                      AND deleted_at IS NULL
+                      AND updated_at IS ?
+                    """,
+                arguments: [merged, pending.recordId, pending.entryUpdatedAt]
             )
+            guard dbConn.changesCount > 0 else { return false }
             try dbConn.execute(
                 sql: "UPDATE _conflict_log SET winner = 'ai_merge', reviewed = 1 WHERE id = ?",
                 arguments: [conflictLogId]
             )
+            return true
         }
-        return true
+        return applied
     }
 
     /// Bulk-resolve all unreviewed conflicts for a notebook, keeping the specified version.

--- a/core/Sources/WiredPartCore/Services/NotebooksService.swift
+++ b/core/Sources/WiredPartCore/Services/NotebooksService.swift
@@ -1915,8 +1915,9 @@ public final class NotebooksService: Sendable {
                     WHERE id = ?
                       AND deleted_at IS NULL
                       AND updated_at IS ?
+                      AND COALESCE("\(pending.fieldName)", '') = ?
                     """,
-                arguments: [merged, pending.recordId, pending.entryUpdatedAt]
+                arguments: [merged, pending.recordId, pending.entryUpdatedAt, pending.local]
             )
             guard dbConn.changesCount > 0 else { return false }
             try dbConn.execute(

--- a/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
@@ -426,7 +426,7 @@ struct NotebooksServiceTests {
             mergeText: { _, _, _ in
                 try? await env.db.writer.write { dbConn in
                     try dbConn.execute(
-                        sql: "UPDATE notebook_entries SET content = ?, updated_at = datetime('now', '+1 second') WHERE id = ?",
+                        sql: "UPDATE notebook_entries SET content = ? WHERE id = ?",
                         arguments: ["Concurrent update", entryId]
                     )
                 }

--- a/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
@@ -393,6 +393,61 @@ struct NotebooksServiceTests {
         #expect(row?["winner"] as String? == "ai_merge")
     }
 
+    @Test("Foundation Models merge preserves conflict when row changes before write")
+    func testFoundationModelsMergeRejectsStaleConflictSnapshot() async throws {
+        let env = try E2ETestHelpers.setUp()
+        let nbId = try env.notebooks.createNotebook(
+            title: "Merge Stale Snapshot",
+            notebookType: "general",
+            createdBy: env.adminUserId
+        )
+        let sectionId = try env.notebooks.createSection(
+            notebookId: nbId,
+            groupId: nil,
+            name: "Main"
+        )
+        let entryId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "text",
+            title: "Conflict note",
+            content: "Local text",
+            createdBy: env.adminUserId
+        )
+        let conflictId = try insertNotebookConflict(
+            db: env.db,
+            entryId: entryId,
+            fieldName: "content",
+            localValue: "Local text",
+            remoteValue: "Remote text"
+        )
+
+        let merged = try await env.notebooks.resolveBlockConflictWithFoundationModels(
+            conflictLogId: conflictId,
+            mergeText: { _, _, _ in
+                try? await env.db.writer.write { dbConn in
+                    try dbConn.execute(
+                        sql: "UPDATE notebook_entries SET content = ?, updated_at = datetime('now', '+1 second') WHERE id = ?",
+                        arguments: ["Concurrent update", entryId]
+                    )
+                }
+                return "Merged text"
+            }
+        )
+        #expect(merged == false)
+
+        let row = try await env.db.writer.read { dbConn in
+            try Row.fetchOne(dbConn, sql: """
+                SELECT ne.content, cl.reviewed, cl.winner
+                FROM notebook_entries ne
+                JOIN _conflict_log cl ON CAST(cl.record_id AS INTEGER) = ne.id
+                WHERE cl.id = ?
+                """, arguments: [conflictId])
+        }
+        #expect(row?["content"] as String? == "Concurrent update")
+        #expect((row?["reviewed"] as Int?) == 0)
+        #expect(row?["winner"] as String? == "local")
+    }
+
     // MARK: - 5. Delete Entry (Soft Delete)
 
     @Test("Soft-delete a block entry removes it from hierarchy")

--- a/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
@@ -258,6 +258,141 @@ struct NotebooksServiceTests {
         }
     }
 
+    @Test("Block edit locks are visible until their five minute expiry")
+    func testBlockEditLockVisibilityAndExpiry() throws {
+        let env = try E2ETestHelpers.setUp()
+        let nbId = try env.notebooks.createNotebook(
+            title: "Lock Visibility",
+            notebookType: "general",
+            createdBy: env.adminUserId
+        )
+        let sectionId = try env.notebooks.createSection(
+            notebookId: nbId,
+            groupId: nil,
+            name: "Main"
+        )
+        let entryId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "text",
+            title: "Shared note",
+            content: "Original",
+            createdBy: env.adminUserId
+        )
+
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        let lock = try env.notebooks.acquireBlockEditLock(
+            entryId: entryId,
+            userId: env.adminUserId,
+            deviceId: "field-ipad",
+            now: base
+        )
+        #expect(lock.entryId == entryId)
+        #expect(lock.deviceId == "field-ipad")
+
+        let active = try env.notebooks.activeBlockEditLocks(notebookId: nbId, now: base.addingTimeInterval(299))
+        #expect(active.count == 1)
+        #expect(active.first?.entryId == entryId)
+        #expect(active.first?.userName == "TestAdmin")
+
+        let expired = try env.notebooks.activeBlockEditLocks(notebookId: nbId, now: base.addingTimeInterval(301))
+        #expect(expired.isEmpty)
+    }
+
+    @Test("Foundation Models merge preserves conflicts when merge is unavailable")
+    func testFoundationModelsMergeFallbackPreservesConflict() async throws {
+        let env = try E2ETestHelpers.setUp()
+        let nbId = try env.notebooks.createNotebook(
+            title: "Merge Fallback",
+            notebookType: "general",
+            createdBy: env.adminUserId
+        )
+        let sectionId = try env.notebooks.createSection(
+            notebookId: nbId,
+            groupId: nil,
+            name: "Main"
+        )
+        let entryId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "text",
+            title: "Conflict note",
+            content: "Local text",
+            createdBy: env.adminUserId
+        )
+        let conflictId = try insertNotebookConflict(
+            db: env.db,
+            entryId: entryId,
+            fieldName: "content",
+            localValue: "Local text",
+            remoteValue: "Remote text"
+        )
+
+        let merged = try await env.notebooks.resolveBlockConflictWithFoundationModels(
+            conflictLogId: conflictId,
+            mergeText: { _, _, _ in nil }
+        )
+        #expect(merged == false)
+
+        let row = try await env.db.writer.read { dbConn in
+            try Row.fetchOne(dbConn, sql: """
+                SELECT ne.content, cl.reviewed, cl.local_value, cl.remote_value
+                FROM notebook_entries ne
+                JOIN _conflict_log cl ON CAST(cl.record_id AS INTEGER) = ne.id
+                WHERE cl.id = ?
+                """, arguments: [conflictId])
+        }
+        #expect(row?["content"] as String? == "Local text")
+        #expect((row?["reviewed"] as Int?) == 0)
+        #expect(row?["local_value"] as String? == "Local text")
+        #expect(row?["remote_value"] as String? == "Remote text")
+    }
+
+    @Test("Foundation Models merge applies merged text and reviews conflict")
+    func testFoundationModelsMergeAppliesMergedText() async throws {
+        let env = try E2ETestHelpers.setUp()
+        let nbId = try env.notebooks.createNotebook(
+            title: "Merge Success",
+            notebookType: "general",
+            createdBy: env.adminUserId
+        )
+        let sectionId = try env.notebooks.createSection(
+            notebookId: nbId,
+            groupId: nil,
+            name: "Main"
+        )
+        let entryId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "text",
+            title: "Conflict note",
+            content: "Local text",
+            createdBy: env.adminUserId
+        )
+        let conflictId = try insertNotebookConflict(
+            db: env.db,
+            entryId: entryId,
+            fieldName: "content",
+            localValue: "Local text",
+            remoteValue: "Remote text"
+        )
+
+        let merged = try await env.notebooks.resolveBlockConflictWithFoundationModels(
+            conflictLogId: conflictId,
+            mergeText: { local, remote, _ in "\(local) + \(remote)" }
+        )
+        #expect(merged == true)
+
+        let row = try await env.db.writer.read { dbConn in
+            try Row.fetchOne(dbConn, sql: """
+                SELECT ne.content, cl.reviewed, cl.winner
+                FROM notebook_entries ne
+                JOIN _conflict_log cl ON CAST(cl.record_id AS INTEGER) = ne.id
+                WHERE cl.id = ?
+                """, arguments: [conflictId])
+        }
+        #expect(row?["content"] as String? == "Local text + Remote text")
+        #expect((row?["reviewed"] as Int?) == 1)
+        #expect(row?["winner"] as String? == "ai_merge")
+    }
+
     // MARK: - 5. Delete Entry (Soft Delete)
 
     @Test("Soft-delete a block entry removes it from hierarchy")
@@ -1981,5 +2116,27 @@ struct NotebooksServiceTests {
         #expect(section.entries.count == 2)
         #expect(section.entries.map { $0.title }.contains("Block 1"))
         #expect(section.entries.map { $0.title }.contains("Block 2"))
+    }
+
+    @discardableResult
+    private func insertNotebookConflict(
+        db: AppDatabase,
+        entryId: Int64,
+        fieldName: String,
+        localValue: String,
+        remoteValue: String
+    ) throws -> Int64 {
+        try db.writer.write { dbConn in
+            try dbConn.execute(sql: """
+                INSERT INTO _conflict_log
+                    (table_name, record_id, field_name, local_value, remote_value, winner,
+                     local_device, remote_device, local_ts, remote_ts, resolved_at, reviewed)
+                VALUES ('notebook_entries', ?, ?, ?, ?, 'local',
+                        'local-device', 'remote-device',
+                        '2026-05-26T10:00:00Z', '2026-05-26T10:01:00Z',
+                        '2026-05-26T10:02:00Z', 0)
+                """, arguments: ["\(entryId)", fieldName, localValue, remoteValue])
+            return dbConn.lastInsertedRowID
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add advisory notebook block edit locks with user/device/timestamps and 5-minute expiry cleanup.
- Surface non-blocking edit indicators in the iOS notebook detail view.
- Add Foundation Models text-conflict merge path with manual fallback that preserves both versions on failure.

## Verification
- swift test --filter NotebooksServiceTests/testBlockEditLockVisibilityAndExpiry
- swift test --filter NotebooksServiceTests/testFoundationModelsMergeFallbackPreservesConflict
- swift test --filter NotebooksServiceTests/testFoundationModelsMergeAppliesMergedText
- xcodebuild -quiet -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" -skipPackagePluginValidation build (interrupted by xcodebuild after warnings, no source error emitted before interruption)

## Notes
- Unsupported conflicts remain in the existing manual resolver.
- AI merge is limited to text-compatible fields: title, content, block_data, checklist_items.