### PR TITLE
[codex] WEI-3118 port parts catalog hardening

### DIFF
--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -1170,6 +1170,7 @@ public final class PartsService: Sendable {
                                AND cbs.type_id = p.type_id
                                AND cbs.deleted_at IS NULL
                             WHERE p.deleted_at IS NULL
+                              AND p.is_active = 1
                               AND (p.name LIKE ? OR p.code LIKE ?
                                    OR pc.part_number LIKE ?
                                    OR pc.name LIKE ?
@@ -1189,6 +1190,7 @@ public final class PartsService: Sendable {
                             SELECT DISTINCT p.* FROM parts p
                             LEFT JOIN part_colors pc ON pc.id = p.color_id AND pc.deleted_at IS NULL
                             WHERE p.deleted_at IS NULL
+                              AND p.is_active = 1
                               AND (p.name LIKE ? OR p.code LIKE ? OR pc.name LIKE ?)
                             ORDER BY p.name ASC
                             LIMIT ?
@@ -5818,7 +5820,7 @@ public final class PartsService: Sendable {
     /// Get summary stats for the import/export page.
     public func getImportExportStats() throws -> ImportExportStats {
         try db.writer.read { dbConn in
-            let parts = try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM parts WHERE deleted_at IS NULL") ?? 0
+            let parts = try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM parts WHERE deleted_at IS NULL AND is_active = 1") ?? 0
             let cats = try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM part_categories WHERE deleted_at IS NULL") ?? 0
             let brands = try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM brands WHERE deleted_at IS NULL") ?? 0
             let suppliers = try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM suppliers WHERE deleted_at IS NULL") ?? 0
@@ -5871,6 +5873,7 @@ public final class PartsService: Sendable {
                 LEFT JOIN brands b ON b.id = p.brand_id AND b.deleted_at IS NULL
                 LEFT JOIN part_colors pco ON pco.id = p.color_id AND pco.deleted_at IS NULL
                 WHERE p.deleted_at IS NULL
+                  AND p.is_active = 1
                 ORDER BY p.name ASC
                 """
 
@@ -6230,7 +6233,7 @@ public final class PartsService: Sendable {
                 if !trimmed.isEmpty { fields[header] = trimmed }
             }
 
-            for numericHeader in ["cost_price", "markup_percent"] {
+            for numericHeader in ["cost_price", "markup_percent", "sell_price"] {
                 if let raw = fields[numericHeader] {
                     guard let value = Double(raw) else {
                         preview.errors.append(PartsImportError(rowNumber: rowNumber, message: "Invalid number for \(numericHeader): \(raw)"))

--- a/core/Tests/WiredPartCoreTests/E2EPartsCatalogTests.swift
+++ b/core/Tests/WiredPartCoreTests/E2EPartsCatalogTests.swift
@@ -118,6 +118,22 @@ struct E2EPartsCatalogTests {
         #expect(conduitResults.count == 1)
     }
 
+    @Test("Search parts excludes inactive catalog rows")
+    func testPartSearchExcludesInactiveParts() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let activeId = try env.parts.createPart(categoryId: catId, name: "Search Active Fuse", code: "SEARCH-ACTIVE")
+        let inactiveId = try env.parts.createPart(categoryId: catId, name: "Search Inactive Fuse", code: "SEARCH-INACTIVE")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE parts SET is_active = 0 WHERE id = ?", arguments: [inactiveId])
+        }
+
+        let results = try env.parts.searchParts(query: "Search")
+        #expect(results.contains { $0.id == activeId })
+        #expect(!results.contains { $0.id == inactiveId })
+    }
+
     @Test("Part list with filters")
     func testPartListFilters() throws {
         let env = try E2ETestHelpers.setUp()
@@ -130,6 +146,22 @@ struct E2EPartsCatalogTests {
         let wireOnly = try env.parts.listParts(categoryId: cat1)
         #expect(wireOnly.count == 1)
         #expect(wireOnly[0].part.name == "Wire Part")
+    }
+
+    @Test("Part list excludes inactive catalog rows")
+    func testPartListExcludesInactiveParts() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let activeId = try env.parts.createPart(categoryId: catId, name: "List Active Fuse", code: "LIST-ACTIVE")
+        let inactiveId = try env.parts.createPart(categoryId: catId, name: "List Inactive Fuse", code: "LIST-INACTIVE")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE parts SET is_active = 0 WHERE id = ?", arguments: [inactiveId])
+        }
+
+        let results = try env.parts.listParts(search: "List")
+        #expect(results.contains { $0.part.id == activeId })
+        #expect(!results.contains { $0.part.id == inactiveId })
     }
 
     // MARK: - Brands & Suppliers
@@ -314,6 +346,23 @@ struct E2EPartsCatalogTests {
         #expect(csv.contains("CSV Part 1"))
         #expect(csv.contains("CSV Part 2"))
         #expect(csv.contains("CSV-001"))
+    }
+
+    @Test("Parts CSV export excludes inactive catalog rows")
+    func testCSVExportExcludesInactiveParts() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "CSVActiveOnly")
+        _ = try env.parts.createPart(categoryId: catId, name: "CSV Active Part", code: "CSV-ACTIVE")
+        let inactiveId = try env.parts.createPart(categoryId: catId, name: "CSV Inactive Part", code: "CSV-INACTIVE")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE parts SET is_active = 0 WHERE id = ?", arguments: [inactiveId])
+        }
+
+        let csv = try env.parts.exportPartsCSV(groups: [.hierarchy])
+        #expect(csv.contains("CSV Active Part"))
+        #expect(!csv.contains("CSV Inactive Part"))
+        #expect(!csv.contains("CSV-INACTIVE"))
     }
 
     // MARK: - Color Part Numbers (#46)

--- a/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
@@ -253,6 +253,25 @@ struct PartsServiceAdvancedTests {
         #expect(after.totalSuppliers == before.totalSuppliers + 1)
     }
 
+    @Test("getImportExportStats excludes inactive parts from active catalog total")
+    func testGetImportExportStatsExcludesInactiveParts() throws {
+        let env = try E2ETestHelpers.setUp()
+        let before = try env.parts.getImportExportStats()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let activePartId = try E2ETestHelpers.seedPart(env, name: "Active Stats Part", categoryId: catId)
+        let inactivePartId = try E2ETestHelpers.seedPart(env, name: "Inactive Stats Part", categoryId: catId)
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE parts SET is_active = 0 WHERE id = ?", arguments: [inactivePartId])
+        }
+
+        let stats = try env.parts.getImportExportStats()
+        let listedParts = try env.parts.listParts()
+        #expect(stats.totalParts == before.totalParts + 1)
+        #expect(try env.parts.getPart(id: activePartId).part.id == activePartId)
+        #expect(!listedParts.contains { $0.part.id == inactivePartId })
+    }
+
     @Test("getImportExportStats returns zeros on empty catalog")
     func testGetImportExportStatsEmpty() throws {
         let env = try E2ETestHelpers.setUp()
@@ -305,6 +324,21 @@ struct PartsServiceAdvancedTests {
         #expect(preview.errors.count == 2)
         #expect(preview.errors.contains { $0.rowNumber == 2 && $0.message == "Invalid number for cost_price: N/A" })
         #expect(preview.errors.contains { $0.rowNumber == 2 && $0.message == "Invalid number for markup_percent: forty" })
+    }
+
+    @Test("previewPartsImportCSV rejects invalid exported sell_price values")
+    func testPreviewPartsImportCSVRejectsInvalidSellPriceValue() throws {
+        let env = try E2ETestHelpers.setUp()
+        let csv = """
+        name,code,category,cost_price,markup_percent,sell_price
+        Bad Sell Price Part,BAD-SELL-001,Test,12.5,20,not-a-number
+        """
+
+        let preview = try env.parts.previewPartsImportCSV(csv)
+
+        #expect(preview.newParts.isEmpty)
+        #expect(preview.errors.count == 1)
+        #expect(preview.errors.contains { $0.rowNumber == 2 && $0.message == "Invalid number for sell_price: not-a-number" })
     }
 
     @Test("previewPartsImportCSV keeps rows with valid numeric pricing fields")


### PR DESCRIPTION
## What changed

- Ported the backend/core parts catalog hardening from WEI-2901 onto current `main` without reverting newer import-source metadata contracts.
- Kept catalog list/search/export/stats active-only by filtering `parts.is_active = 1` where it was still missing.
- Added import preview validation for exported `sell_price` values alongside `cost_price` and `markup_percent`.
- Added focused Swift tests for active-only list/search/export/stats and invalid `sell_price` preview errors.

## Supplier filtering note

I did not add `listParts(... supplierId:)` from the retained WEI-2901 commit. Current `main` does not expose that as the catalog listing contract, and the active supplier-aware import work is carried through import preview/mapping APIs rather than catalog list filtering. This keeps the port to the missing hardening behavior without expanding the public `listParts` signature.

## Validation

- `git diff --check`
- `swift test --filter 'WiredPartCoreTests\.(E2EPartsCatalogTests/test(CSVExportExcludesInactiveParts|PartListExcludesInactiveParts|PartSearchExcludesInactiveParts)|PartsServiceAdvancedTests/test(GetImportExportStatsExcludesInactiveParts|PreviewPartsImportCSVRejectsInvalidSellPriceValue))'`

## Root cause

PR #924 was merged only into retained branch `WEI-2466-job-return-sorting-ui`, so these backend/core catalog hardening lines never reached current `origin/main`.
