### PR TITLE
CI fallback for private repo CodeQL SARIF

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,3 +80,13 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"
+          output: codeql-results
+          upload: never
+
+      - name: Upload CodeQL SARIF artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-${{ matrix.language }}-sarif
+          path: codeql-results
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- Fixes [WEI-2970](/WEI/issues/WEI-2970) fallback path after [WEI-2971](/WEI/issues/WEI-2971) confirmed GitHub code scanning cannot be enabled without Advanced Security purchase.
- Keeps the Swift CodeQL init/build/analyze path on push and schedule.
- Sets CodeQL analyze upload to `never` and uploads generated SARIF as a workflow artifact so private-repo CI can pass without Code Scanning upload access.

## Verification
- Parsed `.github/workflows/codeql.yml` with Ruby YAML loader: `yaml ok`.
- `actionlint` is not installed in the local environment.

## Notes
- PR CodeQL behavior remains the existing recovery gate: pull_request events skip the Swift CodeQL build while push/schedule run full analysis.
- Post-merge validation should confirm the main `Analyze (swift)` job completes and publishes the `codeql-swift-sarif` artifact.