### PR TITLE
Fix company setup draft cleanup failure handling

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Auth/CompanySetupWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/CompanySetupWizard.swift
@@ -68,8 +68,7 @@ struct CompanySetupWizard: View {
             ) {
                 Button("Continue to App") {
                     saveProgress()
-                    cleanupDraft()
-                    hasCompletedCompanySetup = true
+                    completeSetupAfterDraftCleanup()
                 }
                 Button("Cancel", role: .cancel) { }
             } message: {
@@ -546,8 +545,7 @@ struct CompanySetupWizard: View {
             }
 
             Button {
-                cleanupDraft()
-                hasCompletedCompanySetup = true
+                completeSetupAfterDraftCleanup()
             } label: {
                 Text("Go to Dashboard")
                     .fontWeight(.semibold)
@@ -738,8 +736,23 @@ struct CompanySetupWizard: View {
         }
     }
 
-    /// Remove draft row after the wizard finishes successfully.
-    private func cleanupDraft() {
-        try? appCore.settingsService?.deleteSetupDraft()
+    /// Remove draft row before marking setup complete.
+    ///
+    /// The completion flag hides this wizard and exposes the Dashboard checklist instead.
+    /// Gate that flag on cleanup success so a stale setup draft cannot remain hidden after
+    /// a failed delete.
+    private func completeSetupAfterDraftCleanup() {
+        guard let settingsService = appCore.settingsService else {
+            saveError = "Settings are still loading. Please try again in a moment."
+            return
+        }
+
+        do {
+            try settingsService.deleteSetupDraft()
+            hasCompletedCompanySetup = true
+        } catch {
+            saveError = userFriendlyError(error, context: "clear setup draft")
+            logger.error("deleteSetupDraft failed; keeping company setup incomplete to avoid hiding a stale draft: \(error.localizedDescription)")
+        }
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/CompanySetupDraftCleanupRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/CompanySetupDraftCleanupRegressionTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+/// Regression tests for GitHub #950 / WEI-3586.
+///
+/// CompanySetupWizard must not mark setup complete while silently swallowing
+/// deleteSetupDraft failures; otherwise stale setup drafts can remain hidden
+/// behind hasCompletedCompanySetup=true.
+final class CompanySetupDraftCleanupRegressionTests: XCTestCase {
+
+    func testCompletionPathsDoNotSetCompletionFlagDirectly() throws {
+        let source = try Self.readCompanySetupWizardSource()
+
+        XCTAssertFalse(
+            source.contains("cleanupDraft()\n                    hasCompletedCompanySetup = true"),
+            "Exit/continue path must not set hasCompletedCompanySetup immediately after cleanupDraft(); cleanup success must gate completion."
+        )
+        XCTAssertFalse(
+            source.contains("cleanupDraft()\n                hasCompletedCompanySetup = true"),
+            "Dashboard completion path must not set hasCompletedCompanySetup immediately after cleanupDraft(); cleanup success must gate completion."
+        )
+    }
+
+    func testCleanupDraftFailureIsUserVisibleAndNotSwallowed() throws {
+        let source = try Self.readCompanySetupWizardSource()
+
+        XCTAssertFalse(
+            source.contains("try? appCore.settingsService?.deleteSetupDraft()"),
+            "deleteSetupDraft failures must not be swallowed with try?."
+        )
+        XCTAssertTrue(
+            source.contains("completeSetupAfterDraftCleanup") || source.contains("finishSetupAfterDraftCleanup"),
+            "CompanySetupWizard should route finish/skip through a helper that gates completion on draft cleanup success."
+        )
+        XCTAssertTrue(
+            source.contains("saveError = userFriendlyError(error, context: \"clear setup draft\")"),
+            "Draft cleanup failures should be surfaced through the existing Error alert instead of being hidden."
+        )
+    }
+
+    private static func readCompanySetupWizardSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Auth")
+            .appendingPathComponent("CompanySetupWizard.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Gates CompanySetupWizard completion on successful setup-draft cleanup instead of swallowing deleteSetupDraft() with try?
- Surfaces cleanup failures through the existing Error alert and keeps hasCompletedCompanySetup false so stale drafts are not hidden
- Adds regression coverage for both finish/skip completion paths and failure visibility

Closes #950
Paperclip: WEI-3573 / WEI-3586

## Tests
- RED: `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'id=98CEE4F6-D8F5-49C3-A1B3-0F4CD6C11EA8' -only-testing:'Weird Parts IOSTests/CompanySetupDraftCleanupRegressionTests' test` — failed before fix (both regression tests failed)
- GREEN: `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'id=98CEE4F6-D8F5-49C3-A1B3-0F4CD6C11EA8' -derivedDataPath /tmp/wei-3586-derived -only-testing:'Weird Parts IOSTests/CompanySetupDraftCleanupRegressionTests' test` — **TEST SUCCEEDED**
- Follow-up full generic simulator build with `/tmp/wei-3586-derived` timed out after 600s while other Xcode/Swift frontend builds were active on the Mac; no compile errors were emitted before timeout.

## Notes
- The focused XCTest target compiles the touched iOS app source and validates the no-silent-cleanup regression path.
- No UI layout/ARIA changes in this PR.
