### PR TITLE
Fix job material pull source picker

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
@@ -40,6 +40,9 @@ struct IOSJobDetailPage: View {
     @State private var pullPartSearch = ""
     @State private var pullPartResults: [Part] = []
     @State private var selectedPullPart: Part?
+    @State private var pullSourceLocations: [WarehouseService.LedgerLocationSummary] = []
+    @State private var selectedPullSource: WarehouseService.LedgerLocationSummary?
+    @State private var isLoadingPullSources = false
     @State private var highlightedJobPartId: Int64?
     private var canViewJobFinancials: Bool { appCore.hasPermission("view_job_financials") }
 
@@ -1015,6 +1018,7 @@ struct IOSJobDetailPage: View {
 
                 if case .pull = action {
                     pullPartPickerSection
+                    pullSourcePickerSection
                 }
 
                 if case .correctUsed(let part) = action {
@@ -1125,6 +1129,8 @@ struct IOSJobDetailPage: View {
             ForEach(Array(pullPartResults.enumerated()), id: \.offset) { _, part in
                 Button {
                     selectedPullPart = part
+                    materialActionError = nil
+                    loadPullSourceLocations(for: part)
                 } label: {
                     HStack {
                         VStack(alignment: .leading, spacing: 2) {
@@ -1140,6 +1146,41 @@ struct IOSJobDetailPage: View {
                             Image(systemName: "checkmark")
                         }
                     }
+                }
+            }
+        }
+    }
+
+    private var pullSourcePickerSection: some View {
+        Section("Source") {
+            if selectedPullPart?.id == nil {
+                Label("Select a part to load available source locations.", systemImage: "shippingbox")
+                    .foregroundStyle(.secondary)
+            } else if isLoadingPullSources {
+                ProgressView("Loading source locations...")
+            } else if pullSourceLocations.isEmpty {
+                Label("No available stock locations for this part.", systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.orange)
+            } else {
+                ForEach(pullSourceLocations, id: \.displayName) { source in
+                    Button {
+                        selectedPullSource = source
+                        materialQuantity = min(materialQuantity, source.qty)
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(source.displayName)
+                                Text("\(source.qty) available")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            if selectedPullSource == source {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                    .accessibilityLabel("Source \(source.displayName), \(source.qty) available")
                 }
             }
         }
@@ -1307,6 +1348,9 @@ struct IOSJobDetailPage: View {
         materialNote = ""
         materialCondition = .usable
         selectedPullPart = nil
+        selectedPullSource = nil
+        pullSourceLocations = []
+        isLoadingPullSources = false
         switch action {
         case .pull:
             materialQuantity = 1
@@ -1336,6 +1380,34 @@ struct IOSJobDetailPage: View {
         }
     }
 
+    private func loadPullSourceLocations(for part: Part) {
+        selectedPullSource = nil
+        pullSourceLocations = []
+        guard let partId = part.id else {
+            materialActionError = "Select a saved part before choosing a source."
+            return
+        }
+        guard let service = appCore.warehouseService else {
+            materialActionError = "Warehouse service unavailable"
+            return
+        }
+        isLoadingPullSources = true
+        defer { isLoadingPullSources = false }
+
+        do {
+            let ledger = try service.getInventoryLedger(partId: partId)
+            pullSourceLocations = ledger?.locations.filter { $0.qty > 0 } ?? []
+            if pullSourceLocations.count == 1 {
+                selectedPullSource = pullSourceLocations[0]
+                materialQuantity = min(materialQuantity, pullSourceLocations[0].qty)
+            } else if pullSourceLocations.isEmpty {
+                materialQuantity = 1
+            }
+        } catch {
+            materialActionError = userFriendlyError(error, context: "load source locations")
+        }
+    }
+
     private func submitMaterialAction(_ action: MaterialAction) {
         guard let service = appCore.jobsService else {
             materialActionError = "Jobs service unavailable"
@@ -1357,12 +1429,27 @@ struct IOSJobDetailPage: View {
                     materialActionError = "Select a part to pull."
                     return
                 }
+                guard let source = selectedPullSource else {
+                    materialActionError = "Select a source location before pulling material."
+                    return
+                }
+                if let warehouseService = appCore.warehouseService {
+                    let available = try warehouseService.getStockQty(
+                        partId: partId,
+                        locationType: source.locationType,
+                        locationId: source.locationId
+                    )
+                    guard available >= materialQuantity else {
+                        materialActionError = "Only \(available) available in \(source.displayName). Adjust quantity to continue."
+                        return
+                    }
+                }
                 _ = try service.pullJobMaterial(
                     jobId: jobId,
                     partId: partId,
                     qty: materialQuantity,
-                    fromLocationType: "warehouse",
-                    fromLocationId: 1,
+                    fromLocationType: source.locationType,
+                    fromLocationId: source.locationId,
                     performedBy: userId,
                     notes: materialNote.nilIfEmpty
                 )
@@ -1437,7 +1524,7 @@ struct IOSJobDetailPage: View {
     private func materialActionMaxQty(_ action: MaterialAction) -> Int {
         switch action {
         case .pull:
-            return Self.maxPullQty
+            return min(Self.maxPullQty, max(0, selectedPullSource?.qty ?? 0))
         case .useReady(let material), .returnReady(let material):
             return material.stagedQty
         case .returnUsed(let part):
@@ -1450,7 +1537,10 @@ struct IOSJobDetailPage: View {
     private func canSubmitMaterialAction(_ action: MaterialAction) -> Bool {
         switch action {
         case .pull:
-            selectedPullPart?.id != nil && materialQuantity > 0
+            selectedPullPart?.id != nil
+                && selectedPullSource != nil
+                && materialQuantity > 0
+                && materialQuantity <= materialActionMaxQty(action)
         case .useReady, .returnReady, .returnUsed:
             materialQuantity > 0
                 && materialQuantity <= materialActionMaxQty(action)
@@ -1472,6 +1562,10 @@ struct IOSJobDetailPage: View {
         switch action {
         case .pull where selectedPullPart?.id == nil:
             return "Select a part before pulling material."
+        case .pull where selectedPullSource == nil:
+            return "Select a source location before pulling material."
+        case .pull where materialQuantity > materialActionMaxQty(action):
+            return overQuantityMessage(action)
         case .pull:
             return "Enter a valid pull quantity."
         case .correctUsed:
@@ -1488,7 +1582,10 @@ struct IOSJobDetailPage: View {
         case .useReady, .returnReady:
             return "Only \(materialActionMaxQty(action)) remain staged. Adjust quantity to continue."
         case .pull:
-            return "Enter a valid quantity to pull."
+            if let source = selectedPullSource {
+                return "Only \(source.qty) available in \(source.displayName). Adjust quantity to continue."
+            }
+            return "Select a source location with available stock."
         case .correctUsed:
             return "Adjusted quantity cannot be below already returned quantity."
         }
@@ -1538,7 +1635,13 @@ struct IOSJobDetailPage: View {
     private func materialActionSubtitle(_ action: MaterialAction) -> String {
         switch action {
         case .pull:
-            return "Source: Warehouse 1 -> \(job?.jobName ?? "job") staged material"
+            if let source = selectedPullSource {
+                return "Source: \(source.displayName) (\(source.qty) available) -> \(job?.jobName ?? "job") staged material"
+            }
+            if selectedPullPart?.id != nil {
+                return "Select a source location for \(job?.jobName ?? "job") staged material"
+            }
+            return "Select material and source location for \(job?.jobName ?? "job") staged material"
         case .useReady(let material):
             return "\(material.stagedQty) staged for \(job?.jobName ?? "this job")"
         case .returnReady(let material):

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
@@ -1396,7 +1396,7 @@ struct IOSJobDetailPage: View {
 
         do {
             let ledger = try service.getInventoryLedger(partId: partId)
-            pullSourceLocations = ledger?.locations.filter { $0.qty > 0 } ?? []
+            pullSourceLocations = ledger?.locations.filter(Self.isPullMaterialSourceLocation) ?? []
             if pullSourceLocations.count == 1 {
                 selectedPullSource = pullSourceLocations[0]
                 materialQuantity = min(materialQuantity, pullSourceLocations[0].qty)
@@ -1406,6 +1406,10 @@ struct IOSJobDetailPage: View {
         } catch {
             materialActionError = userFriendlyError(error, context: "load source locations")
         }
+    }
+
+    private static func isPullMaterialSourceLocation(_ location: WarehouseService.LedgerLocationSummary) -> Bool {
+        location.qty > 0 && pullMaterialSourceLocationTypes.contains(location.locationType.lowercased())
     }
 
     private func submitMaterialAction(_ action: MaterialAction) {
@@ -1520,6 +1524,12 @@ struct IOSJobDetailPage: View {
     // the current consumed qty to accommodate rounding or re-count adjustments.
     private static let maxPullQty = 999
     private static let maxCorrectionOverage = 100
+    private static let pullMaterialSourceLocationTypes: Set<String> = [
+        "warehouse",
+        "truck",
+        "trailer",
+        "shop",
+    ]
 
     private func materialActionMaxQty(_ action: MaterialAction) -> Int {
         switch action {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
@@ -1162,7 +1162,8 @@ struct IOSJobDetailPage: View {
                 Label("No available stock locations for this part.", systemImage: "exclamationmark.triangle")
                     .foregroundStyle(.orange)
             } else {
-                ForEach(pullSourceLocations, id: \.displayName) { source in
+                ForEach(pullSourceLocations.indices, id: \.self) { index in
+                    let source = pullSourceLocations[index]
                     Button {
                         selectedPullSource = source
                         materialQuantity = min(materialQuantity, source.qty)
@@ -1392,19 +1393,30 @@ struct IOSJobDetailPage: View {
             return
         }
         isLoadingPullSources = true
-        defer { isLoadingPullSources = false }
+        let requestedPartId = partId
 
-        do {
-            let ledger = try service.getInventoryLedger(partId: partId)
-            pullSourceLocations = ledger?.locations.filter(Self.isPullMaterialSourceLocation) ?? []
-            if pullSourceLocations.count == 1 {
-                selectedPullSource = pullSourceLocations[0]
-                materialQuantity = min(materialQuantity, pullSourceLocations[0].qty)
-            } else if pullSourceLocations.isEmpty {
-                materialQuantity = 1
+        DispatchQueue.global(qos: .userInitiated).async {
+            let result = Result {
+                try service.getInventoryLedger(partId: requestedPartId)
             }
-        } catch {
-            materialActionError = userFriendlyError(error, context: "load source locations")
+
+            DispatchQueue.main.async {
+                guard selectedPullPart?.id == requestedPartId else { return }
+                isLoadingPullSources = false
+
+                do {
+                    let ledger = try result.get()
+                    pullSourceLocations = ledger?.locations.filter(Self.isPullMaterialSourceLocation) ?? []
+                    if pullSourceLocations.count == 1 {
+                        selectedPullSource = pullSourceLocations[0]
+                        materialQuantity = min(materialQuantity, pullSourceLocations[0].qty)
+                    } else if pullSourceLocations.isEmpty {
+                        materialQuantity = 1
+                    }
+                } catch {
+                    materialActionError = userFriendlyError(error, context: "load source locations")
+                }
+            }
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
@@ -154,6 +154,34 @@ final class PartsBrandsPageRegressionTests: XCTestCase {
             "Selecting a pull part should load available stock locations for that part."
         )
         XCTAssertTrue(
+            source.contains("pullMaterialSourceLocationTypes: Set<String>") &&
+                source.contains("\"warehouse\"") &&
+                source.contains("\"truck\"") &&
+                source.contains("\"trailer\"") &&
+                source.contains("\"shop\""),
+            "Pull material should only expose external inventory source buckets."
+        )
+        let allowlistStart = try XCTUnwrap(source.range(of: "pullMaterialSourceLocationTypes: Set<String>"))
+        let allowlistTail = source[allowlistStart.lowerBound...]
+        let allowlistEnd = try XCTUnwrap(allowlistTail.range(of: "]"))
+        let allowlistSource = String(allowlistTail[..<allowlistEnd.upperBound])
+        XCTAssertFalse(
+            allowlistSource.contains("\"pulled\"") || allowlistSource.contains("\"job\""),
+            "Pull material source allowlist must exclude internal pulled/job stock buckets."
+        )
+        XCTAssertTrue(
+            source.contains("pullSourceLocations = ledger?.locations.filter(Self.isPullMaterialSourceLocation)"),
+            "Pull material should filter ledger locations through the source-bucket predicate."
+        )
+        XCTAssertTrue(
+            source.contains("location.qty > 0 && pullMaterialSourceLocationTypes.contains(location.locationType.lowercased())"),
+            "The pull source predicate should require positive stock and an allowed external source type."
+        )
+        XCTAssertFalse(
+            source.contains("pullSourceLocations = ledger?.locations.filter { $0.qty > 0 }"),
+            "The pull source picker must not expose every positive ledger bucket, because pulled/job rows are not valid sources."
+        )
+        XCTAssertTrue(
             source.contains("fromLocationType: source.locationType") &&
                 source.contains("fromLocationId: source.locationId"),
             "Pull material must pass the selected source location into JobsService.pullJobMaterial."

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
@@ -142,6 +142,32 @@ final class PartsBrandsPageRegressionTests: XCTestCase {
         )
     }
 
+    func testJobMaterialPullUsesSelectedSourceInsteadOfWarehouseOneDefault() throws {
+        let source = try Self.readJobsPageSource(named: "IOSJobDetailPage.swift")
+
+        XCTAssertTrue(
+            source.contains("@State private var selectedPullSource: WarehouseService.LedgerLocationSummary?"),
+            "Pull material should track the selected source location."
+        )
+        XCTAssertTrue(
+            source.contains("loadPullSourceLocations(for: part)"),
+            "Selecting a pull part should load available stock locations for that part."
+        )
+        XCTAssertTrue(
+            source.contains("fromLocationType: source.locationType") &&
+                source.contains("fromLocationId: source.locationId"),
+            "Pull material must pass the selected source location into JobsService.pullJobMaterial."
+        )
+        XCTAssertFalse(
+            source.contains("fromLocationType: \"warehouse\",\n                    fromLocationId: 1"),
+            "The iOS pull flow must not hard-code warehouse/1 as the source location."
+        )
+        XCTAssertFalse(
+            source.contains("Source: Warehouse 1"),
+            "The pull sheet subtitle should describe the selected source, not a hard-coded Warehouse 1."
+        )
+    }
+
     private static func readPartsBrandsPageSource(
         file: StaticString = #filePath
     ) throws -> String {

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsBrandsPageRegressionTests.swift
@@ -174,6 +174,16 @@ final class PartsBrandsPageRegressionTests: XCTestCase {
             "Pull material should filter ledger locations through the source-bucket predicate."
         )
         XCTAssertTrue(
+            source.contains("ForEach(pullSourceLocations.indices, id: \\.self)"),
+            "Pull source picker should not use displayName as its row identity because source names are not guaranteed unique."
+        )
+        XCTAssertTrue(
+            source.contains("DispatchQueue.global(qos: .userInitiated).async") &&
+                source.contains("DispatchQueue.main.async") &&
+                source.contains("guard selectedPullPart?.id == requestedPartId else { return }"),
+            "Pull source loading should run the ledger read off the main thread and ignore stale completions."
+        )
+        XCTAssertTrue(
             source.contains("location.qty > 0 && pullMaterialSourceLocationTypes.contains(location.locationType.lowercased())"),
             "The pull source predicate should require positive stock and an allowed external source type."
         )

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -844,6 +844,43 @@ struct JobsServiceTests {
         #expect(history.contains { $0.eventType == StockMovement.MovementType.stockReturn.rawValue && $0.qty == 3 })
     }
 
+    @Test("job material pull uses selected non-warehouse source")
+    func testJobMaterialPullUsesSelectedNonWarehouseSource() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-MAT-TRUCK", name: "Truck Material Job")
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, name: "Truck Stock Only Part", categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 5, locationType: "truck", locationId: 42)
+
+        _ = try env.jobs.pullJobMaterial(
+            jobId: jobId,
+            partId: partId,
+            qty: 3,
+            fromLocationType: "truck",
+            fromLocationId: 42,
+            performedBy: env.adminUserId,
+            notes: "Pulled from service truck"
+        )
+
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "truck", locationId: 42) == 2)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 0)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "pulled", locationId: jobId) == 3)
+
+        let movement = try env.db.writer.read { db in
+            try Row.fetchOne(db, sql: """
+                SELECT from_location_type, from_location_id, to_location_type, to_location_id
+                FROM stock_movements
+                WHERE job_id = ? AND part_id = ? AND qty = 3 AND deleted_at IS NULL
+                ORDER BY id DESC
+                LIMIT 1
+                """, arguments: [jobId, partId])
+        }
+        #expect(movement?["from_location_type"] as String? == "truck")
+        #expect(movement?["from_location_id"] as Int64? == 42)
+        #expect(movement?["to_location_type"] as String? == "pulled")
+        #expect(movement?["to_location_id"] as Int64? == jobId)
+    }
+
     @Test("returnConsumedJobMaterial credits job totals once and creates return intake")
     func testReturnConsumedJobMaterialContract() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Fixes the iOS Job Detail -> Materials -> Pull Material sheet so selecting a part loads positive-stock source locations from `WarehouseService.getInventoryLedger(partId:)`.
- Requires a selected source before submit, caps/validates quantity against selected-source availability, and passes `source.locationType/source.locationId` into `JobsService.pullJobMaterial`.
- Replaces the hard-coded `Source: Warehouse 1` subtitle with selected-source name and available quantity.

## Root cause
The pull material UI always submitted `fromLocationType: "warehouse"` and `fromLocationId: 1`, even when the selected part only had stock in another source such as a truck/trailer/shop bucket.

## Validation
- `swift test --filter JobsServiceTests/testJobMaterialPullUsesSelectedNonWarehouseSource` passed.
- `xcodebuild build -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,id=2CF0CBB4-DC01-4F5C-989E-26BDB42D2C60'` passed.
- iOS unit test selector was attempted, but the scheme currently builds the UI test target and is blocked by existing duplicate `configureUITestingEnvironment` in `Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift` (GitHub #961). A shell source guard passed for the hard-coded source strings and selected-source service call.

Closes #963
