### PR TITLE
Fix LAN peer sync URL construction

### DIFF
--- a/core/Sources/WiredPartCore/Sync/PeerDiscovery.swift
+++ b/core/Sources/WiredPartCore/Sync/PeerDiscovery.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Network
 import os.log
+import Darwin
 
 // MARK: - DiscoveredPeer
 
@@ -53,7 +54,7 @@ public struct DiscoveredPeer: Sendable, Identifiable {
 /// and advertise WiredPart devices on the local network.
 ///
 /// Service type: `_wiredpart._tcp`
-/// TXT records: `device_id`, `device_name`, `company_id`, `version`
+/// TXT records: `device_id`, `device_name`, `company_id`, `version`, `sync_port`
 /// Instance name: `WiredPart-{device_id[0..<8]}`
 ///
 /// Filtering: Only peers from the same company are reported.
@@ -93,6 +94,7 @@ public final class PeerDiscovery: @unchecked Sendable {
     private var listener: NWListener?
     private var peers: [String: DiscoveredPeer] = [:]  // keyed by device_id
     private var isRunning = false
+    private var browseGeneration = 0
 
     public init(
         deviceId: String,
@@ -143,7 +145,8 @@ public final class PeerDiscovery: @unchecked Sendable {
             "device_id": deviceId,
             "device_name": deviceName,
             "company_id": companyId,
-            "version": "1.0.0"
+            "version": "1.0.0",
+            "sync_port": String(port)
         ]
 
         // Build TXT record
@@ -210,10 +213,12 @@ public final class PeerDiscovery: @unchecked Sendable {
     }
 
     private func handleBrowseResults(_ results: Set<NWBrowser.Result>) {
-        var updatedPeers: [String: DiscoveredPeer] = [:]
+        browseGeneration += 1
+        let generation = browseGeneration
+        var seenPeerIds: Set<String> = []
 
         for result in results {
-            guard case .service(let name, _, _, _) = result.endpoint else {
+            guard case .service(let name, let type, let domain, _) = result.endpoint else {
                 continue
             }
 
@@ -227,31 +232,45 @@ public final class PeerDiscovery: @unchecked Sendable {
             let peerDeviceName = txtDict["device_name"] ?? name
             let peerCompanyId = txtDict["company_id"] ?? ""
             let peerVersion = txtDict["version"] ?? "unknown"
+            let peerPort = UInt16(txtDict["sync_port"] ?? "") ?? 0
 
             // Filter: skip self
             guard peerDeviceId != deviceId else { continue }
             // Filter: same company only
             guard peerCompanyId == companyId else { continue }
+            seenPeerIds.insert(peerDeviceId)
 
-            // Extract host/port from the endpoint
-            // NWBrowser results don't directly expose IP/port — those are
-            // resolved when a connection is made. For our purposes we store
-            // the service name; the peer manager will connect using the
-            // NWEndpoint directly or resolve the service.
-            let peer = DiscoveredPeer(
-                deviceId: peerDeviceId,
-                deviceName: peerDeviceName,
-                companyId: peerCompanyId,
-                host: name,  // Service name — resolved at connection time
-                port: port,  // Advertised port from TXT
-                version: peerVersion,
-                transport: "lan"
-            )
-            updatedPeers[peerDeviceId] = peer
+            resolveBonjourService(
+                name: name,
+                type: type,
+                domain: domain,
+                fallbackPort: peerPort,
+                generation: generation
+            ) { [weak self] endpoint in
+                guard let self, let endpoint else { return }
+                self.queue.async { [weak self] in
+                    guard let self, self.isRunning, self.browseGeneration == generation else { return }
+                    let peer = DiscoveredPeer(
+                        deviceId: peerDeviceId,
+                        deviceName: peerDeviceName,
+                        companyId: peerCompanyId,
+                        host: endpoint.host,
+                        port: endpoint.port,
+                        version: peerVersion,
+                        transport: "lan"
+                    )
+                    self.peers[peerDeviceId] = peer
+                    self.notifyPeersChangedFromQueue()
+                }
+            }
         }
 
-        peers = updatedPeers
-        let snapshot = Array(updatedPeers.values)
+        peers = peers.filter { seenPeerIds.contains($0.key) }
+        notifyPeersChangedFromQueue()
+    }
+
+    private func notifyPeersChangedFromQueue() {
+        let snapshot = Array(peers.values)
         // Fix #187: capture the callback under the lock so it can't race with a reassignment.
         let callback = callbackLock.withLock { _onPeersChanged }
         if let callback {
@@ -260,5 +279,107 @@ public final class PeerDiscovery: @unchecked Sendable {
             }
         }
     }
+
+    private func resolveBonjourService(
+        name: String,
+        type: String,
+        domain: String,
+        fallbackPort: UInt16,
+        generation: Int,
+        completion: @escaping @Sendable (ResolvedBonjourEndpoint?) -> Void
+    ) {
+        Task.detached(priority: .utility) {
+            let resolved = BonjourServiceResolver.resolve(
+                name: name,
+                type: type,
+                domain: domain,
+                fallbackPort: fallbackPort,
+                timeout: 3
+            )
+            completion(resolved)
+        }
+    }
 }
 
+private struct ResolvedBonjourEndpoint: Sendable {
+    let host: String
+    let port: UInt16
+}
+
+private final class BonjourServiceResolver: NSObject, NetServiceDelegate {
+    private var resolvedEndpoint: ResolvedBonjourEndpoint?
+    private var finished = false
+    private let fallbackPort: UInt16
+
+    private init(fallbackPort: UInt16) {
+        self.fallbackPort = fallbackPort
+    }
+
+    static func resolve(
+        name: String,
+        type: String,
+        domain: String,
+        fallbackPort: UInt16,
+        timeout: TimeInterval
+    ) -> ResolvedBonjourEndpoint? {
+        let resolver = BonjourServiceResolver(fallbackPort: fallbackPort)
+        let service = NetService(
+            domain: normalizeDNSLabel(domain.isEmpty ? "local" : domain),
+            type: normalizeDNSLabel(type),
+            name: name
+        )
+        service.delegate = resolver
+        service.resolve(withTimeout: timeout)
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while !resolver.finished && Date() < deadline {
+            RunLoop.current.run(mode: .default, before: min(deadline, Date().addingTimeInterval(0.05)))
+        }
+
+        service.stop()
+        service.delegate = nil
+        return resolver.resolvedEndpoint
+    }
+
+    private static func normalizeDNSLabel(_ value: String) -> String {
+        value.hasSuffix(".") ? value : "\(value)."
+    }
+
+    func netServiceDidResolveAddress(_ sender: NetService) {
+        let resolvedPort = UInt16(exactly: sender.port) ?? fallbackPort
+        guard resolvedPort > 0 else {
+            finished = true
+            return
+        }
+
+        if let host = sender.addresses?.compactMap(Self.host(from:)).first {
+            resolvedEndpoint = ResolvedBonjourEndpoint(host: host, port: resolvedPort)
+        }
+        finished = true
+    }
+
+    func netService(_ sender: NetService, didNotResolve errorDict: [String : NSNumber]) {
+        finished = true
+    }
+
+    private static func host(from address: Data) -> String? {
+        address.withUnsafeBytes { rawBuffer -> String? in
+            guard let baseAddress = rawBuffer.baseAddress else { return nil }
+            let sockaddrPointer = baseAddress.assumingMemoryBound(to: sockaddr.self)
+            var hostBuffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            let result = getnameinfo(
+                sockaddrPointer,
+                socklen_t(address.count),
+                &hostBuffer,
+                socklen_t(hostBuffer.count),
+                nil,
+                0,
+                NI_NUMERICHOST
+            )
+            guard result == 0 else { return nil }
+            let count = hostBuffer.firstIndex(of: 0) ?? hostBuffer.count
+            let bytes = hostBuffer.prefix(count).map { UInt8(bitPattern: $0) }
+            return String(decoding: bytes, as: UTF8.self)
+        }
+    }
+}

--- a/core/Sources/WiredPartCore/Sync/PeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/PeerManager.swift
@@ -425,7 +425,7 @@ public actor PeerManager {
         var pushed = 0
         var pulled = 0
 
-        let baseURL = "http://\(peer.host):\(peer.port)"
+        let baseURL = try Self.makeLANSyncBaseURL(for: peer)
         let lastSyncAt = state.lastPeerSyncs[peer.deviceId]?.syncedAt
 
         // Resolve shared key for this peer (fetches /sync/key once then caches)
@@ -443,9 +443,7 @@ public actor PeerManager {
             let encoder = JSONEncoder()
             let plainPushBody = try encoder.encode(pushRequest)
 
-            guard let pushURL = URL(string: "\(baseURL)/sync/push") else {
-                throw URLError(.badURL)
-            }
+            let pushURL = baseURL.appendingPathComponent("sync/push")
             var urlRequest = URLRequest(url: pushURL)
             urlRequest.httpMethod = "POST"
             urlRequest.timeoutInterval = 30
@@ -472,9 +470,7 @@ public actor PeerManager {
         )
 
         let plainPullBody = try JSONEncoder().encode(pullRequest)
-        guard let pullURL = URL(string: "\(baseURL)/sync/pull") else {
-            throw URLError(.badURL)
-        }
+        let pullURL = baseURL.appendingPathComponent("sync/pull")
         var pullURLRequest = URLRequest(url: pullURL)
         pullURLRequest.httpMethod = "POST"
         pullURLRequest.timeoutInterval = 30
@@ -510,11 +506,67 @@ public actor PeerManager {
         return (pushed, pulled)
     }
 
+    static func makeLANSyncBaseURL(for peer: DiscoveredPeer) throws -> URL {
+        let trimmedHost = peer.host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedHost.isEmpty, peer.port > 0 else {
+            throw URLError(.badURL)
+        }
+        guard !trimmedHost.hasPrefix("WiredPart-") || trimmedHost.contains(".") else {
+            throw URLError(.badURL)
+        }
+
+        let normalized = normalizedLANHostAndPort(trimmedHost, fallbackPort: peer.port)
+
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = normalized.host
+        components.port = Int(normalized.port)
+
+        guard let url = components.url else {
+            throw URLError(.badURL)
+        }
+        return url
+    }
+
+    private static func normalizedLANHostAndPort(
+        _ rawHost: String,
+        fallbackPort: UInt16
+    ) -> (host: String, port: UInt16) {
+        if let components = URLComponents(string: rawHost),
+           components.scheme != nil,
+           let host = components.host {
+            return (host: host, port: normalizedPort(components.port, fallback: fallbackPort))
+        }
+
+        if let components = URLComponents(string: "http://\(rawHost)"),
+           let host = components.host {
+            return (host: host, port: normalizedPort(components.port, fallback: fallbackPort))
+        }
+
+        if rawHost.hasPrefix("[") {
+            return (host: rawHost, port: fallbackPort)
+        }
+
+        if rawHost.contains(":") {
+            let escapedZone = rawHost.replacingOccurrences(of: "%", with: "%25")
+            return (host: "[\(escapedZone)]", port: fallbackPort)
+        }
+
+        return (host: rawHost, port: fallbackPort)
+    }
+
+    private static func normalizedPort(_ port: Int?, fallback: UInt16) -> UInt16 {
+        guard let port, let exact = UInt16(exactly: port) else {
+            return fallback
+        }
+        return exact
+    }
+
     // MARK: - Private: Payload Encryption Helpers
 
     /// Fetch the peer's X25519 KA public key from GET /sync/key (cached).
     /// Returns nil if the peer doesn't support encryption (old version or network error).
-    private func resolveSharedKey(baseURL: String, peerDeviceId: String) async -> Data? {
+    private func resolveSharedKey(baseURL: URL, peerDeviceId: String) async -> Data? {
         // Use cached peer KA public key if available
         let peerKAKey: String
         if let cached = peerKAPublicKeys[peerDeviceId], !cached.isEmpty {
@@ -536,10 +588,8 @@ public actor PeerManager {
     /// Returns the key if successful, nil if encryption is not supported.
     /// Fixes #197: no longer silently falls back — callers must handle nil explicitly.
     /// Fixes #191: sends X-Company-ID header so the server can reject unknown peers.
-    private func fetchPeerKAPublicKey(baseURL: String, peerDeviceId: String) async -> String? {
-        guard let url = URL(string: "\(baseURL)/sync/key") else {
-            return nil
-        }
+    private func fetchPeerKAPublicKey(baseURL: URL, peerDeviceId: String) async -> String? {
+        let url = baseURL.appendingPathComponent("sync/key")
         var req = URLRequest(url: url)
         req.timeoutInterval = 5
         // Fix #191: identify our company so the server can gate key exchange to known peers.

--- a/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
@@ -141,6 +141,67 @@ struct PeerManagerTests {
         await pm.stopPeerSync()
     }
 
+    @Test("LAN sync base URL is built from host and discovered port")
+    func testLANSyncBaseURLUsesPeerHostAndPort() throws {
+        let peer = DiscoveredPeer(
+            deviceId: "dev-url",
+            deviceName: "Office Mac",
+            companyId: "co",
+            host: "192.168.1.50",
+            port: 51943
+        )
+
+        let baseURL = try PeerManager.makeLANSyncBaseURL(for: peer)
+
+        #expect(baseURL.absoluteString == "http://192.168.1.50:51943")
+        #expect(baseURL.appendingPathComponent("sync/pull").absoluteString == "http://192.168.1.50:51943/sync/pull")
+    }
+
+    @Test("LAN sync base URL normalizes bracketless IPv6")
+    func testLANSyncBaseURLNormalizesIPv6() throws {
+        let peer = DiscoveredPeer(
+            deviceId: "dev-ipv6",
+            deviceName: "Office Mac",
+            companyId: "co",
+            host: "fe80::1",
+            port: 51943
+        )
+
+        let baseURL = try PeerManager.makeLANSyncBaseURL(for: peer)
+
+        #expect(baseURL.absoluteString == "http://[fe80::1]:51943")
+    }
+
+    @Test("LAN sync base URL rejects incomplete Bonjour endpoint data")
+    func testLANSyncBaseURLRejectsMissingPort() {
+        let peer = DiscoveredPeer(
+            deviceId: "dev-bad",
+            deviceName: "Office Mac",
+            companyId: "co",
+            host: "WiredPart-dev-bad",
+            port: 0
+        )
+
+        #expect(throws: URLError.self) {
+            _ = try PeerManager.makeLANSyncBaseURL(for: peer)
+        }
+    }
+
+    @Test("LAN sync base URL rejects raw Bonjour service instance hosts")
+    func testLANSyncBaseURLRejectsRawBonjourInstanceName() {
+        let peer = DiscoveredPeer(
+            deviceId: "dev-bonjour",
+            deviceName: "Office Mac",
+            companyId: "co",
+            host: "WiredPart-dev-bonjour",
+            port: 51943
+        )
+
+        #expect(throws: URLError.self) {
+            _ = try PeerManager.makeLANSyncBaseURL(for: peer)
+        }
+    }
+
     @Test("PeerSyncResult stores all fields correctly")
     func testPeerSyncResult() {
         let result = PeerSyncResult(


### PR DESCRIPTION
## Summary
- resolves Bonjour `NWEndpoint.service` results into URLSession-routable hosts before LAN HTTP sync
- carries advertised `sync_port` from peer TXT records into `DiscoveredPeer`
- validates LAN sync base URLs and rejects raw `WiredPart-*` Bonjour instance names before `/sync/key`, `/sync/push`, or `/sync/pull`
- adds regression coverage for resolved hosts, IPv6 normalization, missing endpoint data, and raw Bonjour host rejection

## Test Plan
- `swift test --package-path core --filter 'PeerManagerTests|PeerDiscoveryTests'` — 13 tests in 2 suites passed
- `git diff --check` — passed

## Paperclip
- Tracked by WEI-2872
- Surfaced again by WEI-3177 GitHub Issue Fisher pass; branch existed but had no PR and was behind main, so this run rebased it and opened the PR.

Closes #920
