### PR TITLE
WEI-2532 Preserve shop server sync scope fix

### DIFF
--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -35,6 +35,12 @@ struct Weird_Parts_IOSTests {
     }
 
     @MainActor
+    @Test func shopServerAddressSettingsAreDeviceScoped() async throws {
+        #expect(IOSSyncManager.settingSyncScope(for: "sync_server_address") == .device)
+        #expect(IOSSyncManager.settingSyncScope(for: "shop_server_address") == .device)
+    }
+
+    @MainActor
     @Test func lanPeerDiscoveryStartupFailureSurfacesErrorAndStopsLanOnlyScan() async throws {
         let manager = IOSSyncManager()
         manager.isScanning = true

--- a/core/Sources/WiredPartCore/Services/SettingsService.swift
+++ b/core/Sources/WiredPartCore/Services/SettingsService.swift
@@ -974,7 +974,13 @@ public final class SettingsService: Sendable {
         "device_private_key",
         "last_backup_time",
         "last_update_check",
+        "local_db_path",
         "local_database_path",
+        "paired_company_id",
+        "paired_shop_device_id",
+        "device_pairing_verified_at",
+        "shop_server_address",
+        "sync_server_address",
         "update_channel",
     ]
 }

--- a/core/Tests/WiredPartCoreTests/SettingsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SettingsServiceTests.swift
@@ -78,9 +78,45 @@ struct SettingsServiceTests {
 
         #expect(SettingsService.syncScope(for: "update_channel", category: "general") == .device)
         #expect(SettingsService.syncScope(for: "custom_backup_key", category: "backup") == .device)
+        #expect(SettingsService.syncScope(for: "sync_server_address", category: "general") == .device)
+        #expect(SettingsService.syncScope(for: "shop_server_address", category: "general") == .device)
+        #expect(SettingsService.syncScope(for: "paired_shop_device_id", category: "general") == .device)
+        #expect(SettingsService.syncScope(for: "paired_company_id", category: "general") == .device)
+        #expect(SettingsService.syncScope(for: "device_pairing_verified_at", category: "general") == .device)
+        #expect(SettingsService.syncScope(for: "local_database_path", category: "general") == .device)
+        #expect(SettingsService.syncScope(for: "local_db_path", category: "general") == .device)
 
         #expect(SettingsService.syncScope(for: "payment_terms", category: "pdf") == .company)
         #expect(SettingsService.syncScope(for: "unknown_future_setting") == .company)
+    }
+
+    @Test("server pairing and local database settings stay out of company sync rows")
+    func testDeviceOnlySyncSettingsExcludedFromCompanySyncRows() throws {
+        let db = try freshDB()
+        let svc = SettingsService(db: db)
+        let deviceOnlyKeys = [
+            "sync_server_address",
+            "shop_server_address",
+            "paired_shop_device_id",
+            "paired_company_id",
+            "device_pairing_verified_at",
+            "local_database_path",
+            "local_db_path",
+        ]
+
+        for key in deviceOnlyKeys {
+            try svc.upsertSetting(key: key, value: "device-only", category: "general")
+        }
+        try svc.upsertSetting(key: "payment_terms", value: "Net 30", category: "pdf")
+
+        let deviceRows = try svc.getSettings(scope: .device)
+        let syncableRows = try svc.getSettings(excludingScope: .device)
+
+        for key in deviceOnlyKeys {
+            #expect(deviceRows.contains { $0.key == key && $0.syncScope == .device })
+            #expect(!syncableRows.contains { $0.key == key })
+        }
+        #expect(syncableRows.contains { $0.key == "payment_terms" && $0.syncScope == .company })
     }
 
     @Test("getSettings filters rows by sync scope")


### PR DESCRIPTION
Preserves source/test delta found in WEI-2532 dirty worktree during WEI-2981 triage.

Changes:
- treat shop_server_address as a device-scoped sync setting
- add iOS source-level regression coverage

Verification: pending targeted/source verification after preservation pass.

GitHub sync: WEI-2984 preservation of WEI-2532 branch.
