### PR TITLE
WEI-3099 upgrade README and QA docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,105 @@
 # WiredPart
 
-Native iOS field service management app for an electrical contracting company. Manages parts inventory, warehouse operations, fleet tracking, job management, labor hours, procurement, scheduling, and reporting — all running on-device with local SQLite storage and peer-to-peer sync.
+Native iOS field-service operations app for an electrical contracting shop. WiredPart manages parts inventory, warehouse operations, fleet tracking, job labor, procurement, scheduling, reporting, notebooks, chat/RFIs, and local device sync from a SwiftUI app backed by a shared Swift package.
 
----
+Tracking:
+
+- GitHub: [xXKillerNoobYT/Weird-Part-Run-2#942](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/942)
+- Paperclip parent: `WEI-3096`
+- Paperclip active implementation: `WEI-3099`
+- Paperclip QA review: `WEI-3100`
+
+## Start Here
+
+| Need | Read |
+| --- | --- |
+| Build or test locally | [docs/SETUP.md](docs/SETUP.md) |
+| Pick the right code area | [docs/WORKING-AREAS.md](docs/WORKING-AREAS.md) |
+| Verify a change | [docs/QA-PROCESS.md](docs/QA-PROCESS.md) |
+| Current staged roadmap | [docs/plans/staged-paperclip-goals.md](docs/plans/staged-paperclip-goals.md) |
+| Dependency and runner notes | [docs/DEPENDENCIES.md](docs/DEPENDENCIES.md) |
+| Historical implementation context | [docs/DEVELOPMENT-HANDOFF.md](docs/DEVELOPMENT-HANDOFF.md) |
+
+## Repository Map
+
+```text
+Weird-Part-Run-2/
+├── Weird Parts IOS/
+│   ├── Weird Parts.xcodeproj/        iOS Xcode project
+│   ├── Weird Parts IOS/              SwiftUI app target
+│   ├── Weird Parts IOSTests/         app-level unit/regression tests
+│   └── Weird Parts IOSUITests/       XCUITest suites and launch tests
+├── core/
+│   ├── Package.swift                 WiredPartCore Swift package
+│   ├── Sources/WiredPartCore/        models, services, database, sync, AI, QR/OCR
+│   └── Tests/WiredPartCoreTests/     Swift Testing package tests
+├── docs/                             setup, QA, plans, trackers, runbooks
+├── scripts/                          repo hygiene, GitHub/Paperclip sync, guards
+├── tests/                            static/repo-level checks
+├── tools/                            local developer utilities
+└── xcode-ai/                         AI-agent prompts, skills, and observations
+```
 
 ## Architecture
 
-| Component | Technology |
-|-----------|-----------|
-| **UI** | SwiftUI (iOS 18+) |
-| **Core Library** | WiredPartCore Swift Package (shared models, services, sync) |
-| **Database** | GRDB.swift / SQLite |
-| **Sync** | LAN HTTP (swift-nio) + MultipeerConnectivity (BT/Wi-Fi P2P) |
-| **AI** | Apple Foundation Models (iOS 26+, on-device) |
-| **Security** | CryptoKit (Ed25519 device trust) |
-| **OCR** | Apple Vision framework |
-| **QR** | AVFoundation barcode scanning |
+| Area | Technology |
+| --- | --- |
+| App UI | SwiftUI, iOS app target in `Weird Parts IOS/` |
+| Shared domain core | Swift Package Manager library `WiredPartCore` |
+| Database | GRDB.swift with SQLCipher-backed pinned dependency |
+| Sync | Local-first service layer, LAN/peer sync surfaces, device trust primitives |
+| AI/OCR/QR | Apple Foundation Models surfaces where available, Vision, AVFoundation |
+| Tests | Swift Testing for core package, Xcode test plans/XCUITest for app flows |
+| Automation | GitHub Actions plus local self-hosted Mac runner for Xcode/iOS work |
 
----
+The app is intentionally local-first. Core business rules belong in `core/Sources/WiredPartCore` where they can be tested without booting the UI. SwiftUI feature screens should remain thin composition layers over shared services, view models, and app navigation state.
 
-## Project Structure
+## Feature Areas
 
-```
-Weird-Part-Run-2/
-├── Weird Parts IOS/           ← iOS app target (SwiftUI)
-│   └── Weird Parts IOS/
-│       ├── App/               ← AppCore, entry point
-│       ├── Auth/              ← Onboarding, pairing, setup
-│       ├── Features/          ← 14 feature modules
-│       │   ├── Chat/
-│       │   ├── Dashboard/
-│       │   ├── Fleet/
-│       │   ├── Jobs/
-│       │   ├── Notebooks/
-│       │   ├── Office/
-│       │   ├── Orders/
-│       │   ├── Parts/
-│       │   ├── People/
-│       │   ├── Reports/
-│       │   ├── Scheduling/
-│       │   ├── Settings/
-│       │   ├── Tools/
-│       │   └── Warehouse/
-│       ├── Navigation/        ← Router, tab config, main view
-│       ├── Scanning/          ← OCR, QR scanner adapters
-│       ├── Shared/            ← Reusable components, charts
-│       ├── Sync/              ← Peer browser, sync manager, status
-│       └── Theme/             ← Theme manager, glass modifiers
-├── core/                      ← WiredPartCore Swift Package
-│   └── Sources/WiredPartCore/
-│       ├── AI/                ← Foundation Models service, AI tools
-│       ├── Database/          ← AppDatabase, migrations, base repo
-│       ├── ImageMatch/        ← Vision-based image matching
-│       ├── Models/            ← Domain models (12 modules)
-│       ├── OCR/               ← OCR processor adapter
-│       ├── QR/                ← QR codec, generator, scanner
-│       ├── Services/          ← 15 business logic services
-│       └── Sync/              ← Sync engine, peer management, crypto
-└── docs/                      ← Plans, specs, architecture docs
+| Area | Purpose | Primary App Path |
+| --- | --- | --- |
+| Dashboard | KPIs, alerts, quick actions | `Features/Dashboard` |
+| Parts | catalog, categories, brands, suppliers, pricing, forecasting, import/export | `Features/Parts` |
+| Warehouse | locations, movements, receiving, staging, returns, audits, trailers | `Features/Warehouse` |
+| Jobs | job lifecycle, labor, clock, questionnaire, daily reports | `Features/Jobs` |
+| Orders | JPOs, purchase orders, returns, procurement, approvals | `Features/Orders` |
+| Fleet | vehicles, trailers, inspections, maintenance, mileage, fuel | `Features/Fleet` |
+| People | employees, customers, contacts, hats, teams, permissions | `Features/People` |
+| Scheduling | calendar, dispatch, time off, templates, availability | `Features/Scheduling` |
+| Tools | tool registry, kits, checkout, maintenance | `Features/Tools` |
+| Notebooks | all notebooks, templates, job notebooks | `Features/Notebooks` |
+| Reports | timesheets, spending, daily summaries, pre-billing exports | `Features/Reports` |
+| Chat | messages, Q&A, RFIs | `Features/Chat` |
+| Office | office management dashboards and admin workflows | `Features/Office` |
+| Settings | company config, security, sync, theme, devices, AI settings | `Features/Settings` |
+
+## Common Commands
+
+```bash
+# Core package tests
+cd core
+swift test
+
+# Static artifact guard from repo root
+python3 scripts/guard-tracked-artifacts.py
+
+# Xcode app build/test from repo root; choose an installed simulator
+xcodebuild \
+  -project "Weird Parts IOS/Weird Parts.xcodeproj" \
+  -scheme "Weird Parts IOS" \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  build
 ```
 
----
+For PR validation that needs iOS/macOS/Xcode, prefer the repository's local self-hosted Mac runner labels documented in [docs/QA-PROCESS.md](docs/QA-PROCESS.md). Do not call a WPR2 PR blocked only because GitHub-hosted macOS capacity or billing is unavailable until the local runner state has been checked.
 
-## Modules
+## Work Rules
 
-| Module | Description |
-|--------|-------------|
-| Dashboard | KPI cards, quick actions |
-| Parts | Catalog, categories, brands, suppliers, pricing, companions, forecasting, import/export |
-| Warehouse | Dashboard, movements, locations, staging, receiving, returns, audit, inventory grid, tools, network, settings |
-| Jobs | Job list, labor, reports, clock, detail, questionnaire, daily reports |
-| Orders | JPO requests, purchase orders, returns, procurement, staging, approvals |
-| Fleet | Vehicles, maintenance, mileage, fuel, trailers, inspections, GPS, my truck, trailer locations, truck tools |
-| People | Employees, customers, contacts, hats, teams, contractors, permissions |
-| Scheduling | Calendar, dispatch, time off, templates, availability, sub schedule, config |
-| Tools | Registry, checkouts, kits, dashboard, admin, maintenance |
-| Notebooks | All notebooks, templates, job notebooks |
-| Reports | Timesheets, spending, daily summary, profitability, pre-billing, bookkeeper, labor overview |
-| Chat | Messages, Q&A, RFIs |
-| Office | Manage jobs, warehouse exec, spending dashboard |
-| Settings | Themes, app config, company, sync, bluetooth, AI config, devices, security, and more |
-
----
-
-## Auth & Permissions
-
-Hat-based permission system. Users wear one or more hats (roles), and their permissions are the union of all hat permissions. 7 built-in roles from Admin (full access) to Grunt (minimal access), with 30+ permission keys.
-
----
-
-## Sync
-
-Devices sync via LAN HTTP and Apple MultipeerConnectivity. Each device maintains its own SQLite database. Change tracking via `_change_log` table with last-writer-wins + field-level merge conflict resolution. Ed25519 device trust via CryptoKit.
-
----
+- Keep generated/runtime files out of commits. Run `python3 scripts/guard-tracked-artifacts.py` before handing off.
+- Put domain rules in `WiredPartCore` first when practical, then adapt them in the app.
+- Add or update the smallest relevant test for behavior changes.
+- Capture UI evidence for user-facing changes: route/screen, device or simulator, viewport/orientation, command, and result.
+- Link the GitHub issue and Paperclip ID in docs, PRs, and handoff comments when a change is part of tracked work.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ python3 scripts/guard-tracked-artifacts.py
 # Xcode app build/test from repo root; choose an installed simulator
 xcodebuild \
   -project "Weird Parts IOS/Weird Parts.xcodeproj" \
-  -scheme "Weird Parts IOS" \
-  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -scheme "Weird Parts" \
+  -destination 'generic/platform=iOS Simulator' \
   build
 ```
 

--- a/docs/QA-PROCESS.md
+++ b/docs/QA-PROCESS.md
@@ -1,0 +1,118 @@
+# QA Process And Evidence Guide
+
+Tracking:
+
+- GitHub: [xXKillerNoobYT/Weird-Part-Run-2#942](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/942)
+- Paperclip parent: `WEI-3096`
+- Paperclip active implementation: `WEI-3099`
+- Paperclip QA review: `WEI-3100`
+
+This document defines the minimum verification handoff for code, UI, docs, and automation changes. UIExpertVerifier should use this as the review surface for `WEI-3100`.
+
+## Evidence Required By Change Type
+
+| Change type | Minimum evidence |
+| --- | --- |
+| Docs only | `git diff --check`; links resolve relative to repo; no secrets/runtime artifacts added |
+| Core domain logic | relevant `swift test` suite or focused `swift test --filter ...` from `core` |
+| Database/migration | migration test or seeded open/migrate smoke plus rollback/data-impact note |
+| SwiftUI screen | focused app build plus screenshot or UI test evidence for the affected route |
+| Navigation/routing | app build plus route smoke on phone and tablet destinations |
+| Sync/conflict behavior | unit/integration coverage for merge or queue rule plus manual multi-device note if applicable |
+| Security/auth | focused tests, no secret logging, least-privilege and persistence notes |
+| CI/workflow | workflow syntax/readback plus local runner routing note for Xcode/iOS jobs |
+
+## Local Commands
+
+Run the smallest command that proves the change. Do not default to full workspace validation for docs-only or isolated edits.
+
+```bash
+# Docs and Markdown hygiene
+git diff --check
+python3 scripts/guard-tracked-artifacts.py
+
+# Core package
+cd core
+swift test
+swift test --filter "SuiteOrTestName"
+
+# App build; choose an installed simulator
+xcodebuild \
+  -project "Weird Parts IOS/Weird Parts.xcodeproj" \
+  -scheme "Weird Parts IOS" \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  build
+
+# App unit tests
+xcodebuild \
+  -project "Weird Parts IOS/Weird Parts.xcodeproj" \
+  -scheme "Weird Parts IOS" \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  test
+```
+
+If the simulator name is unavailable, run `xcrun simctl list devices available` and pick an installed iPhone/iPad simulator. Record the exact destination used.
+
+## UI Evidence Expectations
+
+For user-facing app changes, the handoff should include:
+
+- Route or screen name.
+- Simulator/device and OS if known.
+- Viewport/orientation: at minimum phone portrait for compact surfaces; add iPad/tablet when layout changes are responsive.
+- Screenshot, XCUITest attachment, or precise manual observation.
+- Accessibility notes when tap targets, text size, contrast, keyboard, or VoiceOver behavior is relevant.
+
+Expected baseline viewports:
+
+| Device class | Minimum evidence |
+| --- | --- |
+| iPhone compact | portrait smoke for navigation and clipping |
+| iPad/tablet | portrait or landscape when grids, split views, sidebars, or sheets change |
+| Dark mode | required for visual-system, color, card, modal, chart, or dashboard work |
+
+## PR Testing On The Local Mac Runner
+
+For `xXKillerNoobYT/Weird-Part-Run-2`, iOS/macOS/Xcode PR checks should not be treated as blocked solely because GitHub-hosted macOS capacity or billing is unavailable. The repo has a local self-hosted Mac runner intended for this path.
+
+Known runner context:
+
+- Runner directory: `/Users/IA/actions-runner/Weird-Part-Run-2`
+- Service: `IA-Mac-WPR2`
+- Intended labels: `self-hosted`, `macOS`, `ARM64`/`arm64`, `xcode`, `ios`, `local-mac`
+
+Useful checks:
+
+```bash
+gh api repos/xXKillerNoobYT/Weird-Part-Run-2/actions/runners \
+  --jq '.runners[] | {name,status,busy,labels:[.labels[].name]}'
+
+gh run list -R xXKillerNoobYT/Weird-Part-Run-2 --limit 10
+
+grep -R "runs-on:" .github/workflows
+```
+
+When a workflow needs Xcode/iOS, evidence should state whether it was routed to the local runner labels or why the local runner could not be used. Related tracking: GitHub [#943](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/943), Paperclip `WEI-3097`.
+
+## Handoff Template
+
+```markdown
+QA handoff
+
+- Tracking: GitHub #NNN / Paperclip WEI-NNNN
+- Scope: files or screens changed
+- Verification: command(s), result, device/simulator if UI
+- Evidence: screenshots, logs, or exact observations
+- Not run: commands skipped and why
+- Residual risk: known gaps
+- Next owner: reviewer or follow-up issue
+```
+
+## WEI-3100 Review Notes
+
+For the `WEI-3099` docs upgrade, UIExpertVerifier should verify:
+
+- README links route to the support docs added or updated in this branch.
+- `docs/SETUP.md`, `docs/WORKING-AREAS.md`, and this QA guide describe the native iOS/core Swift repo rather than stale web-only startup instructions.
+- GitHub [#942](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/942), `WEI-3096`, `WEI-3099`, and `WEI-3100` are traceable in the docs.
+- The docs do not include secrets, `.env` values, local tokens, database files, derived data, screenshots, or runtime artifacts.

--- a/docs/QA-PROCESS.md
+++ b/docs/QA-PROCESS.md
@@ -39,19 +39,34 @@ swift test --filter "SuiteOrTestName"
 # App build; choose an installed simulator
 xcodebuild \
   -project "Weird Parts IOS/Weird Parts.xcodeproj" \
-  -scheme "Weird Parts IOS" \
-  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -scheme "Weird Parts" \
+  -destination 'generic/platform=iOS Simulator' \
   build
 
 # App unit tests
 xcodebuild \
   -project "Weird Parts IOS/Weird Parts.xcodeproj" \
-  -scheme "Weird Parts IOS" \
-  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -scheme "Weird Parts" \
+  -destination 'generic/platform=iOS Simulator' \
   test
 ```
 
-If the simulator name is unavailable, run `xcrun simctl list devices available` and pick an installed iPhone/iPad simulator. Record the exact destination used.
+For route-specific simulator validation, replace the generic destination with an installed iPhone/iPad from `xcrun simctl list devices available`. Record the exact destination used.
+
+## Documentation Maintenance Cadence
+
+QA owns a docs spot-check whenever a change adds, removes, renames, or materially changes a user-facing route, service workflow, setup command, test command, runner label, permission/security behavior, sync behavior, or release-readiness gate.
+
+Use this checklist before approving the change:
+
+- Update `README.md` when the repo map, feature-area summary, common commands, or top-level status changes.
+- Update `docs/WORKING-AREAS.md` when code moves between app feature folders, `WiredPartCore`, tests, scripts, or workflow ownership areas.
+- Update `docs/SETUP.md` when Xcode project names, schemes, destinations, package commands, runner setup, or prerequisites change.
+- Update this `docs/QA-PROCESS.md` when evidence expectations, smoke commands, device matrix, artifact rules, or PR validation routes change.
+- Update feature-specific docs or file a GitHub follow-up when product behavior changes faster than the guide can be fixed in the current PR.
+- In the PR handoff, state `Docs checked: yes/no` and list any follow-up GitHub issue for mismatches intentionally deferred.
+
+Minimum cadence: run this checklist for every release-candidate PR, every field-test workflow PR, every GitHub/Paperclip automation PR, and any user-facing feature PR. For purely internal refactors, document why no guide update was required.
 
 ## UI Evidence Expectations
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -62,20 +62,20 @@ xcrun simctl list devices available
 
 xcodebuild \
   -project "Weird Parts IOS/Weird Parts.xcodeproj" \
-  -scheme "Weird Parts IOS" \
-  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -scheme "Weird Parts" \
+  -destination 'generic/platform=iOS Simulator' \
   build
 ```
 
-If `iPhone 16` is not installed, choose another available simulator and record the destination in your handoff.
+For manual simulator validation, replace the generic destination with an installed device from `xcrun simctl list devices available` and record the destination in your handoff.
 
 ## Run App Tests
 
 ```bash
 xcodebuild \
   -project "Weird Parts IOS/Weird Parts.xcodeproj" \
-  -scheme "Weird Parts IOS" \
-  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -scheme "Weird Parts" \
+  -destination 'generic/platform=iOS Simulator' \
   test
 ```
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,226 +1,135 @@
-# Wired-Part — Customer Setup Guide
+# WiredPart Local Setup
 
-Everything you need to get Wired-Part running at your shop.
+Tracking:
 
----
+- GitHub: [xXKillerNoobYT/Weird-Part-Run-2#942](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/942)
+- Paperclip parent: `WEI-3096`
+- Paperclip active implementation: `WEI-3099`
+- Paperclip QA review: `WEI-3100`
 
-## What You Need
+This guide is for the current native iOS and Swift package repository. Older web/server deployment notes may still exist in historical plans, but they are not the front-door setup path for this repo.
 
-| Item | Purpose | Notes |
-|------|---------|-------|
-| **Shop computer** | Runs the server (Windows 10/11 or Mac) | Any desktop/laptop at the shop |
-| **Wi-Fi router** | Connects all devices on same network | Any standard home/office router |
-| **Web browser** | Access from shop desktops | Chrome, Edge, or Safari |
-| **Mobile devices** (optional) | iPads, iPhones, Android phones for field workers | Requires Capacitor app install |
+## Prerequisites
 
----
+| Requirement | Purpose |
+| --- | --- |
+| macOS with Xcode installed | builds the SwiftUI iOS app and runs simulators |
+| Xcode command line tools | provides `xcodebuild`, `xcrun`, SwiftPM |
+| Swift 6-compatible toolchain | builds `core/Package.swift` |
+| GitHub CLI `gh` | optional, for PR/runner checks |
+| Python 3 | optional, for repo guard scripts |
 
-## Step 1: Install on the Shop Computer
+Check local tools:
 
-### Prerequisites
-
-1. **Python 3.12+** — Download from [python.org](https://www.python.org/downloads/)
-   - During install, check "Add Python to PATH"
-2. **Node.js 18+** — Download from [nodejs.org](https://nodejs.org/)
-
-### Installation
-
-1. Copy the `Weird-Part-Run-2` folder to your shop computer (e.g., `C:\WiredPart`)
-2. Open **Terminal** (Mac) or **PowerShell** (Windows)
-3. Run the startup script:
-
-**Windows:**
-```powershell
-cd C:\WiredPart
-powershell -ExecutionPolicy Bypass -File scripts\start-server.ps1
-```
-
-**Mac:**
 ```bash
-cd ~/WiredPart
-bash scripts/start-server.sh
+xcodebuild -version
+swift --version
+python3 --version
+gh --version
 ```
 
-The script will:
-- Create a Python virtual environment
-- Install backend dependencies
-- Build the frontend
-- Detect your LAN IP address
-- Start the server
+## Clone And Open
 
-You'll see output like:
-```
-  Server starting at:
-    Local:   http://localhost:8000
-    Network: http://192.168.1.100:8000
-
-  Field devices connect to: http://192.168.1.100:8000
-```
-
-**Write down the Network URL** — you'll need it for Step 3.
-
----
-
-## Step 2: Access from Shop Computers
-
-On any computer connected to the same Wi-Fi:
-
-1. Open a web browser (Chrome, Edge, or Safari)
-2. Go to `http://<shop-ip>:8000` (the Network URL from Step 1)
-3. The first time, you'll see the login screen
-
-### First Login
-
-1. Select the admin user ("Admin")
-2. Enter the default PIN: **1234**
-3. You're in! Go to **Settings → People** to create employee accounts
-
-### Create Employee Accounts
-
-1. Go to **People → Employees**
-2. Click **Add Employee**
-3. Set their name, email, phone, and a 4-6 digit PIN
-4. Assign their **hats** (roles) — this controls what they can see and do
-5. A default Mon-Fri schedule is automatically created
-
----
-
-## Step 3: Connect Mobile Devices (Optional)
-
-### For iPads/iPhones
-
-1. Install the Wired-Part app via sideloading (see `docs/plans/sideloading-guide.md`)
-2. Open the app
-3. Go to **Settings → Sync**
-4. Enter the shop server URL: `http://<shop-ip>:8000`
-5. Tap **Test** to verify connection
-6. Tap **Sync Now** for initial data load
-
-### For Android
-
-1. Install the APK (transfer via USB or file share)
-2. Same setup as iOS above
-
-### How Sync Works
-
-- Mobile devices work **fully offline** — no Wi-Fi needed for daily tasks
-- When on the shop Wi-Fi, changes sync automatically every 5 minutes
-- You can also tap the sync icon in the header to sync manually
-- The shop server is the "truth" — if two people edit the same thing, the last edit wins
-
----
-
-## Step 4: Daily Operations
-
-### For Field Workers (Mobile)
-
-- **Clock in/out** — Tap a job, then Clock In. Clock Out prompts questionnaire.
-- **Move parts** — Use the warehouse movement wizard to pull/transfer parts
-- **Create orders** — Submit parts requests from job sites
-- **Check tools** — View assigned tools, do kit verification
-- **Write notes** — Job notebooks for daily updates
-
-### For Office Staff (Desktop)
-
-- **Dashboard** — KPI overview, quick actions
-- **Manage orders** — Review parts requests, create purchase orders
-- **Approve time-off** — Review and approve/deny requests
-- **Dispatch** — Assign workers to jobs for the day
-- **Reports** — Pre-billing, timesheets, labor overview, profitability
-- **Cost tracking** — FIFO/LIFO cost analysis, budget monitoring
-
----
-
-## Step 5: Auto-Start on Boot
-
-### Windows
-
-1. Press `Win+R`, type `taskschd.msc`, press Enter
-2. Click **Create Basic Task**
-3. Name: "Wired-Part Server"
-4. Trigger: "When the computer starts"
-5. Action: "Start a program"
-6. Program: `powershell.exe`
-7. Arguments: `-ExecutionPolicy Bypass -File C:\WiredPart\scripts\start-server.ps1`
-8. Finish
-
-### Mac
-
-Create `~/Library/LaunchAgents/com.wiredpart.server.plist`:
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key><string>com.wiredpart.server</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>bash</string>
-        <string>/Users/YOU/WiredPart/scripts/start-server.sh</string>
-    </array>
-    <key>RunAtLoad</key><true/>
-    <key>KeepAlive</key><true/>
-</dict>
-</plist>
-```
-
-Then run: `launchctl load ~/Library/LaunchAgents/com.wiredpart.server.plist`
-
----
-
-## Backups
-
-### Automatic Backups
-
-Set up a daily backup using the backup script:
-
-**Windows** (Task Scheduler):
-- Program: `powershell.exe`
-- Arguments: `-File C:\WiredPart\scripts\backup-db.ps1`
-- Schedule: Daily at midnight
-
-**Mac** (cron):
 ```bash
-crontab -e
-# Add this line:
-0 0 * * * bash /Users/YOU/WiredPart/scripts/backup-db.sh
+git clone git@github.com:xXKillerNoobYT/Weird-Part-Run-2.git
+cd Weird-Part-Run-2
+open "Weird Parts IOS/Weird Parts.xcodeproj"
 ```
 
-Backups are saved to `backups/` and the last 30 are kept automatically.
+The app target lives under `Weird Parts IOS/`. The shared package lives under `core/` and is the preferred place for business logic, persistence, sync, QR/OCR, and service tests.
 
-### Restore from Backup
+## Build The Core Package
 
-If something goes wrong, restore from a backup:
-
-**Windows:**
-```powershell
-powershell -File scripts\restore-db.ps1
-```
-
-**Mac:**
 ```bash
-bash scripts/restore-db.sh
+cd core
+swift build
+swift test
 ```
 
-The script will show available backups and let you choose one. A safety backup of your current database is created before restoring.
+Use focused tests while iterating:
 
----
+```bash
+cd core
+swift test --filter "AuthServiceTests"
+```
+
+## Build The iOS App
+
+From the repo root:
+
+```bash
+xcrun simctl list devices available
+
+xcodebuild \
+  -project "Weird Parts IOS/Weird Parts.xcodeproj" \
+  -scheme "Weird Parts IOS" \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  build
+```
+
+If `iPhone 16` is not installed, choose another available simulator and record the destination in your handoff.
+
+## Run App Tests
+
+```bash
+xcodebuild \
+  -project "Weird Parts IOS/Weird Parts.xcodeproj" \
+  -scheme "Weird Parts IOS" \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  test
+```
+
+For UI work, capture route/screen evidence using Xcode test attachments, simulator screenshots, or a concise manual note with device, orientation, and result. See [QA-PROCESS.md](QA-PROCESS.md).
+
+## Repo Guards
+
+Before handing off:
+
+```bash
+git diff --check
+python3 scripts/guard-tracked-artifacts.py
+git status --short
+```
+
+Do not commit:
+
+- `.env`, tokens, credentials, provisioning secrets, or API keys.
+- Local databases, DerivedData, build products, caches, or logs.
+- Runtime screenshots unless the issue explicitly requests checked-in documentation images.
+- Temporary agent workspaces or generated artifacts.
+
+## GitHub Actions And PR Validation
+
+Static checks can run on GitHub-hosted Linux/macOS as configured. For iOS/macOS/Xcode PR work, use the local self-hosted Mac runner path before declaring CI blocked by hosted runner billing/capacity.
+
+```bash
+gh api repos/xXKillerNoobYT/Weird-Part-Run-2/actions/runners \
+  --jq '.runners[] | {name,status,busy,labels:[.labels[].name]}'
+
+gh run list -R xXKillerNoobYT/Weird-Part-Run-2 --limit 10
+grep -R "runs-on:" .github/workflows
+```
+
+Known local runner:
+
+- Directory: `/Users/IA/actions-runner/Weird-Part-Run-2`
+- Service: `IA-Mac-WPR2`
+- Labels: `self-hosted`, `macOS`, `ARM64`/`arm64`, `xcode`, `ios`, `local-mac`
+
+Runner tracking: GitHub [#943](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/943), Paperclip `WEI-3097`.
 
 ## Troubleshooting
 
-| Problem | Solution |
-|---------|----------|
-| Server won't start | Check Python is installed: `python --version` |
-| Can't access from other computers | Ensure all devices are on the same Wi-Fi network |
-| Mobile app can't connect | Check the shop URL in Settings → Sync. Must include `http://` and port |
-| "Invalid PIN" | Default admin PIN is 1234. Ask your admin to reset your PIN |
-| Slow performance | The database grows over time. Regular backups + cleanup help |
-| Data not syncing | Tap the sync icon in the header. Check if shop is reachable |
+| Symptom | Check |
+| --- | --- |
+| Swift package dependency fails | Confirm `core/Package.resolved` is present and rerun `swift package resolve` from `core`. |
+| Simulator destination not found | Run `xcrun simctl list devices available` and use an installed device name. |
+| App build cannot find package products | Reopen the Xcode project and let package resolution finish. |
+| Xcode test hangs in CI | Check local runner availability and workflow `runs-on` labels before treating it as a cloud blocker. |
+| Guard script fails | Remove generated/runtime artifact from tracking or update ignore/guard rules only when the artifact is intentionally source-controlled. |
 
----
+## Next Reads
 
-## Getting Help
-
-- Check the **API docs** at `http://<shop-ip>:8000/docs`
-- Review logs at `backend/logs/wiredpart.log`
-- Database is at `backend/wiredpart.db` (SQLite — can browse with DB Browser)
+- [README.md](../README.md) for the repo map.
+- [WORKING-AREAS.md](WORKING-AREAS.md) for area ownership.
+- [QA-PROCESS.md](QA-PROCESS.md) for evidence expectations.

--- a/docs/TESTING-REQUIREMENTS.md
+++ b/docs/TESTING-REQUIREMENTS.md
@@ -1,10 +1,13 @@
 # WiredPart v1.0 — Testing Requirements & Verification Procedures
 
 > **Document Owner:** QA Lead
-> **Last Updated:** 2026-03-27
+> **Last Updated:** 2026-06-07
 > **Scope:** Complete testing strategy covering unit, integration, E2E, UI, performance, and security testing
 > **Standard:** Production-grade quality for enterprise deployment
 > **Paperclip staging update:** This remains the quality gate reference. The stage order and active/planned status live in `docs/plans/staged-paperclip-goals.md`.
+> **Docs upgrade tracking:** GitHub [#942](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/942), Paperclip `WEI-3096` / `WEI-3099`; QA review `WEI-3100`.
+
+For current command examples, local runner expectations, and handoff template, start with [`docs/QA-PROCESS.md`](QA-PROCESS.md). This file remains the detailed test-standard reference.
 
 ---
 

--- a/docs/WORKING-AREAS.md
+++ b/docs/WORKING-AREAS.md
@@ -1,0 +1,95 @@
+# Working Area Guide
+
+Tracking:
+
+- GitHub: [xXKillerNoobYT/Weird-Part-Run-2#942](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/942)
+- Paperclip parent: `WEI-3096`
+- Paperclip active implementation: `WEI-3099`
+- Paperclip QA review: `WEI-3100`
+
+Use this guide to route work to the right part of the repo before editing. Keep changes small and area-owned; avoid cross-area refactors unless the issue explicitly calls for them.
+
+## App Shell
+
+| Path | Owns | Notes |
+| --- | --- | --- |
+| `Weird Parts IOS/Weird Parts IOS/App` | app entry, app-level composition | Keep launch/setup logic thin. |
+| `Weird Parts IOS/Weird Parts IOS/Navigation` | routing, tabs, page selection | Update route maps when adding feature screens. |
+| `Weird Parts IOS/Weird Parts IOS/DesignSystem` | shared tokens, primitives, app styling | Prefer existing components before adding new visual styles. |
+| `Weird Parts IOS/Weird Parts IOS/Shared` | reusable SwiftUI components and charts | Only place broadly reusable UI here. |
+| `Weird Parts IOS/Weird Parts IOS/WebFallback` | fallback surfaces | Do not route primary native work here unless issue scope says so. |
+
+## Feature Modules
+
+Each feature folder under `Weird Parts IOS/Weird Parts IOS/Features` should own its screens, view-local state, and feature-specific UI composition. Shared business logic belongs in `core/Sources/WiredPartCore`.
+
+| Feature | Folder | Typical evidence |
+| --- | --- | --- |
+| Chat/RFI | `Features/Chat` | message thread, Q&A, RFI create/review screenshots or UI test |
+| Dashboard | `Features/Dashboard` | KPI/alert screen at phone and tablet sizes |
+| Fleet | `Features/Fleet` | vehicle/trailer detail and inspection workflow evidence |
+| Jobs | `Features/Jobs` | job list/detail, clock, questionnaire, daily report flow |
+| Notebooks | `Features/Notebooks` | notebook list/detail/template state |
+| Office | `Features/Office` | office dashboards and management flows |
+| Orders | `Features/Orders` | JPO/PO lifecycle, approvals, receiving links |
+| Parts | `Features/Parts` | catalog/category/brand/supplier/pricing/import flows |
+| People | `Features/People` | employee/customer/contact/hat flows |
+| Reports | `Features/Reports` | report generation/export screens |
+| Scheduling | `Features/Scheduling` | calendar, dispatch, time-off, templates |
+| Settings | `Features/Settings` | company, security, sync, devices, AI settings |
+| Tools | `Features/Tools` | tool registry, kits, checkout, maintenance |
+| Warehouse | `Features/Warehouse` | floor plan, movement, receiving, staging, audit flows |
+
+## Core Package
+
+| Path | Owns | Guidance |
+| --- | --- | --- |
+| `core/Sources/WiredPartCore/Models` | domain entities and value types | Keep model changes backward-compatible with migrations and test fixtures. |
+| `core/Sources/WiredPartCore/Services` | business operations | Put testable workflow rules here instead of embedding them in SwiftUI views. |
+| `core/Sources/WiredPartCore/Database` | GRDB setup, migrations, repositories | Migration changes need tests and rollback/seed impact notes. |
+| `core/Sources/WiredPartCore/Sync` | change tracking, peer/device sync, conflict handling | Include multi-device or conflict evidence for sync changes. |
+| `core/Sources/WiredPartCore/AI` | AI service adapters and tools | Guard availability and keep privacy/local-first assumptions explicit. |
+| `core/Sources/WiredPartCore/OCR` | OCR processing | Include image/input fixture notes where possible. |
+| `core/Sources/WiredPartCore/QR` | QR encoding/scanning core | Include round-trip tests for format changes. |
+
+## Tests
+
+| Test area | Path | Use for |
+| --- | --- | --- |
+| Core package tests | `core/Tests/WiredPartCoreTests` | service, repository, migration, model, sync, QR/OCR logic |
+| App tests | `Weird Parts IOS/Weird Parts IOSTests` | app-level regressions that need app target integration |
+| UI tests | `Weird Parts IOS/Weird Parts IOSUITests` | XCUITest coverage, screenshots, launch and navigation flows |
+| Repo/static checks | `tests`, `scripts` | tracked artifact guards, helper script validation |
+
+## Automation And GitHub
+
+| Path | Purpose |
+| --- | --- |
+| `.github/workflows` | GitHub Actions workflows |
+| `scripts/guard-tracked-artifacts.py` | blocks committed runtime/generated artifacts |
+| `scripts/github-issue-sync.sh` | GitHub issue synchronization helper |
+| `scripts/paperclip-github-tracker-sync.sh` | Paperclip tracker sync workflow helper |
+| `scripts/pr-merge-maintenance.sh` | one-PR-at-a-time maintenance automation |
+
+For WPR2 PR testing, iOS/macOS/Xcode work should use the local self-hosted Mac runner path when CI capacity is the only blocker. See [docs/QA-PROCESS.md](QA-PROCESS.md).
+
+## Documentation
+
+| Path | Use |
+| --- | --- |
+| `README.md` | repo front door and contributor map |
+| `docs/SETUP.md` | local setup and command reference |
+| `docs/QA-PROCESS.md` | verification evidence and reviewer handoff |
+| `docs/TESTING-REQUIREMENTS.md` | detailed testing standards |
+| `docs/DEPENDENCIES.md` | dependency decisions and runner context |
+| `docs/plans` | active and historical plans |
+| `docs/DevTODO` | implementation findings that need follow-up |
+| `xcode-ai` | AI-agent prompts, observations, and local fix order |
+
+## Handoff Checklist
+
+- Name the feature/core area touched.
+- Name the GitHub issue and Paperclip ID.
+- List commands run and whether they passed.
+- For UI changes, attach or describe simulator/device evidence and viewport/orientation.
+- State residual risk and next owner.


### PR DESCRIPTION
## Summary
- Replaces the repo front-door README with a native iOS/core Swift repo map, command guide, feature-area map, and tracking links.
- Rewrites docs/SETUP.md for the current Xcode/SwiftPM setup path instead of stale web/server instructions.
- Adds docs/WORKING-AREAS.md and docs/QA-PROCESS.md for working-area routing and WEI-3100 QA evidence expectations.
- Cross-links GitHub #942 and Paperclip WEI-3096 / WEI-3099 / WEI-3100.

## Verification
- git diff --check
- python3 scripts/guard-tracked-artifacts.py
- WEI-3100 QA follow-up: relative markdown link check, Xcode scheme readback, and generic iOS Simulator app build (`BUILD SUCCEEDED`).

## Notes
- Docs-only change; no source, secrets, runtime artifacts, screenshots, database files, or build outputs changed.
- WPR2 branch/worktree preflight: 215 remote branches, 26 open PRs, many registered worktrees, no prunable worktree metadata from `git worktree prune -n -v`.
- GitHub checks were queued when WEI-3100 completed; local self-hosted runner path remains tracked by #943 / WEI-3097.

Closes #942

Refs Paperclip WEI-3096, WEI-3099, WEI-3100.
