### PR TITLE
WEI-3270 Consolidate auth revocation PRs

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/SecurityAdminPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/SecurityAdminPage.swift
@@ -3,10 +3,8 @@ import WiredPartCore
 
 /// Security and device administration page.
 ///
-/// Shows registered devices, active sessions, and provides force-logout
+/// Shows registered devices, active auth sessions, and provides force-logout
 /// capability. Uses AuthService methods to read device and session data.
-/// On mobile this is primarily a view-only status page; full
-/// administration is expected on desktop.
 struct SecurityAdminPage: View {
     @EnvironmentObject private var appCore: AppCore
 
@@ -54,8 +52,8 @@ struct SecurityAdminPage: View {
         }
         .sheet(item: $activeSheet) { _ in
             PageHelpSheet(title: "Security Help", sections: [
-                ("What This Page Does", "Shows registered devices and active user sessions. Administrators can force-logout sessions from this page."),
-                ("How to Use It", "Review device status and active sessions. To end a session, tap the red X button next to it (admin permission required). Full device and session management is available on the desktop application."),
+                ("What This Page Does", "Shows registered device status and active user auth sessions. Administrators can force-logout sessions from this page."),
+                ("How to Use It", "Review device status and active sessions. To end a session, tap the red X button next to it (admin permission required)."),
             ])
         }
         .task { loadData() }
@@ -146,7 +144,7 @@ struct SecurityAdminPage: View {
 
     private var securityInfoSection: some View {
         Section {
-            Text("Full device and session management is available on the desktop application. This page provides a read-only view of the current security state.")
+            Text("Registered devices show sync status. Active sessions are revocable login sessions; force logout invalidates the selected session tokens.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/core/Tests/WiredPartCoreTests/AuthServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/AuthServiceTests.swift
@@ -737,6 +737,19 @@ struct AuthServiceTests {
         #expect(sessions.isEmpty)
     }
 
+    @Test("listActiveSessions returns active token sessions")
+    func testListActiveSessionsReturnsTokenSessions() throws {
+        let db = try freshDB()
+        let auth = AuthService(db: db)
+        _ = try auth.seedFirstAdmin(displayName: "Admin", pin: "1234")
+
+        let sessions = try auth.listActiveSessions()
+        #expect(sessions.count == 1)
+        #expect(sessions[0].userName == "Admin")
+        #expect(sessions[0].userId == "1")
+        #expect(!sessions[0].id.isEmpty)
+    }
+
     @Test("deactivateSession still marks a legacy device-registry row as deactivated")
     func testDeactivateSession() throws {
         let db = try freshDB()
@@ -756,6 +769,27 @@ struct AuthServiceTests {
             try Int.fetchOne(dbConn, sql: "SELECT is_deactivated FROM _device_registry WHERE rowid = ?", arguments: [rowId])
         }
         #expect(deactivated == 1)
+    }
+
+    @Test("deactivateSession revokes rotated token family")
+    func testDeactivateSessionRevokesRotatedTokenFamily() throws {
+        let db = try freshDB()
+        let auth = AuthService(db: db)
+        let seed = try auth.seedFirstAdmin(displayName: "Admin", pin: "1234")
+        let originalRefreshToken = try #require(seed.refreshToken)
+        let originalSessionId = try #require(AuthService.parseLocalToken(originalRefreshToken)?.jti)
+
+        let rotated = try auth.refreshLocalSession(refreshToken: originalRefreshToken)
+        _ = try auth.getLocalUserProfile(token: rotated.accessToken)
+
+        try auth.deactivateSession(sessionId: originalSessionId)
+
+        #expect(throws: AuthService.AuthError.sessionRevoked) {
+            _ = try auth.getLocalUserProfile(token: rotated.accessToken)
+        }
+        #expect(throws: AuthService.AuthError.sessionRevoked) {
+            _ = try auth.refreshLocalSession(refreshToken: rotated.refreshToken)
+        }
     }
 
     @Test("listRegisteredDevices shows Unassigned for soft-deleted assigned user")

--- a/core/Tests/WiredPartCoreTests/AuthServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/AuthServiceTests.swift
@@ -741,12 +741,13 @@ struct AuthServiceTests {
     func testListActiveSessionsReturnsTokenSessions() throws {
         let db = try freshDB()
         let auth = AuthService(db: db)
-        _ = try auth.seedFirstAdmin(displayName: "Admin", pin: "1234")
+        let seed = try auth.seedFirstAdmin(displayName: "Admin", pin: "1234")
+        let expectedUserId = try #require(seed.user?.id)
 
         let sessions = try auth.listActiveSessions()
         #expect(sessions.count == 1)
         #expect(sessions[0].userName == "Admin")
-        #expect(sessions[0].userId == "1")
+        #expect(sessions[0].userId == "\(expectedUserId)")
         #expect(!sessions[0].id.isEmpty)
     }
 


### PR DESCRIPTION
## Summary
- Consolidates the auth revocation behavior preserved in draft/conflicting PRs #937 and #932 without carrying over stale workflow runner edits or unrelated OrdersService churn.
- Keeps current mainline AuthService behavior, which already lists active sessions from `auth_token_sessions`, revokes token families, and retains legacy device-registry fallback behavior.
- Updates SecurityAdminPage copy so active sessions are described as revocable auth sessions rather than desktop-only/read-only state.
- Adds AuthService regression coverage for active token-session listing and rotated refresh-token family revocation.

## PR consolidation notes
- #937 unique auth/UI delta: SecurityAdminPage copy plus active-session/token-family regression coverage.
- #932 unique auth delta: active-session/token-family regression coverage; its OrdersService changes are unrelated supplier/receiving backlog work and are intentionally excluded here.
- Both #937 and #932 include workflow runner edits and stale-base conflicts; neither should be merged directly after this PR accounts for the auth behavior.

## Changed files
- `Weird Parts IOS/Weird Parts IOS/Features/Settings/SecurityAdminPage.swift`
- `core/Tests/WiredPartCoreTests/AuthServiceTests.swift`

## Verification
- `git diff --check` passed.
- `swift test --filter AuthServiceTests` in `core/` completed build successfully after 768.94s, then the filtered Swift Testing runner stayed active with no suite output for several minutes under heavy concurrent Swift/Xcode load. I terminated only that local test process to avoid leaving a live heartbeat process.

## Residual risk
- The new AuthService tests compiled, but the filtered suite did not reach a pass/fail result in this local run. Reviewer should rerun `swift test --filter AuthServiceTests` in a less saturated local environment before merge.

Supersedes the auth portion of #937 and #932.
