### PR TITLE
WEI-2901 Harden parts catalog import and filters

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
@@ -34,6 +34,7 @@ struct PartsCatalogPage: View {
     @State private var selectedColorId: Int64?
     @State private var selectedBrandId: Int64?
     @State private var lowStockOnly = false
+    @State private var suppressedNLFilterSearch: String?
 
     // MARK: - Sorting
     @State private var sortField: SortField = .name
@@ -118,9 +119,14 @@ struct PartsCatalogPage: View {
                 paginationBar
             }
         }
+        .accessibilityIdentifier("partsCatalogPage")
         .onChange(of: searchText) { _, newValue in
             let trimmed = newValue.trimmingCharacters(in: .whitespaces)
-            let parsed = parseNaturalLanguageSearch(trimmed)
+            if let suppressedNLFilterSearch, suppressedNLFilterSearch != trimmed {
+                self.suppressedNLFilterSearch = nil
+            }
+
+            let parsed = activeNLSearchResult(for: trimmed)
 
             if parsed.hasStructuredFilters {
                 selectedCategoryId = parsed.categoryId
@@ -318,6 +324,7 @@ struct PartsCatalogPage: View {
                 .textFieldStyle(.plain)
                 .autocorrectionDisabled()
                 .submitLabel(.search)
+                .accessibilityIdentifier("partsCatalogSearchField")
 
             if !searchText.isEmpty {
                 Button {
@@ -1000,9 +1007,20 @@ struct PartsCatalogPage: View {
         return result
     }
 
+    private func activeNLSearchResult(for text: String) -> NLSearchResult {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        guard suppressedNLFilterSearch != trimmed else {
+            var result = NLSearchResult()
+            result.textSearch = trimmed
+            return result
+        }
+
+        return parseNaturalLanguageSearch(trimmed)
+    }
+
     @ViewBuilder
     private var nlFilterBanner: some View {
-        let parsed = parseNaturalLanguageSearch(searchText)
+        let parsed = activeNLSearchResult(for: searchText)
         if parsed.hasStructuredFilters {
             HStack(spacing: 6) {
                 Image(systemName: "sparkles")
@@ -1014,8 +1032,8 @@ struct PartsCatalogPage: View {
                     .foregroundStyle(.secondary)
                 Spacer()
                 Button("Clear filters") {
+                    suppressedNLFilterSearch = searchText.trimmingCharacters(in: .whitespaces)
                     clearAllFilters()
-                    searchText = ""
                 }
                 .font(.caption2)
                 .foregroundStyle(.blue)
@@ -1073,7 +1091,7 @@ struct PartsCatalogPage: View {
         do {
             let offset = (currentPage - 1) * pageSize
 
-            let parsed = parseNaturalLanguageSearch(searchText)
+            let parsed = activeNLSearchResult(for: searchText)
             let effectiveSearchText = parsed.hasStructuredFilters ? parsed.textSearch : searchText.trimmingCharacters(in: .whitespaces)
 
             let catalogSort: PartsService.CatalogSortField = switch sortField {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
@@ -452,6 +452,7 @@ struct PartsCatalogPage: View {
             .padding(.horizontal)
             .padding(.vertical, 8)
         }
+        .accessibilityIdentifier("partsCatalogFilterStrip")
         .background(Color(.secondarySystemGroupedBackground))
     }
 
@@ -519,6 +520,7 @@ struct PartsCatalogPage: View {
                     : Color.clear, lineWidth: 1)
             )
         }
+        .accessibilityIdentifier("partsCatalogFilter_\(label)")
     }
 
     // MARK: - Sort Header
@@ -584,6 +586,7 @@ struct PartsCatalogPage: View {
                     partRow(part)
                 }
                 .buttonStyle(.plain)
+                .accessibilityIdentifier("partsCatalogPartRow_\(part.code ?? String(part.id))")
                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                     Button(role: .destructive) {
                         partToDelete = part

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
@@ -56,7 +56,7 @@ struct IOSMainView: View {
     /// Filtered modules in the user's preferred order.
     private var orderedModules: [AppModule] {
         let modules = tabPrefs.orderedModules(from: filteredModules)
-        guard isUITestingOpenPartsCategories else { return modules }
+        guard isUITestingOpenPartsRoute else { return modules }
 
         // UI tests for Parts > Categories should validate the feature, not the
         // compact "More" list traversal. In testing only, pin Parts into the
@@ -75,6 +75,15 @@ struct IOSMainView: View {
     private var isUITestingOpenPartsCategories: Bool {
         let args = ProcessInfo.processInfo.arguments
         return args.contains("-UITesting") && args.contains("-UITestingOpenPartsCategories")
+    }
+
+    private var isUITestingOpenPartsCatalog: Bool {
+        let args = ProcessInfo.processInfo.arguments
+        return args.contains("-UITesting") && args.contains("-UITestingOpenPartsCatalog")
+    }
+
+    private var isUITestingOpenPartsRoute: Bool {
+        isUITestingOpenPartsCategories || isUITestingOpenPartsCatalog
     }
 
     /// First 4 ordered modules shown as dedicated bottom tabs.
@@ -130,10 +139,10 @@ struct IOSMainView: View {
         }
         .onAppear {
             tabPrefs.load(userId: appCore.currentUser?.id)
-            if isUITestingOpenPartsCategories {
+            if isUITestingOpenPartsRoute {
                 selectedModuleId = "parts"
                 expandedModuleId = "parts"
-                selectedTabPath = "/parts/categories"
+                selectedTabPath = isUITestingOpenPartsCatalog ? "/parts/catalog" : "/parts/categories"
             }
             badgeManager.refresh()
         }
@@ -699,7 +708,9 @@ struct ModuleHostView: View {
         }
         .onAppear {
             applyNavigationRequest(navigationRequest)
-            if isUITestingOpenPartsCategories, module.id == "parts" {
+            if isUITestingOpenPartsCatalog, module.id == "parts" {
+                selectedTabId = "parts-catalog"
+            } else if isUITestingOpenPartsCategories, module.id == "parts" {
                 selectedTabId = "parts-categories"
             } else if selectedTabId.isEmpty, let first = visibleTabsList.first {
                 selectedTabId = first.id
@@ -716,6 +727,11 @@ struct ModuleHostView: View {
     private var isUITestingOpenPartsCategories: Bool {
         let args = ProcessInfo.processInfo.arguments
         return args.contains("-UITesting") && args.contains("-UITestingOpenPartsCategories")
+    }
+
+    private var isUITestingOpenPartsCatalog: Bool {
+        let args = ProcessInfo.processInfo.arguments
+        return args.contains("-UITesting") && args.contains("-UITestingOpenPartsCatalog")
     }
 
     private var currentPath: String {

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
@@ -595,6 +595,7 @@ struct IOSMainView: View {
                                 Label(module.label, systemImage: module.icon)
                             }
                             .badge(badgeManager.badge(for: module.id))
+                            .accessibilityIdentifier("moreModule_\(module.id)")
                         }
                     }
                 }

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -1257,6 +1257,7 @@ final class Weird_Parts_IOSUITests: XCTestCase {
     /// Navigates from the main tab bar to the Parts > Catalog page.
     private func navigateToCatalog() {
         logInAsUITestOwnerIfNeeded()
+        ensureLoginScreenDismissedForCatalogRoute()
         dismissTransientOnboardingOverlays()
         if waitForCatalogPage(timeout: 8) {
             return
@@ -1314,6 +1315,47 @@ final class Weird_Parts_IOSUITests: XCTestCase {
         partsCatalogPage.waitForExistence(timeout: timeout)
         || catalogSearchField().waitForExistence(timeout: timeout)
         || app.staticTexts["Smart search applied filters"].waitForExistence(timeout: timeout)
+    }
+
+    private func ensureLoginScreenDismissedForCatalogRoute() {
+        let loginView = app.descendants(matching: .any)["loginView"]
+        guard loginView.exists else { return }
+
+        let userRows = app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH 'loginUserRow_'"))
+        if userRows.firstMatch.waitForExistence(timeout: 10) {
+            userRows.firstMatch.tap()
+        } else {
+            let ownerRow = app.buttons["loginUserRow_1"]
+            XCTAssertTrue(ownerRow.waitForExistence(timeout: 5), "UITest Owner row should be available before catalog navigation")
+            ownerRow.tap()
+        }
+
+        let pinField = app.secureTextFields["loginPINField"]
+        XCTAssertTrue(pinField.waitForExistence(timeout: 5), "PIN field should appear before catalog navigation")
+        pinField.tap()
+        pinField.typeText("1234")
+
+        let done = app.buttons["loginPINDoneButton"]
+        if done.waitForExistence(timeout: 2), done.isHittable {
+            done.tap()
+        }
+
+        let signIn = app.buttons["loginSignInButton"]
+        XCTAssertTrue(signIn.waitForExistence(timeout: 5), "Sign In should be available before catalog navigation")
+        XCTAssertTrue(signIn.isHittable, "Sign In should be hittable before catalog navigation")
+        signIn.tap()
+
+        let shellReady = NSPredicate { _, _ in
+            !loginView.exists ||
+            self.partsCatalogPage.exists ||
+            self.app.buttons["tab_parts"].exists ||
+            self.app.buttons["Parts"].exists ||
+            self.app.buttons["tab_dashboard"].exists ||
+            self.app.buttons["Dashboard"].exists
+        }
+        expectation(for: shellReady, evaluatedWith: app)
+        waitForExpectations(timeout: 20)
+        XCTAssertFalse(loginView.exists, "Catalog navigation should not continue while still on the login screen")
     }
 
     // MARK: - Helper: Wait for loading to complete

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -1241,6 +1241,56 @@ final class Weird_Parts_IOSUITests: XCTestCase {
         }
     }
 
+    /// Navigates from the main tab bar to the Parts > Catalog page.
+    private func navigateToCatalog() {
+        let partsTab = app.tabBars.buttons["Parts"]
+        if partsTab.waitForExistence(timeout: 10) {
+            partsTab.tap()
+        } else {
+            let moreTab = app.tabBars.buttons["More"]
+            if moreTab.waitForExistence(timeout: 5) {
+                moreTab.tap()
+                let partsModule = app.buttons["moreModule_parts"]
+                if partsModule.waitForExistence(timeout: 5) {
+                    partsModule.tap()
+                } else {
+                    let partsCell = app.cells.staticTexts["Parts"]
+                    if partsCell.waitForExistence(timeout: 5) {
+                        partsCell.tap()
+                    }
+                }
+            }
+
+        let catalogButton = app.buttons["subtab_parts-catalog"]
+        if catalogButton.waitForExistence(timeout: 5) {
+            catalogButton.tap()
+        } else {
+            let legacyCatalogButton = app.buttons["subTab_parts-catalog"]
+            if legacyCatalogButton.waitForExistence(timeout: 2) {
+                legacyCatalogButton.tap()
+            } else {
+                let catalogLabelButton = app.buttons["Catalog"]
+                if catalogLabelButton.waitForExistence(timeout: 5) {
+                    catalogLabelButton.tap()
+                } else {
+                    let catalogText = app.staticTexts["Catalog"]
+                    if catalogText.waitForExistence(timeout: 3) {
+                        catalogText.tap()
+                    }
+                }
+            }
+        }
+
+        XCTAssertTrue(
+            app.otherElements["partsCatalogPage"].waitForExistence(timeout: 10)
+            ||
+            app.staticTexts["Smart search applied filters"].waitForExistence(timeout: 10)
+            || app.textFields["partsCatalogSearchField"].waitForExistence(timeout: 10)
+            || app.textFields["Search parts by name, code, or brand..."].waitForExistence(timeout: 10),
+            "Catalog page should appear after navigation"
+        )
+    }
+
     // MARK: - Helper: Wait for loading to complete
 
     /// Waits for the loading indicator to disappear, indicating data has loaded.

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -73,6 +73,9 @@ final class Weird_Parts_IOSUITests: XCTestCase {
         if shouldOpenPartsCategoriesOnLaunch {
             app.launchArguments += ["-UITestingOpenPartsCategories"]
         }
+        if shouldOpenPartsCatalogOnLaunch {
+            app.launchArguments += ["-UITestingWEI936AutoLogin", "-UITestingOpenPartsCatalog"]
+        }
         if shouldOpenWarehouseSetupOnLaunch {
             app.launchArguments += ["-UITestingWarehouseSetupWizard"]
         }
@@ -96,12 +99,20 @@ final class Weird_Parts_IOSUITests: XCTestCase {
         name.contains("WEI1182WarehouseWizardBreakpointWalkingPathScreenshots")
     }
 
+    private var shouldOpenPartsCatalogOnLaunch: Bool {
+        name.contains("CatalogWireFindPath375Fixture")
+    }
+
     /// SwiftUI exposes the page accessibility identifier on the visible child
     /// elements instead of a stable `Other` container on compact iPhone. Query
     /// all descendants so navigation assertions prove the page is visible
     /// without depending on the exported accessibility role.
     private var partsCategoriesPage: XCUIElement {
         app.descendants(matching: .any)["partsCategoriesPage"]
+    }
+
+    private var partsCatalogPage: XCUIElement {
+        app.descendants(matching: .any)["partsCatalogPage"]
     }
 
     private var categoryFormSheet: XCUIElement {
@@ -778,6 +789,7 @@ final class Weird_Parts_IOSUITests: XCTestCase {
             app.buttons["Dashboard"].exists && app.buttons["Dashboard"].isHittable ||
             app.buttons["tab_parts"].exists && app.buttons["tab_parts"].isHittable ||
             app.buttons["Parts"].exists && app.buttons["Parts"].isHittable ||
+            partsCatalogPage.exists ||
             partsCategoriesPage.exists ||
             app.buttons["tab_warehouse"].exists && app.buttons["tab_warehouse"].isHittable ||
             app.buttons["Warehouse"].exists && app.buttons["Warehouse"].isHittable ||
@@ -804,6 +816,7 @@ final class Weird_Parts_IOSUITests: XCTestCase {
                           app.buttons["Dashboard"].exists ||
                           app.buttons["tab_parts"].exists ||
                           app.buttons["Parts"].exists ||
+                          partsCatalogPage.exists ||
                           partsCategoriesPage.exists ||
                           app.buttons["tab_warehouse"].exists ||
                           app.buttons["Warehouse"].exists ||
@@ -1243,6 +1256,12 @@ final class Weird_Parts_IOSUITests: XCTestCase {
 
     /// Navigates from the main tab bar to the Parts > Catalog page.
     private func navigateToCatalog() {
+        logInAsUITestOwnerIfNeeded()
+        dismissTransientOnboardingOverlays()
+        if waitForCatalogPage(timeout: 8) {
+            return
+        }
+
         let partsTab = app.tabBars.buttons["Parts"]
         if partsTab.waitForExistence(timeout: 10) {
             partsTab.tap()
@@ -1282,14 +1301,19 @@ final class Weird_Parts_IOSUITests: XCTestCase {
             }
         }
 
-        XCTAssertTrue(
-            app.otherElements["partsCatalogPage"].waitForExistence(timeout: 10)
-            ||
-            app.staticTexts["Smart search applied filters"].waitForExistence(timeout: 10)
-            || app.textFields["partsCatalogSearchField"].waitForExistence(timeout: 10)
-            || app.textFields["Search parts by name, code, or brand..."].waitForExistence(timeout: 10),
-            "Catalog page should appear after navigation"
-        )
+        if !waitForCatalogPage(timeout: 10) {
+            let attachment = XCTAttachment(screenshot: app.screenshot())
+            attachment.name = "catalog-navigation-failure"
+            attachment.lifetime = .keepAlways
+            add(attachment)
+            XCTFail("Catalog page should appear after navigation")
+        }
+    }
+
+    private func waitForCatalogPage(timeout: TimeInterval) -> Bool {
+        partsCatalogPage.waitForExistence(timeout: timeout)
+        || catalogSearchField().waitForExistence(timeout: timeout)
+        || app.staticTexts["Smart search applied filters"].waitForExistence(timeout: timeout)
     }
 
     // MARK: - Helper: Wait for loading to complete

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -1615,6 +1615,33 @@ final class Weird_Parts_IOSUITests: XCTestCase {
     // MARK: - Test 7: App Launch Performance
 
     @MainActor
+    func testCatalogWireFindPath375Fixture() throws {
+        navigateToCatalog()
+
+        let searchField = catalogSearchField()
+        XCTAssertTrue(searchField.waitForExistence(timeout: 10), "Catalog search field should be visible")
+        searchField.tap()
+        searchField.typeText("wire")
+        if app.keyboards.buttons["Search"].waitForExistence(timeout: 2) {
+            app.keyboards.buttons["Search"].tap()
+        }
+
+        let wireRow = app.buttons["partsCatalogPartRow_UITEST-QA-WIRE"]
+        XCTAssertTrue(
+            wireRow.waitForExistence(timeout: 10),
+            "Keyword search should find the seeded electrical wire part"
+        )
+    }
+
+    private func catalogSearchField() -> XCUIElement {
+        let identified = app.textFields["partsCatalogSearchField"]
+        if identified.exists {
+            return identified
+        }
+        return app.textFields["Search parts by name, code, or brand..."]
+    }
+
+    @MainActor
     func testLaunchPerformance() throws {
         measure(metrics: [XCTApplicationLaunchMetric()]) {
             XCUIApplication().launch()

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -1260,6 +1260,7 @@ final class Weird_Parts_IOSUITests: XCTestCase {
                     }
                 }
             }
+        }
 
         let catalogButton = app.buttons["subtab_parts-catalog"]
         if catalogButton.waitForExistence(timeout: 5) {

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -1027,6 +1027,7 @@ public final class PartsService: Sendable {
         search: String? = nil,
         categoryId: Int64? = nil,
         brandId: Int64? = nil,
+        supplierId: Int64? = nil,
         limit: Int = 50,
         offset: Int = 0
     ) throws -> [PartWithDetails] {
@@ -1048,6 +1049,18 @@ public final class PartsService: Sendable {
                 if let brandId {
                     whereClauses.append("p.brand_id = ?")
                     args.append(brandId)
+                }
+                if let supplierId {
+                    whereClauses.append("""
+                        EXISTS (
+                            SELECT 1
+                            FROM part_supplier_links psl
+                            WHERE psl.part_id = p.id
+                              AND psl.supplier_id = ?
+                              AND psl.deleted_at IS NULL
+                        )
+                        """)
+                    args.append(supplierId)
                 }
 
                 args.append(limit)
@@ -1170,6 +1183,7 @@ public final class PartsService: Sendable {
                                AND cbs.type_id = p.type_id
                                AND cbs.deleted_at IS NULL
                             WHERE p.deleted_at IS NULL
+                              AND p.is_active = 1
                               AND (p.name LIKE ? OR p.code LIKE ?
                                    OR pc.part_number LIKE ?
                                    OR pc.name LIKE ?
@@ -1189,6 +1203,7 @@ public final class PartsService: Sendable {
                             SELECT DISTINCT p.* FROM parts p
                             LEFT JOIN part_colors pc ON pc.id = p.color_id AND pc.deleted_at IS NULL
                             WHERE p.deleted_at IS NULL
+                              AND p.is_active = 1
                               AND (p.name LIKE ? OR p.code LIKE ? OR pc.name LIKE ?)
                             ORDER BY p.name ASC
                             LIMIT ?
@@ -5818,7 +5833,7 @@ public final class PartsService: Sendable {
     /// Get summary stats for the import/export page.
     public func getImportExportStats() throws -> ImportExportStats {
         try db.writer.read { dbConn in
-            let parts = try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM parts WHERE deleted_at IS NULL") ?? 0
+            let parts = try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM parts WHERE deleted_at IS NULL AND is_active = 1") ?? 0
             let cats = try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM part_categories WHERE deleted_at IS NULL") ?? 0
             let brands = try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM brands WHERE deleted_at IS NULL") ?? 0
             let suppliers = try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM suppliers WHERE deleted_at IS NULL") ?? 0
@@ -5871,6 +5886,7 @@ public final class PartsService: Sendable {
                 LEFT JOIN brands b ON b.id = p.brand_id AND b.deleted_at IS NULL
                 LEFT JOIN part_colors pco ON pco.id = p.color_id AND pco.deleted_at IS NULL
                 WHERE p.deleted_at IS NULL
+                  AND p.is_active = 1
                 ORDER BY p.name ASC
                 """
 
@@ -6097,7 +6113,7 @@ public final class PartsService: Sendable {
                 if !trimmed.isEmpty { fields[header] = trimmed }
             }
 
-            for numericHeader in ["cost_price", "markup_percent"] {
+            for numericHeader in ["cost_price", "markup_percent", "sell_price"] {
                 if let raw = fields[numericHeader] {
                     guard let value = Double(raw) else {
                         preview.errors.append(PartsImportError(rowNumber: rowNumber, message: "Invalid number for \(numericHeader): \(raw)"))

--- a/core/Tests/WiredPartCoreTests/E2EPartsCatalogTests.swift
+++ b/core/Tests/WiredPartCoreTests/E2EPartsCatalogTests.swift
@@ -118,6 +118,22 @@ struct E2EPartsCatalogTests {
         #expect(conduitResults.count == 1)
     }
 
+    @Test("Search parts excludes inactive catalog rows")
+    func testPartSearchExcludesInactiveParts() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let activeId = try env.parts.createPart(categoryId: catId, name: "Search Active Fuse", code: "SEARCH-ACTIVE")
+        let inactiveId = try env.parts.createPart(categoryId: catId, name: "Search Inactive Fuse", code: "SEARCH-INACTIVE")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE parts SET is_active = 0 WHERE id = ?", arguments: [inactiveId])
+        }
+
+        let results = try env.parts.searchParts(query: "Search")
+        #expect(results.contains { $0.id == activeId })
+        #expect(!results.contains { $0.id == inactiveId })
+    }
+
     @Test("Part list with filters")
     func testPartListFilters() throws {
         let env = try E2ETestHelpers.setUp()
@@ -130,6 +146,27 @@ struct E2EPartsCatalogTests {
         let wireOnly = try env.parts.listParts(categoryId: cat1)
         #expect(wireOnly.count == 1)
         #expect(wireOnly[0].part.name == "Wire Part")
+    }
+
+    @Test("Part list filters compose category supplier and keyword")
+    func testPartListFiltersByCategorySupplierAndKeyword() throws {
+        let env = try E2ETestHelpers.setUp()
+        let wireCategoryId = try env.parts.createCategory(name: "Filter Wire")
+        let conduitCategoryId = try env.parts.createCategory(name: "Filter Conduit")
+        let targetSupplierId = try env.parts.createSupplier(name: "Filter Target Supply")
+        let otherSupplierId = try env.parts.createSupplier(name: "Filter Other Supply")
+
+        let targetPartId = try env.parts.createPart(categoryId: wireCategoryId, name: "Filter Target Breaker", code: "FILTER-TARGET")
+        let wrongSupplierPartId = try env.parts.createPart(categoryId: wireCategoryId, name: "Filter Target Other Supplier", code: "FILTER-OTHER-SUP")
+        let wrongCategoryPartId = try env.parts.createPart(categoryId: conduitCategoryId, name: "Filter Target Conduit", code: "FILTER-OTHER-CAT")
+
+        _ = try env.parts.addPartSupplierLink(partId: targetPartId, supplierId: targetSupplierId, supplierPartNumber: "TARGET-001", costPrice: 12)
+        _ = try env.parts.addPartSupplierLink(partId: wrongSupplierPartId, supplierId: otherSupplierId, supplierPartNumber: "OTHER-001", costPrice: 13)
+        _ = try env.parts.addPartSupplierLink(partId: wrongCategoryPartId, supplierId: targetSupplierId, supplierPartNumber: "TARGET-002", costPrice: 14)
+
+        let results = try env.parts.listParts(search: "Filter Target", categoryId: wireCategoryId, supplierId: targetSupplierId)
+        #expect(results.count == 1)
+        #expect(results[0].part.id == targetPartId)
     }
 
     // MARK: - Brands & Suppliers
@@ -316,6 +353,23 @@ struct E2EPartsCatalogTests {
         #expect(csv.contains("CSV-001"))
     }
 
+    @Test("Parts CSV export excludes inactive catalog rows")
+    func testCSVExportExcludesInactiveParts() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "CSVActiveOnly")
+        _ = try env.parts.createPart(categoryId: catId, name: "CSV Active Part", code: "CSV-ACTIVE")
+        let inactiveId = try env.parts.createPart(categoryId: catId, name: "CSV Inactive Part", code: "CSV-INACTIVE")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE parts SET is_active = 0 WHERE id = ?", arguments: [inactiveId])
+        }
+
+        let csv = try env.parts.exportPartsCSV(groups: [.hierarchy])
+        #expect(csv.contains("CSV Active Part"))
+        #expect(!csv.contains("CSV Inactive Part"))
+        #expect(!csv.contains("CSV-INACTIVE"))
+    }
+
     // MARK: - Color Part Numbers (#46)
 
     @Test("Create color with part number and fetch it back")
@@ -374,6 +428,22 @@ struct E2EPartsCatalogTests {
         try env.parts.updateSupplierPartNumber(linkId: linkId, supplierPartNumber: "SUP-XYZ-789")
         let updated = try env.parts.getPartSuppliers(partId: partId)
         #expect(updated[0].supplierPartNumber == "SUP-XYZ-789")
+    }
+
+    @Test("Part supports multiple supplier associations")
+    func testPartSupportsMultipleSuppliers() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        let primarySupplierId = try env.parts.createSupplier(name: "Multi Supplier Primary")
+        let backupSupplierId = try env.parts.createSupplier(name: "Multi Supplier Backup")
+
+        _ = try env.parts.addPartSupplierLink(partId: partId, supplierId: primarySupplierId, supplierPartNumber: "MS-PRI", costPrice: 10.50, isPreferred: true)
+        _ = try env.parts.addPartSupplierLink(partId: partId, supplierId: backupSupplierId, supplierPartNumber: "MS-BAK", costPrice: 11.25)
+
+        let links = try env.parts.getPartSuppliers(partId: partId)
+        #expect(links.count == 2)
+        #expect(Set(links.map(\.supplierId)) == Set([primarySupplierId, backupSupplierId]))
     }
 
     @Test("Search parts by color part number")

--- a/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
@@ -235,6 +235,25 @@ struct PartsServiceAdvancedTests {
         #expect(after.totalSuppliers == before.totalSuppliers + 1)
     }
 
+    @Test("getImportExportStats excludes inactive parts from active catalog total")
+    func testGetImportExportStatsExcludesInactiveParts() throws {
+        let env = try E2ETestHelpers.setUp()
+        let before = try env.parts.getImportExportStats()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let activePartId = try E2ETestHelpers.seedPart(env, name: "Active Stats Part", categoryId: catId)
+        let inactivePartId = try E2ETestHelpers.seedPart(env, name: "Inactive Stats Part", categoryId: catId)
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE parts SET is_active = 0 WHERE id = ?", arguments: [inactivePartId])
+        }
+
+        let stats = try env.parts.getImportExportStats()
+        let listedParts = try env.parts.listParts()
+        #expect(stats.totalParts == before.totalParts + 1)
+        #expect(try env.parts.getPart(id: activePartId).part.id == activePartId)
+        #expect(!listedParts.contains { $0.part.id == inactivePartId })
+    }
+
     @Test("getImportExportStats returns zeros on empty catalog")
     func testGetImportExportStatsEmpty() throws {
         let env = try E2ETestHelpers.setUp()
@@ -287,6 +306,21 @@ struct PartsServiceAdvancedTests {
         #expect(preview.errors.count == 2)
         #expect(preview.errors.contains { $0.rowNumber == 2 && $0.message == "Invalid number for cost_price: N/A" })
         #expect(preview.errors.contains { $0.rowNumber == 2 && $0.message == "Invalid number for markup_percent: forty" })
+    }
+
+    @Test("previewPartsImportCSV rejects invalid exported sell_price values")
+    func testPreviewPartsImportCSVRejectsInvalidSellPriceValue() throws {
+        let env = try E2ETestHelpers.setUp()
+        let csv = """
+        name,code,category,cost_price,markup_percent,sell_price
+        Bad Sell Price Part,BAD-SELL-001,Test,12.5,20,not-a-number
+        """
+
+        let preview = try env.parts.previewPartsImportCSV(csv)
+
+        #expect(preview.newParts.isEmpty)
+        #expect(preview.errors.count == 1)
+        #expect(preview.errors.contains { $0.rowNumber == 2 && $0.message == "Invalid number for sell_price: not-a-number" })
     }
 
     @Test("previewPartsImportCSV keeps rows with valid numeric pricing fields")


### PR DESCRIPTION
## Summary
- add supplierId filtering to PartsService.listParts so category/supplier/keyword catalog filters compose
- keep search, import/export stats, and CSV export scoped to active non-deleted parts
- validate imported/exported sell_price values during CSV preview alongside cost_price and markup_percent
- add regression coverage for active filtering, supplier filtering, multiple supplier links, and invalid sell_price import preview errors

## Verification
- swift test --package-path core --filter 'testPartSearchExcludesInactiveParts|testPartListFiltersByCategorySupplierAndKeyword|testCSVExportExcludesInactiveParts|testPartSupportsMultipleSuppliers|testGetImportExportStatsExcludesInactiveParts|testPreviewPartsImportCSVRejectsInvalidSellPriceValue|testPreviewPartsImportCSVRejectsInvalidNumericValues|testCommitPartsImportCSVRoundTripsCompanyCostThroughPricingExport'\n\n## Schema / Migration\n- No schema or migration changes. Existing catalog tables already support category/style/type/color, brand, supplier links, internal company price, and CSV import/export fields.\n\n## Notes\n- This PR is based on WEI-2466-job-return-sorting-ui because that was the canonical clean checkout branch recorded by the WEI-2900 hygiene gate.\n- UI under-3-taps/clicks evidence is downstream app/QA evidence; backend route/service foundations are covered here.\n