### PR TITLE
WEI-3188 preserve PR 955 import preview fixture

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
@@ -54,6 +54,10 @@ struct WiredPartIOSApp: App {
         ProcessInfo.processInfo.arguments.contains("-UITestingWEI3144JobMaterials")
     }
 
+    private var shouldShowWEI3140ImportPreviewFixture: Bool {
+        ProcessInfo.processInfo.arguments.contains("-UITestingWEI3140ImportPreviewFixture")
+    }
+
     /// Resolved color scheme from the user's theme setting.
     private var resolvedColorScheme: ColorScheme? {
         switch appCore.theme.themeMode {
@@ -71,7 +75,9 @@ struct WiredPartIOSApp: App {
     var body: some Scene {
         WindowGroup {
             Group {
-                if appCore.isReady {
+                if shouldShowWEI3140ImportPreviewFixture {
+                    WEI3140ImportPreviewFixtureView()
+                } else if appCore.isReady {
                     if shouldShowWEI936WelcomeFixture {
                         OnboardingWelcomeView()
                             .environmentObject(appCore)

--- a/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
@@ -54,9 +54,15 @@ struct WiredPartIOSApp: App {
         ProcessInfo.processInfo.arguments.contains("-UITestingWEI3144JobMaterials")
     }
 
+    #if DEBUG
     private var shouldShowWEI3140ImportPreviewFixture: Bool {
         ProcessInfo.processInfo.arguments.contains("-UITestingWEI3140ImportPreviewFixture")
     }
+    #else
+    private var shouldShowWEI3140ImportPreviewFixture: Bool {
+        false
+    }
+    #endif
 
     /// Resolved color scheme from the user's theme setting.
     private var resolvedColorScheme: ColorScheme? {
@@ -76,7 +82,11 @@ struct WiredPartIOSApp: App {
         WindowGroup {
             Group {
                 if shouldShowWEI3140ImportPreviewFixture {
+                    #if DEBUG
                     WEI3140ImportPreviewFixtureView()
+                    #else
+                    EmptyView()
+                    #endif
                 } else if appCore.isReady {
                     if shouldShowWEI936WelcomeFixture {
                         OnboardingWelcomeView()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsImportExportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsImportExportPage.swift
@@ -1460,3 +1460,146 @@ private struct ImportPreviewContent: View {
         }
     }
 }
+
+
+// MARK: - WEI-3140 UI verification fixture (test-only launch surface)
+
+#if DEBUG
+struct WEI3140ImportPreviewFixtureView: View {
+    @State private var preview: ImportPreview
+
+    init() {
+        let mode = ProcessInfo.processInfo.arguments.drop(while: { $0 != "-WEI3140FixtureMode" }).dropFirst().first ?? "csv"
+        _preview = State(initialValue: Self.makePreview(mode: String(mode)))
+    }
+
+    var body: some View {
+        NavigationStack {
+            ImportPreviewContent(
+                preview: $preview,
+                onConfirm: {},
+                onApplyMapping: { updated in preview = updated }
+            )
+            .navigationTitle("Import Preview")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private static func row(_ rowNumber: Int, _ name: String, code: String, category: String, brand: String? = nil) -> PartsService.PartsImportParsedRow {
+        PartsService.PartsImportParsedRow(
+            rowNumber: rowNumber,
+            name: name,
+            code: code,
+            category: category,
+            brand: brand,
+            fields: ["cost_price": "12.45", "unit_of_measure": "ea", "shelf_location": "A-\(rowNumber)"]
+        )
+    }
+
+    private static func makePreview(mode: String) -> ImportPreview {
+        switch mode {
+        case "pdf":
+            let ocr = PartsService.PartsOCRImportPreview(
+                chunks: [
+                    .init(id: "p1-c1", pageNumber: 1, text: "Pump seal kit PS-100", snippet: "Pump seal kit PS-100 — qty 4"),
+                    .init(id: "p1-c2", pageNumber: 1, text: "Unclear scan row", snippet: "?? gasket line unreadable")
+                ],
+                candidates: [
+                    .init(rowNumber: 1, chunkId: "p1-c1", pageNumber: 1, sourceSnippet: "Pump seal kit PS-100 — qty 4", confidence: 0.82, name: "Pump Seal Kit", code: "PS-100", category: "Pump Parts", brand: "Acme", fields: ["confidence": "0.82"])
+                ],
+                errors: [
+                    .init(pageNumber: 1, sourceSnippet: "?? gasket line unreadable", message: "OCR could not prove name/category from source evidence")
+                ],
+                isCommitAllowed: false
+            )
+            return ImportPreview(
+                servicePreview: PartsService.PartsImportPreview(totalRows: 2, source: .init(sourceKind: "pdf", filename: "supplier-scan.pdf")),
+                sourceKind: .pdf,
+                filename: "supplier-scan.pdf",
+                sheetName: nil,
+                workbookSheets: [],
+                sourceColumns: [],
+                columnMappings: [],
+                sourceRows: [],
+                skippedNewParts: [],
+                ocrPreview: ocr,
+                commitDisabledReason: "PDF/OCR import is preview-only until source evidence review and backend commit policy are approved.",
+                mappingError: nil
+            )
+        case "error":
+            var conflict = PartsService.PartsImportConflict(
+                parsedRow: row(4, "Field Valve Rebuild Kit With Very Long Supplier Description", code: "FV-REBUILD-2026-LONG", category: "Valve Parts", brand: "Acme"),
+                existingPartId: 99,
+                existingPartName: "Field Valve Rebuild Kit",
+                existingPartCode: "FV-OLD"
+            )
+            conflict.resolution = .ask
+            return ImportPreview(
+                servicePreview: PartsService.PartsImportPreview(
+                    newParts: [row(2, "Hydraulic Hose Assembly", code: "HHA-24", category: "Hydraulics", brand: "Parker")],
+                    conflicts: [conflict],
+                    errors: [
+                        .init(rowNumber: 5, message: "Missing required category"),
+                        .init(rowNumber: 6, message: "Cost price is not a valid number")
+                    ],
+                    totalRows: 5,
+                    source: .init(sourceKind: "csv", filename: "large-supplier-import.csv")
+                ),
+                sourceKind: .csv,
+                filename: "large-supplier-import.csv",
+                sheetName: nil,
+                workbookSheets: [],
+                sourceColumns: ["Part #", "Description", "Unit Price", "Category"],
+                columnMappings: [
+                    .init(sourceColumn: "Part #", target: .code, confidence: .alias),
+                    .init(sourceColumn: "Description", target: .name, confidence: .alias),
+                    .init(sourceColumn: "Unit Price", target: .costPrice, confidence: .alias),
+                    .init(sourceColumn: "Category", target: .category, confidence: .exact)
+                ],
+                sourceRows: [],
+                skippedNewParts: [row(3, "Skipped Compressor Belt", code: "SCB-77", category: "Belts", brand: "Gates")],
+                ocrPreview: nil,
+                commitDisabledReason: nil,
+                mappingError: nil
+            )
+        default:
+            var updateConflict = PartsService.PartsImportConflict(
+                parsedRow: row(4, "Copper Elbow 90 Degree", code: "CE-90", category: "Fittings", brand: "Nibco"),
+                existingPartId: 42,
+                existingPartName: "Copper Elbow 90°",
+                existingPartCode: "CE90"
+            )
+            updateConflict.resolution = .update
+            return ImportPreview(
+                servicePreview: PartsService.PartsImportPreview(
+                    newParts: [
+                        row(2, "Hydraulic Hose Assembly", code: "HHA-24", category: "Hydraulics", brand: "Parker"),
+                        row(3, "Stainless Hex Bolt 3/8 x 2", code: "BOLT-SS-382", category: "Fasteners", brand: "Hillman")
+                    ],
+                    conflicts: [updateConflict],
+                    errors: [],
+                    totalRows: 3,
+                    source: .init(sourceKind: "csv", filename: "supplier-clean-import.csv")
+                ),
+                sourceKind: .csv,
+                filename: "supplier-clean-import.csv",
+                sheetName: nil,
+                workbookSheets: [],
+                sourceColumns: ["Part #", "Description", "Unit Price", "Category", "Brand"],
+                columnMappings: [
+                    .init(sourceColumn: "Part #", target: .code, confidence: .alias),
+                    .init(sourceColumn: "Description", target: .name, confidence: .alias),
+                    .init(sourceColumn: "Unit Price", target: .costPrice, confidence: .alias),
+                    .init(sourceColumn: "Category", target: .category, confidence: .exact),
+                    .init(sourceColumn: "Brand", target: .brand, confidence: .exact)
+                ],
+                sourceRows: [],
+                skippedNewParts: [],
+                ocrPreview: nil,
+                commitDisabledReason: nil,
+                mappingError: nil
+            )
+        }
+    }
+}
+#endif

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -1795,4 +1795,56 @@ final class Weird_Parts_IOSUITests: XCTestCase {
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         try? screenshot.pngRepresentation.write(to: dir.appendingPathComponent("\(name).png"), options: .atomic)
     }
+
+    @MainActor
+    func testWEI3140CSVMappingPreviewScreenshot() throws {
+        launchWEI3140Fixture(mode: "csv")
+        XCTAssertTrue(app.navigationBars["Import Preview"].waitForExistence(timeout: 12))
+        captureWEI3140("01-csv-mapping-preview")
+    }
+
+    @MainActor
+    func testWEI3140LargeErrorQuarantineScreenshot() throws {
+        launchWEI3140Fixture(mode: "error")
+        XCTAssertTrue(app.navigationBars["Import Preview"].waitForExistence(timeout: 12))
+        captureWEI3140("02-large-error-preview-top")
+        app.swipeUp()
+        app.swipeUp()
+        captureWEI3140("03-large-error-quarantine-commit-disabled")
+    }
+
+    @MainActor
+    func testWEI3140PDFPreviewOnlyScreenshot() throws {
+        launchWEI3140Fixture(mode: "pdf")
+        XCTAssertTrue(app.staticTexts["PDF / OCR Review"].waitForExistence(timeout: 12))
+        captureWEI3140("04-pdf-ocr-preview-only")
+        app.swipeUp()
+        captureWEI3140("05-pdf-ocr-commit-disabled")
+    }
+
+    private func launchWEI3140Fixture(mode: String) {
+        app.terminate()
+        app = XCUIApplication()
+        app.launchArguments = ["-UITestingWEI3140ImportPreviewFixture", "-WEI3140FixtureMode", mode]
+        app.launch()
+    }
+
+    private var wei3140ArtifactDirectory: URL {
+        if let path = ProcessInfo.processInfo.environment["WEI_3140_ARTIFACT_DIR"], !path.isEmpty {
+            return URL(fileURLWithPath: path, isDirectory: true)
+        }
+        return URL(fileURLWithPath: "/tmp/wpr2-pr955-wei3140-screens", isDirectory: true)
+    }
+
+    private func captureWEI3140(_ name: String) {
+        try? FileManager.default.createDirectory(at: wei3140ArtifactDirectory, withIntermediateDirectories: true)
+        let screenshot = XCUIScreen.main.screenshot()
+        let url = wei3140ArtifactDirectory.appendingPathComponent("\(name).png")
+        try? screenshot.pngRepresentation.write(to: url)
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
 }

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -5966,6 +5966,15 @@ public final class PartsService: Sendable {
         public var supplierPartNumber: String? {
             fields["supplier_part_number"]
         }
+
+        public init(rowNumber: Int, name: String, code: String?, category: String, brand: String?, fields: [String: String]) {
+            self.rowNumber = rowNumber
+            self.name = name
+            self.code = code
+            self.category = category
+            self.brand = brand
+            self.fields = fields
+        }
     }
 
     /// A validation error surfaced during import preview. The row number is 1-based


### PR DESCRIPTION
## Summary

- Issue: WEI-3188
- Scope: Preserves unique dirty worktree residue from retained PR #955 preview worktree as a reviewable branch instead of deleting or resetting it.

## Validation

- [x] Tests added/updated as needed
- [x] Lint/type checks pass
- [x] Backward compatibility considered

Validation performed:
- `git status --short --branch` in `/private/tmp/wpr2-pr955`: branch `pr-955-ui-verify` with four dirty files retained.
- `git log -1 --oneline` in `/private/tmp/wpr2-pr955`: `ad1057f93 Implement parts import preview UI states`.
- Compared dirty files against merged PR #955 merge commit `a81c6fb5ff3fbc1e059011515352ac85d5ed5401`; the WEI-3140 fixture launch path, fixture view, screenshot UI tests, and public parsed-row initializer were not present in `origin/main` or the merge commit.
- `xcodebuild -list -project "Weird Parts IOS/Weird Parts.xcodeproj"` passed.
- `xcodebuild build -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO` passed with existing warnings.
- `swift test` in `core/` compiled through `PartsService` and began executing tests, but was interrupted after becoming too long/quiet for this heartbeat; not counted as a full pass.

## AI Assistance Disclosure

- [x] AI assistance used in this PR
- Tools used: OpenAI Codex CLI
- AI-assisted areas (files/functions): conflict resolution and preservation branch creation for `WiredPartIOSApp.swift`, `PartsImportExportPage.swift`, `Weird_Parts_IOSUITests.swift`, and `PartsService.swift`.
- Reviewer focus notes for AI-generated/assisted code: verify the DEBUG-only WEI-3140 fixture launch surface remains acceptable test infrastructure and that the UI screenshot tests should live in the main UI test target.

## Copilot-assisted Change Checklist

- [ ] Copilot used for this PR: Yes / No
- [x] Reviewed Copilot-generated/assisted changes line-by-line
- [x] No secrets, credentials, or customer-sensitive prompt data shared
- [x] Licensing/origin risk checked for non-trivial generated snippets
- [x] Tests added/updated for generated or modified logic
- [x] Manual verification notes added for security/auth/config changes

## Risk Check

- [x] No secrets or sensitive data were shared with AI tools
- [x] Security-sensitive paths received required reviewer attention
- [x] No destructive ops introduced without explicit approval
