### PR TITLE
Docs: align Paperclip execution loop

### DIFF
--- a/docs/paperclip-handoff.md
+++ b/docs/paperclip-handoff.md
@@ -24,6 +24,7 @@
 ### What "preserving discipline" means
 
 - **Plans before prompts.** ALL design decisions go to `docs/plans/*.md` BEFORE any code is generated. CLAUDE.md §"Plan Filing & History" is the rule. If you find yourself coding without a plan, stop and ask the user (Q&A workflow in §7).
+- **Goal -> plan -> issue -> PR loop.** For Paperclip/GitHub routing, read `docs/plans/paperclip-agentic-execution-loop.md`. It defines the required fields for GitHub issues, Paperclip child issues, branch/worktree hygiene, PR evidence, and closeout comments.
 - **Slow, focused, one-area-at-a-time.** AUTO GO's soul (`docs/auto-go-soul.md`) is the canonical statement. Convergence over breadth. 25-minute cap per iteration. No spraying.
 - **No finding gets lost.** Anything you notice that's out-of-scope for the current check goes to a GitHub issue with the right area label and tier (T1/T2/T3) BEFORE you continue. See `feedback_issue_ordering.md`.
 - **Per-POV Q&A.** Each `Answer: _pending_` line in `docs/dev-qa.md` waits for a role-specific answer (Owner / Manager / Developer / User). Never collapse. See `feedback_qa_workflow.md`.
@@ -45,7 +46,8 @@ In this order. Stop if anything is unclear and ask the user before going further
 7. **`~/.claude/projects/-Users-IA-GitHub-Weird-Part-Run-2/memory/MEMORY.md`** — index of all the user-feedback files. Each linked file is < 100 lines and tells you something specific about how the user works.
 8. **`docs/dev-pipeline.md`** — the master pipeline tracker. Read the top "Master Status" table; skip the Active Work Items table unless investigating a specific item.
 9. **`docs/dev-qa.md`** — the Q&A file. Pending Questions section first; if non-empty, those need owner ratification before code.
-10. The plan files in `docs/plans/` that are tagged "Status: Design approved, implementation pending" — these are the on-deck work items.
+10. **`docs/plans/paperclip-agentic-execution-loop.md`** — how Paperclip goals, repo plans, GitHub issues, Paperclip execution issues, PRs, CI, and closeout evidence connect.
+11. The plan files in `docs/plans/` that are tagged "Status: Design approved, implementation pending" — these are the on-deck work items.
 
 After this 30–45 minutes you should have the model in your head: who the user is, what we're building, what's queued, and how the loop is supposed to run.
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,16 +1,16 @@
 # WiredPart — Plans Directory
 
-> **Last updated:** 2026-03-18
-> **Current work:** Dashboard Hub, iOS audit fixes, brand-supplier linking
-> **Completed phases:** 1-10 + all gap closures + Tauri migration + production hardening
+> **Last updated:** 2026-05-26
+> **Current work:** Field-test beta stabilization for the native iOS app
+> **Coordination plan:** `paperclip-agentic-execution-loop.md`
 
 ---
 
 ## Project Summary
 
-WiredPart is a construction/trade business management app. Local-first, offline-capable, syncs peer-to-peer over Bluetooth and Wi-Fi. Runs on iOS (iPhone + iPad), macOS, and Windows via shared core package.
+WiredPart is a local-first construction/trade business management app. The current beta target is the native iOS app with a shared Swift core package. Historical Tauri, React, macOS, and Windows plans remain useful background, but they are not active beta scope unless a current GitHub/Paperclip issue explicitly reactivates them.
 
-**Stats:** ~160 Swift files (iOS) + 50 core files | 23 migrations, ~130 tables (GRDB/SQLite) | 15 services
+**Current posture:** SwiftUI iOS app + shared Swift core package, GRDB/SQLite, Apple Multipeer Connectivity sync, Apple Foundation Models integration, and beta-readiness work across the 14 product areas listed in `docs/paperclip-handoff.md`.
 
 ---
 
@@ -18,9 +18,19 @@ WiredPart is a construction/trade business management app. Local-first, offline-
 
 | Plan | Status | Description |
 |------|--------|-------------|
+| `paperclip-agentic-execution-loop.md` | **ACTIVE** | Goal -> repo plan -> GitHub issue -> Paperclip issue -> PR/CI/merge -> closeout routing rules for autonomous execution |
 | `dashboard-hub-plan.md` | **ACTIVE** | Dashboard as user hub: 4 tabs (Overview + clock banner, Clock with GPS-sorted jobs + geofencing, Daily Report command center, Fast QR scanner) |
 | `deployment-master-plan.md` | 19/23 | App Store, DMG, NSIS distribution. 4 remaining tasks need physical devices |
 | `qr_plan.md` | Reference | QR v2 payload schema, 8 entity types, auto-fill pipeline |
