### PR TITLE
[Sync][Security] Fail closed without peer discovery company id

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -214,6 +214,15 @@ final class IOSSyncManager {
             errorMessage = "Sync not configured. Enable Bluetooth sync or set a server address in Settings."
             return
         }
+
+        let companyId: String
+        do {
+            companyId = try peerDiscoveryCompanyId()
+        } catch {
+            handlePeerDiscoveryCompanyIdFailure(error)
+            return
+        }
+
         isScanning = true
 
         // Start multipeer if BT is enabled
@@ -222,7 +231,6 @@ final class IOSSyncManager {
             if multipeerManager == nil {
                 let deviceId = DeviceIdentity.current
                 let deviceName = UIDevice.current.name
-                let companyId = (try? settingsService?.getSettingsByCategory("company"))?["company_id"] ?? "default"
                 multipeerManager = MultipeerManager(
                     deviceId: deviceId,
                     deviceName: deviceName,
@@ -242,7 +250,6 @@ final class IOSSyncManager {
             Task {
                 let deviceId = DeviceIdentity.current
                 let deviceName = UIDevice.current.name
-                let companyId = (try? settingsService?.getSettingsByCategory("company"))?["company_id"] ?? "default"
                 do {
                     try await pm.startPeerSync(
                         deviceId: deviceId,
@@ -282,6 +289,33 @@ final class IOSSyncManager {
         }
     }
 
+    private func peerDiscoveryCompanyId() throws -> String {
+        guard let settingsService else {
+            throw SyncError.noCompanyIdConfigured
+        }
+        return try Self.peerDiscoveryCompanyId {
+            try settingsService.getSettingsByCategory("company")
+        }
+    }
+
+    static func peerDiscoveryCompanyId(
+        loadCompanySettings: () throws -> [String: String]
+    ) throws -> String {
+        let settings = try loadCompanySettings()
+        let companyId = settings["company_id"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !companyId.isEmpty else {
+            throw SyncError.noCompanyIdConfigured
+        }
+        return companyId
+    }
+
+    func handlePeerDiscoveryCompanyIdFailure(_ error: Error) {
+        logger.error("[IOSSyncManager] Peer discovery blocked because company id could not be verified: \(error.localizedDescription)")
+        syncStatus = .error
+        errorMessage = "Peer discovery unavailable: \(error.localizedDescription)"
+        isScanning = false
+    }
+
     /// Issue a one-time pairing code from the shop-side sync server.
     func issueShopPairingCode() async throws -> String {
         guard let pm = peerManager else {
@@ -292,7 +326,13 @@ final class IOSSyncManager {
         if !currentState.running {
             let deviceId = DeviceIdentity.current
             let deviceName = UIDevice.current.name
-            let companyId = (try? settingsService?.getSettingsByCategory("company"))?["company_id"] ?? "default"
+            let companyId: String
+            do {
+                companyId = try peerDiscoveryCompanyId()
+            } catch {
+                handlePeerDiscoveryCompanyIdFailure(error)
+                throw error
+            }
             try await pm.startPeerSync(
                 deviceId: deviceId,
                 deviceName: deviceName,
@@ -682,6 +722,7 @@ final class IOSSyncManager {
     enum SyncError: LocalizedError {
         case noDatabaseAvailable
         case noServerConfigured
+        case noCompanyIdConfigured
         case invalidPairingCode
         case invalidShopAddress
         case pairingVerificationFailed(String)
@@ -691,6 +732,7 @@ final class IOSSyncManager {
             switch self {
             case .noDatabaseAvailable: return "Database not available."
             case .noServerConfigured: return "No sync server configured."
+            case .noCompanyIdConfigured: return "Company ID is not configured. Open Settings and verify the company profile before starting peer discovery."
             case .invalidPairingCode: return "Pairing code must be eight letters or numbers."
             case .invalidShopAddress: return "Shop address is invalid."
             case .pairingVerificationFailed(let msg): return msg

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -15,6 +15,10 @@ private enum QuestionnaireBreakTestError: Error {
     case autoFillFailed
 }
 
+private enum PeerDiscoveryCompanyIdTestError: Error {
+    case lookupFailed
+}
+
 struct Weird_Parts_IOSTests {
 
     struct LANPeerDiscoveryStartupError: Error, LocalizedError {
@@ -68,6 +72,46 @@ struct Weird_Parts_IOSTests {
         #expect(manager.syncStatus == .error)
         #expect(manager.errorMessage == "LAN peer discovery failed: port unavailable")
         #expect(manager.isScanning)
+    }
+
+    @MainActor
+    @Test func peerDiscoveryCompanyIdResolutionUsesStoredNonEmptyValue() throws {
+        let companyId = try IOSSyncManager.peerDiscoveryCompanyId {
+            ["company_id": "  company-123  "]
+        }
+
+        #expect(companyId == "company-123")
+    }
+
+    @MainActor
+    @Test func peerDiscoveryCompanyIdResolutionFailsClosedWhenMissing() throws {
+        #expect(throws: IOSSyncManager.SyncError.self) {
+            _ = try IOSSyncManager.peerDiscoveryCompanyId { [:] }
+        }
+        #expect(throws: IOSSyncManager.SyncError.self) {
+            _ = try IOSSyncManager.peerDiscoveryCompanyId { ["company_id": "   "] }
+        }
+    }
+
+    @MainActor
+    @Test func peerDiscoveryCompanyIdResolutionPropagatesSettingsLookupFailure() throws {
+        #expect(throws: PeerDiscoveryCompanyIdTestError.self) {
+            _ = try IOSSyncManager.peerDiscoveryCompanyId {
+                throw PeerDiscoveryCompanyIdTestError.lookupFailed
+            }
+        }
+    }
+
+    @MainActor
+    @Test func peerDiscoveryCompanyIdFailureSurfacesErrorAndStopsScanning() throws {
+        let manager = IOSSyncManager()
+        manager.isScanning = true
+
+        manager.handlePeerDiscoveryCompanyIdFailure(IOSSyncManager.SyncError.noCompanyIdConfigured)
+
+        #expect(manager.syncStatus == .error)
+        #expect(manager.errorMessage == "Peer discovery unavailable: Company ID is not configured. Open Settings and verify the company profile before starting peer discovery.")
+        #expect(!manager.isScanning)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Replaces peer-discovery `company_id` default fallback with a verified company-id resolver.
- Fails peer discovery closed with visible sync error state when settings lookup throws or `company_id` is missing/blank.
- Reuses the same resolver for pairing-code LAN peer startup so no related peer-sync startup path advertises as company `default`.

## Paperclip traceability
- Paperclip: WEI-3585
- Parent: WEI-3573

## Verification
- `xcodebuild test -project "Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:'Weird Parts IOSTests/Weird_Parts_IOSTests'` — TEST SUCCEEDED after rebasing onto `origin/main`.
- Repository search confirmed no remaining `getSettingsByCategory("company")` / `company_id` fallback to literal `"default"` in Swift sources.

Closes #948
