### PR TITLE
WEI-2773: Persist receiving price verification

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPODetailPage.swift
@@ -1746,7 +1746,7 @@ struct IOSPODetailPage: View {
                     Text("\(item.receivedQty)")
                         .font(.caption)
                         .fontWeight(.semibold)
-                        .foregroundStyle(item.hasDiscrepancy ? .orange : .primary)
+                        .foregroundStyle(item.hasQuantityDiscrepancy ? .orange : .primary)
                     Text("/")
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
@@ -1755,12 +1755,22 @@ struct IOSPODetailPage: View {
                         .foregroundStyle(.secondary)
                 }
 
-                if item.hasDiscrepancy {
+                if item.hasQuantityDiscrepancy {
                     let diff = item.receivedQty - item.expectedQty
                     Text(diff > 0 ? "+\(diff) over" : "\(-diff) short")
                         .font(.caption)
                         .fontWeight(.semibold)
                         .foregroundStyle(diff > 0 ? .blue : .red)
+                }
+
+                if item.hasPriceDiscrepancy,
+                   let orderUnitCost = item.orderUnitCost,
+                   let receivedUnitCost = item.receivedUnitCost {
+                    Text("\(formatCurrency(orderUnitCost)) -> \(formatCurrency(receivedUnitCost))")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.orange)
+                        .accessibilityLabel("Price discrepancy")
                 }
             }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -953,10 +953,19 @@ struct IOSReceiveShipmentPage: View {
         actionError = nil
 
         do {
-            // Update received quantities
+            // Update received quantities and any verified invoice cost before completion.
             for item in sessionItems {
                 let qty = receivedQtys[item.id] ?? item.expectedQty
-                try warehouseService.updateSessionItem(itemId: item.id, receivedQty: qty)
+                let verifiedCost: Double?
+                switch priceVerifications[item.id] {
+                case .matches:
+                    verifiedCost = item.unitPrice
+                case .different(let newPrice):
+                    verifiedCost = newPrice > 0 ? newPrice : nil
+                case .notShown, .none:
+                    verifiedCost = nil
+                }
+                try warehouseService.updateSessionItem(itemId: item.id, receivedQty: qty, actualCost: verifiedCost)
             }
 
             // Complete the session (creates stock movements for non-routed items)

--- a/core/Sources/WiredPartCore/Services/OrdersService.swift
+++ b/core/Sources/WiredPartCore/Services/OrdersService.swift
@@ -3520,12 +3520,20 @@ public final class OrdersService: Sendable {
         public let expectedQty: Int
         public let receivedQty: Int
         public let hasDiscrepancy: Bool
+        public let hasQuantityDiscrepancy: Bool
+        public let hasPriceDiscrepancy: Bool
+        public let orderUnitCost: Double?
+        public let receivedUnitCost: Double?
         public let notes: String?
 
         public init(
             id: Int64, partName: String, partCode: String?,
             expectedQty: Int, receivedQty: Int,
-            hasDiscrepancy: Bool, notes: String?
+            hasDiscrepancy: Bool, notes: String?,
+            hasQuantityDiscrepancy: Bool? = nil,
+            hasPriceDiscrepancy: Bool = false,
+            orderUnitCost: Double? = nil,
+            receivedUnitCost: Double? = nil
         ) {
             self.id = id
             self.partName = partName
@@ -3533,6 +3541,10 @@ public final class OrdersService: Sendable {
             self.expectedQty = expectedQty
             self.receivedQty = receivedQty
             self.hasDiscrepancy = hasDiscrepancy
+            self.hasQuantityDiscrepancy = hasQuantityDiscrepancy ?? hasDiscrepancy
+            self.hasPriceDiscrepancy = hasPriceDiscrepancy
+            self.orderUnitCost = orderUnitCost
+            self.receivedUnitCost = receivedUnitCost
             self.notes = notes
         }
     }
@@ -3555,9 +3567,17 @@ public final class OrdersService: Sendable {
                        COALESCE(
                            (SELECT COUNT(*)
                             FROM receiving_session_items rsi
+                            LEFT JOIN po_line_items pli ON pli.id = rsi.po_line_id AND pli.deleted_at IS NULL
                             WHERE rsi.session_id = rs.id
                               AND rsi.deleted_at IS NULL
-                              AND rsi.received_qty != rsi.expected_qty), 0
+                              AND (
+                                  rsi.received_qty != rsi.expected_qty
+                                  OR (
+                                      rsi.actual_cost IS NOT NULL
+                                      AND pli.unit_cost IS NOT NULL
+                                      AND ABS(rsi.actual_cost - pli.unit_cost) > 0.0001
+                                  )
+                              )), 0
                        ) AS discrepancy_count
                 FROM receiving_sessions rs
                 LEFT JOIN users u ON u.id = rs.started_by AND u.deleted_at IS NULL
@@ -3589,6 +3609,8 @@ public final class OrdersService: Sendable {
                        p.code AS part_code,
                        rsi.expected_qty,
                        rsi.received_qty,
+                       pli.unit_cost,
+                       rsi.actual_cost,
                        rsi.notes
                 FROM receiving_session_items rsi
                 LEFT JOIN po_line_items pli ON pli.id = rsi.po_line_id AND pli.deleted_at IS NULL
@@ -3599,14 +3621,27 @@ public final class OrdersService: Sendable {
             return rows.map { row in
                 let expected: Int = row["expected_qty"] ?? 0
                 let received: Int = row["received_qty"] ?? 0
+                let orderUnitCost: Double? = row["unit_cost"] as Double?
+                let receivedUnitCost: Double? = row["actual_cost"] as Double?
+                let hasQuantityDiscrepancy = expected != received
+                let hasPriceDiscrepancy: Bool
+                if let orderUnitCost, let receivedUnitCost {
+                    hasPriceDiscrepancy = abs(orderUnitCost - receivedUnitCost) > 0.0001
+                } else {
+                    hasPriceDiscrepancy = false
+                }
                 return ReceiptHistoryItem(
                     id: row["id"] ?? 0,
                     partName: row["part_name"] ?? "Unknown Part",
                     partCode: row["part_code"] as String?,
                     expectedQty: expected,
                     receivedQty: received,
-                    hasDiscrepancy: expected != received,
-                    notes: row["notes"] as String?
+                    hasDiscrepancy: hasQuantityDiscrepancy || hasPriceDiscrepancy,
+                    notes: row["notes"] as String?,
+                    hasQuantityDiscrepancy: hasQuantityDiscrepancy,
+                    hasPriceDiscrepancy: hasPriceDiscrepancy,
+                    orderUnitCost: orderUnitCost,
+                    receivedUnitCost: receivedUnitCost
                 )
             }
         }

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -1670,17 +1670,20 @@ public final class WarehouseService: Sendable {
         }
     }
 
-    /// Update a receiving session item's received quantity.
-    public func updateSessionItem(itemId: Int64, receivedQty: Int, notes: String? = nil) throws {
+    /// Update a receiving session item's received quantity and optional verified receipt cost.
+    public func updateSessionItem(itemId: Int64, receivedQty: Int, notes: String? = nil, actualCost: Double? = nil) throws {
         guard receivedQty >= 0 else { throw WarehouseError.invalidQuantity }
         try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
                     UPDATE receiving_session_items
-                    SET received_qty = ?, notes = COALESCE(?, notes), scanned_at = datetime('now')
+                    SET received_qty = ?,
+                        notes = COALESCE(?, notes),
+                        actual_cost = COALESCE(?, actual_cost),
+                        scanned_at = datetime('now')
                     WHERE id = ? AND deleted_at IS NULL
                     """,
-                arguments: [receivedQty, notes, itemId]
+                arguments: [receivedQty, notes, actualCost, itemId]
             )
         }
     }
@@ -1849,7 +1852,7 @@ public final class WarehouseService: Sendable {
         }
 
         let receivedRows = try Row.fetchAll(dbConn, sql: """
-            SELECT rsi.po_line_id, rsi.received_qty
+            SELECT rsi.po_line_id, rsi.received_qty, rsi.actual_cost
             FROM receiving_session_items rsi
             JOIN po_line_items pli ON pli.id = rsi.po_line_id AND pli.deleted_at IS NULL
             WHERE rsi.session_id = ?
@@ -1859,18 +1862,20 @@ public final class WarehouseService: Sendable {
         for row in receivedRows {
             let lineId: Int64 = row["po_line_id"] ?? 0
             let receivedQty: Int = row["received_qty"] ?? 0
+            let actualCost: Double? = row["actual_cost"] as Double?
             guard lineId > 0 else { continue }
 
             try dbConn.execute(sql: """
                 UPDATE po_line_items
                 SET qty_received = COALESCE(qty_received, 0) + ?,
+                    received_unit_cost = COALESCE(?, received_unit_cost),
                     status = CASE
                         WHEN COALESCE(qty_received, 0) + ? >= qty_ordered THEN 'received'
                         WHEN COALESCE(qty_received, 0) + ? > 0 THEN 'backorder'
                         ELSE status
                     END
                 WHERE id = ? AND deleted_at IS NULL
-                """, arguments: [receivedQty, receivedQty, receivedQty, lineId])
+                """, arguments: [receivedQty, actualCost, receivedQty, receivedQty, lineId])
 
             try dbConn.execute(sql: """
                 UPDATE jpo_line_items

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -2082,6 +2082,57 @@ struct WarehouseServiceExtTests {
         #expect(badMovements == 0)
     }
 
+    @Test("receiving completion persists verified invoice price discrepancy")
+    func testReceivingCompletionPersistsVerifiedInvoicePriceDiscrepancy() throws {
+        let env = try E2ETestHelpers.setUp()
+        let supplierId = try E2ETestHelpers.seedSupplier(env)
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, name: "Verified Cost Part", categoryId: catId)
+        let poId = try env.orders.createPurchaseOrder(poNumber: "PO-PRICE-DIFF", supplierId: supplierId, notes: nil)
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO po_line_items (po_id, part_id, qty_ordered, unit_cost)
+                VALUES (?, ?, 3, 10.0)
+                """, arguments: [poId, partId])
+        }
+
+        let sessionId = try env.warehouse.startReceivingSession(poId: poId, startedBy: env.adminUserId)
+        let item = try #require(try env.warehouse.getSessionItems(sessionId: sessionId).first)
+
+        try env.warehouse.updateSessionItem(itemId: item.id, receivedQty: 3, actualCost: 12.5)
+        try env.warehouse.completeSession(sessionId: sessionId, completedBy: env.adminUserId)
+
+        try env.db.writer.read { db in
+            let row = try Row.fetchOne(db, sql: """
+                SELECT rsi.actual_cost,
+                       pli.received_unit_cost,
+                       sm.unit_cost_at_move
+                FROM receiving_session_items rsi
+                JOIN po_line_items pli ON pli.id = rsi.po_line_id
+                JOIN stock_movements sm ON sm.part_id = pli.part_id
+                WHERE rsi.id = ?
+                  AND sm.movement_type = 'receiving'
+                """, arguments: [item.id])
+
+            #expect(row?["actual_cost"] as Double? == 12.5)
+            #expect(row?["received_unit_cost"] as Double? == 12.5)
+            #expect(row?["unit_cost_at_move"] as Double? == 12.5)
+        }
+
+        let entries = try env.orders.getReceiptHistoryEntries(poId: poId)
+        let entry = try #require(entries.first)
+        #expect(entry.hasDiscrepancies)
+
+        let historyItems = try env.orders.getReceiptHistoryItems(sessionId: sessionId)
+        let historyItem = try #require(historyItems.first)
+        #expect(historyItem.hasDiscrepancy)
+        #expect(!historyItem.hasQuantityDiscrepancy)
+        #expect(historyItem.hasPriceDiscrepancy)
+        #expect(historyItem.orderUnitCost == 10.0)
+        #expect(historyItem.receivedUnitCost == 12.5)
+    }
+
     @Test("completeSession does not add routed PO incoming items to shelf stock")
     func testCompleteSession_skipsRoutedPOIncomingShelfStock() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- persist verified receipt invoice cost on receiving session items before completion
- propagate actual receipt cost to PO lines and receiving stock movements
- flag price discrepancies in receipt history and show receipt cost deltas in PO detail

## Validation
- swift test --filter WarehouseServiceExtTests.testReceivingCompletionPersistsVerifiedInvoicePriceDiscrepancy
- swift test --filter 'WarehouseServiceExtTests.testReceivingCompletionUpdatesOrderLifecycle|OrdersServiceTests.testGetReceiptHistoryItemsHidesDeletedPartName'
- xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'generic/platform=iOS Simulator' -skipPackagePluginValidation build

Paperclip: WEI-2773