### PR TITLE
fix: inventory counting P2 bugs — movement wizard 999 sentinel (#749) + break auto-fill skips afternoon (#727)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
@@ -911,7 +911,7 @@ struct IOSMovementWizard: View {
             name: part.name,
             code: part.code,
             qty: 1,
-            availableQty: part.availableQty ?? 999
+            availableQty: part.availableQty ?? 0
         ))
     }
 
@@ -923,9 +923,9 @@ struct IOSMovementWizard: View {
         guard !selectedParts.contains(where: { $0.partId == partId }) else { return }
         guard selectedParts.count < 20 else { return }
 
-        var availableQty = 999
+        var availableQty = 0
         if let service = appCore.partsService {
-            availableQty = (try? service.getPartStockSummary(partId: partId).total) ?? 999
+            availableQty = (try? service.getPartStockSummary(partId: partId).total) ?? 0
         }
 
         selectedParts.append(WizardPart(

--- a/core/Sources/WiredPartCore/Services/BreakService.swift
+++ b/core/Sources/WiredPartCore/Services/BreakService.swift
@@ -283,10 +283,12 @@ public final class BreakService: Sendable {
         let dateStr = Self.formatDateUTC(date)  // must match the UTC date used in getBreakRecordsForDay
 
         do { try db.writer.write { dbConn in
-            // Auto-fill morning break if missing
-            let hasBreak = existing.contains { $0.breakType == "break" }
-            if !hasBreak {
-                if let morningTime = settings.defaultMorningBreak {
+            // Auto-fill morning break if missing — evaluated independently of afternoon (#727)
+            if let morningTime = settings.defaultMorningBreak {
+                let hasMorningBreak = existing.contains {
+                    $0.breakType == "break" && $0.startedAt.hasPrefix("\(dateStr)T\(morningTime)")
+                }
+                if !hasMorningBreak {
                     let startStr = "\(dateStr)T\(morningTime):00"
                     var record = BreakRecord(
                         id: nil, userId: userId, laborEntryId: laborEntryId,
@@ -298,8 +300,14 @@ public final class BreakService: Sendable {
                     )
                     try record.insert(dbConn)
                 }
+            }
 
-                if let afternoonTime = settings.defaultAfternoonBreak {
+            // Auto-fill afternoon break if missing — evaluated independently of morning (#727)
+            if let afternoonTime = settings.defaultAfternoonBreak {
+                let hasAfternoonBreak = existing.contains {
+                    $0.breakType == "break" && $0.startedAt.hasPrefix("\(dateStr)T\(afternoonTime)")
+                }
+                if !hasAfternoonBreak {
                     let startStr = "\(dateStr)T\(afternoonTime):00"
                     var record = BreakRecord(
                         id: nil, userId: userId, laborEntryId: laborEntryId,


### PR DESCRIPTION
## Summary
Closes #749
Closes #727
Also closes #354 (already fixed in main — verified, no code change needed)

---

### #749 — Movement wizard treats unknown stock as 999 available
**Root cause:** Two sites in `IOSMovementWizard.swift` used `999` as the fallback `availableQty` when a part's stock lookup fails (nil from search row or failed QR scan service call). This let workers enter a qty up to 999 and execute a movement against phantom stock.

**Fix:** Changed both fallback sites to `0`. Unknown stock = 0 available = wizard qty step correctly blocks or restricts movement.

---

### #727 — Break auto-fill skips missing second break when one break exists
**Root cause:** `BreakService.autoFillBreaksForDay` used a single `hasBreak` boolean that checked if ANY break record existed for the day. Both morning and afternoon fills were gated under one `if !hasBreak`. If morning break existed but afternoon was missing, `hasBreak = true` → afternoon never filled.

**Fix:** Each break slot is now evaluated independently using time-prefix matching (`startedAt.hasPrefix(dateStr + "T" + time)`). Morning and afternoon are checked and filled in separate `if` blocks.

---

### #354 — adjustAuditCount already correct
Verified in current main: `adjustAuditCount` already reads `currentQty`, computes `delta = newQty - currentQty`, writes `newQty` to stock (correct — sets the counted value) and writes `delta` to `stock_movements.qty` (correct — records the change amount). Issue was filed against older code. No code change needed.

## Tests
- ✅ 14 BreakServiceTests pass