### PR TITLE
fix: fail closed on cart placement persistence

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/CartManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/CartManager.swift
@@ -203,8 +203,24 @@ struct CartSheetView: View {
         let currentPlacements = placements
         let service = appCore.partsService
 
+        if items.contains(where: { $0.partId != nil }) {
+            guard let service else {
+                placementError = "Inventory service is still loading. Cart items were not placed; keep the cart open and try again."
+                isPlacingItems = false
+                return
+            }
+
+            placeItems(items, placements: currentPlacements, partsService: service)
+        } else {
+            placeBins(items, placements: currentPlacements)
+        }
+    }
+
+    private func placeItems(_ items: [CartItem], placements currentPlacements: [UUID: String], partsService service: PartsService) {
+
         Task {
             var placed: Set<UUID> = []
+            var failedPartIDs: Set<UUID> = []
             var errorMsg: String?
 
             for item in items {
@@ -213,9 +229,10 @@ struct CartSheetView: View {
 
                 if let partId = item.partId {
                     do {
-                        try service?.updatePart(id: partId, notes: "Location: \(location)")
+                        try service.updatePart(id: partId, notes: "Location: \(location)")
                         placed.insert(item.id)
                     } catch {
+                        failedPartIDs.insert(item.id)
                         errorMsg = userFriendlyError(error, context: "place item")
                     }
                 } else {
@@ -224,8 +241,29 @@ struct CartSheetView: View {
                 }
             }
 
+            placed.subtract(failedPartIDs)
             placedItems.formUnion(placed)
             if let msg = errorMsg { placementError = msg }
+            isPlacingItems = false
+
+            if placedItems.count == cartManager.itemCount {
+                try? await Task.sleep(for: .milliseconds(500))
+                cartManager.removeAll()
+                dismiss()
+            }
+        }
+    }
+
+    private func placeBins(_ items: [CartItem], placements currentPlacements: [UUID: String]) {
+        Task {
+            var placed: Set<UUID> = []
+
+            for item in items {
+                guard currentPlacements[item.id]?.trimmingCharacters(in: .whitespaces).isEmpty == false else { continue }
+                placed.insert(item.id)
+            }
+
+            placedItems.formUnion(placed)
             isPlacingItems = false
 
             if placedItems.count == cartManager.itemCount {

--- a/Weird Parts IOS/Weird Parts IOSTests/CartPlacementRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/CartPlacementRegressionTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+/// Regression tests for GitHub #975 / WEI-3584.
+///
+/// Cart placement must fail closed when persistence is unavailable or throws;
+/// otherwise unsaved warehouse cart items can be counted as placed and cleared.
+final class CartPlacementRegressionTests: XCTestCase {
+
+    func testPartPlacementRequiresLoadedPartsServiceBeforeCountingSuccess() throws {
+        let source = try Self.readCartManagerSource()
+
+        XCTAssertTrue(
+            source.contains("guard let service else"),
+            "CartManager.placeAllItems() should fail closed when appCore.partsService is nil instead of treating optional updatePart as a no-op success."
+        )
+        XCTAssertFalse(
+            source.contains("try service?.updatePart"),
+            "Optional chaining on updatePart silently succeeds when partsService is nil, causing unsaved items to be counted as placed."
+        )
+    }
+
+    func testFailedPartUpdateLeavesItemUnplacedAndUserVisible() throws {
+        let source = try Self.readCartManagerSource()
+
+        XCTAssertTrue(
+            source.contains("failedPartIDs.insert(item.id)"),
+            "Thrown updatePart failures should track failed cart item IDs so they remain visible/retryable."
+        )
+        XCTAssertTrue(
+            source.contains("placed.subtract(failedPartIDs)"),
+            "Failed part updates must be removed from the placed set before CartManager updates UI state."
+        )
+        XCTAssertTrue(
+            source.contains("placementError = msg"),
+            "Failed placement attempts should surface actionable error feedback instead of silently clearing/dismissing."
+        )
+    }
+
+    private static func readCartManagerSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Warehouse")
+            .appendingPathComponent("CartManager.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Fail closed when warehouse cart placement includes part items but `appCore.partsService` is unavailable.
- Replace optional `updatePart` persistence with a required service call so no-op persistence cannot count as success.
- Keep failed part updates out of the placed set and surface retryable error feedback while leaving unplaced cart items visible.
- Add regression coverage for GitHub #975 / Paperclip WEI-3584.

## Tests
- RED: `xcodebuild test -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI-899 iPhone 13 mini 375pt,OS=26.4.1' -only-testing:"Weird Parts IOSTests/CartPlacementRegressionTests"` failed before the implementation on the new CartPlacementRegressionTests assertions.
- GREEN: `rm -rf /tmp/wpr2-975-dd && xcodebuild test -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI-899 iPhone 13 mini 375pt,OS=26.4.1' -derivedDataPath /tmp/wpr2-975-dd -only-testing:"Weird Parts IOSTests/CartPlacementRegressionTests"` → `** TEST SUCCEEDED **`

Closes #975
Paperclip: WEI-3584 (parent WEI-3573)
