### PR TITLE
WEI-3097 teach CI agents to use local Mac runner

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,23 +18,19 @@ cd core && swift build && swift test
 
 ### Local Mac Actions Runner For PR CI
 
-For `xXKillerNoobYT/Weird-Part-Run-2`, PR build/test/QA work and repo-owned Actions automation should use the local self-hosted Mac runner before treating GitHub-hosted Actions billing, `macos-latest`, `ubuntu-latest`, or cloud queue capacity as a blocker.
+For `xXKillerNoobYT/Weird-Part-Run-2`, trusted PR build/test/QA work and repo-owned Actions automation should use the local self-hosted Mac runner before treating GitHub-hosted Actions billing, `macos-latest`, `ubuntu-latest`, or cloud queue capacity as a blocker.
 
-Known runner:
-
-- Directory: `/Users/IA/actions-runner/Weird-Part-Run-2`
-- Service: `IA-Mac-WPR2`
-- Labels: `self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`
+Use `docs/runbooks/local-mac-actions-runner.md` as the canonical runner reference instead of duplicating machine-specific details here.
 
 Before marking CI blocked on cloud runner capacity, check:
 
 ```bash
 gh api repos/xXKillerNoobYT/Weird-Part-Run-2/actions/runners --jq '.runners[] | {name,status,busy,labels:[.labels[].name]}'
 gh run list -R xXKillerNoobYT/Weird-Part-Run-2 --limit 10
-rg -n "runs-on:" .github/workflows
+rg -n "runs-on:" .github/workflows || grep -R "runs-on:" .github/workflows
 ```
 
-Use `runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]` for jobs that need macOS, iOS, Swift, or Xcode, required PR gates, and repo-owned automation jobs. If the runner is offline or missing labels, record that exact evidence in the PR/issue comment and name the owner/action needed to restore the runner.
+The runner API requires a GitHub token with permission to read repository Actions runner state. If API access is unavailable, use the repository Actions UI to inspect runner status and recent runs. Use `runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]` for trusted jobs that need macOS, iOS, Swift, or Xcode, required PR gates, and repo-owned automation jobs. Do not run untrusted fork PR code on the self-hosted runner. If the runner is offline or missing labels, record that exact evidence in the PR/issue comment and name the owner/action needed to restore the runner.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,26 @@ cd core && swift build && swift test
 - Do not add a new failing test and leave it skipped.
 - If `swift build` fails, fix the compile error before pushing.
 
+### Local Mac Actions Runner For PR CI
+
+For `xXKillerNoobYT/Weird-Part-Run-2`, PR build/test/QA work and repo-owned Actions automation should use the local self-hosted Mac runner before treating GitHub-hosted Actions billing, `macos-latest`, `ubuntu-latest`, or cloud queue capacity as a blocker.
+
+Known runner:
+
+- Directory: `/Users/IA/actions-runner/Weird-Part-Run-2`
+- Service: `IA-Mac-WPR2`
+- Labels: `self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`
+
+Before marking CI blocked on cloud runner capacity, check:
+
+```bash
+gh api repos/xXKillerNoobYT/Weird-Part-Run-2/actions/runners --jq '.runners[] | {name,status,busy,labels:[.labels[].name]}'
+gh run list -R xXKillerNoobYT/Weird-Part-Run-2 --limit 10
+rg -n "runs-on:" .github/workflows
+```
+
+Use `runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]` for jobs that need macOS, iOS, Swift, or Xcode, required PR gates, and repo-owned automation jobs. If the runner is offline or missing labels, record that exact evidence in the PR/issue comment and name the owner/action needed to restore the runner.
+
 ---
 
 ## 2. Schema Is Canonical

--- a/.github/workflows/artifact-guard.yml
+++ b/.github/workflows/artifact-guard.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   tracked-artifacts:
     name: Tracked artifact guard
-    runs-on: ubuntu-latest
+    # This repo's PR gates run on the local Mac runner because GitHub-hosted
+    # billing/capacity is not a reliable unblock path for WPR2.
+    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
     timeout-minutes: 5
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,7 @@ on:
 jobs:
   required-codeql-compat:
     name: CodeQL
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     # Required compatibility context for the private WPR2 repo. Route through
     # the local Mac runner instead of cloud runners so PRs do not get blocked by
     # billing/hosted-runner availability.
