### PR TITLE
[iOS][Runtime] Recover simulator SQLCipher decrypt mismatch

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -118,8 +118,8 @@ final class AppCore: ObservableObject {
                     // Remove the .unencrypted.bak file after it has been retained for 7 days.
                     AppDatabase.cleanupStaleUnencryptedBackup(atPath: path)
                 } catch {
-                    #if DEBUG
-                    if Self.isRecoverableDebugCipherOpenFailure(error) {
+                    #if DEBUG && targetEnvironment(simulator)
+                    if Self.shouldResetLocalDatabaseAfterCipherOpenFailure(error) {
                         self.logger.warning(
                             "[AppCore] DEBUG SQLCipher open failed with decrypt/notadb; resetting local simulator database and retrying."
                         )
@@ -369,6 +369,14 @@ final class AppCore: ObservableObject {
         return description.contains("file is not a database")
             || description.contains("not a database")
             || description.contains("decrypt")
+    }
+
+    nonisolated static func shouldResetLocalDatabaseAfterCipherOpenFailure(_ error: Error) -> Bool {
+        #if DEBUG && targetEnvironment(simulator)
+        return isRecoverableDebugCipherOpenFailure(error)
+        #else
+        return false
+        #endif
     }
 
     // MARK: - Auth Actions

--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -118,15 +118,28 @@ final class AppCore: ObservableObject {
                     // Remove the .unencrypted.bak file after it has been retained for 7 days.
                     AppDatabase.cleanupStaleUnencryptedBackup(atPath: path)
                 } catch {
+                    #if DEBUG
+                    if Self.isRecoverableDebugCipherOpenFailure(error) {
+                        self.logger.warning(
+                            "[AppCore] DEBUG SQLCipher open failed with decrypt/notadb; resetting local simulator database and retrying."
+                        )
+                        try DeviceResetService.deleteDatabaseStorage(atPath: path)
+                        let keyHex = try Self.deviceBootstrapKeyHex()
+                        database = try AppDatabase.openEncryptedDatabase(atPath: path, keyHex: keyHex)
+                    } else {
+                        throw error
+                    }
+                    #else
                     #if !DEBUG
                     // Migration failed — try to restore from backup
                     if let backup = backupPath {
                         try? AppDatabase.restoreDatabase(from: backup, to: path)
                         // Retry with restored DB (old schema, but data preserved)
-                        logger.error("[AppCore] Migration failed, restored from backup. Error: \(error.localizedDescription)")
+                        self.logger.error("[AppCore] Migration failed, restored from backup. Error: \(error.localizedDescription)")
                     }
                     #endif
                     throw error
+                    #endif
                 }
 
                 let auth = AuthService(db: database)
@@ -346,6 +359,16 @@ final class AppCore: ObservableObject {
         Task { @MainActor in
             await bootstrap()
         }
+    }
+
+    nonisolated static func isRecoverableDebugCipherOpenFailure(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        guard nsError.code == 26 else { return false }
+
+        let description = error.localizedDescription.lowercased()
+        return description.contains("file is not a database")
+            || description.contains("not a database")
+            || description.contains("decrypt")
     }
 
     // MARK: - Auth Actions

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -70,6 +70,22 @@ struct Weird_Parts_IOSTests {
         #expect(!AppCore.shouldUseLocalBootstrapKeyFallback(for: errSecAuthFailed))
     }
 
+    @Test func debugCipherRecoveryOnlyMatchesDecryptNotADB() {
+        let sqlCipherError = NSError(
+            domain: "GRDB.DatabaseError",
+            code: 26,
+            userInfo: [NSLocalizedDescriptionKey: "SQLite error 26: file is not a database - while executing `PRAGMA journal_mode = WAL`"]
+        )
+        let unrelatedDatabaseError = NSError(
+            domain: "GRDB.DatabaseError",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "SQLite error 1: no such table: settings"]
+        )
+
+        #expect(AppCore.isRecoverableDebugCipherOpenFailure(sqlCipherError))
+        #expect(!AppCore.isRecoverableDebugCipherOpenFailure(unrelatedDatabaseError))
+    }
+
     @MainActor
     @Test func bulkHoldSelectionCarriesAllSelectedRowsIntoSheetSnapshot() throws {
         let first = OrdersService.JPOLineRow(

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -86,6 +86,20 @@ struct Weird_Parts_IOSTests {
         #expect(!AppCore.isRecoverableDebugCipherOpenFailure(unrelatedDatabaseError))
     }
 
+    @Test func debugCipherDatabaseResetGateIsSimulatorOnly() {
+        let sqlCipherError = NSError(
+            domain: "GRDB.DatabaseError",
+            code: 26,
+            userInfo: [NSLocalizedDescriptionKey: "SQLite error 26: file is not a database - while executing `PRAGMA journal_mode = WAL`"]
+        )
+
+        #if DEBUG && targetEnvironment(simulator)
+        #expect(AppCore.shouldResetLocalDatabaseAfterCipherOpenFailure(sqlCipherError))
+        #else
+        #expect(!AppCore.shouldResetLocalDatabaseAfterCipherOpenFailure(sqlCipherError))
+        #endif
+    }
+
     @MainActor
     @Test func bulkHoldSelectionCarriesAllSelectedRowsIntoSheetSnapshot() throws {
         let first = OrdersService.JPOLineRow(


### PR DESCRIPTION
Fixes the remaining startup blocker from WEI-2565 / GitHub issue #884 after the simulator bootstrap-key fallback.

What changed:
- Adds DEBUG-only AppCore recovery for SQLCipher `SQLITE_NOTADB` / decrypt mismatch on local simulator database open.
- Deletes only local database storage and retries encrypted DB open with the current device bootstrap key.
- Release builds still fail closed and preserve data.
- Adds Swift Testing coverage for the decrypt/notadb classifier.

Validation:
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "id=145DE584-9492-43FE-8C19-A9573D24DC7F" -only-testing:"Weird PartsTests/Weird_Parts_IOSTests/debugCipherRecoveryOnlyMatchesDecryptNotADB" -only-testing:"Weird PartsTests/Weird_Parts_IOSTests/simulatorMissingEntitlementCanUseLocalBootstrapKeyFallback"` passed.
- Reinstalled and launched on simulator `145DE584-9492-43FE-8C19-A9573D24DC7F`; app recovered from the SQLCipher HMAC failure and reached first-run onboarding. Screenshot: `/tmp/wei-2565-startup-after-fix.png`.
