### PR TITLE
Fix CodeQL Swift build failure in AuthService

### DIFF
--- a/core/Sources/WiredPartCore/Services/AuthService.swift
+++ b/core/Sources/WiredPartCore/Services/AuthService.swift
@@ -1114,14 +1114,11 @@ public final class AuthService: Sendable {
     }
 
     private static func loadLittleEndianUInt64(_ bytes: [UInt8], at offset: Int) -> UInt64 {
-        UInt64(bytes[offset]) |
-        (UInt64(bytes[offset + 1]) << 8) |
-        (UInt64(bytes[offset + 2]) << 16) |
-        (UInt64(bytes[offset + 3]) << 24) |
-        (UInt64(bytes[offset + 4]) << 32) |
-        (UInt64(bytes[offset + 5]) << 40) |
-        (UInt64(bytes[offset + 6]) << 48) |
-        (UInt64(bytes[offset + 7]) << 56)
+        var value: UInt64 = 0
+        for index in 0..<8 {
+            value |= UInt64(bytes[offset + index]) << UInt64(index * 8)
+        }
+        return value
     }
 
     private static func storeLittleEndianUInt32(_ value: UInt32, into bytes: inout [UInt8], at offset: Int) {


### PR DESCRIPTION
## Summary
- Fixes [WEI-2966](/WEI/issues/WEI-2966).
- Rewrites `AuthService.loadLittleEndianUInt64` from one long chained bitwise expression into a small accumulation loop.
- Preserves the same little-endian output while avoiding the Swift type-checker failure seen in the CodeQL Swift analyze build.

## Root Cause
The main-branch CodeQL Swift Analyze job failed because Swift could not type-check the chained `UInt64(...) | (...) << ...` expression in `loadLittleEndianUInt64` in reasonable time.

## Verification
- `cd core && swift build`
- `cd core && swift test --filter AuthServiceTests` (69 tests passed)

## Notes
No API, persistence, migration, permission, or consumer contract impact. CodeQL confirmation is expected from PR CI.