### PR TITLE
WEI-2957: Add supplier-aware import mapping preview

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -5737,7 +5737,7 @@ extension AppDatabase {
         migrator.registerMigration("101_part_import_saved_mappings") { db in
             try db.create(table: "part_import_saved_mappings", ifNotExists: true) { t in
                 t.autoIncrementedPrimaryKey("id")
-                t.column("supplier_id", .integer).references("suppliers", onDelete: .setNull)
+                t.column("supplier_id", .integer).references("suppliers", onDelete: .cascade)
                 t.column("source_kind", .text).notNull()
                 t.column("header_fingerprint", .text).notNull()
                 t.column("schema_version", .integer).notNull()

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -140,6 +140,7 @@ extension AppDatabase {
         registerMigration099ReceivingItemRoutingDisposition(&migrator)
         registerMigration100POEmailRequestType(&migrator)
         registerMigration100StagingBoxContentsAndDeliveryState(&migrator)
+        registerMigration101PartImportSavedMappings(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -5727,6 +5728,38 @@ extension AppDatabase {
             try db.create(index: "idx_staging_box_contents_tag",
                           on: "staging_box_contents",
                           columns: ["staging_tag_id"])
+        }
+    }
+
+    // MARK: - Migration 101: Saved part import mappings
+
+    private static func registerMigration101PartImportSavedMappings(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("101_part_import_saved_mappings") { db in
+            try db.create(table: "part_import_saved_mappings", ifNotExists: true) { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("supplier_id", .integer).references("suppliers", onDelete: .setNull)
+                t.column("source_kind", .text).notNull()
+                t.column("header_fingerprint", .text).notNull()
+                t.column("schema_version", .integer).notNull()
+                t.column("column_mapping_json", .text).notNull()
+                t.column("source_headers_json", .text).notNull()
+                t.column("accepted_by", .integer).references("users")
+                t.column("use_count", .integer).notNull().defaults(to: 0)
+                t.column("last_used_at", .text)
+                t.column("created_at", .text).notNull().defaults(sql: "(datetime('now'))")
+                t.column("updated_at", .text).notNull().defaults(sql: "(datetime('now'))")
+                t.column("deleted_at", .text)
+            }
+            try db.execute(sql: """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_part_import_saved_mappings_lookup
+                ON part_import_saved_mappings (
+                    COALESCE(supplier_id, -1),
+                    source_kind,
+                    header_fingerprint,
+                    schema_version
+                )
+                WHERE deleted_at IS NULL
+                """)
         }
     }
 }

--- a/core/Sources/WiredPartCore/Services/PartsService+XLSXImport.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService+XLSXImport.swift
@@ -6,7 +6,7 @@ extension PartsService {
     ///
     /// XLSX rows are normalized into the same draft row path used by CSV import so duplicate
     /// detection, validation, conflict generation, and atomic commit behavior stay shared.
-    public func previewPartsImportXLSX(_ data: Data) throws -> PartsImportPreview {
+    public func previewPartsImportXLSX(_ data: Data, supplierId: Int64? = nil) throws -> PartsImportPreview {
         let workbook = try PartsImportXLSXReader(data: data).readFirstWorksheet()
         guard workbook.rows.count > 1 else {
             throw PartsError.invalidInput("XLSX sheet '\(workbook.sheetName)' is empty or has no data rows.")
@@ -16,7 +16,9 @@ extension PartsService {
         do {
             preview = try previewPartsImportRows(
                 workbook.rows.map { PartsImportTabularRow(rowNumber: $0.rowNumber, columns: $0.columns) },
-                emptyDescription: "XLSX sheet '\(workbook.sheetName)' is empty or has no data rows."
+                emptyDescription: "XLSX sheet '\(workbook.sheetName)' is empty or has no data rows.",
+                sourceKind: "xlsx",
+                supplierId: supplierId
             )
         } catch PartsError.invalidInput(let message) {
             throw PartsError.invalidInput("XLSX sheet '\(workbook.sheetName)' row 1: \(message)")
@@ -31,7 +33,12 @@ extension PartsService {
         preview.source = PartsImportSourceMetadata(
             sourceKind: "xlsx",
             sheetName: workbook.sheetName,
-            sourceHash: importSourceHash(data)
+            sourceHash: importSourceHash(data),
+            supplierId: supplierId,
+            headerFingerprint: preview.source?.headerFingerprint,
+            sourceHeaders: preview.source?.sourceHeaders ?? [],
+            acceptedColumnMapping: preview.source?.acceptedColumnMapping ?? [:],
+            savedMappingId: preview.source?.savedMappingId
         )
         return preview
     }

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -5959,6 +5959,10 @@ public final class PartsService: Sendable {
         public let category: String
         public let brand: String?
         public let fields: [String: String]
+
+        public var supplierPartNumber: String? {
+            fields["supplier_part_number"]
+        }
     }
 
     /// A validation error surfaced during import preview. The row number is 1-based
@@ -5980,23 +5984,93 @@ public final class PartsService: Sendable {
         public let existingPartId: Int64
         public let existingPartName: String
         public let existingPartCode: String?
+        public let matchReason: String
         public var resolution: PartsImportConflictResolution = .ask
+
+        public init(
+            parsedRow: PartsImportParsedRow,
+            existingPartId: Int64,
+            existingPartName: String,
+            existingPartCode: String?,
+            matchReason: String = "code",
+            resolution: PartsImportConflictResolution = .ask
+        ) {
+            self.parsedRow = parsedRow
+            self.existingPartId = existingPartId
+            self.existingPartName = existingPartName
+            self.existingPartCode = existingPartCode
+            self.matchReason = matchReason
+            self.resolution = resolution
+        }
+    }
+
+    public enum PartsImportPreviewClassification: String, Sendable {
+        case new
+        case update
+        case duplicateSkip = "duplicate_skip"
+        case conflictReview = "conflict_review"
+        case quarantined
+    }
+
+    public struct PartsImportPreviewDecision: Sendable {
+        public let rowNumber: Int
+        public let classification: PartsImportPreviewClassification
+        public let parsedRow: PartsImportParsedRow?
+        public let existingPartId: Int64?
+        public let matchReason: String?
+        public let message: String?
+    }
+
+    public struct PartsImportSavedMapping: Sendable {
+        public let id: Int64
+        public let supplierId: Int64?
+        public let sourceKind: String
+        public let headerFingerprint: String
+        public let schemaVersion: Int
+        public let columnMapping: [String: String]
+        public let sourceHeaders: [String]
     }
 
     /// Metadata that ties an import preview/commit to a durable source artifact.
     public struct PartsImportSourceMetadata: Sendable {
+        public static let mappingSchemaVersion = 1
+
         public var sourceKind: String
         public var filename: String?
         public var sheetName: String?
         public var sourceHash: String?
         public var userId: Int64?
+        public var supplierId: Int64?
+        public var headerFingerprint: String?
+        public var mappingSchemaVersion: Int
+        public var sourceHeaders: [String]
+        public var acceptedColumnMapping: [String: String]
+        public var savedMappingId: Int64?
 
-        public init(sourceKind: String, filename: String? = nil, sheetName: String? = nil, sourceHash: String? = nil, userId: Int64? = nil) {
+        public init(
+            sourceKind: String,
+            filename: String? = nil,
+            sheetName: String? = nil,
+            sourceHash: String? = nil,
+            userId: Int64? = nil,
+            supplierId: Int64? = nil,
+            headerFingerprint: String? = nil,
+            mappingSchemaVersion: Int = PartsImportSourceMetadata.mappingSchemaVersion,
+            sourceHeaders: [String] = [],
+            acceptedColumnMapping: [String: String] = [:],
+            savedMappingId: Int64? = nil
+        ) {
             self.sourceKind = sourceKind
             self.filename = filename
             self.sheetName = sheetName
             self.sourceHash = sourceHash
             self.userId = userId
+            self.supplierId = supplierId
+            self.headerFingerprint = headerFingerprint
+            self.mappingSchemaVersion = mappingSchemaVersion
+            self.sourceHeaders = sourceHeaders
+            self.acceptedColumnMapping = acceptedColumnMapping
+            self.savedMappingId = savedMappingId
         }
     }
 
@@ -6005,13 +6079,15 @@ public final class PartsService: Sendable {
         public var newParts: [PartsImportParsedRow] = []
         public var conflicts: [PartsImportConflict] = []
         public var errors: [PartsImportError] = []
+        public var decisions: [PartsImportPreviewDecision] = []
         public var totalRows: Int = 0
         public var source: PartsImportSourceMetadata?
 
-        public init(newParts: [PartsImportParsedRow] = [], conflicts: [PartsImportConflict] = [], errors: [PartsImportError] = [], totalRows: Int = 0, source: PartsImportSourceMetadata? = nil) {
+        public init(newParts: [PartsImportParsedRow] = [], conflicts: [PartsImportConflict] = [], errors: [PartsImportError] = [], decisions: [PartsImportPreviewDecision] = [], totalRows: Int = 0, source: PartsImportSourceMetadata? = nil) {
             self.newParts = newParts
             self.conflicts = conflicts
             self.errors = errors
+            self.decisions = decisions
             self.totalRows = totalRows
             self.source = source
         }
@@ -6036,7 +6112,7 @@ public final class PartsService: Sendable {
         let columns: [String]
     }
 
-    public func previewPartsImportCSV(_ csv: String) throws -> PartsImportPreview {
+    public func previewPartsImportCSV(_ csv: String, supplierId: Int64? = nil) throws -> PartsImportPreview {
         let rows = csv.components(separatedBy: .newlines)
             .enumerated()
             .compactMap { offset, line -> PartsImportTabularRow? in
@@ -6047,30 +6123,61 @@ public final class PartsService: Sendable {
                     columns: parseImportCSVLine(trimmed)
                 )
             }
-        var preview = try previewPartsImportRows(rows, emptyDescription: "CSV file is empty or has no data rows.")
+        var preview = try previewPartsImportRows(rows, emptyDescription: "CSV file is empty or has no data rows.", sourceKind: "csv", supplierId: supplierId)
         preview.source = PartsImportSourceMetadata(
             sourceKind: "csv",
-            sourceHash: importSourceHash(Data(csv.utf8))
+            sourceHash: importSourceHash(Data(csv.utf8)),
+            supplierId: supplierId,
+            headerFingerprint: preview.source?.headerFingerprint,
+            sourceHeaders: preview.source?.sourceHeaders ?? [],
+            acceptedColumnMapping: preview.source?.acceptedColumnMapping ?? [:],
+            savedMappingId: preview.source?.savedMappingId
         )
         return preview
     }
 
-    func previewPartsImportRows(_ rows: [PartsImportTabularRow], emptyDescription: String) throws -> PartsImportPreview {
+    func previewPartsImportRows(
+        _ rows: [PartsImportTabularRow],
+        emptyDescription: String,
+        sourceKind: String = "tabular",
+        supplierId: Int64? = nil
+    ) throws -> PartsImportPreview {
         guard rows.count > 1 else {
             throw PartsError.invalidInput(emptyDescription)
         }
 
-        let headers = rows[0].columns.map { $0.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) }
-        guard let nameIdx = headers.firstIndex(of: "name") else {
+        let rawHeaders = rows[0].columns.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        let headerFingerprint = importHeaderFingerprint(rawHeaders)
+        let savedMapping = try findSavedPartsImportMapping(
+            supplierId: supplierId,
+            sourceKind: sourceKind,
+            headerFingerprint: headerFingerprint
+        )
+        let columnMapping = savedMapping?.columnMapping ?? deterministicPartsImportColumnMapping(rawHeaders)
+        let canonicalHeaders = rawHeaders.enumerated().map { index, header in
+            let normalized = normalizedImportHeader(header)
+            return columnMapping[header] ?? columnMapping[normalized] ?? (normalized.isEmpty ? "column_\(index + 1)" : normalized)
+        }
+        guard let nameIdx = canonicalHeaders.firstIndex(of: "name") else {
             throw PartsError.invalidInput("CSV must have a 'name' column.")
         }
-        guard let categoryIdx = headers.firstIndex(of: "category") else {
+        guard let categoryIdx = canonicalHeaders.firstIndex(of: "category") else {
             throw PartsError.invalidInput("CSV must have a 'category' column.")
         }
-        let codeIdx = headers.firstIndex(of: "code")
-        let brandIdx = headers.firstIndex(of: "brand")
+        let codeIdx = canonicalHeaders.firstIndex(of: "code")
+        let brandIdx = canonicalHeaders.firstIndex(of: "brand")
 
-        var preview = PartsImportPreview(totalRows: rows.count - 1)
+        var preview = PartsImportPreview(
+            totalRows: rows.count - 1,
+            source: PartsImportSourceMetadata(
+                sourceKind: sourceKind,
+                supplierId: supplierId,
+                headerFingerprint: headerFingerprint,
+                sourceHeaders: rawHeaders,
+                acceptedColumnMapping: columnMapping,
+                savedMappingId: savedMapping?.id
+            )
+        )
         for row in rows.dropFirst() {
             let rowNumber = row.rowNumber
             let columns = row.columns
@@ -6090,7 +6197,7 @@ public final class PartsService: Sendable {
             }
 
             var fields: [String: String] = [:]
-            for (index, header) in headers.enumerated() {
+            for (index, header) in canonicalHeaders.enumerated() {
                 guard index < columns.count else { continue }
                 guard !["name", "code", "category", "brand"].contains(header) else { continue }
                 let trimmed = columns[index].trimmingCharacters(in: .whitespacesAndNewlines)
@@ -6109,7 +6216,17 @@ public final class PartsService: Sendable {
                     }
                 }
             }
-            if preview.errors.contains(where: { $0.rowNumber == rowNumber }) { continue }
+            if preview.errors.contains(where: { $0.rowNumber == rowNumber }) {
+                preview.decisions.append(PartsImportPreviewDecision(
+                    rowNumber: rowNumber,
+                    classification: .quarantined,
+                    parsedRow: nil,
+                    existingPartId: nil,
+                    matchReason: nil,
+                    message: preview.errors.filter { $0.rowNumber == rowNumber }.map(\.message).joined(separator: "; ")
+                ))
+                continue
+            }
 
             let parsed = PartsImportParsedRow(
                 rowNumber: rowNumber,
@@ -6120,26 +6237,264 @@ public final class PartsService: Sendable {
                 fields: fields
             )
 
-            let existingPart = try db.writer.read { dbConn -> Part? in
-                if let code = parsed.code, !code.isEmpty,
-                   let byCode = try Part.fetchOne(dbConn, sql: "SELECT * FROM parts WHERE code = ? AND deleted_at IS NULL", arguments: [code]) {
-                    return byCode
-                }
-                return try Part.fetchOne(dbConn, sql: "SELECT * FROM parts WHERE LOWER(name) = LOWER(?) AND deleted_at IS NULL", arguments: [parsed.name])
-            }
+            let match = try findPartsImportMatch(parsed, supplierId: supplierId)
 
-            if let existingPart, let id = existingPart.id {
+            if let match, let existingPart = match.part, let id = existingPart.id {
+                let classification = match.isAmbiguous ? PartsImportPreviewClassification.conflictReview : previewClassification(for: parsed, existingPart: existingPart, matchReason: match.reason)
                 preview.conflicts.append(PartsImportConflict(
                     parsedRow: parsed,
                     existingPartId: id,
                     existingPartName: existingPart.name,
-                    existingPartCode: existingPart.code
+                    existingPartCode: existingPart.code,
+                    matchReason: match.reason
+                ))
+                preview.decisions.append(PartsImportPreviewDecision(
+                    rowNumber: rowNumber,
+                    classification: classification,
+                    parsedRow: parsed,
+                    existingPartId: id,
+                    matchReason: match.reason,
+                    message: match.isAmbiguous ? "Multiple existing parts matched \(match.reason); review before commit." : nil
                 ))
             } else {
                 preview.newParts.append(parsed)
+                preview.decisions.append(PartsImportPreviewDecision(
+                    rowNumber: rowNumber,
+                    classification: .new,
+                    parsedRow: parsed,
+                    existingPartId: nil,
+                    matchReason: nil,
+                    message: nil
+                ))
             }
         }
         return preview
+    }
+
+    public func saveAcceptedPartsImportMapping(
+        supplierId: Int64?,
+        sourceKind: String,
+        sourceHeaders: [String],
+        columnMapping: [String: String],
+        acceptedBy: Int64? = nil,
+        schemaVersion: Int = PartsImportSourceMetadata.mappingSchemaVersion
+    ) throws -> PartsImportSavedMapping {
+        let fingerprint = importHeaderFingerprint(sourceHeaders)
+        return try upsertPartsImportSavedMapping(
+            supplierId: supplierId,
+            sourceKind: sourceKind,
+            headerFingerprint: fingerprint,
+            schemaVersion: schemaVersion,
+            sourceHeaders: sourceHeaders,
+            columnMapping: columnMapping,
+            acceptedBy: acceptedBy
+        )
+    }
+
+    public func findSavedPartsImportMapping(
+        supplierId: Int64?,
+        sourceKind: String,
+        headerFingerprint: String,
+        schemaVersion: Int = PartsImportSourceMetadata.mappingSchemaVersion
+    ) throws -> PartsImportSavedMapping? {
+        try db.writer.read { dbConn in
+            let row = try Row.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT * FROM part_import_saved_mappings
+                    WHERE source_kind = ?
+                      AND header_fingerprint = ?
+                      AND schema_version = ?
+                      AND deleted_at IS NULL
+                      AND (supplier_id = ? OR (supplier_id IS NULL AND ? IS NULL))
+                    ORDER BY supplier_id IS NULL ASC
+                    LIMIT 1
+                    """,
+                arguments: [sourceKind, headerFingerprint, schemaVersion, supplierId, supplierId]
+            )
+            guard let row else { return nil }
+            let id: Int64 = row["id"]
+            return PartsImportSavedMapping(
+                id: id,
+                supplierId: row["supplier_id"] as Int64?,
+                sourceKind: row["source_kind"] as String,
+                headerFingerprint: row["header_fingerprint"] as String,
+                schemaVersion: row["schema_version"] as Int,
+                columnMapping: decodeJSONStringDictionary(row["column_mapping_json"] as String?),
+                sourceHeaders: decodeJSONStringArray(row["source_headers_json"] as String?)
+            )
+        }
+    }
+
+    private struct PartsImportMatch {
+        let part: Part?
+        let reason: String
+        let isAmbiguous: Bool
+    }
+
+    private func findPartsImportMatch(_ parsed: PartsImportParsedRow, supplierId: Int64?) throws -> PartsImportMatch? {
+        try db.writer.read { dbConn in
+            if let supplierId,
+               let supplierPartNumber = parsed.supplierPartNumber?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !supplierPartNumber.isEmpty {
+                let rows = try Part.fetchAll(
+                    dbConn,
+                    sql: """
+                        SELECT p.*
+                        FROM parts p
+                        JOIN part_supplier_links psl ON psl.part_id = p.id AND psl.deleted_at IS NULL
+                        WHERE psl.supplier_id = ?
+                          AND LOWER(psl.supplier_part_number) = LOWER(?)
+                          AND p.deleted_at IS NULL
+                        ORDER BY p.id ASC
+                        """,
+                    arguments: [supplierId, supplierPartNumber]
+                )
+                if let first = rows.first {
+                    return PartsImportMatch(part: first, reason: "supplier_part_number", isAmbiguous: rows.count > 1)
+                }
+            }
+
+            if let code = parsed.code?.trimmingCharacters(in: .whitespacesAndNewlines), !code.isEmpty {
+                let rows = try Part.fetchAll(
+                    dbConn,
+                    sql: "SELECT * FROM parts WHERE LOWER(code) = LOWER(?) AND deleted_at IS NULL ORDER BY id ASC",
+                    arguments: [code]
+                )
+                if let first = rows.first {
+                    return PartsImportMatch(part: first, reason: "code", isAmbiguous: rows.count > 1)
+                }
+            }
+
+            let normalizedName = normalizedImportValue(parsed.name)
+            let normalizedCategory = normalizedImportValue(parsed.category)
+            let normalizedBrand = normalizedImportValue(parsed.brand ?? "")
+            let rows = try Part.fetchAll(
+                dbConn,
+                sql: """
+                    SELECT p.*
+                    FROM parts p
+                    JOIN part_categories c ON c.id = p.category_id AND c.deleted_at IS NULL
+                    LEFT JOIN brands b ON b.id = p.brand_id AND b.deleted_at IS NULL
+                    WHERE LOWER(TRIM(p.name)) = ?
+                      AND LOWER(TRIM(c.name)) = ?
+                      AND LOWER(TRIM(COALESCE(b.name, ''))) = ?
+                      AND p.deleted_at IS NULL
+                    ORDER BY p.id ASC
+                    """,
+                arguments: [normalizedName, normalizedCategory, normalizedBrand]
+            )
+            guard let first = rows.first else { return nil }
+            return PartsImportMatch(part: first, reason: "name_category_brand", isAmbiguous: rows.count > 1)
+        }
+    }
+
+    private func previewClassification(for parsed: PartsImportParsedRow, existingPart: Part, matchReason: String) -> PartsImportPreviewClassification {
+        if rowsAreEquivalent(parsed, existingPart: existingPart) {
+            return .duplicateSkip
+        }
+        return matchReason == "name_category_brand" ? .conflictReview : .update
+    }
+
+    private func rowsAreEquivalent(_ parsed: PartsImportParsedRow, existingPart: Part) -> Bool {
+        normalizedImportValue(parsed.name) == normalizedImportValue(existingPart.name)
+            && normalizedImportValue(parsed.code ?? "") == normalizedImportValue(existingPart.code ?? "")
+    }
+
+    private func deterministicPartsImportColumnMapping(_ headers: [String]) -> [String: String] {
+        var mapping: [String: String] = [:]
+        for header in headers {
+            let normalized = normalizedImportHeader(header)
+            if let canonical = canonicalImportHeader(for: normalized) {
+                mapping[header] = canonical
+                mapping[normalized] = canonical
+            }
+        }
+        return mapping
+    }
+
+    private func canonicalImportHeader(for normalized: String) -> String? {
+        let aliases: [String: Set<String>] = [
+            "name": ["name", "part_name", "part", "item_name"],
+            "code": ["code", "part_code", "part_number", "item_code", "sku", "internal_code"],
+            "category": ["category", "part_category", "type"],
+            "brand": ["brand", "manufacturer", "mfg"],
+            "supplier_part_number": ["supplier_part_number", "supplier_part", "supplier_code", "vendor_part_number", "vendor_part", "vendor_code", "mfr_part_number"],
+            "cost_price": ["cost_price", "cost", "unit_cost", "price"],
+            "markup_percent": ["markup_percent", "markup", "margin_percent"],
+            "unit_of_measure": ["unit_of_measure", "uom", "unit"],
+            "shelf_location": ["shelf_location", "shelf"],
+            "bin_location": ["bin_location", "bin"],
+            "part_type": ["part_type"],
+            "description": ["description", "part_description", "notes"]
+        ]
+        return aliases.first { $0.value.contains(normalized) }?.key
+    }
+
+    private func importHeaderFingerprint(_ headers: [String]) -> String {
+        let canonical = headers.map(normalizedImportHeader).joined(separator: "|")
+        let digest = SHA256.hash(data: Data(canonical.utf8))
+        return "sha256:\(digest.map { String(format: "%02x", $0) }.joined())"
+    }
+
+    private func normalizedImportHeader(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "[^a-z0-9]+", with: "_", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+    }
+
+    private func normalizedImportValue(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private func upsertPartsImportSavedMapping(
+        supplierId: Int64?,
+        sourceKind: String,
+        headerFingerprint: String,
+        schemaVersion: Int,
+        sourceHeaders: [String],
+        columnMapping: [String: String],
+        acceptedBy: Int64?
+    ) throws -> PartsImportSavedMapping {
+        let mappingJSON = encodeJSONObject(columnMapping)
+        let headersJSON = encodeJSONObject(sourceHeaders)
+        return try db.writer.write { dbConn in
+            let existingId = try Int64.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT id FROM part_import_saved_mappings
+                    WHERE source_kind = ?
+                      AND header_fingerprint = ?
+                      AND schema_version = ?
+                      AND deleted_at IS NULL
+                      AND (supplier_id = ? OR (supplier_id IS NULL AND ? IS NULL))
+                    """,
+                arguments: [sourceKind, headerFingerprint, schemaVersion, supplierId, supplierId]
+            )
+            if let existingId {
+                try dbConn.execute(
+                    sql: """
+                        UPDATE part_import_saved_mappings
+                        SET column_mapping_json = ?, source_headers_json = ?, accepted_by = ?,
+                            updated_at = datetime('now'), deleted_at = NULL
+                        WHERE id = ?
+                        """,
+                    arguments: [mappingJSON, headersJSON, acceptedBy, existingId]
+                )
+                return PartsImportSavedMapping(id: existingId, supplierId: supplierId, sourceKind: sourceKind, headerFingerprint: headerFingerprint, schemaVersion: schemaVersion, columnMapping: columnMapping, sourceHeaders: sourceHeaders)
+            }
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO part_import_saved_mappings (
+                        supplier_id, source_kind, header_fingerprint, schema_version,
+                        column_mapping_json, source_headers_json, accepted_by, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+                    """,
+                arguments: [supplierId, sourceKind, headerFingerprint, schemaVersion, mappingJSON, headersJSON, acceptedBy]
+            )
+            return PartsImportSavedMapping(id: dbConn.lastInsertedRowID, supplierId: supplierId, sourceKind: sourceKind, headerFingerprint: headerFingerprint, schemaVersion: schemaVersion, columnMapping: columnMapping, sourceHeaders: sourceHeaders)
+        }
     }
 
     /// Commit a clean import preview atomically. If the preview has validation
@@ -6263,6 +6618,7 @@ public final class PartsService: Sendable {
 
                 for row in preview.newParts {
                     let partId = try create(row)
+                    try upsertSupplierLinkIfNeeded(dbConn, row: row, partId: partId, supplierId: preview.source?.supplierId)
                     try recordImportRowEvidence(dbConn, sessionId: importSessionId, row: row, action: "created", partId: partId)
                     created += 1
                 }
@@ -6270,6 +6626,7 @@ public final class PartsService: Sendable {
                     switch conflict.resolution {
                     case .update:
                         try update(conflict)
+                        try upsertSupplierLinkIfNeeded(dbConn, row: conflict.parsedRow, partId: conflict.existingPartId, supplierId: preview.source?.supplierId)
                         try recordImportRowEvidence(dbConn, sessionId: importSessionId, row: conflict.parsedRow, action: "updated", partId: conflict.existingPartId)
                         updated += 1
                     case .skip, .ask:
@@ -6279,6 +6636,7 @@ public final class PartsService: Sendable {
             }
 
             try finishImportSessionIfNeeded(id: importSessionId, status: "committed", created: created, updated: updated, skipped: skipped, error: nil)
+            try persistAcceptedMappingAfterCommit(preview)
             return PartsImportCommitResult(created: created, updated: updated, skipped: skipped, importSessionId: importSessionId)
         } catch {
             try? finishImportSessionIfNeeded(id: importSessionId, status: "failed", created: 0, updated: 0, skipped: 0, error: String(describing: error))
@@ -6352,6 +6710,84 @@ public final class PartsService: Sendable {
             return "{}"
         }
         return json
+    }
+
+    private func encodeJSONObject(_ object: Any) -> String {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+              let json = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return json
+    }
+
+    private func decodeJSONStringDictionary(_ json: String?) -> [String: String] {
+        guard let json,
+              let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return [:]
+        }
+        return object
+    }
+
+    private func decodeJSONStringArray(_ json: String?) -> [String] {
+        guard let json,
+              let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String] else {
+            return []
+        }
+        return object
+    }
+
+    private func upsertSupplierLinkIfNeeded(_ dbConn: Database, row: PartsImportParsedRow, partId: Int64, supplierId: Int64?) throws {
+        guard let supplierId,
+              let supplierPartNumber = row.supplierPartNumber?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !supplierPartNumber.isEmpty else { return }
+
+        let cost = row.fields["cost_price"].flatMap { Double($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        let existingId = try Int64.fetchOne(
+            dbConn,
+            sql: """
+                SELECT id FROM part_supplier_links
+                WHERE part_id = ? AND supplier_id = ? AND deleted_at IS NULL
+                """,
+            arguments: [partId, supplierId]
+        )
+        if let existingId {
+            try dbConn.execute(
+                sql: """
+                    UPDATE part_supplier_links
+                    SET supplier_part_number = ?, supplier_cost_price = COALESCE(?, supplier_cost_price)
+                    WHERE id = ?
+                    """,
+                arguments: [supplierPartNumber, cost, existingId]
+            )
+        } else {
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO part_supplier_links (
+                        part_id, supplier_id, supplier_part_number, supplier_cost_price, is_preferred, created_at
+                    ) VALUES (?, ?, ?, ?, 0, datetime('now'))
+                    """,
+                arguments: [partId, supplierId, supplierPartNumber, cost]
+            )
+        }
+    }
+
+    private func persistAcceptedMappingAfterCommit(_ preview: PartsImportPreview) throws {
+        guard let source = preview.source,
+              let headerFingerprint = source.headerFingerprint,
+              !source.acceptedColumnMapping.isEmpty,
+              !source.sourceHeaders.isEmpty else { return }
+        _ = try upsertPartsImportSavedMapping(
+            supplierId: source.supplierId,
+            sourceKind: source.sourceKind,
+            headerFingerprint: headerFingerprint,
+            schemaVersion: source.mappingSchemaVersion,
+            sourceHeaders: source.sourceHeaders,
+            columnMapping: source.acceptedColumnMapping,
+            acceptedBy: source.userId
+        )
     }
 
     func importSourceHash(_ data: Data) -> String {

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -6321,6 +6321,7 @@ public final class PartsService: Sendable {
                 savedMappingId: savedMapping?.id
             )
         )
+        var errorsByRowNumber: [Int: [String]] = [:]
         for row in rows.dropFirst() {
             let rowNumber = row.rowNumber
             let columns = row.columns
@@ -6332,10 +6333,12 @@ public final class PartsService: Sendable {
 
             guard let name = value(at: nameIdx) else {
                 preview.errors.append(PartsImportError(rowNumber: rowNumber, message: "Missing required name"))
+                errorsByRowNumber[rowNumber, default: []].append("Missing required name")
                 continue
             }
             guard let category = value(at: categoryIdx) else {
                 preview.errors.append(PartsImportError(rowNumber: rowNumber, message: "Missing required category"))
+                errorsByRowNumber[rowNumber, default: []].append("Missing required category")
                 continue
             }
 
@@ -6350,23 +6353,27 @@ public final class PartsService: Sendable {
             for numericHeader in ["cost_price", "markup_percent"] {
                 if let raw = fields[numericHeader] {
                     guard let value = Double(raw) else {
-                        preview.errors.append(PartsImportError(rowNumber: rowNumber, message: "Invalid number for \(numericHeader): \(raw)"))
+                        let message = "Invalid number for \(numericHeader): \(raw)"
+                        preview.errors.append(PartsImportError(rowNumber: rowNumber, message: message))
+                        errorsByRowNumber[rowNumber, default: []].append(message)
                         continue
                     }
                     if value < 0 {
-                        preview.errors.append(PartsImportError(rowNumber: rowNumber, message: "\(numericHeader) cannot be negative"))
+                        let message = "\(numericHeader) cannot be negative"
+                        preview.errors.append(PartsImportError(rowNumber: rowNumber, message: message))
+                        errorsByRowNumber[rowNumber, default: []].append(message)
                         continue
                     }
                 }
             }
-            if preview.errors.contains(where: { $0.rowNumber == rowNumber }) {
+            if let messages = errorsByRowNumber[rowNumber] {
                 preview.decisions.append(PartsImportPreviewRowDecision(
                     rowNumber: rowNumber,
                     classification: .quarantined,
                     parsedRow: nil,
                     existingPartId: nil,
                     matchReason: nil,
-                    message: preview.errors.filter { $0.rowNumber == rowNumber }.map(\.message).joined(separator: "; ")
+                    message: messages.joined(separator: "; ")
                 ))
                 continue
             }
@@ -6383,7 +6390,11 @@ public final class PartsService: Sendable {
             let match = try findPartsImportMatch(parsed, supplierId: supplierId)
 
             if let match, let existingPart = match.part, let id = existingPart.id {
-                let classification = match.isAmbiguous ? PartsImportPreviewClassification.conflictReview : previewClassification(for: parsed, existingPart: existingPart, matchReason: match.reason)
+                let classification: PartsImportPreviewClassification = if match.isAmbiguous {
+                    .conflictReview
+                } else {
+                    try previewClassification(for: parsed, existingPart: existingPart, matchReason: match.reason)
+                }
                 preview.conflicts.append(PartsImportConflict(
                     parsedRow: parsed,
                     existingPartId: id,
@@ -6532,16 +6543,70 @@ public final class PartsService: Sendable {
         }
     }
 
-    private func previewClassification(for parsed: PartsImportParsedRow, existingPart: Part, matchReason: String) -> PartsImportPreviewClassification {
-        if rowsAreEquivalent(parsed, existingPart: existingPart) {
+    private func previewClassification(for parsed: PartsImportParsedRow, existingPart: Part, matchReason: String) throws -> PartsImportPreviewClassification {
+        if try rowsAreEquivalent(parsed, existingPart: existingPart, matchReason: matchReason) {
             return .duplicateSkip
         }
         return matchReason == "name_category_brand" ? .conflictReview : .update
     }
 
-    private func rowsAreEquivalent(_ parsed: PartsImportParsedRow, existingPart: Part) -> Bool {
-        normalizedImportValue(parsed.name) == normalizedImportValue(existingPart.name)
-            && normalizedImportValue(parsed.code ?? "") == normalizedImportValue(existingPart.code ?? "")
+    private func rowsAreEquivalent(_ parsed: PartsImportParsedRow, existingPart: Part, matchReason: String) throws -> Bool {
+        guard normalizedImportValue(parsed.name) == normalizedImportValue(existingPart.name),
+              normalizedImportValue(parsed.code ?? "") == normalizedImportValue(existingPart.code ?? "") else {
+            return false
+        }
+
+        guard let existingPartId = existingPart.id else { return false }
+        return try db.writer.read { dbConn in
+            let categoryName = try String.fetchOne(
+                dbConn,
+                sql: "SELECT name FROM part_categories WHERE id = ? AND deleted_at IS NULL",
+                arguments: [existingPart.categoryId]
+            ) ?? ""
+            guard normalizedImportValue(parsed.category) == normalizedImportValue(categoryName) else {
+                return false
+            }
+
+            let brandName: String
+            if let brandId = existingPart.brandId {
+                brandName = try String.fetchOne(
+                    dbConn,
+                    sql: "SELECT name FROM brands WHERE id = ? AND deleted_at IS NULL",
+                    arguments: [brandId]
+                ) ?? ""
+            } else {
+                brandName = ""
+            }
+            guard normalizedImportValue(parsed.brand ?? "") == normalizedImportValue(brandName) else {
+                return false
+            }
+
+            if let supplierPartNumber = parsed.supplierPartNumber?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !supplierPartNumber.isEmpty,
+               matchReason != "supplier_part_number" {
+                return false
+            }
+
+            return optionalImportFieldMatches(parsed.fields["part_type"], existingPart.partType)
+                && optionalImportFieldMatches(parsed.fields["description"], existingPart.description)
+                && optionalImportFieldMatches(parsed.fields["unit_of_measure"], existingPart.unitOfMeasure)
+                && optionalImportNumberMatches(parsed.fields["cost_price"], existingPart.companyCostPrice)
+                && optionalImportNumberMatches(parsed.fields["markup_percent"], existingPart.companyMarkupPercent)
+                && optionalImportFieldMatches(parsed.fields["shelf_location"], existingPart.shelfLocation)
+                && optionalImportFieldMatches(parsed.fields["bin_location"], existingPart.binLocation)
+                && existingPartId > 0
+        }
+    }
+
+    private func optionalImportFieldMatches(_ imported: String?, _ existing: String?) -> Bool {
+        guard let imported else { return true }
+        return normalizedImportValue(imported) == normalizedImportValue(existing ?? "")
+    }
+
+    private func optionalImportNumberMatches(_ imported: String?, _ existing: Double) -> Bool {
+        guard let imported else { return true }
+        guard let importedNumber = Double(imported.trimmingCharacters(in: .whitespacesAndNewlines)) else { return false }
+        return abs(importedNumber - existing) < 0.000_001
     }
 
     private func deterministicPartsImportColumnMapping(_ headers: [String]) -> [String: String] {
@@ -6600,44 +6665,82 @@ public final class PartsService: Sendable {
         columnMapping: [String: String],
         acceptedBy: Int64?
     ) throws -> PartsImportSavedMapping {
-        let mappingJSON = encodeJSONObject(columnMapping)
-        let headersJSON = encodeJSONObject(sourceHeaders)
+        let mappingJSON = try encodeJSONDictionary(columnMapping)
+        let headersJSON = try encodeJSONArray(sourceHeaders)
         return try db.writer.write { dbConn in
-            let existingId = try Int64.fetchOne(
+            try upsertPartsImportSavedMapping(
                 dbConn,
-                sql: """
-                    SELECT id FROM part_import_saved_mappings
-                    WHERE source_kind = ?
-                      AND header_fingerprint = ?
-                      AND schema_version = ?
-                      AND deleted_at IS NULL
-                      AND (supplier_id = ? OR (supplier_id IS NULL AND ? IS NULL))
-                    """,
-                arguments: [sourceKind, headerFingerprint, schemaVersion, supplierId, supplierId]
+                supplierId: supplierId,
+                sourceKind: sourceKind,
+                headerFingerprint: headerFingerprint,
+                schemaVersion: schemaVersion,
+                sourceHeaders: sourceHeaders,
+                columnMapping: columnMapping,
+                acceptedBy: acceptedBy,
+                mappingJSON: mappingJSON,
+                headersJSON: headersJSON
             )
-            if let existingId {
-                try dbConn.execute(
-                    sql: """
-                        UPDATE part_import_saved_mappings
-                        SET column_mapping_json = ?, source_headers_json = ?, accepted_by = ?,
-                            updated_at = datetime('now'), deleted_at = NULL
-                        WHERE id = ?
-                        """,
-                    arguments: [mappingJSON, headersJSON, acceptedBy, existingId]
-                )
-                return PartsImportSavedMapping(id: existingId, supplierId: supplierId, sourceKind: sourceKind, headerFingerprint: headerFingerprint, schemaVersion: schemaVersion, columnMapping: columnMapping, sourceHeaders: sourceHeaders)
-            }
+        }
+    }
+
+    private func upsertPartsImportSavedMapping(
+        _ dbConn: Database,
+        supplierId: Int64?,
+        sourceKind: String,
+        headerFingerprint: String,
+        schemaVersion: Int,
+        sourceHeaders: [String],
+        columnMapping: [String: String],
+        acceptedBy: Int64?,
+        mappingJSON: String? = nil,
+        headersJSON: String? = nil
+    ) throws -> PartsImportSavedMapping {
+        let resolvedMappingJSON: String
+        if let mappingJSON {
+            resolvedMappingJSON = mappingJSON
+        } else {
+            resolvedMappingJSON = try encodeJSONDictionary(columnMapping)
+        }
+        let resolvedHeadersJSON: String
+        if let headersJSON {
+            resolvedHeadersJSON = headersJSON
+        } else {
+            resolvedHeadersJSON = try encodeJSONArray(sourceHeaders)
+        }
+        let existingId = try Int64.fetchOne(
+            dbConn,
+            sql: """
+                SELECT id FROM part_import_saved_mappings
+                WHERE source_kind = ?
+                  AND header_fingerprint = ?
+                  AND schema_version = ?
+                  AND deleted_at IS NULL
+                  AND (supplier_id = ? OR (supplier_id IS NULL AND ? IS NULL))
+                """,
+            arguments: [sourceKind, headerFingerprint, schemaVersion, supplierId, supplierId]
+        )
+        if let existingId {
             try dbConn.execute(
                 sql: """
-                    INSERT INTO part_import_saved_mappings (
-                        supplier_id, source_kind, header_fingerprint, schema_version,
-                        column_mapping_json, source_headers_json, accepted_by, created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+                    UPDATE part_import_saved_mappings
+                    SET column_mapping_json = ?, source_headers_json = ?, accepted_by = COALESCE(?, accepted_by),
+                        updated_at = datetime('now'), deleted_at = NULL
+                    WHERE id = ?
                     """,
-                arguments: [supplierId, sourceKind, headerFingerprint, schemaVersion, mappingJSON, headersJSON, acceptedBy]
+                arguments: [resolvedMappingJSON, resolvedHeadersJSON, acceptedBy, existingId]
             )
-            return PartsImportSavedMapping(id: dbConn.lastInsertedRowID, supplierId: supplierId, sourceKind: sourceKind, headerFingerprint: headerFingerprint, schemaVersion: schemaVersion, columnMapping: columnMapping, sourceHeaders: sourceHeaders)
+            return PartsImportSavedMapping(id: existingId, supplierId: supplierId, sourceKind: sourceKind, headerFingerprint: headerFingerprint, schemaVersion: schemaVersion, columnMapping: columnMapping, sourceHeaders: sourceHeaders)
         }
+        try dbConn.execute(
+            sql: """
+                INSERT INTO part_import_saved_mappings (
+                    supplier_id, source_kind, header_fingerprint, schema_version,
+                    column_mapping_json, source_headers_json, accepted_by, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+                """,
+            arguments: [supplierId, sourceKind, headerFingerprint, schemaVersion, resolvedMappingJSON, resolvedHeadersJSON, acceptedBy]
+        )
+        return PartsImportSavedMapping(id: dbConn.lastInsertedRowID, supplierId: supplierId, sourceKind: sourceKind, headerFingerprint: headerFingerprint, schemaVersion: schemaVersion, columnMapping: columnMapping, sourceHeaders: sourceHeaders)
     }
 
     /// Commit a clean import preview atomically. If the preview has validation
@@ -6776,10 +6879,10 @@ public final class PartsService: Sendable {
                         skipped += 1
                     }
                 }
+                try persistAcceptedMappingAfterCommit(dbConn, preview: preview)
             }
 
             try finishImportSessionIfNeeded(id: importSessionId, status: "committed", created: created, updated: updated, skipped: skipped, error: nil)
-            try persistAcceptedMappingAfterCommit(preview)
             return PartsImportCommitResult(created: created, updated: updated, skipped: skipped, importSessionId: importSessionId)
         } catch {
             try? finishImportSessionIfNeeded(id: importSessionId, status: "failed", created: 0, updated: 0, skipped: 0, error: String(describing: error))
@@ -6855,11 +6958,21 @@ public final class PartsService: Sendable {
         return json
     }
 
-    private func encodeJSONObject(_ object: Any) -> String {
-        guard JSONSerialization.isValidJSONObject(object),
-              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
-              let json = String(data: data, encoding: .utf8) else {
-            return "{}"
+    private func encodeJSONDictionary(_ dictionary: [String: String]) throws -> String {
+        try encodeJSONValue(dictionary)
+    }
+
+    private func encodeJSONArray(_ array: [String]) throws -> String {
+        try encodeJSONValue(array)
+    }
+
+    private func encodeJSONValue(_ value: Any) throws -> String {
+        guard JSONSerialization.isValidJSONObject(value) else {
+            throw PartsError.invalidInput("Invalid JSON value for parts import metadata.")
+        }
+        let data = try JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw PartsError.invalidInput("Unable to encode parts import metadata JSON.")
         }
         return json
     }
@@ -6917,12 +7030,13 @@ public final class PartsService: Sendable {
         }
     }
 
-    private func persistAcceptedMappingAfterCommit(_ preview: PartsImportPreview) throws {
+    private func persistAcceptedMappingAfterCommit(_ dbConn: Database, preview: PartsImportPreview) throws {
         guard let source = preview.source,
               let headerFingerprint = source.headerFingerprint,
               !source.acceptedColumnMapping.isEmpty,
               !source.sourceHeaders.isEmpty else { return }
         _ = try upsertPartsImportSavedMapping(
+            dbConn,
             supplierId: source.supplierId,
             sourceKind: source.sourceKind,
             headerFingerprint: headerFingerprint,

--- a/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
@@ -901,6 +901,22 @@ struct PartsServiceAdvancedTests {
         #expect(lookup.id == saved.id)
         #expect(lookup.columnMapping["Vendor Part"] == "supplier_part_number")
         #expect(try env.parts.findPartByCode("Vendor Part") == nil)
+
+        _ = try env.parts.saveAcceptedPartsImportMapping(
+            supplierId: supplierId,
+            sourceKind: "csv",
+            sourceHeaders: ["Item", "Vendor Part", "Group"],
+            columnMapping: ["Item": "name", "Vendor Part": "supplier_part_number", "Group": "category"],
+            acceptedBy: nil
+        )
+        let acceptedBy = try env.db.writer.read { db in
+            try Int64.fetchOne(
+                db,
+                sql: "SELECT accepted_by FROM part_import_saved_mappings WHERE id = ?",
+                arguments: [saved.id]
+            )
+        }
+        #expect(acceptedBy == env.adminUserId)
     }
 
     @Test("previewPartsImportCSV prefers supplier part number matches before internal code")
@@ -949,6 +965,26 @@ struct PartsServiceAdvancedTests {
         #expect(decisionsByRow[5] == .quarantined)
         #expect(decisionsByRow[6] == .new)
         #expect(preview.errors.contains { $0.rowNumber == 5 })
+    }
+
+    @Test("previewPartsImportCSV classifies update when mutable import fields differ")
+    func testPreviewPartsImportCSVClassifiesUpdateWhenMutableFieldsDiffer() throws {
+        let env = try E2ETestHelpers.setUp()
+        let categoryId = try E2ETestHelpers.seedCategory(env, name: "Mutable Field Category")
+        _ = try env.parts.createPart(
+            categoryId: categoryId,
+            name: "Mutable Field Part",
+            code: "MUT-001",
+            description: "old description"
+        )
+
+        let preview = try env.parts.previewPartsImportCSV("""
+        name,code,category,description
+        Mutable Field Part,MUT-001,Mutable Field Category,new description
+        """)
+
+        let decision = try #require(preview.decisions.first)
+        #expect(decision.classification == .update)
     }
 
     // MARK: - approveScheduledDeletion

--- a/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
@@ -714,6 +714,99 @@ struct PartsServiceAdvancedTests {
         #expect(try env.parts.findPartByCode("NO-NAME") == nil)
     }
 
+    @Test("commitPartsImportCSV persists saved supplier mapping only after successful commit")
+    func testCommitPartsImportCSVPersistsSavedSupplierMappingAfterCommit() throws {
+        let env = try E2ETestHelpers.setUp()
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "Mapping Supplier")
+
+        let previewOnly = try env.parts.previewPartsImportCSV("""
+        Part Name,Vendor Code,Category
+        Preview Only,PV-001,Preview Category
+        """, supplierId: supplierId)
+        let previewFingerprint = try #require(previewOnly.source?.headerFingerprint)
+        #expect(try env.parts.findSavedPartsImportMapping(supplierId: supplierId, sourceKind: "csv", headerFingerprint: previewFingerprint) == nil)
+
+        let result = try env.parts.commitPartsImportCSV(previewOnly)
+        #expect(result.created == 1)
+
+        let saved = try #require(try env.parts.findSavedPartsImportMapping(supplierId: supplierId, sourceKind: "csv", headerFingerprint: previewFingerprint))
+        #expect(saved.supplierId == supplierId)
+        #expect(saved.columnMapping["Part Name"] == "name")
+        #expect(saved.columnMapping["Vendor Code"] == "supplier_part_number")
+        #expect(saved.schemaVersion == PartsService.PartsImportSourceMetadata.mappingSchemaVersion)
+    }
+
+    @Test("accepted mapping flow saves mapping without committing preview rows")
+    func testAcceptedPartsImportMappingFlowPersistsMapping() throws {
+        let env = try E2ETestHelpers.setUp()
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "Accepted Mapping Supplier")
+
+        let saved = try env.parts.saveAcceptedPartsImportMapping(
+            supplierId: supplierId,
+            sourceKind: "csv",
+            sourceHeaders: ["Item", "Vendor Part", "Group"],
+            columnMapping: ["Item": "name", "Vendor Part": "supplier_part_number", "Group": "category"],
+            acceptedBy: env.adminUserId
+        )
+
+        let lookup = try #require(try env.parts.findSavedPartsImportMapping(
+            supplierId: supplierId,
+            sourceKind: "csv",
+            headerFingerprint: saved.headerFingerprint
+        ))
+        #expect(lookup.id == saved.id)
+        #expect(lookup.columnMapping["Vendor Part"] == "supplier_part_number")
+        #expect(try env.parts.findPartByCode("Vendor Part") == nil)
+    }
+
+    @Test("previewPartsImportCSV prefers supplier part number matches before internal code")
+    func testPreviewPartsImportCSVPrefersSupplierAwareMatch() throws {
+        let env = try E2ETestHelpers.setUp()
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "Supplier Match")
+        let categoryId = try E2ETestHelpers.seedCategory(env, name: "Supplier Match Category")
+        let supplierPartId = try env.parts.createPart(categoryId: categoryId, name: "Supplier Existing", code: "SUP-INTERNAL")
+        let codePartId = try env.parts.createPart(categoryId: categoryId, name: "Code Existing", code: "CODE-MATCH")
+        _ = try env.parts.addPartSupplierLink(partId: supplierPartId, supplierId: supplierId, supplierPartNumber: "V-100")
+
+        let preview = try env.parts.previewPartsImportCSV("""
+        name,code,category,supplier_part_number
+        Supplier Replacement,CODE-MATCH,Supplier Match Category,V-100
+        """, supplierId: supplierId)
+
+        let decision = try #require(preview.decisions.first)
+        #expect(decision.classification == .update)
+        #expect(decision.existingPartId == supplierPartId)
+        #expect(decision.existingPartId != codePartId)
+        #expect(decision.matchReason == "supplier_part_number")
+        #expect(preview.conflicts.first?.existingPartId == supplierPartId)
+    }
+
+    @Test("previewPartsImportCSV classifies duplicate, ambiguous, conflict, and quarantined rows")
+    func testPreviewPartsImportCSVClassifiesStage2Decisions() throws {
+        let env = try E2ETestHelpers.setUp()
+        let categoryId = try E2ETestHelpers.seedCategory(env, name: "Decision Category")
+        _ = try env.parts.createPart(categoryId: categoryId, name: "Same Part", code: "SAME-001")
+        _ = try env.parts.createPart(categoryId: categoryId, name: "Ambiguous Part")
+        _ = try env.parts.createPart(categoryId: categoryId, name: "Ambiguous Part")
+
+        let preview = try env.parts.previewPartsImportCSV("""
+        name,code,category,cost_price
+        Same Part,SAME-001,Decision Category,
+        Changed Name,SAME-001,Decision Category,
+        Ambiguous Part,,Decision Category,
+        Bad Cost,BAD-001,Decision Category,not-a-number
+        New Part,NEW-DEC-001,Decision Category,
+        """)
+
+        let decisionsByRow = Dictionary(uniqueKeysWithValues: preview.decisions.map { ($0.rowNumber, $0.classification) })
+        #expect(decisionsByRow[2] == .duplicateSkip)
+        #expect(decisionsByRow[3] == .update)
+        #expect(decisionsByRow[4] == .conflictReview)
+        #expect(decisionsByRow[5] == .quarantined)
+        #expect(decisionsByRow[6] == .new)
+        #expect(preview.errors.contains { $0.rowNumber == 5 })
+    }
+
     // MARK: - approveScheduledDeletion
 
     @Test("approveScheduledDeletion soft-deletes the entity and marks schedule approved")


### PR DESCRIPTION
## Summary
- Add saved parts import mappings keyed by supplier/source/header fingerprint/schema version.
- Extend CSV/XLSX preview with deterministic header aliasing, row decisions, and supplier-aware dedupe order: supplier part number, code, then normalized name/category/brand.
- Persist accepted mappings only after successful commit or explicit accepted mapping flow; preview lookup remains read-only.
- Preserve existing newParts/conflicts/errors import contract for current CSV/XLSX consumers.

## Traceability
Refs: [WEI-2957](http://127.0.0.1:3100/WEI/issues/WEI-2957) — Stage 2 saved mappings and supplier-aware dedupe preview.
Refs: [WEI-2812](http://127.0.0.1:3100/WEI/issues/WEI-2812) — parent AI-assisted universal data import feature.
Refs: [WEI-3087](http://127.0.0.1:3100/WEI/issues/WEI-3087) — executable PR #938 review/CI fix issue.
Refs: [WEI-3089](http://127.0.0.1:3100/WEI/issues/WEI-3089) — PR #938 merge-lane issue.

Paperclip merge lane: PR #939 Stage 5 Time -> PR #940 runner routing -> PR #938 supplier-aware import. Do not merge this PR until linked Paperclip blockers are done/cancelled, checks pass, review threads are resolved, and the branch is current.

## Tests
- swift test --filter PartsServiceAdvancedTests.testCommitPartsImportCSVPersistsSavedSupplierMappingAfterCommit
- swift test --filter PartsServiceAdvancedTests.testAcceptedPartsImportMappingFlowPersistsMapping
- swift test --filter PartsServiceAdvancedTests.testPreviewPartsImportCSVPrefersSupplierAwareMatch
- swift test --filter PartsServiceAdvancedTests.testPreviewPartsImportCSVClassifiesStage2Decisions
- swift test --filter PartsServiceAdvancedTests.testPreviewPartsImportCSVClassifiesRows
- swift test --filter PartsServiceAdvancedTests.testCommitPartsImportCSVCreatesAndUpdates
- swift test --filter PartsServiceAdvancedTests.testPreviewPartsImportXLSXClassifiesRows

Review lane: LocalFirstReviewer first; GPTReviewer for schema/migration review.