+
+## Paperclip / GitHub Routing
+
+Use `paperclip-agentic-execution-loop.md` before creating or delegating autonomous engineering work. It defines:
+
+- Required GitHub issue fields: field-test relevance, labels, acceptance criteria, repo plan link, Paperclip link, and verification.
+- Required Paperclip child issue fields: owner lane, repo/project, exact scope, acceptance criteria, required evidence, review lane, and pass-up trigger.
+- Branch/worktree hygiene preflight before opening new Weird Parts coding work.
+- Closeout evidence expected for PRs, CI, worktree cleanup, and Paperclip status comments.
 
 ## Future Plans (Designed, Not Started)
 
@@ -34,21 +44,21 @@ WiredPart is a construction/trade business management app. Local-first, offline-
 | `apple-foundation-models-integration.md` | Apple Foundation Models (macOS 26+), on-device AI, tool use |
 | `ai-assistant-plan.md` | AI assistant panel, text prediction, contextual suggestions |
 | `supplier-communication-bridge-plan.md` | Supplier portal, PO acknowledgments, delivery tracking |
-| `phase-12-pwa-desktop.md` | Service worker, keyboard shortcuts, command palette |
-| `Mobile device bootstrap.md` | App Store shell that downloads real program from shop |
-| `windows-architecture.md` | Tauri/React dual-platform, llama.cpp for Windows AI |
+| `phase-12-pwa-desktop.md` | Historical/reference unless reactivated by a current beta issue |
+| `Mobile device bootstrap.md` | Historical/reference unless reactivated by a current beta issue |
+| `windows-architecture.md` | Historical/reference unless reactivated by a current beta issue |
 | `sideloading-guide.md` | Enterprise distribution without App Store |
 
 ## Architecture
 
 - **Sync:** Apple Multipeer Connectivity (BT/Wi-Fi P2P) + LAN HTTP. LWW + field-level merge. Ed25519 device trust. Vector clocks.
-- **AI:** Foundation Models (Apple), llama.cpp (Windows), no cloud. On-device only.
+- **AI:** Foundation Models (Apple). Historical Windows/local-LLM plans are reference only unless reactivated.
 - **QR:** VisionKit DataScannerViewController. V2 schema with 8 entity types. Auto-fill pipeline.
 - **Constraint:** Everything offline. Bluetooth-only sync. No cloud APIs.
 
 ## Completed Phase History
 
-All completed plans archived in `archive/`. Phases 1→10, Tauri migration, production hardening, testing strategy, all gap closures — all done.
+Completed and inactive plans are archived in `archive/` or retained as reference plans. Treat pre-iOS-native architecture plans as historical unless a current issue links them as active scope.
 
 ## Build & Test
 