@@ -36,6 +37,7 @@ jobs:
 
   analyze:
     name: Analyze (${{ matrix.language }})
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     # Swift CodeQL requires macOS; WPR2 uses the local self-hosted Mac runner.
     runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
     timeout-minutes: 60

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,9 @@ on:
 jobs:
   required-codeql-compat:
     name: CodeQL
-    runs-on: ubuntu-latest
+    # Compatibility gate for the legacy required CodeQL context. Keep it on
+    # the same local runner path as the Swift analyzer so billing cannot block PRs.
+    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
     steps:
       - name: Required CodeQL compatibility gate
         run: |
@@ -33,7 +35,9 @@ jobs:
 
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: macos-latest  # Swift CodeQL requires macOS runners
+    # Swift CodeQL requires macOS/Xcode. Use the repository's local Mac
+    # runner instead of paid GitHub-hosted macOS capacity for PR blockers.
+    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
     timeout-minutes: 60
 
     permissions:

--- a/.github/workflows/paperclip-tracker-sync.yml
+++ b/.github/workflows/paperclip-tracker-sync.yml
@@ -11,7 +11,9 @@ permissions:
 
 jobs:
   sync-tracker:
-    runs-on: ubuntu-latest
+    # Scheduled repo automation uses the local Mac runner while cloud Actions
+    # billing is unavailable for this private repo.
+    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
     timeout-minutes: 10
     env:
       PAPERCLIP_API_URL: ${{ secrets.PAPERCLIP_API_URL }}

--- a/.github/workflows/pr-merge-maintenance.yml
+++ b/.github/workflows/pr-merge-maintenance.yml
@@ -34,7 +34,9 @@ permissions:
 
 jobs:
   maintain-prs:
-    runs-on: ubuntu-latest
+    # Merge maintenance must not stall behind GitHub-hosted Actions billing.
+    # Use the WPR2 local Mac runner for repo automation.
+    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
     timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,26 @@ Errors are learning opportunities. When something breaks:
 
 **GitHub Issues is the single source of truth** for all bugs, features, and improvements. Every unfixed problem MUST have a GitHub issue. Every fix should reference and close its issue.
 
+## WPR2 PR CI: Local Mac Actions Runner
+
+For this repo, do not treat GitHub-hosted Actions billing, `macos-latest`, `ubuntu-latest`, or queued cloud runners as the first PR blocker. The repo has a local self-hosted Mac runner intended for iOS/macOS/Xcode PR build, test, QA work, and repo-owned Actions automation while cloud billing is unavailable.
+
+Known runner:
+
+- Directory: `/Users/IA/actions-runner/Weird-Part-Run-2`
+- Service: `IA-Mac-WPR2`
+- Labels: `self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`
+
+Before calling CI blocked on cloud capacity, check:
+
+```bash
+gh api repos/xXKillerNoobYT/Weird-Part-Run-2/actions/runners --jq '.runners[] | {name,status,busy,labels:[.labels[].name]}'
+gh run list -R xXKillerNoobYT/Weird-Part-Run-2 --limit 10
+rg -n "runs-on:" .github/workflows
+```
+
+If a workflow needs macOS/iOS/Xcode or is a required PR gate/repo-owned automation job, use `runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]`. If the local runner is offline or mislabelled, record that exact evidence as the blocker and name the owner/action needed to restore it. PR descriptions, PR-info notes, merge/review issues, and closeout comments must mention the local runner test path whenever they discuss CI.
+
 ## GitHub Account Context
 
 This repo is currently under the user's personal GitHub account (`xXKillerNoobYT`), not a GitHub organization. Do not assume organization teams, organization policy pages, organization-level settings, or organization Copilot controls exist. Verify the repo owner before applying GitHub admin instructions. If a requested control is organization-only, document it as not applicable unless/until the user transfers the repo to an organization; use repo-level or user-account-level settings where available. See `docs/github-account-context.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,23 +96,19 @@ Errors are learning opportunities. When something breaks:
 
 ## WPR2 PR CI: Local Mac Actions Runner
 
