### PR TITLE
WEI-2769 Build inventory ledger movement workflow

### DIFF
--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -416,6 +416,22 @@ public final class WarehouseService: Sendable {
         }
     }
 
+    public struct LedgerLocationSummary: Sendable, Equatable {
+        public let locationType: String
+        public let locationId: Int64
+        public let qty: Int
+        public let displayName: String
+    }
+
+    public struct InventoryLedger: Sendable {
+        public let partId: Int64
+        public let partName: String
+        public let partCode: String?
+        public let totalQty: Int
+        public let locations: [LedgerLocationSummary]
+        public let movements: [MovementRow]
+    }
+
     /// Legacy sort order for movement list queries.
     public enum MovementSortOrder: Sendable, Equatable {
         case newestFirst
@@ -719,6 +735,95 @@ public final class WarehouseService: Sendable {
         }
     }
 
+    /// Current stock by location plus immutable movement history for a part.
+    public func getInventoryLedger(partId: Int64, movementLimit: Int = 100) throws -> InventoryLedger? {
+        do {
+            return try db.writer.read { dbConn -> InventoryLedger? in
+                guard let part = try Row.fetchOne(
+                    dbConn,
+                    sql: "SELECT id, name, code FROM parts WHERE id = ? AND deleted_at IS NULL",
+                    arguments: [partId]
+                ) else {
+                    return nil
+                }
+
+                let locationRows = try Row.fetchAll(
+                    dbConn,
+                    sql: """
+                        SELECT location_type, location_id, COALESCE(SUM(qty), 0) AS qty
+                        FROM stock
+                        WHERE part_id = ? AND deleted_at IS NULL AND qty > 0
+                        GROUP BY location_type, location_id
+                        ORDER BY location_type, location_id
+                        """,
+                    arguments: [partId]
+                )
+                let locations = locationRows.map { row in
+                    let locationType: String = row["location_type"]
+                    let locationId: Int64 = row["location_id"]
+                    let qty: Int = row["qty"]
+                    return LedgerLocationSummary(
+                        locationType: locationType,
+                        locationId: locationId,
+                        qty: qty,
+                        displayName: Self.locationDisplayName(type: locationType, id: locationId)
+                    )
+                }
+                let totalQty = locations.reduce(0) { $0 + $1.qty }
+
+                let movementRows = try Row.fetchAll(
+                    dbConn,
+                    sql: """
+                        SELECT sm.*,
+                               p.name AS part_name,
+                               COALESCE(u.display_name, u.email, 'Unknown') AS performed_by_name
+                        FROM stock_movements sm
+                        LEFT JOIN parts p ON p.id = sm.part_id AND p.deleted_at IS NULL
+                        LEFT JOIN users u ON u.id = sm.performed_by AND u.deleted_at IS NULL
+                        WHERE sm.part_id = ? AND sm.deleted_at IS NULL
+                        ORDER BY sm.created_at DESC, sm.id DESC
+                        LIMIT ?
+                        """,
+                    arguments: [partId, movementLimit]
+                )
+                let movements = movementRows.map { row in
+                    MovementRow(
+                        id: row["id"] as Int64,
+                        partId: row["part_id"] as Int64,
+                        partName: (row["part_name"] as String?) ?? "Unknown Part",
+                        qty: row["qty"] as Int,
+                        fromLocationType: row["from_location_type"] as String?,
+                        fromLocationId: row["from_location_id"] as Int64?,
+                        toLocationType: row["to_location_type"] as String?,
+                        toLocationId: row["to_location_id"] as Int64?,
+                        movementType: row["movement_type"] as String,
+                        reason: row["reason"] as String?,
+                        notes: row["notes"] as String?,
+                        performedBy: row["performed_by"] as Int64,
+                        performedByName: row["performed_by_name"] as String?,
+                        verifiedBy: row["verified_by"] as Int64?,
+                        scanConfirmed: ((row["scan_confirmed"] as Int?) ?? 0) == 1,
+                        gpsLat: row["gps_lat"] as Double?,
+                        gpsLng: row["gps_lng"] as Double?,
+                        createdAt: row["created_at"] as String?
+                    )
+                }
+
+                return InventoryLedger(
+                    partId: part["id"],
+                    partName: part["name"],
+                    partCode: part["code"] as String?,
+                    totalQty: totalQty,
+                    locations: locations,
+                    movements: movements
+                )
+            }
+        } catch {
+            if isTableNotFoundError(error) { return nil }
+            throw error
+        }
+    }
+
     /// Record a new stock movement and adjust stock accordingly.
     ///
     /// - Returns: The new movement's row ID.
