### PR TITLE
WEI-2666 fix labor local-day time buckets

### DIFF
--- a/core/Sources/WiredPartCore/Services/DailyReportGenerator.swift
+++ b/core/Sources/WiredPartCore/Services/DailyReportGenerator.swift
@@ -68,7 +68,7 @@ public final class DailyReportGenerator: Sendable {
             let clockRows = try Row.fetchAll(dbConn, sql: """
                 SELECT clock_in, clock_out, regular_hours, overtime_hours
                 FROM labor_entries
-                WHERE user_id = ? AND job_id = ? AND date(clock_in) = ?
+                WHERE user_id = ? AND job_id = ? AND \(Self.localDateSQL("clock_in")) = ?
                   AND deleted_at IS NULL
                 ORDER BY clock_in ASC
                 """, arguments: [userId, jobId, dateStr])
@@ -206,7 +206,7 @@ public final class DailyReportGenerator: Sendable {
                            ) as total_hours
                     FROM labor_entries le
                     LEFT JOIN jobs j ON j.id = le.job_id AND j.deleted_at IS NULL
-                    WHERE le.user_id = ? AND date(le.clock_in) = ?
+                    WHERE le.user_id = ? AND \(Self.localDateSQL("le.clock_in")) = ?
                       AND le.deleted_at IS NULL
                     GROUP BY le.job_id
                     ORDER BY total_hours DESC
@@ -234,6 +234,10 @@ public final class DailyReportGenerator: Sendable {
     }
 
     private func parseDateTime(_ str: String) -> Date? { CoreFormatters.parseDateTime(str) }
+
+    private static func localDateSQL(_ expression: String) -> String {
+        "CASE WHEN length(\(expression)) <= 10 THEN date(\(expression)) ELSE date(\(expression), 'localtime') END"
+    }
 
     private func isTableNotFoundError(_ error: Error) -> Bool {
         let message = String(describing: error)

--- a/core/Sources/WiredPartCore/Services/DashboardService.swift
+++ b/core/Sources/WiredPartCore/Services/DashboardService.swift
@@ -588,7 +588,7 @@ public final class DashboardService: Sendable {
                 var totalHours = try Double.fetchOne(conn, sql: """
                     SELECT COALESCE(SUM(regular_hours + overtime_hours), 0)
                     FROM labor_entries
-                    WHERE user_id = ? AND date(clock_in) = date('now') AND deleted_at IS NULL
+                    WHERE user_id = ? AND \(Self.localDateSQL("clock_in")) = date('now', 'localtime') AND deleted_at IS NULL
                     """, arguments: [userId]) ?? 0
 
                 // Active clock-in session
@@ -630,7 +630,7 @@ public final class DashboardService: Sendable {
                            ) AS total_hours
                     FROM labor_entries le
                     LEFT JOIN jobs j ON j.id = le.job_id AND j.deleted_at IS NULL
-                    WHERE le.user_id = ? AND date(le.clock_in) = date('now') AND le.deleted_at IS NULL
+                    WHERE le.user_id = ? AND \(Self.localDateSQL("le.clock_in")) = date('now', 'localtime') AND le.deleted_at IS NULL
                     GROUP BY le.job_id
                     ORDER BY total_hours DESC
                     """, arguments: [userId])
@@ -656,7 +656,7 @@ public final class DashboardService: Sendable {
                     ), 0)
                     FROM break_records
                     WHERE user_id = ?
-                      AND date(started_at) = date('now')
+                      AND \(Self.localDateSQL("started_at")) = date('now', 'localtime')
                       AND deleted_at IS NULL
                     """, arguments: [userId]) ?? 0
 
@@ -803,11 +803,11 @@ public final class DashboardService: Sendable {
                     let dateStr = isoFormatter.string(from: date)
                     let regular = try Double.fetchOne(conn, sql: """
                         SELECT COALESCE(SUM(regular_hours), 0) FROM labor_entries
-                        WHERE date(clock_in) = ? AND deleted_at IS NULL
+                        WHERE \(Self.localDateSQL("clock_in")) = ? AND deleted_at IS NULL
                         """, arguments: [dateStr]) ?? 0
                     let overtime = try Double.fetchOne(conn, sql: """
                         SELECT COALESCE(SUM(overtime_hours), 0) FROM labor_entries
-                        WHERE date(clock_in) = ? AND deleted_at IS NULL
+                        WHERE \(Self.localDateSQL("clock_in")) = ? AND deleted_at IS NULL
                         """, arguments: [dateStr]) ?? 0
                     results.append(LaborDayRow(dateString: dateStr, regularHours: regular, overtimeHours: overtime))
                 }
@@ -1665,7 +1665,7 @@ public final class DashboardService: Sendable {
         let approvalsPending = try pendingOfficeApprovalCount()
         let workingToday = try safeCount(sql: """
             SELECT COUNT(DISTINCT user_id) FROM labor_entries
-            WHERE date(clock_in) = date('now')
+            WHERE \(Self.localDateSQL("clock_in")) = date('now', 'localtime')
               AND clock_out IS NULL
               AND deleted_at IS NULL
         """)
@@ -2208,7 +2208,7 @@ public final class DashboardService: Sendable {
         """)
         let clockedInToday = try safeCount(sql: """
             SELECT COUNT(DISTINCT user_id) FROM labor_entries
-            WHERE date(clock_in) = date('now')
+            WHERE \(Self.localDateSQL("clock_in")) = date('now', 'localtime')
               AND clock_out IS NULL
               AND deleted_at IS NULL
         """)
@@ -2363,6 +2363,10 @@ public final class DashboardService: Sendable {
     public func processQRScan(_ rawString: String) throws -> QRAutoFillResult {
         let autoFill = QRAutoFillService(db: db)
         return try autoFill.processQRScan(rawString)
+    }
+
+    private static func localDateSQL(_ expression: String) -> String {
+        "CASE WHEN length(\(expression)) <= 10 THEN date(\(expression)) ELSE date(\(expression), 'localtime') END"
     }
 
     /// Detect whether a GRDB/SQLite error indicates a missing table.

--- a/core/Sources/WiredPartCore/Services/JobEstimationService.swift
+++ b/core/Sources/WiredPartCore/Services/JobEstimationService.swift
@@ -843,10 +843,10 @@ public final class JobEstimationService: Sendable {
 
             let avgHoursPerDay = try Double.fetchOne(dbConn, sql: """
                 SELECT AVG(daily_hours) FROM (
-                    SELECT date(clock_in) as work_date, SUM(regular_hours + overtime_hours) as daily_hours
+                    SELECT \(Self.localDateSQL("clock_in")) as work_date, SUM(regular_hours + overtime_hours) as daily_hours
                     FROM labor_entries
                     WHERE clock_in >= ? AND deleted_at IS NULL AND (regular_hours + overtime_hours) > 0
-                    GROUP BY user_id, date(clock_in)
+                    GROUP BY user_id, \(Self.localDateSQL("clock_in"))
                 )
                 """, arguments: [sinceDate]) ?? 8.0
 
@@ -875,6 +875,10 @@ public final class JobEstimationService: Sendable {
     // =========================================================================
 
     private static func nowString() -> String { CoreFormatters.nowISO() }
+
+    private static func localDateSQL(_ expression: String) -> String {
+        "CASE WHEN length(\(expression)) <= 10 THEN date(\(expression)) ELSE date(\(expression), 'localtime') END"
+    }
 
     private func isTableNotFoundError(_ error: Error) -> Bool {
         let message = String(describing: error)

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -1168,7 +1168,7 @@ public final class JobsService: Sendable {
                   AND id != ?
                   AND status = 'completed'
                   AND deleted_at IS NULL
-                  AND date(clock_in) = date(?)
+                  AND \(Self.localDateSQL("clock_in")) = date(?, 'localtime')
                   AND clock_in < ?
                 """, arguments: [userId, laborEntryId, clockIn, clockIn]) ?? 0
             let remainingRegularHours = max(0, 8.0 - priorWorkedHours)
@@ -2218,7 +2218,7 @@ public final class JobsService: Sendable {
             sql: """
                 SELECT COALESCE(SUM(regular_hours + overtime_hours), 0)
                 FROM labor_entries
-                WHERE date(clock_in) = date('now') AND deleted_at IS NULL
+                WHERE \(Self.localDateSQL("clock_in")) = date('now', 'localtime') AND deleted_at IS NULL
                 """
         )
 
@@ -2417,6 +2417,11 @@ public final class JobsService: Sendable {
             if isTableNotFoundError(error) { return [] }
             throw error
         }
+    }
+
+    /// Detect whether a GRDB/SQLite error indicates a missing table.
+    private static func localDateSQL(_ expression: String) -> String {
+        "CASE WHEN length(\(expression)) <= 10 THEN date(\(expression)) ELSE date(\(expression), 'localtime') END"
     }
 
     /// Detect whether a GRDB/SQLite error indicates a missing table.

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -1478,8 +1478,8 @@ public final class JobsService: Sendable {
                 let todoName: String? = row["todo_name"] as String?
                 let wType: String = row["work_type"] ?? "new_work"
 
-                let startDate = CoreFormatters.parseDateTime(clockInStr) ?? Date()
-                let endDate: Date? = clockOutStr.flatMap { CoreFormatters.parseDateTime($0) }
+                let startDate = Self.parseSQLiteUTCDateTime(clockInStr) ?? Date()
+                let endDate: Date? = clockOutStr.flatMap { Self.parseSQLiteUTCDateTime($0) }
 
                 let summary = ClockEntrySummary(
                     id: entryId,
@@ -2417,7 +2417,19 @@ public final class JobsService: Sendable {
         }
     }
 
-    /// Detect whether a GRDB/SQLite error indicates a missing table.
+    private static let sqliteUTCDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+
+    private static func parseSQLiteUTCDateTime(_ string: String) -> Date? {
+        if let date = CoreFormatters.parseISO(string) { return date }
+        return sqliteUTCDateFormatter.date(from: string)
+    }
+
+    /// Convert SQLite datetime/date text into the current local operational day.
     private static func localDateSQL(_ expression: String) -> String {
         "CASE WHEN length(\(expression)) <= 10 THEN date(\(expression)) ELSE date(\(expression), 'localtime') END"
     }

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -1452,8 +1452,6 @@ public final class JobsService: Sendable {
     /// Get today's clock entries for a user, grouped by job with optional to-do names.
     public func getTodaysClockEntries(userId: Int64) throws -> [JobClockGroup] {
         do { return try db.writer.read { dbConn -> [JobClockGroup] in
-            let todayPrefix = String(CoreFormatters.nowISO().prefix(10))
-
             let rows = try Row.fetchAll(dbConn, sql: """
                 SELECT le.id, le.job_id, j.job_name, le.clock_in, le.clock_out,
                        le.linked_todo_id, le.work_type,
@@ -1462,10 +1460,10 @@ public final class JobsService: Sendable {
                 LEFT JOIN jobs j ON j.id = le.job_id AND j.deleted_at IS NULL
                 LEFT JOIN notebook_entries ne ON ne.id = le.linked_todo_id AND ne.deleted_at IS NULL
                 WHERE le.user_id = ?
-                  AND le.clock_in LIKE ?
+                  AND \(Self.localDateSQL("le.clock_in")) = date('now', 'localtime')
                   AND le.deleted_at IS NULL
                 ORDER BY le.clock_in ASC
-                """, arguments: [userId, "\(todayPrefix)%"])
+                """, arguments: [userId])
 
             var groupMap: [Int64: [ClockEntrySummary]] = [:]
             var groupOrder: [Int64] = []
@@ -1480,8 +1478,8 @@ public final class JobsService: Sendable {
                 let todoName: String? = row["todo_name"] as String?
                 let wType: String = row["work_type"] ?? "new_work"
 
-                let startDate = CoreFormatters.parseISO(clockInStr) ?? Date()
-                let endDate: Date? = clockOutStr.flatMap { CoreFormatters.parseISO($0) }
+                let startDate = CoreFormatters.parseDateTime(clockInStr) ?? Date()
+                let endDate: Date? = clockOutStr.flatMap { CoreFormatters.parseDateTime($0) }
 
                 let summary = ClockEntrySummary(
                     id: entryId,

--- a/core/Sources/WiredPartCore/Services/ReportsService.swift
+++ b/core/Sources/WiredPartCore/Services/ReportsService.swift
@@ -141,12 +141,12 @@ public final class ReportsService: Sendable {
                            COALESCE(SUM(le.regular_hours), 0) AS regular_hours,
                            COALESCE(SUM(le.overtime_hours), 0) AS overtime_hours,
                            COALESCE(SUM(le.regular_hours), 0) + COALESCE(SUM(le.overtime_hours), 0) AS total_hours,
-                           COUNT(DISTINCT date(le.clock_in)) AS days_worked
+                           COUNT(DISTINCT \(Self.localDateSQL("le.clock_in"))) AS days_worked
                     FROM labor_entries le
                     LEFT JOIN users u ON u.id = le.user_id AND u.deleted_at IS NULL
                     WHERE le.deleted_at IS NULL
-                      AND date(le.clock_in) >= date(?)
-                      AND date(le.clock_in) <= date(?)
+                      AND \(Self.localDateSQL("le.clock_in")) >= date(?)
+                      AND \(Self.localDateSQL("le.clock_in")) <= date(?)
                     GROUP BY le.user_id
                     ORDER BY user_name ASC
                     """
@@ -191,7 +191,7 @@ public final class ReportsService: Sendable {
                     JOIN jobs j ON j.id = le.job_id
                     WHERE le.deleted_at IS NULL
                       AND j.deleted_at IS NULL
-                      AND date(le.clock_in) = date(?)
+                      AND \(Self.localDateSQL("le.clock_in")) = date(?)
                     GROUP BY j.id
                     ORDER BY j.job_name ASC
                     """
@@ -376,7 +376,7 @@ public final class ReportsService: Sendable {
                            COALESCE(SUM(le.overtime_hours), 0) AS overtime_hours
                     FROM jobs j
                     LEFT JOIN labor_entries le ON le.job_id = j.id
-                        AND date(le.clock_in) >= ? AND date(le.clock_in) <= ?
+                        AND \(Self.localDateSQL("le.clock_in")) >= ? AND \(Self.localDateSQL("le.clock_in")) <= ?
                         AND le.deleted_at IS NULL
                         AND NOT EXISTS (
                             SELECT 1
@@ -384,8 +384,8 @@ public final class ReportsService: Sendable {
                             WHERE (bp.job_id = le.job_id OR bp.job_id IS NULL)
                               AND bp.locked_at IS NOT NULL
                               AND bp.deleted_at IS NULL
-                              AND date(le.clock_in) >= date(bp.period_start)
-                              AND date(le.clock_in) <= date(bp.period_end)
+                              AND \(Self.localDateSQL("le.clock_in")) >= date(bp.period_start)
+                              AND \(Self.localDateSQL("le.clock_in")) <= date(bp.period_end)
                         )
                     WHERE j.deleted_at IS NULL
                     GROUP BY j.id
@@ -458,7 +458,7 @@ public final class ReportsService: Sendable {
                            COALESCE(SUM(le.overtime_hours), 0) AS overtime_hours
                     FROM users u
                     JOIN labor_entries le ON le.user_id = u.id
-                    WHERE date(le.clock_in) >= ? AND date(le.clock_in) <= ?
+                    WHERE \(Self.localDateSQL("le.clock_in")) >= ? AND \(Self.localDateSQL("le.clock_in")) <= ?
                       AND le.deleted_at IS NULL
                     GROUP BY u.id
                     ORDER BY name
@@ -531,7 +531,7 @@ public final class ReportsService: Sendable {
                 SELECT COUNT(*) FROM labor_entries
                 WHERE status = 'clocked_in'
                   AND deleted_at IS NULL
-                  AND date(clock_in) >= date('now', 'start of month')
+                  AND \(Self.localDateSQL("clock_in")) >= date('now', 'localtime', 'start of month')
                 """
         )
 
@@ -540,7 +540,7 @@ public final class ReportsService: Sendable {
                 SELECT COALESCE(SUM(regular_hours + overtime_hours), 0)
                 FROM labor_entries
                 WHERE deleted_at IS NULL
-                  AND date(clock_in) >= date('now', 'start of month')
+                  AND \(Self.localDateSQL("clock_in")) >= date('now', 'localtime', 'start of month')
                 """
         )
 
@@ -706,7 +706,7 @@ public final class ReportsService: Sendable {
             return try db.writer.read { dbConn -> [[String]] in
                 let rows = try Row.fetchAll(dbConn, sql: """
                     SELECT COALESCE(u.display_name, u.email, 'Unknown') AS employee_name,
-                           date(le.clock_in) AS date,
+                           \(Self.localDateSQL("le.clock_in")) AS date,
                            ROUND(le.regular_hours + le.overtime_hours, 2) AS hours,
                            COALESCE(j.job_name, '') AS job_name,
                            COALESCE(le.status, '') AS activity_type,
@@ -717,7 +717,7 @@ public final class ReportsService: Sendable {
                     LEFT JOIN users u ON u.id = le.user_id AND u.deleted_at IS NULL
                     LEFT JOIN jobs j ON j.id = le.job_id AND j.deleted_at IS NULL
                     WHERE le.deleted_at IS NULL
-                      AND date(le.clock_in) >= ? AND date(le.clock_in) <= ?
+                      AND \(Self.localDateSQL("le.clock_in")) >= ? AND \(Self.localDateSQL("le.clock_in")) <= ?
                     ORDER BY le.clock_in DESC, employee_name
                     """, arguments: [startStr, endStr])
                 return rows.map { row in
@@ -793,7 +793,7 @@ public final class ReportsService: Sendable {
                                      FROM labor_entries le
                                      LEFT JOIN users u2 ON u2.id = le.user_id
                                      WHERE le.job_id = j.id AND le.deleted_at IS NULL
-                                       AND date(le.clock_in) >= ? AND date(le.clock_in) <= ?), 0) AS labor_cost,
+                                       AND \(Self.localDateSQL("le.clock_in")) >= ? AND \(Self.localDateSQL("le.clock_in")) <= ?), 0) AS labor_cost,
                            COALESCE((SELECT SUM(ABS(sm.qty) * COALESCE(sm.unit_cost_at_move, 0))
                                      FROM stock_movements sm
                                      WHERE sm.job_id = j.id AND sm.deleted_at IS NULL
@@ -933,6 +933,10 @@ public final class ReportsService: Sendable {
             if isTableNotFoundError(error) { return [] }
             throw error
         }
+    }
+
+    private static func localDateSQL(_ expression: String) -> String {
+        "CASE WHEN length(\(expression)) <= 10 THEN date(\(expression)) ELSE date(\(expression), 'localtime') END"
     }
 
     /// Detect whether a GRDB/SQLite error indicates a missing table.

--- a/core/Tests/WiredPartCoreTests/DailyReportGeneratorTests.swift
+++ b/core/Tests/WiredPartCoreTests/DailyReportGeneratorTests.swift
@@ -1,12 +1,14 @@
 import Foundation
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Glibc)
+import Glibc
 #endif
 import Testing
 import GRDB
 @testable import WiredPartCore
 
-@Suite("DailyReportGenerator Tests")
+@Suite("DailyReportGenerator Tests", .serialized)
 struct DailyReportGeneratorTests {
 
     private func freshEnv() throws -> (E2ETestHelpers.TestEnvironment, DailyReportGenerator) {
@@ -209,9 +211,18 @@ struct DailyReportGeneratorTests {
     }()
 
     private func withMountainTimeZone<T>(_ body: () throws -> T) rethrows -> T {
-        #if canImport(Darwin)
+        #if canImport(Darwin) || canImport(Glibc)
+        let originalTZ = getenv("TZ").map { String(cString: $0) }
         setenv("TZ", "America/Denver", 1)
         tzset()
+        defer {
+            if let originalTZ {
+                setenv("TZ", originalTZ, 1)
+            } else {
+                unsetenv("TZ")
+            }
+            tzset()
+        }
         #endif
         return try body()
     }

--- a/core/Tests/WiredPartCoreTests/DailyReportGeneratorTests.swift
+++ b/core/Tests/WiredPartCoreTests/DailyReportGeneratorTests.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
 import Testing
 import GRDB
 @testable import WiredPartCore
@@ -153,5 +156,63 @@ struct DailyReportGeneratorTests {
         // date match; the critical regression check is that generateReport doesn't
         // silently drop errors as empty results.
         #expect(report.jobId == jobId)
+    }
+
+    @Test("Generate report buckets UTC end-of-day labor into local report date")
+    func testGenerateReportUsesLocalClockInDateBucket() throws {
+        try withMountainTimeZone {
+            let (env, gen) = try freshEnv()
+            let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-DRG", name: "Local Daily Report")
+
+            try env.db.writer.write { db in
+                try db.execute(sql: """
+                    INSERT INTO labor_entries
+                        (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                    VALUES (?, ?, '2026-02-01 02:30:00', '2026-02-01 04:30:00', 2.0, 0.0, 'completed', datetime('now'))
+                    """, arguments: [env.adminUserId, jobId])
+            }
+
+            let date = try #require(Self.dayFormatter.date(from: "2026-01-31"))
+            let report = try gen.generateReport(userId: env.adminUserId, jobId: jobId, date: date)
+
+            #expect(report.clockIn == "2026-02-01 02:30:00")
+            #expect(report.totalHours == 2.0)
+        }
+    }
+
+    @Test("Today's jobs buckets UTC end-of-day labor into local work date")
+    func testTodaysJobsUsesLocalClockInDateBucket() throws {
+        try withMountainTimeZone {
+            let (env, gen) = try freshEnv()
+            let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-JOBS", name: "Local Jobs")
+
+            try env.db.writer.write { db in
+                try db.execute(sql: """
+                    INSERT INTO labor_entries
+                        (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                    VALUES (?, ?, '2026-02-01 02:30:00', '2026-02-01 04:30:00', 2.0, 0.0, 'completed', datetime('now'))
+                    """, arguments: [env.adminUserId, jobId])
+            }
+
+            let date = try #require(Self.dayFormatter.date(from: "2026-01-31"))
+            let jobs = try gen.getTodaysJobs(userId: env.adminUserId, date: date)
+
+            #expect(jobs.contains { $0.jobId == jobId && abs($0.hours - 2.0) < 0.001 })
+        }
+    }
+
+    private static let dayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = TimeZone(identifier: "America/Denver")
+        return formatter
+    }()
+
+    private func withMountainTimeZone<T>(_ body: () throws -> T) rethrows -> T {
+        #if canImport(Darwin)
+        setenv("TZ", "America/Denver", 1)
+        tzset()
+        #endif
+        return try body()
     }
 }

--- a/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
@@ -3,8 +3,22 @@ import Testing
 import GRDB
 @testable import WiredPartCore
 
-@Suite("DashboardService Tests")
+@Suite("DashboardService Tests", .serialized)
 struct DashboardServiceTests {
+    private func withDenverTimeZone(_ work: () throws -> Void) throws {
+        let originalTZ = getenv("TZ").map { String(cString: $0) }
+        setenv("TZ", "America/Denver", 1)
+        tzset()
+        defer {
+            if let originalTZ {
+                setenv("TZ", originalTZ, 1)
+            } else {
+                unsetenv("TZ")
+            }
+            tzset()
+        }
+        try work()
+    }
 
     private func freshEnv() throws -> (E2ETestHelpers.TestEnvironment, DashboardService) {
         let env = try E2ETestHelpers.setUp()
@@ -95,6 +109,49 @@ struct DashboardServiceTests {
         let (_, dash) = try freshEnv()
         let data = try dash.getDashboardData()
         #expect(data.kpiSummary.activeJobs >= 0)
+    }
+
+    @Test("Labor chart buckets UTC evening clock-in into local work day")
+    func testLaborChartUsesLocalOperationalDayForUtcClockIn() throws {
+        try withDenverTimeZone {
+            let (env, dash) = try freshEnv()
+            let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-DASH", name: "Local Dashboard Job")
+
+            var localCalendar = Calendar(identifier: .gregorian)
+            localCalendar.timeZone = TimeZone(identifier: "America/Denver")!
+            let localStartOfDay = localCalendar.startOfDay(for: Date())
+            let localEvening = localCalendar.date(bySettingHour: 21, minute: 30, second: 0, of: localStartOfDay)!
+
+            let utcFormatter = DateFormatter()
+            utcFormatter.calendar = Calendar(identifier: .gregorian)
+            utcFormatter.locale = Locale(identifier: "en_US_POSIX")
+            utcFormatter.timeZone = TimeZone(identifier: "UTC")
+            utcFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+            let localDayFormatter = DateFormatter()
+            localDayFormatter.calendar = Calendar(identifier: .gregorian)
+            localDayFormatter.locale = Locale(identifier: "en_US_POSIX")
+            localDayFormatter.timeZone = TimeZone(identifier: "America/Denver")
+            localDayFormatter.dateFormat = "yyyy-MM-dd"
+
+            let clockIn = utcFormatter.string(from: localEvening)
+            let clockOut = utcFormatter.string(from: localEvening.addingTimeInterval(2 * 60 * 60))
+            let localDay = localDayFormatter.string(from: localEvening)
+
+            try env.db.writer.write { db in
+                try db.execute(sql: """
+                    INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                    VALUES (?, ?, ?, ?, 2.0, 0.0, 'completed', datetime('now'))
+                    """, arguments: [env.adminUserId, jobId, clockIn, clockOut])
+            }
+
+            let chartRows = try dash.getLaborChartData()
+            let localDayRow = chartRows.first(where: { $0.dateString == localDay })
+
+            #expect(localDayRow != nil)
+            #expect(abs((localDayRow?.regularHours ?? 0) - 2.0) < 0.01)
+        }
     }
 
     // MARK: - Delivery & Budget

--- a/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 import Testing
 import GRDB
 @testable import WiredPartCore

--- a/core/Tests/WiredPartCoreTests/JobEstimationServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobEstimationServiceTests.swift
@@ -1,12 +1,14 @@
 import Foundation
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Glibc)
+import Glibc
 #endif
 import Testing
 import GRDB
 @testable import WiredPartCore
 
-@Suite("JobEstimationService Tests")
+@Suite("JobEstimationService Tests", .serialized)
 struct JobEstimationServiceTests {
 
     private func freshEnv() throws -> (E2ETestHelpers.TestEnvironment, JobEstimationService) {
@@ -383,9 +385,18 @@ struct JobEstimationServiceTests {
     }
 
     private func withMountainTimeZone<T>(_ body: () throws -> T) rethrows -> T {
-        #if canImport(Darwin)
+        #if canImport(Darwin) || canImport(Glibc)
+        let originalTZ = getenv("TZ").map { String(cString: $0) }
         setenv("TZ", "America/Denver", 1)
         tzset()
+        defer {
+            if let originalTZ {
+                setenv("TZ", originalTZ, 1)
+            } else {
+                unsetenv("TZ")
+            }
+            tzset()
+        }
         #endif
         return try body()
     }

--- a/core/Tests/WiredPartCoreTests/JobEstimationServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobEstimationServiceTests.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
 import Testing
 import GRDB
 @testable import WiredPartCore
@@ -306,12 +309,85 @@ struct JobEstimationServiceTests {
         #expect(capacity >= 0)
     }
 
+    @Test("Monthly capacity groups UTC-split labor by local work date")
+    func testMonthlyCapacityUsesLocalClockInDateBucket() throws {
+        try withMountainTimeZone {
+            let (env, est) = try freshEnv()
+            let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-CAP-LOCAL", name: "Local Capacity")
+            let utcFormatter = Self.utcTimestampFormatter
+
+            let firstClockIn = utcFormatter.string(from: try Self.localToday(hour: 16, minute: 30))
+            let secondClockIn = utcFormatter.string(from: try Self.localToday(hour: 18, minute: 30))
+
+            try env.db.writer.write { db in
+                try db.execute(sql: "DELETE FROM labor_entries")
+                try db.execute(sql: """
+                    INSERT INTO labor_entries
+                        (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                    VALUES
+                        (?, ?, ?, ?, 4.0, 0.0, 'completed', datetime('now')),
+                        (?, ?, ?, ?, 4.0, 0.0, 'completed', datetime('now'))
+                    """, arguments: [
+                        env.adminUserId, jobId, firstClockIn, firstClockIn,
+                        env.adminUserId, jobId, secondClockIn, secondClockIn
+                    ])
+            }
+
+            let workerCount = try env.db.writer.read { db in
+                try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM users WHERE deleted_at IS NULL") ?? 1
+            }
+
+            let capacity = try est.calculateMonthlyCapacity()
+            let expected = Double(workerCount * Self.weekdaysInCurrentMonth())
+
+            #expect(abs(capacity - expected) < 0.001)
+        }
+    }
+
     @Test("Historical average query")
     func testHistoricalAverage() throws {
         let (_, est) = try freshEnv()
         let avg = try est.getHistoricalAverage()
         // May be nil if no historical data
         #expect(avg == nil || avg!.avgDays >= 0)
+    }
+
+    private static let utcTimestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+
+    private static func localToday(hour: Int, minute: Int) throws -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "America/Denver"))
+        var components = calendar.dateComponents([.year, .month, .day], from: Date())
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+        return try #require(calendar.date(from: components))
+    }
+
+    private static func weekdaysInCurrentMonth() -> Int {
+        let calendar = Calendar.current
+        let now = Date()
+        let range = calendar.range(of: .day, in: .month, for: now) ?? 1..<31
+        return range.reduce(0) { count, day in
+            var components = calendar.dateComponents([.year, .month], from: now)
+            components.day = day
+            guard let date = calendar.date(from: components) else { return count }
+            let weekday = calendar.component(.weekday, from: date)
+            return count + (weekday >= 2 && weekday <= 6 ? 1 : 0)
+        }
+    }
+
+    private func withMountainTimeZone<T>(_ body: () throws -> T) rethrows -> T {
+        #if canImport(Darwin)
+        setenv("TZ", "America/Denver", 1)
+        tzset()
+        #endif
+        return try body()
     }
 
     @Test("Regression: getHistoricalAverage finds jobs with status 'completed' (not 'complete')")

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -467,6 +467,32 @@ struct JobsServiceTests {
         #expect(groups.first?.jobId == jobId)
     }
 
+    @Test("Today's clock entries use local-day completed labor")
+    func testGetTodaysClockEntriesUsesLocalOperationalDayForCompletedLabor() throws {
+        try withMountainTimeZone {
+            let env = try E2ETestHelpers.setUp()
+            let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-CLOCK-LOCAL", name: "Local Clock Job")
+            let clockIn = Self.utcTimestampFormatter.string(from: try Self.localToday(hour: 22, minute: 30))
+            let clockOut = Self.utcTimestampFormatter.string(from: try Self.localToday(hour: 23, minute: 30))
+
+            try env.db.writer.write { db in
+                try db.execute(sql: "DELETE FROM labor_entries")
+                try db.execute(sql: """
+                    INSERT INTO labor_entries
+                        (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                    VALUES (?, ?, ?, ?, 1.0, 0.0, 'completed', datetime('now'))
+                    """, arguments: [env.adminUserId, jobId, clockIn, clockOut])
+            }
+
+            let groups = try env.jobs.getTodaysClockEntries(userId: env.adminUserId)
+            let group = try #require(groups.first(where: { $0.jobId == jobId }))
+
+            #expect(group.jobName == "Local Clock Job")
+            #expect(group.entries.count == 1)
+            #expect(abs(group.totalDuration - 3600) < 1)
+        }
+    }
+
     // MARK: - Report Detail & Review
 
     @Test("Get report detail and mark reviewed")

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -1,12 +1,14 @@
 import Foundation
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Glibc)
+import Glibc
 #endif
 import Testing
 import GRDB
 @testable import WiredPartCore
 
-@Suite("JobsService Tests")
+@Suite("JobsService Tests", .serialized)
 struct JobsServiceTests {
 
     // MARK: - Job CRUD
@@ -610,9 +612,18 @@ struct JobsServiceTests {
     }
 
     private func withMountainTimeZone<T>(_ body: () throws -> T) rethrows -> T {
-        #if canImport(Darwin)
+        #if canImport(Darwin) || canImport(Glibc)
+        let originalTZ = getenv("TZ").map { String(cString: $0) }
         setenv("TZ", "America/Denver", 1)
         tzset()
+        defer {
+            if let originalTZ {
+                setenv("TZ", originalTZ, 1)
+            } else {
+                unsetenv("TZ")
+            }
+            tzset()
+        }
         #endif
         return try body()
     }

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
 import Testing
 import GRDB
 @testable import WiredPartCore
@@ -255,48 +258,43 @@ struct JobsServiceTests {
 
     @Test("Daily overtime threshold spans multiple labor entries")
     func testDailyOvertimeThresholdSpansMultipleLaborEntries() throws {
-        let env = try E2ETestHelpers.setUp()
-        let firstJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-OT-1", name: "First OT Job")
-        let secondJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-OT-2", name: "Second OT Job")
+        try withMountainTimeZone {
+            let env = try E2ETestHelpers.setUp()
+            let firstJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-OT-1", name: "First OT Job")
+            let secondJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-OT-2", name: "Second OT Job")
 
-        try env.db.writer.write { db in
-            try db.execute(sql: """
-                INSERT INTO labor_entries
-                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
-                VALUES
-                    (
-                        ?,
-                        ?,
-                        date(datetime('now', '-4 hours')) || ' 00:00:00',
-                        date(datetime('now', '-4 hours')) || ' 06:00:00',
-                        6.0,
-                        0.0,
-                        'completed',
-                        datetime('now')
-                    )
-                """, arguments: [env.adminUserId, firstJobId])
+            let firstClockIn = Self.utcTimestampFormatter.string(from: try Self.localToday(hour: 8, minute: 0))
+            let firstClockOut = Self.utcTimestampFormatter.string(from: try Self.localToday(hour: 14, minute: 0))
+
+            try env.db.writer.write { db in
+                try db.execute(sql: """
+                    INSERT INTO labor_entries
+                        (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                    VALUES (?, ?, ?, ?, 6.0, 0.0, 'completed', datetime('now'))
+                    """, arguments: [env.adminUserId, firstJobId, firstClockIn, firstClockOut])
+            }
+
+            let secondLaborEntryId = try env.jobs.clockIn(userId: env.adminUserId, jobId: secondJobId)
+            try env.db.writer.write { db in
+                try db.execute(
+                    sql: "UPDATE labor_entries SET clock_in = datetime('now', '-4 hours'), clock_out = NULL WHERE id = ?",
+                    arguments: [secondLaborEntryId]
+                )
+            }
+
+            try env.jobs.clockOut(laborEntryId: secondLaborEntryId)
+
+            let secondEntry = try env.db.writer.read { db in
+                try Row.fetchOne(
+                    db,
+                    sql: "SELECT regular_hours, overtime_hours FROM labor_entries WHERE id = ?",
+                    arguments: [secondLaborEntryId]
+                )
+            }
+
+            #expect(secondEntry?["regular_hours"] as Double? == 2.0)
+            #expect(secondEntry?["overtime_hours"] as Double? == 2.0)
         }
-
-        let secondLaborEntryId = try env.jobs.clockIn(userId: env.adminUserId, jobId: secondJobId)
-        try env.db.writer.write { db in
-            try db.execute(
-                sql: "UPDATE labor_entries SET clock_in = datetime('now', '-4 hours') WHERE id = ?",
-                arguments: [secondLaborEntryId]
-            )
-        }
-
-        try env.jobs.clockOut(laborEntryId: secondLaborEntryId)
-
-        let secondEntry = try env.db.writer.read { db in
-            try Row.fetchOne(
-                db,
-                sql: "SELECT regular_hours, overtime_hours FROM labor_entries WHERE id = ?",
-                arguments: [secondLaborEntryId]
-            )
-        }
-
-        #expect(secondEntry?["regular_hours"] as Double? == 2.0)
-        #expect(secondEntry?["overtime_hours"] as Double? == 2.0)
     }
 
     // MARK: - Team Members
@@ -526,6 +524,28 @@ struct JobsServiceTests {
         #expect(kpis.activeJobs >= 1)
     }
 
+    @Test("Jobs dashboard KPIs bucket UTC end-of-day labor into local today")
+    func testJobsDashboardKPIsUseLocalClockInDateBucket() throws {
+        try withMountainTimeZone {
+            let env = try E2ETestHelpers.setUp()
+            let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-KPI-LOCAL", name: "Local KPI")
+            let clockIn = Self.utcTimestampFormatter.string(from: try Self.localToday(hour: 23, minute: 30))
+
+            try env.db.writer.write { db in
+                try db.execute(sql: "DELETE FROM labor_entries")
+                try db.execute(sql: """
+                    INSERT INTO labor_entries
+                        (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                    VALUES (?, ?, ?, ?, 3.0, 0.0, 'completed', datetime('now'))
+                    """, arguments: [env.adminUserId, jobId, clockIn, clockIn])
+            }
+
+            let kpis = try env.jobs.getJobsDashboardKPIs()
+
+            #expect(kpis.todayLaborHours == 3.0)
+        }
+    }
+
     // MARK: - Supply Run Toggle & Labor Notes
 
     @Test("Toggle supply run updates labor entry notes")
@@ -544,6 +564,31 @@ struct JobsServiceTests {
         #expect(notesAfter?.contains("supply_run_start") == true)
 
         try env.jobs.clockOut(laborEntryId: laborEntryId)
+    }
+
+    private static let utcTimestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+
+    private static func localToday(hour: Int, minute: Int) throws -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "America/Denver"))
+        var components = calendar.dateComponents([.year, .month, .day], from: Date())
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+        return try #require(calendar.date(from: components))
+    }
+
+    private func withMountainTimeZone<T>(_ body: () throws -> T) rethrows -> T {
+        #if canImport(Darwin)
+        setenv("TZ", "America/Denver", 1)
+        tzset()
+        #endif
+        return try body()
     }
 
     // MARK: - Jobs for Customer

--- a/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 import Testing
 import GRDB
 @testable import WiredPartCore

--- a/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
@@ -3,8 +3,22 @@ import Testing
 import GRDB
 @testable import WiredPartCore
 
-@Suite("ReportsService Tests")
+@Suite("ReportsService Tests", .serialized)
 struct ReportsServiceTests {
+    private func withDenverTimeZone(_ work: () throws -> Void) throws {
+        let originalTZ = getenv("TZ").map { String(cString: $0) }
+        setenv("TZ", "America/Denver", 1)
+        tzset()
+        defer {
+            if let originalTZ {
+                setenv("TZ", originalTZ, 1)
+            } else {
+                unsetenv("TZ")
+            }
+            tzset()
+        }
+        try work()
+    }
 
     // MARK: - Timesheet
 
@@ -22,9 +36,32 @@ struct ReportsServiceTests {
         let laborEntryId = try env.jobs.clockIn(userId: env.adminUserId, jobId: jobId)
         try env.jobs.clockOut(laborEntryId: laborEntryId)
 
-        let today = ISO8601DateFormatter().string(from: Date()).prefix(10)
-        let data = try env.reports.getTimesheetData(startDate: String(today), endDate: String(today))
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let today = formatter.string(from: Date())
+        let data = try env.reports.getTimesheetData(startDate: today, endDate: today)
         #expect(data.count >= 1)
+    }
+
+    @Test("Timesheet data buckets UTC evening clock-in into local work day")
+    func testTimesheetUsesLocalOperationalDayForUtcClockIn() throws {
+        try withDenverTimeZone {
+            let env = try E2ETestHelpers.setUp()
+            let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-TS", name: "Local Timesheet Job")
+            try env.db.writer.write { db in
+                try db.execute(sql: """
+                    INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                    VALUES (?, ?, '2026-03-06 03:30:00', '2026-03-06 04:30:00', 1.0, 0.0, 'completed', datetime('now'))
+                    """, arguments: [env.adminUserId, jobId])
+            }
+
+            let localDayRows = try env.reports.getTimesheetData(startDate: "2026-03-05", endDate: "2026-03-05")
+
+            #expect(localDayRows.count == 1)
+            #expect(localDayRows.first?.daysWorked == 1)
+            #expect(abs((localDayRows.first?.totalHours ?? 0) - 1.0) < 0.01)
+        }
     }
 
     // MARK: - Daily Report Summary
@@ -34,6 +71,28 @@ struct ReportsServiceTests {
         let env = try E2ETestHelpers.setUp()
         let summary = try env.reports.getDailyReportSummary(date: "2026-03-29")
         #expect(summary.isEmpty)
+    }
+
+    @Test("Daily report summary buckets UTC evening clock-in into local work day")
+    func testDailyReportSummaryUsesLocalOperationalDayForUtcClockIn() throws {
+        try withDenverTimeZone {
+            let env = try E2ETestHelpers.setUp()
+            let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-DR", name: "Local Daily Report Job")
+            try env.db.writer.write { db in
+                try db.execute(sql: """
+                    INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                    VALUES (?, ?, '2026-03-06 03:30:00', '2026-03-06 04:30:00', 1.5, 0.0, 'completed', datetime('now'))
+                    """, arguments: [env.adminUserId, jobId])
+            }
+
+            let rows = try env.reports.getDailyReportSummary(date: "2026-03-05")
+            let row = rows.first(where: { $0.id == jobId })
+
+            #expect(row != nil)
+            #expect(row?.workerCount == 1)
+            #expect(abs((row?.totalHours ?? 0) - 1.5) < 0.01)
+        }
     }
 
     // MARK: - Spending


### PR DESCRIPTION
## Summary
- Replaced remaining raw labor `clock_in` date bucketing in `DailyReportGenerator`, `JobEstimationService`, and `JobsService` with fixture-safe local-day SQL semantics from WEI-2668.
- Added focused regressions for west-of-UTC end-of-day labor in daily reports, today's jobs, job capacity, jobs dashboard KPIs, and the overtime threshold fixture.

## Verification
- `swift test --filter DailyReportGeneratorTests` passed before the final serialization cleanup.
- `swift test --filter JobEstimationServiceTests` passed before the final serialization cleanup.
- `swift test --filter JobsServiceTests` was run; all tests passed except the pre-existing overtime fixture after local-day semantics changed, then the fixture was corrected and targeted reruns passed.
- `swift test --filter DailyReportGeneratorTests/testGenerateReportUsesLocalClockInDateBucket`
- `swift test --filter DailyReportGeneratorTests/testTodaysJobsUsesLocalClockInDateBucket`
- `swift test --filter JobEstimationServiceTests/testMonthlyCapacityUsesLocalClockInDateBucket`
- `swift test --filter JobsServiceTests/testJobsDashboardKPIsUseLocalClockInDateBucket`
- `swift test --filter JobsServiceTests/testDailyOvertimeThresholdSpansMultipleLaborEntries`
- `rg -n "date\\((le\\.)?clock_in\\)|date\\([^\\n]*(le\\.)?clock_in\\)|GROUP BY user_id, date\\(clock_in\\)" core/Sources/WiredPartCore/Services || true` returned no raw labor `clock_in` date buckets.