-For this repo, do not treat GitHub-hosted Actions billing, `macos-latest`, `ubuntu-latest`, or queued cloud runners as the first PR blocker. The repo has a local self-hosted Mac runner intended for iOS/macOS/Xcode PR build, test, QA work, and repo-owned Actions automation while cloud billing is unavailable.
+For this repo, do not treat GitHub-hosted Actions billing, `macos-latest`, `ubuntu-latest`, or queued cloud runners as the first PR blocker. The repo has a local self-hosted Mac runner intended for trusted iOS/macOS/Xcode PR build, test, QA work, and repo-owned Actions automation while cloud billing is unavailable.
 
-Known runner:
-
-- Directory: `/Users/IA/actions-runner/Weird-Part-Run-2`
-- Service: `IA-Mac-WPR2`
-- Labels: `self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`
+Use `docs/runbooks/local-mac-actions-runner.md` as the canonical runner reference instead of duplicating machine-specific details here.
 
 Before calling CI blocked on cloud capacity, check:
 
 ```bash
 gh api repos/xXKillerNoobYT/Weird-Part-Run-2/actions/runners --jq '.runners[] | {name,status,busy,labels:[.labels[].name]}'
 gh run list -R xXKillerNoobYT/Weird-Part-Run-2 --limit 10
-rg -n "runs-on:" .github/workflows
+rg -n "runs-on:" .github/workflows || grep -R "runs-on:" .github/workflows
 ```
 
-If a workflow needs macOS/iOS/Xcode or is a required PR gate/repo-owned automation job, use `runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]`. If the local runner is offline or mislabelled, record that exact evidence as the blocker and name the owner/action needed to restore it. PR descriptions, PR-info notes, merge/review issues, and closeout comments must mention the local runner test path whenever they discuss CI.
+The runner API requires a GitHub token with permission to read repository Actions runner state. If API access is unavailable, use the repository Actions UI to inspect runner status and recent runs. If a workflow needs macOS/iOS/Xcode or is a required PR gate/repo-owned automation job, use `runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]` only for trusted repo events or same-repository PRs. If the local runner is offline or mislabelled, record that exact evidence as the blocker and name the owner/action needed to restore it. PR descriptions, PR-info notes, merge/review issues, and closeout comments must mention the local runner test path whenever they discuss CI.
 
 ## GitHub Account Context
 

--- a/docs/plans/paperclip-agentic-execution-loop.md
+++ b/docs/plans/paperclip-agentic-execution-loop.md
@@ -83,6 +83,31 @@ If the repo is above branch soft-cap pressure or has many active worktrees, pref
 
 Never delete a live worktree, local branch, remote branch, or PR without evidence that it is clean, merged, superseded, or intentionally abandoned.
 
+## Local Mac Actions Runner Gate
+
+For `xXKillerNoobYT/Weird-Part-Run-2`, PR build/test/QA work and repo-owned Actions automation must use the local self-hosted Mac runner path before treating GitHub-hosted Actions billing or queue capacity as a blocker.
+
+Known runner:
+
+- Directory: `/Users/IA/actions-runner/Weird-Part-Run-2`
+- Service: `IA-Mac-WPR2`
+- Labels: `self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`
+
+Before calling a PR blocked by CI, run:
+
+```bash
+gh api repos/xXKillerNoobYT/Weird-Part-Run-2/actions/runners --jq '.runners[] | {name,status,busy,labels:[.labels[].name]}'
+gh run list -R xXKillerNoobYT/Weird-Part-Run-2 --limit 10
+rg -n "runs-on:" .github/workflows
+```
+
+Required disposition:
+
+- If an Apple-platform or required PR-gate job is on `macos-latest`/`ubuntu-latest`, reroute it to `[self-hosted, macOS, ARM64, xcode, ios, local-mac]` or create a bounded CI child issue that does.
+- If the local runner is online with those labels, do not escalate cloud billing as the primary blocker.
+- If the local runner is offline, busy, or missing labels, record the exact runner evidence and make that the named blocker.
+- PR descriptions, merge issues, review comments, and Paperclip closeout comments that mention CI must include the local-runner check result.
+
 ## PR And Closeout Requirements
 
 A PR or closeout comment must include:
