### PR TITLE
WEI-2956: Add shared import source contracts

### DIFF
--- a/core/Sources/WiredPartCore/Services/PartsService+XLSXImport.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService+XLSXImport.swift
@@ -7,40 +7,96 @@ extension PartsService {
     /// XLSX rows are normalized into the same draft row path used by CSV import so duplicate
     /// detection, validation, conflict generation, and atomic commit behavior stay shared.
     public func previewPartsImportXLSX(_ data: Data) throws -> PartsImportPreview {
-        let workbook = try PartsImportXLSXReader(data: data).readFirstWorksheet()
-        guard workbook.rows.count > 1 else {
-            throw PartsError.invalidInput("XLSX sheet '\(workbook.sheetName)' is empty or has no data rows.")
+        let parsedSource = try PartsImportXLSXAdapter(service: self).parse(data)
+        let table = parsedSource.table
+        let sheetName = table.sheetName ?? "Sheet1"
+        guard table.rows.count > 1 else {
+            throw PartsError.invalidInput("XLSX sheet '\(sheetName)' is empty or has no data rows.")
         }
 
         var preview: PartsImportPreview
         do {
             preview = try previewPartsImportRows(
-                workbook.rows.map { PartsImportTabularRow(rowNumber: $0.rowNumber, columns: $0.columns) },
-                emptyDescription: "XLSX sheet '\(workbook.sheetName)' is empty or has no data rows."
+                table.rows.map { PartsImportTabularRow(rowNumber: $0.rowNumber, columns: $0.columns) },
+                emptyDescription: "XLSX sheet '\(sheetName)' is empty or has no data rows."
             )
         } catch PartsError.invalidInput(let message) {
-            throw PartsError.invalidInput("XLSX sheet '\(workbook.sheetName)' row 1: \(message)")
+            throw PartsError.invalidInput("XLSX sheet '\(sheetName)' row 1: \(message)")
         }
 
         preview.errors = preview.errors.map { error in
             PartsImportError(
                 rowNumber: error.rowNumber,
-                message: "XLSX sheet '\(workbook.sheetName)' row \(error.rowNumber): \(error.message)"
+                message: "XLSX sheet '\(sheetName)' row \(error.rowNumber): \(error.message)"
             )
         }
-        preview.source = PartsImportSourceMetadata(
-            sourceKind: "xlsx",
-            sheetName: workbook.sheetName,
-            sourceHash: importSourceHash(data)
-        )
+        preview.source = parsedSource.source
         return preview
     }
 
 }
 
+private struct PartsImportXLSXAdapter {
+    let service: PartsService
+
+    func parse(_ data: Data) throws -> PartsService.PartsImportParsedSource {
+        let hash = service.importSourceHash(data)
+        let workbook = try PartsImportXLSXReader(data: data).readWorkbook()
+        let firstWorksheet = workbook.worksheets[0]
+        let rows = firstWorksheet.rows.map { row in
+            PartsService.PartsImportDraftRow(
+                rowNumber: row.rowNumber,
+                columns: row.columns,
+                evidence: [
+                    PartsService.PartsImportSourceEvidence(
+                        kind: .row,
+                        sheetName: firstWorksheet.sheet.name,
+                        rowNumber: row.rowNumber
+                    )
+                ]
+            )
+        }
+        let table = PartsService.PartsImportExtractedTable(
+            id: "xlsx:\(firstWorksheet.sheet.index)",
+            sourceKind: .xlsx,
+            sourceName: firstWorksheet.sheet.name,
+            sheetName: firstWorksheet.sheet.name,
+            headerRowNumber: rows.first?.rowNumber,
+            rows: rows,
+            evidence: [PartsService.PartsImportSourceEvidence(kind: .sourceHash, text: hash)]
+        )
+        let parserMetadata = PartsService.PartsImportParserMetadata(
+            parserName: "wiredpart.xlsx",
+            parserVersion: "1",
+            sourceKind: .xlsx,
+            sourceHash: hash,
+            rowCount: rows.count,
+            columnCount: rows.map(\.columns.count).max() ?? 0,
+            sheetMetadata: workbook.sheetMetadata,
+            boundedArchiveProtectionsApplied: true
+        )
+        let source = PartsService.PartsImportSourceMetadata(
+            sourceKind: PartsService.PartsImportSourceKind.xlsx.rawValue,
+            sheetName: firstWorksheet.sheet.name,
+            sourceHash: hash,
+            parserMetadata: parserMetadata,
+            evidence: table.evidence
+        )
+        return PartsService.PartsImportParsedSource(table: table, source: source)
+    }
+}
+
 private struct PartsImportXLSXWorksheet {
-    let sheetName: String
+    let sheet: PartsService.PartsImportWorkbookSheetMetadata
     let rows: [PartsImportXLSXRow]
+}
+
+private struct PartsImportXLSXWorkbook {
+    let worksheets: [PartsImportXLSXWorksheet]
+
+    var sheetMetadata: [PartsService.PartsImportWorkbookSheetMetadata] {
+        worksheets.map(\.sheet)
+    }
 }
 
 private struct PartsImportXLSXRow {
@@ -71,14 +127,18 @@ private struct PartsImportXLSXReader {
               let workbookXML = String(data: workbookData, encoding: .utf8) else {
             throw PartsService.PartsError.invalidInput("Unsupported XLSX file: missing workbook metadata at xl/workbook.xml.")
         }
-        let firstSheet = workbookXML.xmlElements(named: "sheet").first
-        let relationshipId = firstSheet?.xmlAttribute("r:id") ?? firstSheet?.xmlAttribute("id")
         let relationshipXML = extracted["xl/_rels/workbook.xml.rels"].flatMap { String(data: $0, encoding: .utf8) }
-        let worksheetPath = Self.resolveWorksheetPath(relationshipId: relationshipId, relationshipsXML: relationshipXML)
+        let worksheetPaths = workbookXML.xmlElements(named: "sheet").map { sheet in
+            Self.resolveWorksheetPath(
+                relationshipId: sheet.xmlAttribute("r:id") ?? sheet.xmlAttribute("id"),
+                relationshipsXML: relationshipXML
+            )
+        }
+        let wantedSheetPaths = worksheetPaths.isEmpty ? ["xl/worksheets/sheet1.xml"] : worksheetPaths
 
         let sheetEntries = try Self.extractEntries(
             from: archive,
-            wantedPaths: [worksheetPath, "xl/sharedStrings.xml"]
+            wantedPaths: Set(wantedSheetPaths + ["xl/sharedStrings.xml"])
         )
         for (path, data) in sheetEntries {
             extracted[path] = data
@@ -133,23 +193,33 @@ private struct PartsImportXLSXReader {
         return "xl/worksheets/sheet1.xml"
     }
 
-    func readFirstWorksheet() throws -> PartsImportXLSXWorksheet {
+    func readWorkbook() throws -> PartsImportXLSXWorkbook {
         let workbookXML = try stringEntry("xl/workbook.xml", description: "workbook metadata")
         let sheets = workbookXML.xmlElements(named: "sheet")
-        guard let firstSheet = sheets.first else {
+        guard !sheets.isEmpty else {
             throw PartsService.PartsError.invalidInput("Unsupported XLSX file: workbook has no worksheets.")
         }
-
-        let sheetName = firstSheet.xmlAttribute("name") ?? "Sheet1"
-        let relationshipId = firstSheet.xmlAttribute("r:id") ?? firstSheet.xmlAttribute("id")
-        let worksheetPath = try resolveWorksheetPath(relationshipId: relationshipId)
-        let worksheetXML = try stringEntry(worksheetPath, description: "first worksheet")
         let sharedStrings = try readSharedStrings()
-        let rows = try parseRows(from: worksheetXML, sharedStrings: sharedStrings)
-        guard !rows.isEmpty else {
-            throw PartsService.PartsError.invalidInput("Unsupported XLSX sheet '\(sheetName)': no readable rows found.")
+        let worksheets = try sheets.enumerated().map { offset, sheetElement -> PartsImportXLSXWorksheet in
+            let sheetName = sheetElement.xmlAttribute("name") ?? "Sheet\(offset + 1)"
+            let relationshipId = sheetElement.xmlAttribute("r:id") ?? sheetElement.xmlAttribute("id")
+            let worksheetPath = try resolveWorksheetPath(relationshipId: relationshipId)
+            let worksheetXML = try stringEntry(worksheetPath, description: "worksheet \(sheetName)")
+            let rows = try parseRows(from: worksheetXML, sharedStrings: sharedStrings)
+            let metadata = PartsService.PartsImportWorkbookSheetMetadata(
+                index: offset,
+                name: sheetName,
+                relationshipId: relationshipId,
+                path: worksheetPath,
+                rowCount: rows.count,
+                columnCount: rows.map(\.columns.count).max() ?? 0
+            )
+            return PartsImportXLSXWorksheet(sheet: metadata, rows: rows)
         }
-        return PartsImportXLSXWorksheet(sheetName: sheetName, rows: rows)
+        guard let first = worksheets.first, !first.rows.isEmpty else {
+            throw PartsService.PartsError.invalidInput("Unsupported XLSX sheet '\(worksheets.first?.sheet.name ?? "Sheet1")': no readable rows found.")
+        }
+        return PartsImportXLSXWorkbook(worksheets: worksheets)
     }
 
     private func resolveWorksheetPath(relationshipId: String?) throws -> String {

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -5983,6 +5983,144 @@ public final class PartsService: Sendable {
         public var resolution: PartsImportConflictResolution = .ask
     }
 
+    public enum PartsImportSourceKind: String, Sendable {
+        case csv
+        case xlsx
+        case digitalPDFText = "digital_pdf_text"
+        case ocr
+        case vision
+    }
+
+    public enum PartsImportEvidenceKind: String, Sendable {
+        case cell
+        case row
+        case textBlock = "text_block"
+        case boundingBox = "bounding_box"
+        case sourceHash = "source_hash"
+    }
+
+    /// Source evidence points back to where extracted import data came from.
+    public struct PartsImportSourceEvidence: Sendable {
+        public var kind: PartsImportEvidenceKind
+        public var sheetName: String?
+        public var pageNumber: Int?
+        public var rowNumber: Int?
+        public var columnName: String?
+        public var text: String?
+        public var confidence: Double?
+        public var boundingBox: [Double]?
+
+        public init(kind: PartsImportEvidenceKind, sheetName: String? = nil, pageNumber: Int? = nil, rowNumber: Int? = nil, columnName: String? = nil, text: String? = nil, confidence: Double? = nil, boundingBox: [Double]? = nil) {
+            self.kind = kind
+            self.sheetName = sheetName
+            self.pageNumber = pageNumber
+            self.rowNumber = rowNumber
+            self.columnName = columnName
+            self.text = text
+            self.confidence = confidence
+            self.boundingBox = boundingBox
+        }
+    }
+
+    /// A source-agnostic row extracted by deterministic parsers before WEI field mapping.
+    public struct PartsImportDraftRow: Sendable {
+        public var rowNumber: Int
+        public var columns: [String]
+        public var evidence: [PartsImportSourceEvidence]
+
+        public init(rowNumber: Int, columns: [String], evidence: [PartsImportSourceEvidence] = []) {
+            self.rowNumber = rowNumber
+            self.columns = columns
+            self.evidence = evidence
+        }
+    }
+
+    /// A source-agnostic extracted table. OCR/vision adapters can populate evidence
+    /// without committing rows until later stages add parser implementations.
+    public struct PartsImportExtractedTable: Sendable {
+        public var id: String
+        public var sourceKind: PartsImportSourceKind
+        public var sourceName: String?
+        public var sheetName: String?
+        public var pageNumber: Int?
+        public var headerRowNumber: Int?
+        public var rows: [PartsImportDraftRow]
+        public var evidence: [PartsImportSourceEvidence]
+
+        public init(id: String, sourceKind: PartsImportSourceKind, sourceName: String? = nil, sheetName: String? = nil, pageNumber: Int? = nil, headerRowNumber: Int? = nil, rows: [PartsImportDraftRow], evidence: [PartsImportSourceEvidence] = []) {
+            self.id = id
+            self.sourceKind = sourceKind
+            self.sourceName = sourceName
+            self.sheetName = sheetName
+            self.pageNumber = pageNumber
+            self.headerRowNumber = headerRowNumber
+            self.rows = rows
+            self.evidence = evidence
+        }
+    }
+
+    public struct PartsImportMappingProposal: Sendable {
+        public var sourceColumn: String
+        public var targetField: String
+        public var confidence: Double
+        public var reason: String?
+
+        public init(sourceColumn: String, targetField: String, confidence: Double, reason: String? = nil) {
+            self.sourceColumn = sourceColumn
+            self.targetField = targetField
+            self.confidence = confidence
+            self.reason = reason
+        }
+    }
+
+    public enum PartsImportPreviewDecision: String, Sendable {
+        case create
+        case update
+        case skip
+        case conflict
+        case reject
+    }
+
+    public struct PartsImportWorkbookSheetMetadata: Sendable {
+        public var index: Int
+        public var name: String
+        public var relationshipId: String?
+        public var path: String
+        public var rowCount: Int
+        public var columnCount: Int
+
+        public init(index: Int, name: String, relationshipId: String? = nil, path: String, rowCount: Int = 0, columnCount: Int = 0) {
+            self.index = index
+            self.name = name
+            self.relationshipId = relationshipId
+            self.path = path
+            self.rowCount = rowCount
+            self.columnCount = columnCount
+        }
+    }
+
+    public struct PartsImportParserMetadata: Sendable {
+        public var parserName: String
+        public var parserVersion: String
+        public var sourceKind: PartsImportSourceKind
+        public var sourceHash: String?
+        public var rowCount: Int
+        public var columnCount: Int
+        public var sheetMetadata: [PartsImportWorkbookSheetMetadata]
+        public var boundedArchiveProtectionsApplied: Bool
+
+        public init(parserName: String, parserVersion: String, sourceKind: PartsImportSourceKind, sourceHash: String? = nil, rowCount: Int = 0, columnCount: Int = 0, sheetMetadata: [PartsImportWorkbookSheetMetadata] = [], boundedArchiveProtectionsApplied: Bool = false) {
+            self.parserName = parserName
+            self.parserVersion = parserVersion
+            self.sourceKind = sourceKind
+            self.sourceHash = sourceHash
+            self.rowCount = rowCount
+            self.columnCount = columnCount
+            self.sheetMetadata = sheetMetadata
+            self.boundedArchiveProtectionsApplied = boundedArchiveProtectionsApplied
+        }
+    }
+
     /// Metadata that ties an import preview/commit to a durable source artifact.
     public struct PartsImportSourceMetadata: Sendable {
         public var sourceKind: String
@@ -5990,13 +6128,17 @@ public final class PartsService: Sendable {
         public var sheetName: String?
         public var sourceHash: String?
         public var userId: Int64?
+        public var parserMetadata: PartsImportParserMetadata?
+        public var evidence: [PartsImportSourceEvidence]
 
-        public init(sourceKind: String, filename: String? = nil, sheetName: String? = nil, sourceHash: String? = nil, userId: Int64? = nil) {
+        public init(sourceKind: String, filename: String? = nil, sheetName: String? = nil, sourceHash: String? = nil, userId: Int64? = nil, parserMetadata: PartsImportParserMetadata? = nil, evidence: [PartsImportSourceEvidence] = []) {
             self.sourceKind = sourceKind
             self.filename = filename
             self.sheetName = sheetName
             self.sourceHash = sourceHash
             self.userId = userId
+            self.parserMetadata = parserMetadata
+            self.evidence = evidence
         }
     }
 
@@ -6037,21 +6179,12 @@ public final class PartsService: Sendable {
     }
 
     public func previewPartsImportCSV(_ csv: String) throws -> PartsImportPreview {
-        let rows = csv.components(separatedBy: .newlines)
-            .enumerated()
-            .compactMap { offset, line -> PartsImportTabularRow? in
-                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmed.isEmpty else { return nil }
-                return PartsImportTabularRow(
-                    rowNumber: offset + 1,
-                    columns: parseImportCSVLine(trimmed)
-                )
-            }
+        let parsedSource = PartsImportCSVAdapter(service: self).parse(csv)
+        let rows = parsedSource.table.rows.map {
+            PartsImportTabularRow(rowNumber: $0.rowNumber, columns: $0.columns)
+        }
         var preview = try previewPartsImportRows(rows, emptyDescription: "CSV file is empty or has no data rows.")
-        preview.source = PartsImportSourceMetadata(
-            sourceKind: "csv",
-            sourceHash: importSourceHash(Data(csv.utf8))
-        )
+        preview.source = parsedSource.source
         return preview
     }
 
@@ -6360,7 +6493,57 @@ public final class PartsService: Sendable {
         return "sha256:\(hex)"
     }
 
-    private func parseImportCSVLine(_ line: String) -> [String] {
+    struct PartsImportParsedSource {
+        let table: PartsImportExtractedTable
+        let source: PartsImportSourceMetadata
+    }
+
+    struct PartsImportCSVAdapter {
+        let service: PartsService
+
+        func parse(_ csv: String) -> PartsImportParsedSource {
+            let hash = service.importSourceHash(Data(csv.utf8))
+            let rows = csv.components(separatedBy: .newlines)
+                .enumerated()
+                .compactMap { offset, line -> PartsImportDraftRow? in
+                    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { return nil }
+                    let rowNumber = offset + 1
+                    return PartsImportDraftRow(
+                        rowNumber: rowNumber,
+                        columns: service.parseImportCSVLine(trimmed),
+                        evidence: [
+                            PartsImportSourceEvidence(kind: .row, rowNumber: rowNumber, text: trimmed)
+                        ]
+                    )
+                }
+            let columnCount = rows.map(\.columns.count).max() ?? 0
+            let table = PartsImportExtractedTable(
+                id: "csv:table:1",
+                sourceKind: .csv,
+                headerRowNumber: rows.first?.rowNumber,
+                rows: rows,
+                evidence: [PartsImportSourceEvidence(kind: .sourceHash, text: hash)]
+            )
+            let parserMetadata = PartsImportParserMetadata(
+                parserName: "wiredpart.csv",
+                parserVersion: "1",
+                sourceKind: .csv,
+                sourceHash: hash,
+                rowCount: rows.count,
+                columnCount: columnCount
+            )
+            let source = PartsImportSourceMetadata(
+                sourceKind: PartsImportSourceKind.csv.rawValue,
+                sourceHash: hash,
+                parserMetadata: parserMetadata,
+                evidence: table.evidence
+            )
+            return PartsImportParsedSource(table: table, source: source)
+        }
+    }
+
+    fileprivate func parseImportCSVLine(_ line: String) -> [String] {
         var fields: [String] = []
         var current = ""
         var inQuotes = false

--- a/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
@@ -27,6 +27,10 @@ private func insertPoweredVote(
 // MARK: - Helper: Build a minimal XLSX workbook for import tests
 
 private func makeMinimalXLSX(sheetName: String, rows: [[String]], rowNumbers: [Int]? = nil) throws -> Data {
+    try makeMinimalXLSX(sheets: [(sheetName, rows, rowNumbers)])
+}
+
+private func makeMinimalXLSX(sheets: [(name: String, rows: [[String]], rowNumbers: [Int]?)]) throws -> Data {
     func escapeXML(_ value: String) -> String {
         value
             .replacingOccurrences(of: "&", with: "&amp;")
@@ -47,43 +51,58 @@ private func makeMinimalXLSX(sheetName: String, rows: [[String]], rowNumbers: [I
         return result
     }
 
+    let sheetContentTypes = sheets.enumerated().map { offset, _ in
+        "  <Override PartName=\"/xl/worksheets/sheet\(offset + 1).xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>"
+    }.joined(separator: "\n")
     let contentTypesXML = """
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
       <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
       <Default Extension="xml" ContentType="application/xml"/>
       <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
-      <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+    \(sheetContentTypes)
     </Types>
     """
 
+    let sheetListXML = sheets.enumerated().map { offset, sheet in
+        "<sheet name=\"\(escapeXML(sheet.name))\" sheetId=\"\(offset + 1)\" r:id=\"rId\(offset + 1)\"/>"
+    }.joined()
     let workbookXML = """
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
-      <sheets><sheet name="\(escapeXML(sheetName))" sheetId="1" r:id="rId1"/></sheets>
+      <sheets>\(sheetListXML)</sheets>
     </workbook>
     """
 
+    let relationships = sheets.enumerated().map { offset, _ in
+        "  <Relationship Id=\"rId\(offset + 1)\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet\(offset + 1).xml\"/>"
+    }.joined(separator: "\n")
     let workbookRelationshipsXML = """
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+    \(relationships)
     </Relationships>
     """
 
-    let rowXML: String = rows.enumerated().map { rowIndex, values in
-        let spreadsheetRow = rowNumbers?[rowIndex] ?? rowIndex + 1
-        let cells: String = values.enumerated().map { columnIndex, value in
-            "<c r=\"\(columnName(columnIndex))\(spreadsheetRow)\" t=\"inlineStr\"><is><t>\(escapeXML(value))</t></is></c>"
+    func worksheetXML(rows: [[String]], rowNumbers: [Int]?) -> String {
+        let rowXML: String = rows.enumerated().map { rowIndex, values in
+            let spreadsheetRow = rowNumbers?[rowIndex] ?? rowIndex + 1
+            let cells: String = values.enumerated().map { columnIndex, value in
+                "<c r=\"\(columnName(columnIndex))\(spreadsheetRow)\" t=\"inlineStr\"><is><t>\(escapeXML(value))</t></is></c>"
+            }.joined()
+            return "<row r=\"\(spreadsheetRow)\">\(cells)</row>"
         }.joined()
-        return "<row r=\"\(spreadsheetRow)\">\(cells)</row>"
-    }.joined()
-    let worksheetXML = """
-    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-      <sheetData>\(rowXML)</sheetData>
-    </worksheet>
-    """
+        return """
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+          <sheetData>\(rowXML)</sheetData>
+        </worksheet>
+        """
+    }
+
+    let worksheetEntries = sheets.enumerated().map { offset, sheet in
+        ("xl/worksheets/sheet\(offset + 1).xml", Data(worksheetXML(rows: sheet.rows, rowNumbers: sheet.rowNumbers).utf8))
+    }
 
     let temporaryURL = FileManager.default.temporaryDirectory
         .appendingPathComponent("xlsx-test-\(UUID().uuidString).xlsx")
@@ -93,9 +112,8 @@ private func makeMinimalXLSX(sheetName: String, rows: [[String]], rowNumbers: [I
     let entries: [(String, Data)] = [
         ("[Content_Types].xml", Data(contentTypesXML.utf8)),
         ("xl/workbook.xml", Data(workbookXML.utf8)),
-        ("xl/_rels/workbook.xml.rels", Data(workbookRelationshipsXML.utf8)),
-        ("xl/worksheets/sheet1.xml", Data(worksheetXML.utf8))
-    ]
+        ("xl/_rels/workbook.xml.rels", Data(workbookRelationshipsXML.utf8))
+    ] + worksheetEntries
     for (path, data) in entries {
         try archive.addEntry(with: path, type: .file, uncompressedSize: Int64(data.count)) { position, size in
             data.subdata(in: Int(position)..<Int(position) + size)
@@ -448,6 +466,12 @@ struct PartsServiceAdvancedTests {
         #expect(source.filename == nil)
         #expect(source.sourceHash?.hasPrefix("sha256:") == true)
         #expect(source.sourceHash?.count == 71)
+        #expect(source.parserMetadata?.parserName == "wiredpart.csv")
+        #expect(source.parserMetadata?.sourceKind == .csv)
+        #expect(source.parserMetadata?.sourceHash == source.sourceHash)
+        #expect(source.parserMetadata?.rowCount == 2)
+        #expect(source.parserMetadata?.columnCount == 3)
+        #expect(source.evidence.contains(where: { $0.kind == .sourceHash }) == true)
     }
 
     @Test("previewPartsImportXLSX attaches source metadata for audit sessions")
@@ -465,6 +489,126 @@ struct PartsServiceAdvancedTests {
         #expect(source.filename == nil)
         #expect(source.sourceHash?.hasPrefix("sha256:") == true)
         #expect(source.sourceHash?.count == 71)
+        #expect(source.parserMetadata?.parserName == "wiredpart.xlsx")
+        #expect(source.parserMetadata?.sourceKind == .xlsx)
+        #expect(source.parserMetadata?.sourceHash == source.sourceHash)
+        #expect(source.parserMetadata?.boundedArchiveProtectionsApplied == true)
+        #expect(source.parserMetadata?.sheetMetadata.first?.name == "Audit")
+        #expect(source.parserMetadata?.sheetMetadata.first?.rowCount == 2)
+        #expect(source.parserMetadata?.sheetMetadata.first?.columnCount == 3)
+    }
+
+    @Test("shared import source contracts cover future parser source kinds")
+    func testSharedImportSourceContractsCoverFutureParserKinds() {
+        let kinds: Set<PartsService.PartsImportSourceKind> = [.csv, .xlsx, .digitalPDFText, .ocr, .vision]
+        #expect(kinds.map(\.rawValue).contains("digital_pdf_text"))
+        #expect(kinds.count == 5)
+
+        let evidence = PartsService.PartsImportSourceEvidence(
+            kind: .boundingBox,
+            pageNumber: 2,
+            text: "OCR cell",
+            confidence: 0.92,
+            boundingBox: [1, 2, 3, 4]
+        )
+        let draftRow = PartsService.PartsImportDraftRow(rowNumber: 7, columns: ["Part", "Cost"], evidence: [evidence])
+        let table = PartsService.PartsImportExtractedTable(
+            id: "vision:page:2",
+            sourceKind: .vision,
+            pageNumber: 2,
+            headerRowNumber: 7,
+            rows: [draftRow],
+            evidence: [evidence]
+        )
+
+        #expect(table.sourceKind == .vision)
+        #expect(table.rows.first?.evidence.first?.kind == .boundingBox)
+        #expect(PartsService.PartsImportPreviewDecision.conflict.rawValue == "conflict")
+    }
+
+    @Test("CSV and XLSX adapters produce compatible preview rows and source hashes")
+    func testCSVAndXLSXAdapterParity() throws {
+        let env = try E2ETestHelpers.setUp()
+        let csv = """
+        name,code,category,brand,cost_price
+        Adapter Parity Part,PAR-001,Parity Category,Parity Brand,10.5
+        """
+        let xlsx = try makeMinimalXLSX(sheetName: "Parity", rows: [
+            ["name", "code", "category", "brand", "cost_price"],
+            ["Adapter Parity Part", "PAR-001", "Parity Category", "Parity Brand", "10.5"]
+        ])
+
+        let csvPreview = try env.parts.previewPartsImportCSV(csv)
+        let xlsxPreview = try env.parts.previewPartsImportXLSX(xlsx)
+
+        #expect(csvPreview.newParts.count == 1)
+        #expect(xlsxPreview.newParts.count == 1)
+        #expect(csvPreview.newParts.first?.fields == xlsxPreview.newParts.first?.fields)
+        #expect(csvPreview.newParts.first?.name == xlsxPreview.newParts.first?.name)
+        #expect(csvPreview.source?.parserMetadata?.sourceKind == .csv)
+        #expect(xlsxPreview.source?.parserMetadata?.sourceKind == .xlsx)
+        #expect(csvPreview.source?.sourceHash?.hasPrefix("sha256:") == true)
+        #expect(xlsxPreview.source?.sourceHash?.hasPrefix("sha256:") == true)
+    }
+
+    @Test("preview adapters do not create import sessions or row evidence")
+    func testImportPreviewAdaptersDoNotWriteAuditTables() throws {
+        let env = try E2ETestHelpers.setUp()
+        let beforeSessions = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM part_import_sessions") ?? -1
+        }
+        let beforeEvidence = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM part_import_row_evidence") ?? -1
+        }
+
+        _ = try env.parts.previewPartsImportCSV("""
+        name,code,category
+        Preview CSV Only,PREVIEW-CSV-001,Preview Category
+        """)
+        let xlsx = try makeMinimalXLSX(sheetName: "Preview", rows: [
+            ["name", "code", "category"],
+            ["Preview XLSX Only", "PREVIEW-XLSX-001", "Preview Category"]
+        ])
+        _ = try env.parts.previewPartsImportXLSX(xlsx)
+
+        let afterSessions = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM part_import_sessions") ?? -1
+        }
+        let afterEvidence = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM part_import_row_evidence") ?? -1
+        }
+        #expect(afterSessions == beforeSessions)
+        #expect(afterEvidence == beforeEvidence)
+        #expect(try env.parts.findPartByCode("PREVIEW-CSV-001") == nil)
+        #expect(try env.parts.findPartByCode("PREVIEW-XLSX-001") == nil)
+    }
+
+    @Test("XLSX adapter exposes workbook sheet metadata while preserving first sheet preview behavior")
+    func testPreviewPartsImportXLSXExposesWorkbookSheetMetadata() throws {
+        let env = try E2ETestHelpers.setUp()
+        let xlsx = try makeMinimalXLSX(sheets: [
+            ("First", [
+                ["name", "code", "category"],
+                ["First Sheet Part", "FIRST-XLSX-001", "First Category"]
+            ], nil),
+            ("Second", [
+                ["name", "code", "category", "cost_price"],
+                ["Second Sheet Part", "SECOND-XLSX-001", "Second Category", "42"]
+            ], nil)
+        ])
+
+        let preview = try env.parts.previewPartsImportXLSX(xlsx)
+        let metadata = try #require(preview.source?.parserMetadata)
+
+        #expect(preview.newParts.count == 1)
+        #expect(preview.newParts.first?.code == "FIRST-XLSX-001")
+        #expect(preview.source?.sheetName == "First")
+        #expect(metadata.sheetMetadata.count == 2)
+        #expect(metadata.sheetMetadata.map(\.name) == ["First", "Second"])
+        #expect(metadata.sheetMetadata[0].path == "xl/worksheets/sheet1.xml")
+        #expect(metadata.sheetMetadata[1].path == "xl/worksheets/sheet2.xml")
+        #expect(metadata.sheetMetadata[1].rowCount == 2)
+        #expect(metadata.sheetMetadata[1].columnCount == 4)
     }
 
     @Test("commitPartsImportCSV records durable import session and accepted row evidence")


### PR DESCRIPTION
## Summary
- Add shared import source/evidence/parser metadata contracts for CSV, XLSX, digital PDF text, OCR, and vision sources.
- Route CSV and XLSX previews through deterministic adapter outputs while preserving the existing preview/commit path.
- Expose XLSX workbook sheet metadata for all sheets while preserving first-sheet preview behavior.

## Tests
- swift test --package-path core --filter PartsServiceAdvancedTests

Paperclip: WEI-2956