### PR TITLE
fix: wire JobsList swipe actions (#720) + daily report break quick actions (#856-858)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/DashboardDailyReportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/DashboardDailyReportPage.swift
@@ -40,6 +40,13 @@ struct DashboardDailyReportPage: View {
         case help
         var id: String { rawValue }
     }
+
+    /// Break types for fast action buttons
+    private enum FastActionBreak {
+        case lunch, regularBreak, supplyRun
+    }
+
+    @State private var pendingFastAction: FastActionBreak?
     @State private var activeSheet: ActiveSheet?
 
     private let refreshTimer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
@@ -158,6 +165,27 @@ struct DashboardDailyReportPage: View {
                     ]
                 )
             }
+        }
+        .confirmationDialog(
+            pendingFastAction == .lunch ? "Start Lunch?" :
+            pendingFastAction == .supplyRun ? "Start Supply Run?" : "Start Break?",
+            isPresented: Binding(
+                get: { pendingFastAction != nil },
+                set: { if !$0 { pendingFastAction = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            if let action = pendingFastAction {
+                Button(action == .lunch ? "Start Lunch" :
+                       action == .supplyRun ? "Start Supply Run" : "Start Break") {
+                    startFastActionBreak(action)
+                }
+                Button("Cancel", role: .cancel) { pendingFastAction = nil }
+            }
+        } message: {
+            Text(pendingFastAction == .supplyRun
+                 ? "Records a supply-run break. Geofence auto-ends it when you return."
+                 : "Records a break start. Tap End Break when you return.")
         }
     }
 
@@ -346,10 +374,10 @@ struct DashboardDailyReportPage: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: DS.Space.md) {
                 DSQuickActionButton(title: "Lunch", icon: "fork.knife", color: .green) {
-                    startLunchOrBreak()
+                    pendingFastAction = .lunch
                 }
                 DSQuickActionButton(title: "Break", icon: "cup.and.saucer.fill", color: .purple) {
-                    startLunchOrBreak()
+                    pendingFastAction = .regularBreak
                 }
                 DSQuickActionButton(title: "Problem", icon: "exclamationmark.triangle.fill", color: .red) {
                     activeSheet = .reportProblem
@@ -358,9 +386,7 @@ struct DashboardDailyReportPage: View {
                     activeSheet = .submitReport
                 }
                 DSQuickActionButton(title: "Supply Run", icon: "truck.box.fill", color: .blue) {
-                    // Geofencing (12D) handles supply run transitions automatically.
-                    // This button clocks out as a quick action.
-                    startLunchOrBreak()
+                    pendingFastAction = .supplyRun
                 }
             }
         }
@@ -380,6 +406,29 @@ struct DashboardDailyReportPage: View {
             Task { await loadData() }
         } catch {
             loadError = userFriendlyError(error, context: "load daily report")
+        }
+    }
+
+    /// Records the appropriate break type without clocking out (#856-858).
+    private func startFastActionBreak(_ breakAction: FastActionBreak) {
+        guard let breakService = appCore.breakService,
+              let userId = appCore.currentUser?.id else {
+            loadError = "Break service not available"
+            return
+        }
+        let breakType: String
+        switch breakAction {
+        case .lunch:        breakType = "lunch_paid"
+        case .regularBreak: breakType = "break"
+        case .supplyRun:    breakType = "supply_run"
+        }
+        do {
+            _ = try breakService.startBreak(userId: userId, breakType: breakType)
+            pendingFastAction = nil
+            Task { await loadData() }
+        } catch {
+            loadError = userFriendlyError(error, context: "start break")
+            pendingFastAction = nil
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
@@ -47,11 +47,13 @@ struct JobsListPage: View {
     private enum ActiveSheet: Identifiable {
         case help
         case createJob
+        case jobDetail(Int64)
 
         var id: String {
             switch self {
             case .help: return "help"
             case .createJob: return "createJob"
+            case .jobDetail(let id): return "jobDetail-\(id)"
             }
         }
     }
@@ -140,6 +142,42 @@ struct JobsListPage: View {
                     loadJobs()
                 }
                 .environmentObject(appCore)
+            case .jobDetail(let jobId):
+                NavigationStack {
+                    IOSJobDetailTabView(jobId: jobId)
+                        .environmentObject(appCore)
+                }
+            }
+        }
+        .confirmationDialog(
+            "Change Status",
+            isPresented: Binding(
+                get: { quickStatusTarget != nil },
+                set: { if !$0 { quickStatusTarget = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            if let target = quickStatusTarget {
+                let statuses: [(String, String)] = [
+                    ("active", "Active"),
+                    ("on_hold", "On Hold"),
+                    ("payment_hold", "Payment Hold"),
+                    ("completed", "Completed"),
+                    ("warranty", "Warranty"),
+                    ("continuous", "Continuous")
+                ]
+                ForEach(statuses, id: \.0) { status, label in
+                    if target.job.status != status {
+                        Button(label) {
+                            updateJobStatus(job: target.job, newStatus: status)
+                        }
+                    }
+                }
+                Button("Cancel", role: .cancel) { quickStatusTarget = nil }
+            }
+        } message: {
+            if let target = quickStatusTarget {
+                Text("Job: \(target.job.jobName ?? target.job.jobNumber)"  )
             }
         }
         .onChange(of: searchText) { loadJobs() }
@@ -259,12 +297,12 @@ struct JobsListPage: View {
                     jobCard(job)
                 }
                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                    Button { } label: {
+                    Button { quickStatusTarget = QuickStatusTarget(job: job) } label: {
                         Label("Status", systemImage: "arrow.triangle.2.circlepath")
                     }
                     .tint(.blue)
 
-                    Button { } label: {
+                    Button { activeSheet = .jobDetail(job.id) } label: {
                         Label("Detail", systemImage: "doc.text.magnifyingglass")
                     }
                     .tint(.indigo)
@@ -543,6 +581,20 @@ struct JobsListPage: View {
         return Text(priority.capitalized)
             .font(.caption2)
             .foregroundStyle(color)
+    }
+
+    // MARK: - Status Change
+
+    private func updateJobStatus(job: JobsService.JobListItem, newStatus: String) {
+        guard let service = appCore.jobsService else { return }
+        do {
+            try service.updateJob(id: job.id, status: newStatus)
+            quickStatusTarget = nil
+            loadJobs()
+        } catch {
+            loadError = "Could not update status: \(error.localizedDescription)"
+            quickStatusTarget = nil
+        }
     }
 
     // MARK: - Data Loading


### PR DESCRIPTION
## Summary
Closes #720
Closes #856
Closes #857
Closes #858

---

### #720 — Jobs list swipe actions were empty buttons
Both `Status` and `Detail` swipe actions had empty `Button { }` closures — tapping them did nothing.

**Status fix:** Sets `quickStatusTarget` → triggers a `confirmationDialog` listing all 6 job statuses (active, on_hold, payment_hold, completed, warranty, continuous), excluding the current one. Selecting any calls `JobsService.updateJob(id:status:)` and refreshes the list.

**Detail fix:** Sets `activeSheet = .jobDetail(job.id)` → presents `IOSJobDetailTabView` in a `NavigationStack` sheet. Added `case jobDetail(Int64)` to `ActiveSheet` enum.

---

### #856/#857/#858 — Lunch / Break / Supply Run clocked user OUT
All three fast action buttons called `startLunchOrBreak()` which called `JobsService.clockOut()` — wrong for every one of them.

**Fix:** Each button sets `pendingFastAction` (.lunch / .regularBreak / .supplyRun). A `confirmationDialog` confirms intent, then `startFastActionBreak()` calls `BreakService.startBreak(userId:breakType:)` with:
- Lunch → `lunch_paid`
- Break → `break`
- Supply Run → `supply_run`

Supply Run dialog notes that geofence (12D) auto-ends the run on return. `startLunchOrBreak()` is retained for the existing geofence/clock-out code path.

## Tests
- ✅ Core Swift package builds clean