### PR TITLE
WEI-2770 Build audited job detail workflow

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
@@ -18,6 +18,9 @@ struct IOSJobDetailPage: View {
     @State private var activeTodos: [JobsService.ClockTodoItem] = []
     @State private var todoSummary: JobsService.JobTodoSummary?
     @State private var stages: [JobsService.JobStageStatus] = []
+    @State private var jobParts: [JobsService.JobPartRow] = []
+    @State private var jobNotes: [JobsService.JobNoteRow] = []
+    @State private var inventoryMovements: [JobsService.JobInventoryMovementRow] = []
     @State private var isPaymentHold = false
     @State private var warrantyDaysRemaining: Int?
     @State private var selectedTab: DetailTab = .todos
@@ -28,7 +31,7 @@ struct IOSJobDetailPage: View {
 
     private enum DetailTab: String, CaseIterable, Identifiable {
         case todos = "To-Dos"
-        case jpos = "JPOs"
+        case materials = "Materials"
         case labor = "Labor"
         case notes = "Notes"
         case financial = "Financial"
@@ -82,7 +85,7 @@ struct IOSJobDetailPage: View {
                         title: "Job Detail Help",
                         sections: [
                             ("Dashboard", "Review status, stage progress, smart cards, AI summary, today’s activity, and quick actions from the top of the page."),
-                            ("Tabs", "Use To-Dos, JPOs, Labor, Notes, Financial, and Warranty tabs to focus the detail area."),
+                            ("Tabs", "Use To-Dos, Materials, Labor, Notes, Financial, and Warranty tabs to focus the detail area."),
                             ("Payment Holds", "A red banner appears when a job is on payment hold. Workers can still view details, but clock-in remains blocked by the Jobs service."),
                             ("Weekly Review", "Tap the calendar icon to submit a weekly work review for this job.")
                         ]
@@ -216,7 +219,7 @@ struct IOSJobDetailPage: View {
                     HStack {
                         ForEach(stages) { stage in
                             Button {
-                                activeSheet = .stageDetails(stage.name)
+                                changeStage(stage)
                             } label: {
                                 Text(stage.name)
                                     .font(.caption2)
@@ -227,9 +230,10 @@ struct IOSJobDetailPage: View {
                                     .foregroundStyle(stageTint(stage))
                             }
                             .buttonStyle(.plain)
+                            .disabled(stage.status == "in_progress")
                         }
                     }
-                    .accessibilityLabel("Tap a stage name for details")
+                    .accessibilityLabel("Tap a stage name to move the job to that stage")
                 }
             }
         }
@@ -263,12 +267,12 @@ struct IOSJobDetailPage: View {
                 )
             }
             smartCard(
-                title: "JPOs",
-                value: "—",
-                subtitle: "Linked orders tab",
-                icon: "doc.text.fill",
+                title: "Materials",
+                value: "\(jobParts.count + inventoryMovements.count)",
+                subtitle: "Parts and pulls",
+                icon: "shippingbox.fill",
                 tint: .orange
-            ) { selectedTab = .jpos }
+            ) { selectedTab = .materials }
             smartCard(
                 title: "To-Dos",
                 value: todoValue,
@@ -358,12 +362,8 @@ struct IOSJobDetailPage: View {
                 switch selectedTab {
                 case .todos:
                     todosTab
-                case .jpos:
-                    placeholderTab(
-                        title: "Linked JPOs",
-                        message: "Linked purchase orders will be listed here once the order relationship is exposed to the job detail dashboard.",
-                        icon: "doc.text"
-                    )
+                case .materials:
+                    materialsTab
                 case .labor:
                     laborTab
                 case .notes:
@@ -425,10 +425,73 @@ struct IOSJobDetailPage: View {
         }
     }
 
+    private var materialsTab: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader("Materials", systemImage: "shippingbox")
+            if jobParts.isEmpty && inventoryMovements.isEmpty {
+                placeholderRow("No parts or inventory movements are linked to this job yet.", systemImage: "shippingbox")
+            } else {
+                ForEach(jobParts) { part in
+                    labelRow(
+                        part.partName,
+                        value: "\(part.qtyConsumed - part.qtyReturned) used",
+                        icon: "wrench.and.screwdriver"
+                    )
+                }
+                ForEach(inventoryMovements) { movement in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Label(movement.partName, systemImage: "arrow.left.arrow.right")
+                                .font(.subheadline)
+                            Spacer()
+                            Text("\(movement.qty)")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                        }
+                        Text("\(StockMovement.MovementType.displayName(forRawValue: movement.movementType)) • \(movement.locationSummary) • \(movement.performedByName)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        if let notes = movement.notes, !notes.isEmpty {
+                            Text(notes)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+    }
+
     private func notesTab(_ job: JobsService.JobDetail) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             sectionHeader("Notes", systemImage: "note.text")
-            if let notes = job.notes, !notes.isEmpty {
+            if !jobNotes.isEmpty {
+                ForEach(jobNotes) { note in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack(alignment: .top) {
+                            Label(note.title, systemImage: note.entryType == "stage_change" ? "point.3.connected.trianglepath.dotted" : "note.text")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            Spacer()
+                            if let createdAt = note.createdAt {
+                                Text(formatDate(createdAt))
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        if let content = note.content, !content.isEmpty {
+                            Text(content)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Text(note.authorName)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                    .padding(.vertical, 4)
+                }
+            } else if let notes = job.notes, !notes.isEmpty {
                 Text(notes)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
@@ -742,6 +805,9 @@ struct IOSJobDetailPage: View {
             activeTodos = try service.getActiveJobTodos(jobId: jobId)
             todoSummary = try service.getJobTodoSummary(jobId: jobId)
             stages = try service.listJobStages(forJobId: jobId)
+            jobParts = try service.getJobParts(jobId: jobId)
+            jobNotes = try service.listJobNotes(jobId: jobId)
+            inventoryMovements = try service.listJobInventoryMovements(jobId: jobId)
             isPaymentHold = try service.isJobOnPaymentHold(jobId: jobId)
             warrantyDaysRemaining = try service.warrantyDaysRemaining(jobId: jobId)
             if let job {
@@ -751,6 +817,25 @@ struct IOSJobDetailPage: View {
             loadError = userFriendlyError(error, context: "load job details")
         }
         isLoading = false
+    }
+
+    private func changeStage(_ stage: JobsService.JobStageStatus) {
+        guard stage.status != "in_progress" else { return }
+        guard let service = appCore.jobsService else {
+            loadError = "Jobs service unavailable"
+            return
+        }
+        guard let userId = appCore.currentUser?.id else {
+            loadError = "Not logged in. Please log in and try again."
+            return
+        }
+        do {
+            try service.updateJobStage(jobId: jobId, stageId: stage.id, changedBy: userId)
+            loadData()
+            selectedTab = .notes
+        } catch {
+            loadError = userFriendlyError(error, context: "update job stage")
+        }
     }
 
     private func postAIContext(_ job: JobsService.JobDetail) {

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -178,6 +178,60 @@ public final class JobsService: Sendable {
         }
     }
 
+    /// Timestamped notebook activity surfaced on the job detail screen.
+    public struct JobNoteRow: Sendable, Identifiable {
+        public let id: Int64
+        public let title: String
+        public let content: String?
+        public let entryType: String
+        public let authorId: Int64?
+        public let authorName: String
+        public let createdAt: String?
+
+        public init(id: Int64, title: String, content: String?, entryType: String, authorId: Int64?, authorName: String, createdAt: String?) {
+            self.id = id
+            self.title = title
+            self.content = content
+            self.entryType = entryType
+            self.authorId = authorId
+            self.authorName = authorName
+            self.createdAt = createdAt
+        }
+    }
+
+    /// Inventory movement linked to a job through Stage 3 stock movement records.
+    public struct JobInventoryMovementRow: Sendable, Identifiable {
+        public let id: Int64
+        public let partId: Int64
+        public let partName: String
+        public let partCode: String?
+        public let qty: Int
+        public let movementType: String
+        public let locationSummary: String
+        public let reason: String?
+        public let notes: String?
+        public let performedByName: String
+        public let createdAt: String?
+
+        public init(
+            id: Int64, partId: Int64, partName: String, partCode: String?,
+            qty: Int, movementType: String, locationSummary: String,
+            reason: String?, notes: String?, performedByName: String, createdAt: String?
+        ) {
+            self.id = id
+            self.partId = partId
+            self.partName = partName
+            self.partCode = partCode
+            self.qty = qty
+            self.movementType = movementType
+            self.locationSummary = locationSummary
+            self.reason = reason
+            self.notes = notes
+            self.performedByName = performedByName
+            self.createdAt = createdAt
+        }
+    }
+
     /// Full job detail with aggregated data.
     public struct JobDetail: Sendable {
         public let id: Int64
@@ -732,6 +786,16 @@ public final class JobsService: Sendable {
                 jobType: jobType,
                 createdBy: notebookCreatorId
             )
+            if let initialNote = notes?.trimmingCharacters(in: .whitespacesAndNewlines), !initialNote.isEmpty {
+                _ = try Self.insertJobNotebookEntry(
+                    dbConn,
+                    jobId: jobId,
+                    title: "Initial job note",
+                    content: initialNote,
+                    entryType: "note",
+                    createdBy: notebookCreatorId
+                )
+            }
             return jobId
         }
     }
@@ -807,6 +871,103 @@ public final class JobsService: Sendable {
 
             let sql = "UPDATE jobs SET \(setClauses.joined(separator: ", ")) WHERE id = ? AND deleted_at IS NULL"
             try dbConn.execute(sql: sql, arguments: StatementArguments(args))
+        }
+    }
+
+    /// Add a timestamped, attributed note to the job notebook.
+    @discardableResult
+    public func addJobNote(jobId: Int64, title: String, content: String? = nil, createdBy: Int64) throws -> Int64 {
+        let cleanedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanedTitle.isEmpty else { throw JobsError.requiredFieldEmpty }
+        return try db.writer.write { dbConn in
+            guard try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM jobs WHERE id = ? AND deleted_at IS NULL", arguments: [jobId]) ?? 0 > 0 else {
+                throw JobsError.jobNotFound(jobId)
+            }
+            return try Self.insertJobNotebookEntry(
+                dbConn,
+                jobId: jobId,
+                title: cleanedTitle,
+                content: content,
+                entryType: "note",
+                createdBy: createdBy
+            )
+        }
+    }
+
+    /// List job notebook notes and stage-change audit entries in newest-first order.
+    public func listJobNotes(jobId: Int64, limit: Int = 25) throws -> [JobNoteRow] {
+        do {
+            return try db.writer.read { dbConn in
+                let rows = try Row.fetchAll(dbConn, sql: """
+                    SELECT ne.id, ne.title, ne.content, ne.entry_type, ne.created_by, ne.created_at,
+                           COALESCE(u.display_name, u.email, 'User #' || ne.created_by) AS author_name
+                    FROM notebook_entries ne
+                    JOIN notebook_sections ns ON ns.id = ne.section_id AND ns.deleted_at IS NULL
+                    JOIN notebooks n ON n.id = ns.notebook_id AND n.deleted_at IS NULL
+                    LEFT JOIN users u ON u.id = ne.created_by AND u.deleted_at IS NULL
+                    WHERE n.job_id = ?
+                      AND ne.deleted_at IS NULL
+                      AND COALESCE(ne.is_deleted, 0) = 0
+                      AND ne.entry_type IN ('note', 'stage_change')
+                    ORDER BY ne.created_at DESC, ne.id DESC
+                    LIMIT ?
+                    """, arguments: [jobId, max(1, limit)])
+                return rows.map { row in
+                    JobNoteRow(
+                        id: row["id"] ?? 0,
+                        title: row["title"] ?? "",
+                        content: row["content"],
+                        entryType: row["entry_type"] ?? "note",
+                        authorId: row["created_by"],
+                        authorName: row["author_name"] ?? "Unknown",
+                        createdAt: row["created_at"]
+                    )
+                }
+            }
+        } catch {
+            if isTableNotFoundError(error) || isColumnNotFoundError(error) { return [] }
+            throw error
+        }
+    }
+
+    /// List stock movements linked to the job by Stage 3 inventory workflows.
+    public func listJobInventoryMovements(jobId: Int64, limit: Int = 25) throws -> [JobInventoryMovementRow] {
+        do {
+            return try db.writer.read { dbConn in
+                let rows = try Row.fetchAll(dbConn, sql: """
+                    SELECT sm.id, sm.part_id, sm.qty, sm.movement_type,
+                           sm.from_location_type, sm.to_location_type,
+                           sm.reason, sm.notes, sm.created_at,
+                           p.name AS part_name, p.code AS part_code,
+                           COALESCE(u.display_name, u.email, 'User #' || sm.performed_by) AS performed_by_name
+                    FROM stock_movements sm
+                    LEFT JOIN parts p ON p.id = sm.part_id AND p.deleted_at IS NULL
+                    LEFT JOIN users u ON u.id = sm.performed_by AND u.deleted_at IS NULL
+                    WHERE sm.job_id = ? AND sm.deleted_at IS NULL
+                    ORDER BY sm.created_at DESC, sm.id DESC
+                    LIMIT ?
+                    """, arguments: [jobId, max(1, limit)])
+                return rows.map { row in
+                    let from: String = row["from_location_type"] ?? "Unknown"
+                    let to: String = row["to_location_type"] ?? "Unknown"
+                    return JobInventoryMovementRow(
+                        id: row["id"] ?? 0,
+                        partId: row["part_id"] ?? 0,
+                        partName: row["part_name"] ?? "Unknown Part",
+                        partCode: row["part_code"],
+                        qty: row["qty"] ?? 0,
+                        movementType: row["movement_type"] ?? "movement",
+                        locationSummary: "\(from.capitalized) -> \(to.capitalized)",
+                        reason: row["reason"],
+                        notes: row["notes"],
+                        performedByName: row["performed_by_name"] ?? "Unknown",
+                        createdAt: row["created_at"]
+                    )
+                }
+            }
+        } catch {
+            if isTableNotFoundError(error) || isColumnNotFoundError(error) { return [] }
+            throw error
         }
     }
 
@@ -2956,6 +3117,61 @@ public final class JobsService: Sendable {
         }
     }
 
+    /// Move a job to a stage in its assigned template and append an audit entry to the job notebook.
+    public func updateJobStage(jobId: Int64, stageId: Int64, changedBy: Int64, note: String? = nil) throws {
+        try db.writer.write { dbConn in
+            guard let jobRow = try Row.fetchOne(dbConn, sql: """
+                SELECT id, stage_template_id, current_stage_id
+                FROM jobs
+                WHERE id = ? AND deleted_at IS NULL
+                """, arguments: [jobId]) else {
+                throw JobsError.jobNotFound(jobId)
+            }
+
+            let templateId: Int64? = jobRow["stage_template_id"]
+            let currentStageId: Int64? = jobRow["current_stage_id"]
+            let stageSql: String
+            let stageArgs: [DatabaseValueConvertible?]
+            if let templateId {
+                stageSql = "SELECT id, name FROM job_stages WHERE id = ? AND template_id = ? AND deleted_at IS NULL"
+                stageArgs = [stageId, templateId]
+            } else {
+                stageSql = "SELECT id, name FROM job_stages WHERE id = ? AND deleted_at IS NULL"
+                stageArgs = [stageId]
+            }
+            guard let nextStage = try Row.fetchOne(dbConn, sql: stageSql, arguments: StatementArguments(stageArgs)) else {
+                throw JobsError.stageNotFound(stageId)
+            }
+
+            let previousName: String
+            if let currentStageId,
+               let previous = try String.fetchOne(dbConn, sql: "SELECT name FROM job_stages WHERE id = ?", arguments: [currentStageId]) {
+                previousName = previous
+            } else {
+                previousName = "Unassigned"
+            }
+            let nextName: String = nextStage["name"] ?? "Stage #\(stageId)"
+            guard currentStageId != stageId else { return }
+
+            try dbConn.execute(sql: """
+                UPDATE jobs
+                SET current_stage_id = ?, updated_at = datetime('now')
+                WHERE id = ? AND deleted_at IS NULL
+                """, arguments: [stageId, jobId])
+
+            let content = note?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let auditContent = content?.isEmpty == false ? content : "Changed from \(previousName) to \(nextName)."
+            _ = try Self.insertJobNotebookEntry(
+                dbConn,
+                jobId: jobId,
+                title: "Stage changed: \(previousName) -> \(nextName)",
+                content: auditContent,
+                entryType: "stage_change",
+                createdBy: changedBy
+            )
+        }
+    }
+
     public func setJobStageCategoryMapping(templateId: Int64, categoryId: Int64, stageId: Int64?) throws {
         try db.writer.write { dbConn in
             guard try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM job_stage_templates WHERE id = ? AND archived_at IS NULL", arguments: [templateId]) ?? 0 > 0 else {
@@ -3034,5 +3250,58 @@ public final class JobsService: Sendable {
             }
             return JobStageStatus(id: stage.id, name: stage.name, sortOrder: stage.sortOrder, status: status)
         }
+    }
+
+    private static func insertJobNotebookEntry(
+        _ dbConn: Database,
+        jobId: Int64,
+        title: String,
+        content: String?,
+        entryType: String,
+        createdBy: Int64
+    ) throws -> Int64 {
+        let jobName = try String.fetchOne(
+            dbConn,
+            sql: "SELECT job_name FROM jobs WHERE id = ? AND deleted_at IS NULL",
+            arguments: [jobId]
+        ) ?? "Job \(jobId)"
+        let notebookId: Int64
+        if let existingNotebookId = try Int64.fetchOne(dbConn, sql: """
+            SELECT id FROM notebooks
+            WHERE job_id = ? AND deleted_at IS NULL
+            ORDER BY id ASC LIMIT 1
+            """, arguments: [jobId]) {
+            notebookId = existingNotebookId
+        } else {
+            try dbConn.execute(sql: """
+                INSERT INTO notebooks (title, description, job_id, created_by, notebook_type, status, created_at, updated_at)
+                VALUES (?, 'Auto-created job activity notebook', ?, ?, 'job', 'active', datetime('now'), datetime('now'))
+                """, arguments: ["\(jobName) Notebook", jobId, createdBy])
+            notebookId = dbConn.lastInsertedRowID
+        }
+
+        let sectionId: Int64
+        if let existingSectionId = try Int64.fetchOne(dbConn, sql: """
+            SELECT id FROM notebook_sections
+            WHERE notebook_id = ? AND name = 'Notes' AND deleted_at IS NULL
+            ORDER BY id ASC LIMIT 1
+            """, arguments: [notebookId]) {
+            sectionId = existingSectionId
+        } else {
+            try dbConn.execute(sql: """
+                INSERT INTO notebook_sections (notebook_id, name, section_type, sort_order, created_at)
+                VALUES (?, 'Notes', 'notes', 0, datetime('now'))
+                """, arguments: [notebookId])
+            sectionId = dbConn.lastInsertedRowID
+        }
+
+        try dbConn.execute(sql: """
+            INSERT INTO notebook_entries
+                (section_id, title, content, entry_type, created_by, updated_by, sort_order, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, 0, datetime('now'), datetime('now'))
+            """, arguments: [sectionId, title, content, entryType, createdBy, createdBy])
+        let entryId = dbConn.lastInsertedRowID
+        try dbConn.execute(sql: "UPDATE notebooks SET updated_at = datetime('now') WHERE id = ?", arguments: [notebookId])
+        return entryId
     }
 }

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -423,6 +423,32 @@ struct JobsServiceTests {
         #expect(parts.count >= 1)
     }
 
+    @Test("job notes are timestamped and attributed through job notebook")
+    func testJobNotesAreTimestampedAndAttributed() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try env.jobs.createJob(
+            jobNumber: "J-NOTES",
+            jobName: "Notes Job",
+            notes: "Initial field note",
+            createdBy: env.adminUserId
+        )
+
+        _ = try env.jobs.addJobNote(
+            jobId: jobId,
+            title: "Field update",
+            content: "Crew finished rough-in walkthrough.",
+            createdBy: env.adminUserId
+        )
+
+        let notes = try env.jobs.listJobNotes(jobId: jobId)
+        #expect(notes.count >= 2)
+        #expect(notes.contains { $0.title == "Initial job note" && $0.content == "Initial field note" })
+        let update = try #require(notes.first { $0.title == "Field update" })
+        #expect(update.authorId == env.adminUserId)
+        #expect(!update.authorName.isEmpty)
+        #expect(update.createdAt != nil)
+    }
+
     // MARK: - Job Stages
 
     @Test("List job stages")
@@ -431,6 +457,55 @@ struct JobsServiceTests {
         let jobId = try E2ETestHelpers.seedJob(env)
         let stages = try env.jobs.listJobStages(forJobId: jobId)
         #expect(stages.count >= 0)
+    }
+
+    @Test("updateJobStage records attributed stage-change audit")
+    func testUpdateJobStageRecordsAudit() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let templateId = try #require(try env.jobs.listJobStageTemplates().first?.id)
+        let stages = try env.jobs.listAllJobStages(templateId: templateId)
+        let roughId = try #require(stages.first(where: { $0.name == "Rough-in" })?.id)
+        let trimId = try #require(stages.first(where: { $0.name == "Trim-out" })?.id)
+
+        try env.jobs.updateJobStage(jobId: jobId, stageId: roughId, changedBy: env.adminUserId)
+        try env.jobs.updateJobStage(jobId: jobId, stageId: trimId, changedBy: env.adminUserId, note: "Crew moved to trim.")
+
+        let currentStageId: Int64? = try env.db.writer.read { db in
+            try Int64.fetchOne(db, sql: "SELECT current_stage_id FROM jobs WHERE id = ?", arguments: [jobId])
+        }
+        let auditNotes = try env.jobs.listJobNotes(jobId: jobId).filter { $0.entryType == "stage_change" }
+        #expect(currentStageId == trimId)
+        #expect(auditNotes.count == 2)
+        #expect(auditNotes.contains { $0.title.contains("Rough-in -> Trim-out") && $0.content == "Crew moved to trim." })
+        #expect(auditNotes.allSatisfy { $0.authorId == env.adminUserId && $0.createdAt != nil })
+    }
+
+    @Test("job inventory movement feed reads Stage 3 job-linked stock movements")
+    func testJobInventoryMovementFeedReadsLinkedMovements() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let categoryId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, name: "Job Wire", categoryId: categoryId)
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO stock_movements
+                    (part_id, qty, from_location_type, from_location_id, to_location_type, to_location_id,
+                     movement_type, reason, notes, performed_by, job_id, created_at)
+                VALUES (?, 4, 'warehouse', 1, 'job', ?, ?, 'Job pull', 'Pulled for install',
+                        ?, ?, datetime('now'))
+                """, arguments: [partId, jobId, StockMovement.MovementType.jobPull.rawValue, env.adminUserId, jobId])
+        }
+
+        let movements = try env.jobs.listJobInventoryMovements(jobId: jobId)
+        let movement = try #require(movements.first)
+        #expect(movement.partId == partId)
+        #expect(movement.partName == "Job Wire")
+        #expect(movement.qty == 4)
+        #expect(movement.movementType == StockMovement.MovementType.jobPull.rawValue)
+        #expect(movement.notes == "Pulled for install")
+        #expect(movement.performedByName == env.adminUser.displayName)
     }
 
     // MARK: - Active Clock Entry


### PR DESCRIPTION
## Summary
- Add timestamped, attributed job notebook notes and audited stage changes in JobsService.
- Surface job notes and Stage 3 job-linked inventory movements on the iOS job detail screen.
- Add targeted JobsService coverage for notes, stage-change audit, and inventory movement linkage.

## Verification
- swift test --package-path core --filter JobsServiceTests.testJobNotesAreTimestampedAndAttributed
- swift test --package-path core --filter JobsServiceTests.testUpdateJobStageRecordsAudit
- swift test --package-path core --filter JobsServiceTests.testJobInventoryMovementFeedReadsLinkedMovements
- xcodebuild -workspace 'Wierd Parts.xcworkspace' -scheme 'WiredPart-iOS' -destination 'generic/platform=iOS' -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO build

## Notes
- Initial provisioning-enabled iOS build was blocked by missing local profile for weirdtoo.Weird-Parts-IOS, so compile verification used CODE_SIGNING_ALLOWED=NO.