@@ -777,6 +882,11 @@ public final class WarehouseService: Sendable {
                     """, arguments: [jid]) ?? 0) > 0
                 guard jobExists else { throw WarehouseError.jobNotFound(jid) }
             }
+
+            try Self.validateStockMutationPath(
+                fromLocationType: fromLocationType,
+                toLocationType: toLocationType
+            )
 
             try dbConn.execute(
                 sql: """
@@ -966,6 +1076,11 @@ public final class WarehouseService: Sendable {
                         """, arguments: [jid]) ?? 0) > 0
                     guard jobExists else { throw WarehouseError.jobNotFound(jid) }
                 }
+
+                try Self.validateStockMutationPath(
+                    fromLocationType: m.fromLocationType,
+                    toLocationType: m.toLocationType
+                )
 
                 try dbConn.execute(sql: """
                     INSERT INTO stock_movements
@@ -3743,6 +3858,14 @@ public final class WarehouseService: Sendable {
             return StockMovement.MovementType.stockReturn.rawValue
         }
         return StockMovement.MovementType.transfer.rawValue
+    }
+
+    private static func validateStockMutationPath(fromLocationType: String?, toLocationType: String?) throws {
+        guard let fromLocationType, let toLocationType else { return }
+        let pathKey = "\(fromLocationType)→\(toLocationType)"
+        guard validPaths.contains(pathKey) else {
+            throw WarehouseError.invalidMovementPath(from: fromLocationType, to: toLocationType)
+        }
     }
 
     /// Build a human-readable display name for a location.

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -201,6 +201,121 @@ struct WarehouseServiceExtTests {
         #expect(movement?.gpsLng == -104.9903)
     }
 
+    @Test("Inventory ledger summarizes warehouse truck and job stock with audit movements")
+    func testInventoryLedgerTracksMovementWorkflow() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, name: "Ledger Part", categoryId: catId)
+        let jobId = try E2ETestHelpers.seedJob(env)
+
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 20, locationType: "warehouse", locationId: 1)
+        _ = try env.warehouse.executeMovement(
+            partId: partId,
+            qty: 7,
+            fromLocationType: "warehouse",
+            fromLocationId: 1,
+            toLocationType: "truck",
+            toLocationId: 42,
+            reason: "Load truck",
+            performedBy: env.adminUserId
+        )
+        _ = try env.warehouse.executeMovement(
+            partId: partId,
+            qty: 3,
+            fromLocationType: "truck",
+            fromLocationId: 42,
+            toLocationType: "job",
+            toLocationId: jobId,
+            reason: "Deliver to job",
+            performedBy: env.adminUserId,
+            jobId: jobId
+        )
+
+        let ledger = try #require(try env.warehouse.getInventoryLedger(partId: partId))
+        #expect(ledger.partName == "Ledger Part")
+        #expect(ledger.totalQty == 20)
+        #expect(ledger.locations.contains {
+            $0.locationType == "warehouse" && $0.locationId == 1 && $0.qty == 13
+        })
+        #expect(ledger.locations.contains {
+            $0.locationType == "truck" && $0.locationId == 42 && $0.qty == 4
+        })
+        #expect(ledger.locations.contains {
+            $0.locationType == "job" && $0.locationId == jobId && $0.qty == 3
+        })
+        #expect(ledger.movements.count == 3)
+        #expect(ledger.movements.contains {
+            $0.fromLocationType == "truck" && $0.toLocationType == "job" && $0.qty == 3
+        })
+    }
+
+    @Test("Invalid movement paths do not mutate quantities or leave ledger rows")
+    func testInvalidMovementPathRollsBackStockAndAudit() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10, locationType: "warehouse", locationId: 1)
+
+        #expect(throws: WarehouseService.WarehouseError.invalidMovementPath(from: "job", to: "warehouse")) {
+            try env.warehouse.createMovement(
+                partId: partId,
+                qty: 2,
+                fromLocationType: "job",
+                fromLocationId: 88,
+                toLocationType: "warehouse",
+                toLocationId: 1,
+                movementType: "transfer",
+                reason: "Invalid shortcut",
+                performedBy: env.adminUserId
+            )
+        }
+
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 10)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "job", locationId: 88) == 0)
+        let ledger = try #require(try env.warehouse.getInventoryLedger(partId: partId))
+        #expect(ledger.movements.count == 1)
+        #expect(!ledger.movements.contains { $0.reason == "Invalid shortcut" })
+    }
+
+    @Test("Batch movements validate paths atomically")
+    func testBatchMovementInvalidPathRollsBack() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10, locationType: "warehouse", locationId: 1)
+
+        #expect(throws: WarehouseService.WarehouseError.invalidMovementPath(from: "job", to: "warehouse")) {
+            try env.warehouse.createBatchMovements(
+                movements: [
+                    .init(
+                        partId: partId,
+                        qty: 2,
+                        fromLocationType: "warehouse",
+                        fromLocationId: 1,
+                        toLocationType: "truck",
+                        toLocationId: 42,
+                        movementType: "transfer"
+                    ),
+                    .init(
+                        partId: partId,
+                        qty: 1,
+                        fromLocationType: "job",
+                        fromLocationId: 99,
+                        toLocationType: "warehouse",
+                        toLocationId: 1,
+                        movementType: "transfer"
+                    ),
+                ],
+                performedBy: env.adminUserId
+            )
+        }
+
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 10)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "truck", locationId: 42) == 0)
+        let ledger = try #require(try env.warehouse.getInventoryLedger(partId: partId))
+        #expect(ledger.movements.count == 1)
+    }
+
     @Test("Movement service returns empty defaults when movement table is missing")
     func testMovementMissingTableDefaults() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Add a part-level inventory ledger API that summarizes current stock by warehouse/truck/job locations and includes movement history.
- Enforce valid guided movement paths in shared single and batch movement write paths before stock mutation.
- Add targeted warehouse service tests for ledger visibility, invalid-path rollback, and batch atomicity.

## Verification
- swift test --package-path core --filter 'WiredPartCoreTests.WarehouseServiceExtTests/testInventoryLedgerTracksMovementWorkflow'
- swift test --package-path core --filter 'WiredPartCoreTests.WarehouseServiceExtTests/testInvalidMovementPathRollsBackStockAndAudit'
- swift test --package-path core --filter 'WiredPartCoreTests.WarehouseServiceExtTests/testBatchMovementInvalidPathRollsBack'

## Notes
- Full file-level WarehouseServiceExtTests filter expands to the historical warehouse suite and was stopped after targeted tests began; exact new tests pass individually.