--- a/docs/plans/paperclip-agentic-execution-loop.md
+++ b/docs/plans/paperclip-agentic-execution-loop.md
@@ -1,0 +1,122 @@
+# Paperclip Agentic Execution Loop
+
+> **Status:** Active coordination plan
+> **Created:** 2026-05-26
+> **Tracking:** GitHub #886 / Paperclip WEI-2560
+> **Goal:** Ship Wired Parts Run 2 to stable field-test beta without quality cuts.
+
+## Purpose
+
+This plan defines how Paperclip goals, repo plans, GitHub issues, Paperclip execution issues, PRs, CI, and closeout evidence connect. Use it when creating, selecting, delegating, or closing autonomous engineering work.
+
+The operating rule is: field-test beta work comes first. Process or infrastructure work is valid only when it makes beta execution clearer, safer, faster to verify, or easier to land.
+
+## Current Product Posture
+
+- Product: native iOS shop-management app for Wired Parts Run 2.
+- Primary repo: `xXKillerNoobYT/Weird-Part-Run-2`.
+- Canonical local checkout: `/Users/IA/GitHub/Weird-Part-Run-2`.
+- Runtime direction: iOS-native app plus shared Swift core package. Historical Tauri, React, macOS, and Windows plans are reference material unless a current issue explicitly reactivates them.
+- Priority goal: Paperclip goal "Ship Wired Parts Run 2 to stable field-test beta without quality cuts".
+
+## Execution Chain
+
+| Layer | Source of truth | Owner | Required output |
+|---|---|---|---|
+| Goal | Paperclip goal hierarchy | CEO/CTO | Priority, routing rules, non-goals, blocker policy |
+| Plan | `docs/plans/*.md` and `docs/paperclip-handoff.md` | CTO/engineering lead | Scope, architecture, acceptance criteria, verification lane |
+| Improvement ledger | GitHub issues | CTO/engineers/QA | Field-test relevance, labels, acceptance criteria, linked plan/Paperclip issue |
+| Execution | Paperclip issues and child issues | Assigned Paperclip agent | Bounded implementation/review/QA task with owner and evidence |
+| Landing | Git branch, PR, CI, review | Engineer/reviewer | PR link, CI status, review disposition, merge state |
+| Closeout | GitHub and Paperclip comments | Task owner | What changed, verification, residual risk, next owner action |
+
+## Work Selection Rules
+
+1. Pick field-test beta issues before process cleanup.
+2. Prefer issues with a current repo plan and testable acceptance criteria.
+3. If a GitHub issue is vague, update the issue or create a Paperclip planning child before implementation.
+4. If a plan is stale against the iOS-native app, correct the plan before coding.
+5. If branch or worktree pressure is high, drain/review/merge/close existing PRs before opening broad new implementation branches.
+
+## GitHub Issue Requirements
+
+Every new or materially updated GitHub issue created from Paperclip, QA, or autonomous findings must include:
+
+- **Field-test relevance:** why the issue matters before beta, or why it is explicitly deferred.
+- **Area label:** one of the product areas used by the beta checklist, plus severity/tier labels when applicable.
+- **Acceptance criteria:** observable behavior, not only "update docs" or "investigate".
+- **Plan link:** the relevant `docs/plans/*.md` file, or a statement that the issue is plan-discovery work.
+- **Paperclip link:** the owning Paperclip issue identifier when execution is routed through Paperclip.
+- **Verification:** smallest meaningful command, screenshot, simulator/device check, CI run, or review artifact.
+
+## Paperclip Child Issue Requirements
+
+Every child issue created from this loop must state:
+
+- Owner role and lane: engineering, frontend implementation, UX design, QA, security, or review.
+- Repo/project: usually Weird Parts Run 2.
+- Exact scope and non-goals.
+- Acceptance criteria.
+- Required evidence.
+- Review lane.
+- Pass-up trigger back to the parent issue or GitHub issue.
+
+For frontend/UX work, include the route or screen, expected viewport evidence, and whether UXDesigner, UIFirstRun, UIExpertVerifier, or FrontendCoder owns the next step.
+
+## Branch And Worktree Hygiene Gate
+
+Before starting new Weird Parts implementation work, run a preflight from the canonical checkout:
+
+```bash
+git ls-remote --heads origin | wc -l
+gh pr list --state open --limit 200 --json number,title,headRefName,url
+git worktree list --porcelain
+git worktree prune -n -v
+```
+
+If the repo is above branch soft-cap pressure or has many active worktrees, prefer one of these outcomes:
+
+- Review and merge an existing ready PR.
+- Reconcile a stale worktree with its owning issue.
+- Create a bounded cleanup issue with evidence instead of deleting uncertain branches.
+- For documentation-only work, keep the branch small and link it directly to the process issue that required it.
+
+Never delete a live worktree, local branch, remote branch, or PR without evidence that it is clean, merged, superseded, or intentionally abandoned.
+
+## PR And Closeout Requirements
+
+A PR or closeout comment must include:
+
+- GitHub issue link.
+- Paperclip issue link or identifier.
+- Files changed.
+- Verification performed.
+- CI state or why CI is not applicable.
+- Residual risk.
+- Cleanup state for any agent-created worktree.
+
+Paperclip closeout comments for GitHub-backed work must include a `GitHub sync:` line with one of:
+
+- `pushed/PR/commented URL`
+- `existing PR/CI URL`
+- `not applicable with reason`
+- `blocked with owner/action`
+
+## Verification Matrix
+
+| Change type | Minimum evidence |
+|---|---|
+| Docs/process plan | Markdown diff, linked GitHub issue/PR, no stale contradiction introduced |
+| Swift core behavior | Focused Swift tests or reason a narrower verification is impossible |
+| SwiftUI implementation | Screenshot or simulator evidence for affected screen/viewport when visual behavior changes |
+| Data migration | Migration test, rollback story, and fixture or seeded-data coverage |
+| GitHub issue hygiene | Updated issue body/comment/labels with acceptance criteria and Paperclip link |
+| Branch cleanup | Worktree/branch/PR evidence and owning issue final cleanup note |
+
+## Non-Goals
+
+- Do not restart desktop, web, or Windows work unless a current beta issue explicitly scopes it.
+- Do not create process-only issues that do not help agents choose, verify, land, or close work.
+- Do not broaden a small beta bug into an architecture project without a plan update and owner approval.
+- Do not treat Paperclip comments as completion when a code, PR, CI, review, or GitHub update is required.
+


### PR DESCRIPTION
## Summary
- adds a repo-visible Paperclip agentic execution loop plan for GitHub #886 / Paperclip WEI-2560
- refreshes docs/plans/README.md to match the current iOS-native field-test beta posture
- links the new routing plan from docs/paperclip-handoff.md so agents read it during onboarding

## Verification
- rg verified the new plan and handoff/README links are present
- docs-only change; no build required

Closes #886