### PR TITLE
[Reports] Hide deleted users in bookkeeper labor export

### DIFF
--- a/core/Sources/WiredPartCore/Services/ReportsService.swift
+++ b/core/Sources/WiredPartCore/Services/ReportsService.swift
@@ -928,7 +928,8 @@ public final class ReportsService: Sendable {
         do {
             return try db.writer.read { dbConn -> [BookkeeperLaborRow] in
                 let sql = """
-                    SELECT u.id, COALESCE(u.display_name, u.email, 'Unknown') AS name,
+                    SELECT le.user_id AS id,
+                           COALESCE(u.display_name, u.email, 'Unknown') AS name,
                            COALESCE(SUM(le.regular_hours), 0) AS regular_hours,
                            COALESCE(SUM(le.overtime_hours), 0) AS overtime_hours,
                            ROUND(COALESCE(SUM(
@@ -936,13 +937,13 @@ public final class ReportsService: Sendable {
                                le.overtime_hours * COALESCE(u.pay_rate, 0) * 1.5
                            ), 0), 2) AS gross_pay,
                            COUNT(le.id) AS labor_entry_count
-                    FROM users u
-                    JOIN labor_entries le ON le.user_id = u.id
+                    FROM labor_entries le
+                    LEFT JOIN users u ON u.id = le.user_id AND u.deleted_at IS NULL
                     WHERE \(Self.localDateSQL("le.clock_in")) >= date(?)
                       AND \(Self.localDateSQL("le.clock_in")) <= date(?)
                       AND le.deleted_at IS NULL
-                    GROUP BY u.id
-                    ORDER BY name, u.id
+                    GROUP BY le.user_id
+                    ORDER BY name, le.user_id
                     """
 
                 let rows = try Row.fetchAll(dbConn, sql: sql, arguments: [startDate, endDate])

--- a/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
@@ -949,6 +949,41 @@ struct ReportsServiceTests {
         #expect(row?.sourceSummary == "1 labor entry")
     }
 
+    @Test("Bookkeeper labor summary hides soft-deleted employee identity and payroll rate")
+    func testBookkeeperLaborSummaryHidesSoftDeletedEmployeeDetails() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-BK-LABOR-DELETED", name: "Bookkeeper Deleted Labor Job")
+        let deletedUserId = try env.db.writer.write { db -> Int64 in
+            try db.execute(sql: "UPDATE users SET pay_rate = 20.0 WHERE id = ?", arguments: [env.adminUserId])
+            try db.execute(sql: """
+                INSERT INTO users (display_name, email, pin_hash, pay_rate, is_active, deleted_at, created_at, updated_at)
+                VALUES ('Deleted Payroll Tech', 'deleted-payroll@example.test', 'hash-deleted', 99.0, 0,
+                        '2026-06-02 12:00:00', datetime('now'), datetime('now'))
+                """)
+            let userId = db.lastInsertedRowID
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES
+                    (?, ?, '2026-06-02 07:00:00', '2026-06-02 18:00:00', 8.0, 2.0, 'completed', datetime('now')),
+                    (?, ?, '2026-06-02 08:00:00', '2026-06-02 12:00:00', 4.0, 1.0, 'completed', datetime('now'))
+                """, arguments: [env.adminUserId, jobId, userId, jobId])
+            return userId
+        }
+
+        let rows = try env.reports.getBookkeeperLaborSummary(startDate: "2026-06-02", endDate: "2026-06-02")
+        let activeRow = rows.first { $0.id == env.adminUserId }
+        let deletedRow = rows.first { $0.id == deletedUserId }
+
+        #expect(abs((activeRow?.grossPay ?? 0) - 220.0) < 0.01)
+        #expect(deletedRow != nil)
+        #expect(deletedRow?.employeeName == "Unknown")
+        #expect(deletedRow?.employeeName != "Deleted Payroll Tech")
+        #expect(deletedRow?.employeeName != "deleted-payroll@example.test")
+        #expect(deletedRow?.grossPay == 0.0)
+        #expect(deletedRow?.laborEntryCount == 1)
+    }
+
     @Test("Bookkeeper material export is deterministic and excludes cancelled and deleted POs")
     func testBookkeeperMaterialPOsDeterministicExportRows() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Updates `ReportsService.getBookkeeperLaborSummary(startDate:endDate:)` to drive from active labor entries and left-join only non-deleted users.
- Keeps completed labor rows in the export while degrading soft-deleted employee identity to `Unknown`.
- Prevents deleted users' payroll rates from contributing to `grossPay` by using the existing zero-value pay-rate fallback when the active user join is absent.

## Tests
- RED: `swift test --filter ReportsServiceTests/testBookkeeperLaborSummaryHidesSoftDeletedEmployeeDetails` failed before the fix with leaked `Deleted Payroll Tech` and `grossPay → 544.5`.
- GREEN: `swift test --filter ReportsServiceTests/testBookkeeperLaborSummaryHidesSoftDeletedEmployeeDetails`
- `swift test --filter ReportsServiceTests`
- `swift test`

Paperclip: WEI-3573 / WEI-3583

Closes #985