@@ -119,4 +144,3 @@ Paperclip closeout comments for GitHub-backed work must include a `GitHub sync:`
 - Do not create process-only issues that do not help agents choose, verify, land, or close work.
 - Do not broaden a small beta bug into an architecture project without a plan update and owner approval.
 - Do not treat Paperclip comments as completion when a code, PR, CI, review, or GitHub update is required.
-

--- a/docs/plans/paperclip-agentic-execution-loop.md
+++ b/docs/plans/paperclip-agentic-execution-loop.md
@@ -85,25 +85,24 @@ Never delete a live worktree, local branch, remote branch, or PR without evidenc
 
 ## Local Mac Actions Runner Gate
 
-For `xXKillerNoobYT/Weird-Part-Run-2`, PR build/test/QA work and repo-owned Actions automation must use the local self-hosted Mac runner path before treating GitHub-hosted Actions billing or queue capacity as a blocker.
+For `xXKillerNoobYT/Weird-Part-Run-2`, trusted PR build/test/QA work and repo-owned Actions automation must use the local self-hosted Mac runner path before treating GitHub-hosted Actions billing or queue capacity as a blocker.
 
-Known runner:
-
-- Directory: `/Users/IA/actions-runner/Weird-Part-Run-2`
-- Service: `IA-Mac-WPR2`
-- Labels: `self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`
+Use `docs/runbooks/local-mac-actions-runner.md` as the canonical runner reference instead of duplicating machine-specific details in plans or closeout comments.
 
 Before calling a PR blocked by CI, run:
 
 ```bash
 gh api repos/xXKillerNoobYT/Weird-Part-Run-2/actions/runners --jq '.runners[] | {name,status,busy,labels:[.labels[].name]}'
 gh run list -R xXKillerNoobYT/Weird-Part-Run-2 --limit 10
-rg -n "runs-on:" .github/workflows
+rg -n "runs-on:" .github/workflows || grep -R "runs-on:" .github/workflows
 ```
+
+The runner API requires a GitHub token with permission to read repository Actions runner state. If API access is unavailable, use the repository Actions UI to inspect runner status and recent runs.
 
 Required disposition:
 
 - If an Apple-platform or required PR-gate job is on `macos-latest`/`ubuntu-latest`, reroute it to `[self-hosted, macOS, ARM64, xcode, ios, local-mac]` or create a bounded CI child issue that does.
+- Do not run untrusted fork PR code on the self-hosted runner; keep self-hosted PR jobs limited to same-repository/trusted events.
 - If the local runner is online with those labels, do not escalate cloud billing as the primary blocker.
 - If the local runner is offline, busy, or missing labels, record the exact runner evidence and make that the named blocker.
 - PR descriptions, merge issues, review comments, and Paperclip closeout comments that mention CI must include the local-runner check result.


### PR DESCRIPTION
## Summary

Closes #943.
Refs Paperclip WEI-3097.

- routes all current repo workflows to the local self-hosted Mac runner labels
- adds the local-runner PR blocker rule to `CLAUDE.md` and Copilot agent instructions
- adds the runner verification and escalation gate to the Paperclip execution loop plan

## Local Runner Evidence

Current GitHub runner state checked before this PR:

```json
{"name":"IA-Mac-WPR2","status":"online","busy":false,"labels":["self-hosted","macOS","ARM64","xcode","ios","local-mac"]}
```

Initial PR checks reproduced the blocker: `Analyze (swift)` succeeded on the local runner while the remaining cloud-runner PR gates failed before step execution with the account billing/spending-limit error. This PR then moved those gates and scheduled repo automation to the local runner as well.

## Verification

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].sort.each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `rg -n "runs-on:" .github/workflows` shows every workflow job on `[self-hosted, macOS, ARM64, xcode, ios, local-mac]`
- PR #945 checks after the update:
  - `Tracked artifact guard` success
  - `CodeQL` success
  - `Analyze (swift)` success

## CI Notes

This PR intentionally moves the lightweight PR gates and scheduled repo automation off `ubuntu-latest`/`macos-latest` because the repo's GitHub-hosted runner path is currently blocked by billing, while the intended local runner is online and successfully ran the PR checks.
