### PR TITLE
WEI-3453 make GitHub priority labels optional

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -125,7 +125,7 @@ try db.fetch(
 
 ## 7. Issue Title Tier Tags
 
-All issues use tier tags to signal priority/complexity:
+Use tier tags when they help communicate severity or implementation complexity. They are not required for every issue.
 
 | Tag | Meaning |
 |---|---|
@@ -138,6 +138,8 @@ When filing a follow-up issue from PR work, use the same `[Area][Type]` + tier f
 ```
 [Orders][Bug][T1] PO receiver FK not validated on save
 ```
+
+GitHub `priority:P*` labels are optional severity labels. Do not add `priority:P0` through `priority:P5` just to make an issue fit a process bucket; use them only when the issue needs explicit release or scheduling escalation.
 
 ---
 

--- a/docs/plans/github-issue-fisher-workflow.md
+++ b/docs/plans/github-issue-fisher-workflow.md
@@ -16,7 +16,7 @@ This workflow turns the WEI-2441 "keep GitHub issue work moving" prompt into a r
 
 The repo does not use a root `plans/` directory. If a caller passes a missing or empty plan directory, the runner exits with an error instead of falling back to placeholders.
 
-## Priority Order
+## Work Order
 
 Every run enforces this order:
 
@@ -24,7 +24,9 @@ Every run enforces this order:
 2. `todo`: open issues with priority, triage, bug, or enhancement labels
 3. `backlog`: remaining open issues
 
-The runner selects at most three actions per pass. Within a bucket it prefers higher priority labels first, then older updated issues.
+The runner selects at most three actions per pass. Within a bucket it prefers higher priority labels first when present, then older updated issues.
+
+Priority labels are optional severity signals, not a filing requirement. An issue can move through the workflow with only work-type labels such as `bug`, `enhancement`, `triage`, or `blocked`. Missing `priority:P*` labels do not fail a fisher run and do not require mass relabeling. Use a priority label only when severity materially changes scheduling, release risk, or escalation.
 
 Backlog entries are never treated as promotions by the report itself. When the pass reaches backlog because blocked/todo supply fewer than the requested limit, those entries are labeled as non-promotion candidates and require a separate human or approved-routine confirmation of concrete plan/repo evidence before any GitHub or Paperclip mutation.
 
@@ -64,4 +66,5 @@ Successful verification proves:
 - `docs/plans/` exists and contains markdown plans;
 - GitHub issues can be read with `gh`;
 - actions are ordered `blocked -> todo -> backlog`;
+- priority-label coverage is reported without requiring every GitHub issue to have `priority:P0` through `priority:P5`;
 - the local run report is written without creating fake findings, committing generated artifacts, or mutating GitHub.

--- a/scripts/github-issue-fisher.sh
+++ b/scripts/github-issue-fisher.sh
@@ -8,7 +8,7 @@ Usage:
 
 Runs one GitHub issue-fisher pass:
   1. verifies the canonical plan directory exists and is non-empty;
-  2. classifies open GitHub issues in priority order: blocked, todo, backlog;
+  2. classifies open GitHub issues in work order: blocked, todo, backlog;
   3. performs an evidence scan against repo plans, DevTODOs, and code markers;
   4. writes a dated report with 1-3 issue-moving actions.
 
@@ -111,6 +111,14 @@ jq -n \
     elif (($labelNames | any(test("^priority:P[0-3]$"))) or ($labelNames | index("triage")) or ($labelNames | index("bug")) or ($labelNames | index("enhancement"))) then "todo"
     else "backlog"
     end;
+  def priority_rank($labelNames):
+    if ($labelNames | index("priority:P0")) then 0
+    elif ($labelNames | index("priority:P1")) then 1
+    elif ($labelNames | index("priority:P2")) then 2
+    elif ($labelNames | index("priority:P3")) then 3
+    elif ($labelNames | index("priority:P4")) then 4
+    elif ($labelNames | index("priority:P5")) then 5
+    else 6 end;
   $issues
   | map(. as $issue | ([$issue.labels[].name]) as $labelNames | $issue + {bucket: bucket($labelNames), labelNames: $labelNames})
   | group_by(.bucket)
@@ -118,11 +126,7 @@ jq -n \
       bucket: .[0].bucket,
       items: (
         sort_by(
-          if (.labelNames | index("priority:P0")) then 0
-          elif (.labelNames | index("priority:P1")) then 1
-          elif (.labelNames | index("priority:P2")) then 2
-          elif (.labelNames | index("priority:P3")) then 3
-          else 4 end,
+          priority_rank(.labelNames),
           .updatedAt
         )
       )
@@ -136,7 +140,7 @@ jq -n \
       issue: ("#" + (.number | tostring)),
       title,
       url,
-      evidence: ("Open GitHub issue classified as " + .bucket + " from labels: " + ((.labelNames | join(", ")) // "none")),
+      evidence: ("Open GitHub issue classified as " + .bucket + " from work labels: " + (((.labelNames | map(select(test("^priority:P[0-5]$") | not))) | join(", ")) // "none") + ". Priority labels are optional severity signals only."),
       nextAction: (
         if .bucket == "blocked" then "Resolve or replace the blocker before starting new implementation."
         elif .bucket == "todo" then "Assign the smallest implementation owner or move into an active Paperclip child issue."
@@ -165,6 +169,9 @@ jq -Rn '
 
 ACTION_COUNT="$(jq 'length' "$ACTIONS_JSON")"
 FINDING_COUNT="$(jq 'length' "$FINDINGS_JSON")"
+OPEN_ISSUE_COUNT="$(jq 'length' "$ISSUES_JSON")"
+PRIORITY_LABEL_COUNT="$(jq '[.[] | select([.labels[].name] | any(test("^priority:P[0-5]$")))] | length' "$ISSUES_JSON")"
+UNPRIORITIZED_COUNT="$((OPEN_ISSUE_COUNT - PRIORITY_LABEL_COUNT))"
 
 {
   echo "# GitHub Issue Fisher Report"
@@ -173,7 +180,9 @@ FINDING_COUNT="$(jq 'length' "$FINDINGS_JSON")"
   printf -- "- Run timestamp (UTC): \`%s\`\n" "$STAMP"
   printf -- "- Mode: \`%s\`\n" "$([[ "$DRY_RUN" -eq 1 ]] && echo dry-run || echo report-only)"
   printf -- "- Plan source: \`%s\` (%s markdown files)\n" "$PLANS_DIR" "$PLAN_COUNT"
-  printf -- "- Priority order: \`blocked -> todo -> backlog\`\n"
+  printf -- "- Work order: \`blocked -> todo -> backlog\`\n"
+  printf -- "- Open issues with optional priority labels: \`%s/%s\`\n" "$PRIORITY_LABEL_COUNT" "$OPEN_ISSUE_COUNT"
+  printf -- "- Open issues without priority labels: \`%s\`\n" "$UNPRIORITIZED_COUNT"
   printf -- "- Selected actions: \`%s\`\n" "$ACTION_COUNT"
   printf -- "- Evidence findings sampled: \`%s\`\n" "$FINDING_COUNT"
   echo
@@ -205,6 +214,7 @@ FINDING_COUNT="$(jq 'length' "$FINDINGS_JSON")"
   echo
   echo "- This run refuses to proceed when the plan directory is missing or empty."
   echo "- The workflow selects at most 3 actions per run."
+  printf '%s\n' '- GitHub priority labels are optional severity signals. Missing `priority:P*` labels do not fail the run and do not block issue movement.'
   echo "- Backlog selections are non-promotion candidates until a human or approved routine confirms concrete plan/repo evidence."
   echo "- Reports are evidence; GitHub mutation still requires an explicit follow-up owner or approved routine path."
 } > "$REPORT_MD"


### PR DESCRIPTION
## Summary
- Treat `priority:P*` labels as optional severity metadata in the GitHub issue fisher.
- Report priority-label coverage without failing or implying every GitHub issue needs a P0-P5 label.
- Update workflow and Copilot instructions to stop adding priority labels solely for process fit.

## Verification
- `bash -n scripts/github-issue-fisher.sh`
- `scripts/github-issue-fisher.sh --dry-run`

Refs WEI-3453
