### PR TITLE
fix: prevent blank QR label sheet pages

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Scanning/QRLabelPrintSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Scanning/QRLabelPrintSheet.swift
@@ -7,9 +7,13 @@ struct UsedStickerPicker: View {
     let grid: LabelGrid
     @Binding var usedPositions: Set<Int>
 
+    private var availablePositionCount: Int {
+        QRLabelPDFGenerator.availableStickerPositionCount(grid: grid, usedPositions: usedPositions)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Tap positions already used on your sheet:")
+            Text("Tap positions already used on your sheet. At least one blank position must remain available for the first page.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -20,7 +24,7 @@ struct UsedStickerPicker: View {
                     Button {
                         if usedPositions.contains(position) {
                             usedPositions.remove(position)
-                        } else {
+                        } else if availablePositionCount > 1 {
                             usedPositions.insert(position)
                         }
                     } label: {
@@ -45,18 +49,18 @@ struct UsedStickerPicker: View {
                     }
                     .buttonStyle(.plain)
                     .frame(minHeight: 30)
+                    .disabled(!usedPositions.contains(position) && availablePositionCount <= 1)
                     .accessibilityLabel(usedPositions.contains(position) ? "Position \(position + 1): Used" : "Position \(position + 1): Available")
+                    .accessibilityHint(!usedPositions.contains(position) && availablePositionCount <= 1 ? "At least one blank sticker position must remain available to print." : "Double tap to toggle whether this sticker position is already used.")
                 }
             }
 
             HStack {
-                Text("\(grid.totalPositions - usedPositions.count) labels will print")
+                Text("\(availablePositionCount) blank positions available on first page")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Spacer()
-                Button("Clear All", role: .destructive) { usedPositions.removeAll() }
-                    .font(.caption)
-                Button("Use All") { usedPositions = Set(0..<grid.totalPositions) }
+                Button("Use Full Sheet") { usedPositions.removeAll() }
                     .font(.caption)
             }
         }
@@ -77,6 +81,10 @@ struct QRLabelPrintSheet: View {
     @State private var usedPositions: Set<Int> = []
     @State private var isPrinting = false
     @State private var printError: String?
+
+    private var isPrintUnavailable: Bool {
+        items.isEmpty || isPrinting || availablePositionsPerPage <= 0
+    }
 
     var body: some View {
         NavigationStack {
@@ -145,8 +153,13 @@ struct QRLabelPrintSheet: View {
                 // Page count estimate
                 Section {
                     let available = availablePositionsPerPage
-                    let pages = available > 0 ? Int(ceil(Double(items.count) / Double(available))) : 1
-                    LabeledContent("Pages to Print", value: "\(pages)")
+                    if available > 0 {
+                        let pages = Int(ceil(Double(items.count) / Double(available)))
+                        LabeledContent("Pages to Print", value: "\(pages)")
+                    } else {
+                        Label("Choose at least one available sticker position before printing.", systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                    }
                 }
 
                 // Error
@@ -173,7 +186,7 @@ struct QRLabelPrintSheet: View {
                             Label("Print", systemImage: "printer")
                         }
                     }
-                    .disabled(items.isEmpty || isPrinting)
+                    .disabled(isPrintUnavailable)
                 }
             }
             .onChange(of: paperSize) {
@@ -260,7 +273,7 @@ struct QRLabelPrintSheet: View {
 
     private var availablePositionsPerPage: Int {
         if let grid = paperSize.labelGrid {
-            return grid.totalPositions - usedPositions.count
+            return QRLabelPDFGenerator.availableStickerPositionCount(grid: grid, usedPositions: usedPositions)
         }
         // Plain paper: auto-calculate
         let pageSize = paperSize.pageSizePoints
@@ -273,6 +286,12 @@ struct QRLabelPrintSheet: View {
     private func printLabels() {
         isPrinting = true
         printError = nil
+
+        guard availablePositionsPerPage > 0 else {
+            printError = "Choose at least one available sticker position before printing."
+            isPrinting = false
+            return
+        }
 
         guard let pdfData = QRLabelPDFGenerator.generatePDF(
             items: items,

--- a/core/Sources/WiredPartCore/QR/QRLabelGenerator.swift
+++ b/core/Sources/WiredPartCore/QR/QRLabelGenerator.swift
@@ -192,6 +192,21 @@ public enum QRLabelLayout: String, CaseIterable, Codable, Sendable {
 
 public struct QRLabelPDFGenerator {
 
+    /// Positions on a sticker sheet that can receive labels after already-used slots are skipped.
+    /// Invalid position indexes are ignored so callers cannot accidentally reduce the first page to
+    /// zero printable labels by carrying stale state between different paper grids.
+    public static func availableStickerPositions(grid: LabelGrid, usedPositions: Set<Int>) -> [(col: Int, row: Int)] {
+        (0..<grid.totalPositions).compactMap { position in
+            guard !usedPositions.contains(position) else { return nil }
+            return (col: position % grid.columns, row: position / grid.columns)
+        }
+    }
+
+    /// Printable label slots available on the first sticker-sheet page.
+    public static func availableStickerPositionCount(grid: LabelGrid, usedPositions: Set<Int>) -> Int {
+        availableStickerPositions(grid: grid, usedPositions: usedPositions).count
+    }
+
     /// Generate a PDF containing labels for the given content items.
     ///
     /// - Parameters:
@@ -209,6 +224,12 @@ public struct QRLabelPDFGenerator {
         paperSize: QRPaperSize,
         usedPositions: Set<Int> = []
     ) -> Data? {
+        if let grid = paperSize.labelGrid,
+           !items.isEmpty,
+           availableStickerPositions(grid: grid, usedPositions: usedPositions).isEmpty {
+            return nil
+        }
+
         #if canImport(UIKit)
         let pdfRenderer = UIGraphicsPDFRenderer(bounds: CGRect(origin: .zero,
                                                                 size: paperSize.pageSizePoints))
@@ -245,15 +266,8 @@ public struct QRLabelPDFGenerator {
         usedPositions: Set<Int>
     ) {
         // Build list of available positions (skip used ones)
-        var availablePositions: [(col: Int, row: Int)] = []
-        for row in 0..<grid.rows {
-            for col in 0..<grid.columns {
-                let pos = row * grid.columns + col
-                if !usedPositions.contains(pos) {
-                    availablePositions.append((col, row))
-                }
-            }
-        }
+        var availablePositions = availableStickerPositions(grid: grid, usedPositions: usedPositions)
+        guard !availablePositions.isEmpty else { return }
 
         var itemIndex = 0
         var posIndex = 0

--- a/core/Tests/WiredPartCoreTests/QRLabelGeneratorTests.swift
+++ b/core/Tests/WiredPartCoreTests/QRLabelGeneratorTests.swift
@@ -1,0 +1,60 @@
+import Testing
+import Foundation
+@testable import WiredPartCore
+
+@Suite("QR Label Generator Tests")
+struct QRLabelGeneratorTests {
+
+    @Test("Sticker sheet exposes every position when no positions are used")
+    func testNoUsedStickerPositionsExposeFullSheet() throws {
+        let grid = try #require(QRPaperSize.avery5160.labelGrid)
+
+        let positions = QRLabelPDFGenerator.availableStickerPositions(grid: grid, usedPositions: [])
+
+        #expect(positions.count == grid.totalPositions)
+        #expect(QRLabelPDFGenerator.availableStickerPositionCount(grid: grid, usedPositions: []) == grid.totalPositions)
+        #expect(positions.first?.col == 0)
+        #expect(positions.first?.row == 0)
+        #expect(positions.last?.col == grid.columns - 1)
+        #expect(positions.last?.row == grid.rows - 1)
+    }
+
+    @Test("Sticker sheet skips only the already-used positions")
+    func testPartialUsedStickerPositionsReduceFirstPageCapacity() throws {
+        let grid = try #require(QRPaperSize.avery5160.labelGrid)
+        let usedPositions: Set<Int> = [0, 1, grid.totalPositions - 1]
+
+        let positions = QRLabelPDFGenerator.availableStickerPositions(grid: grid, usedPositions: usedPositions)
+
+        #expect(positions.count == grid.totalPositions - usedPositions.count)
+        #expect(positions.first?.col == 2)
+        #expect(positions.first?.row == 0)
+        #expect(positions.last?.col == grid.columns - 2)
+        #expect(positions.last?.row == grid.rows - 1)
+    }
+
+    @Test("Sticker sheet reports no printable positions when every position is already used")
+    func testAllUsedStickerPositionsAreRejected() throws {
+        let grid = try #require(QRPaperSize.avery5160.labelGrid)
+        let usedPositions = Set(0..<grid.totalPositions)
+        let item = QRLabelContent(entityType: .part, entityId: 1, code: "PART-001", title: "Part 001")
+
+        #expect(QRLabelPDFGenerator.availableStickerPositionCount(grid: grid, usedPositions: usedPositions) == 0)
+        #expect(QRLabelPDFGenerator.availableStickerPositions(grid: grid, usedPositions: usedPositions).isEmpty)
+        #expect(QRLabelPDFGenerator.generatePDF(
+            items: [item],
+            labelSize: .standard,
+            layout: .qrLeft,
+            paperSize: .avery5160,
+            usedPositions: usedPositions
+        ) == nil)
+    }
+
+    @Test("Sticker sheet ignores invalid used-position indexes")
+    func testInvalidUsedStickerPositionsDoNotReducePrintableCapacity() throws {
+        let grid = try #require(QRPaperSize.avery5160.labelGrid)
+        let usedPositions: Set<Int> = [-1, grid.totalPositions, grid.totalPositions + 10]
+
+        #expect(QRLabelPDFGenerator.availableStickerPositionCount(grid: grid, usedPositions: usedPositions) == grid.totalPositions)
+    }
+}


### PR DESCRIPTION
## Summary
- Prevent sticker-sheet QR label printing from proceeding when every first-page position is already marked used.
- Replace the ambiguous `Use All` helper with clear first-page availability wording and a `Use Full Sheet` action.
- Share sticker-position availability logic between the SwiftUI sheet and PDF generator so page count, disabled Print state, and generation guard agree.
- Add regression coverage for none-used, partially-used, all-used, and invalid used-position indexes.

Closes #973.
Paperclip: WEI-3588 (parent WEI-3573).

## Test Plan
- [x] `swift test --filter QRLabelGeneratorTests` — 4 tests passed.
- [x] `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED.

## Notes
- The iOS Simulator generic build was attempted first but exceeded the 600s local timeout after compiling the touched QR files without errors; the device generic build completed successfully with signing disabled.
