### PR TITLE
fix: restore warehouse settings setup reachability

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Auth/ModuleTourView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/ModuleTourView.swift
@@ -19,9 +19,17 @@ struct ModuleTourView: View {
 
     var body: some View {
         // Only show after welcome is dismissed, and only once
-        if hasSeenWelcome && !hasSeenTour {
+        if hasSeenWelcome && !hasSeenTour && !shouldSuppressForUITestFixture {
             tourOverlay
         }
+    }
+
+    private var shouldSuppressForUITestFixture: Bool {
+        let args = ProcessInfo.processInfo.arguments
+        return args.contains("-UITesting") &&
+            (args.contains("-UITestingWarehouseLocations") ||
+             args.contains("-UITestingWarehouseDashboard") ||
+             args.contains("-UITestingWEI936AutoLogin"))
     }
 
     private var tourOverlay: some View {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseSettingsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseSettingsPage.swift
@@ -116,11 +116,20 @@ struct IOSWarehouseSettingsPage: View {
                 }
             }
 
+            if !appCore.hasPermission("manage_warehouse") {
+                Section("Settings Management") {
+                    Text("Warehouse setup wizards are available above. Advanced location, stock, movement, and audit settings require warehouse management permission.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             // Default locations
             Section("Default Locations") {
                 TextField("Receiving Location", text: $defaultReceivingLocation)
                 TextField("Staging Location", text: $defaultStagingLocation)
             }
+            .hideWithoutPermission("manage_warehouse")
 
             // Stock thresholds
             Section {
@@ -135,6 +144,7 @@ struct IOSWarehouseSettingsPage: View {
             } footer: {
                 Text("Parts below the low stock threshold will be flagged. Critical threshold triggers urgent alerts.")
             }
+            .hideWithoutPermission("manage_warehouse")
 
             // Movement policies
             Section {
@@ -150,6 +160,7 @@ struct IOSWarehouseSettingsPage: View {
             } footer: {
                 Text("Controls how warehouse movements are validated and approved.")
             }
+            .hideWithoutPermission("manage_warehouse")
 
             // Audit settings
             Section {
@@ -160,6 +171,7 @@ struct IOSWarehouseSettingsPage: View {
             } footer: {
                 Text("Configure how often audits should occur and what evidence is required.")
             }
+            .hideWithoutPermission("manage_warehouse")
 
             // Save
             Section {
@@ -180,6 +192,7 @@ struct IOSWarehouseSettingsPage: View {
                 }
                 .disabled(isSaving)
             }
+            .hideWithoutPermission("manage_warehouse")
         }
         .scrollDismissesKeyboard(.interactively)
     }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
@@ -44,6 +44,7 @@ struct WarehouseDashboardPage: View {
         case qrScanner
         case onboardingWizard
         case partsFlowWizard
+        case warehouseSettings
         case cartSheet
         case help
 
@@ -135,6 +136,11 @@ struct WarehouseDashboardPage: View {
         case .partsFlowWizard:
             PartsFlowWizard()
                 .environmentObject(appCore)
+        case .warehouseSettings:
+            NavigationStack {
+                IOSWarehouseSettingsPage()
+                    .environmentObject(appCore)
+            }
         case .cartSheet:
             CartSheetView(cartManager: cartManager)
                 .environmentObject(appCore)
@@ -237,6 +243,19 @@ struct WarehouseDashboardPage: View {
                         }
                         .buttonStyle(.plain)
                     }
+
+                    Button { activeSheet = .warehouseSettings } label: {
+                        Text("Warehouse Settings")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .padding(.horizontal, 14)
+                            .frame(minHeight: 44)
+                            .background(Color(.secondarySystemGroupedBackground))
+                            .foregroundStyle(.primary)
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("whAction_warehouseSettings")
 
                     Spacer()
                 }

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
@@ -111,7 +111,7 @@ let appModules: [AppModule] = [
         AppTab(id: "warehouse-tools", label: "Tools", icon: "wrench.and.screwdriver.fill", path: "/warehouse/tools"),
         AppTab(id: "warehouse-leaderboard", label: "Leaderboard", icon: "trophy.fill", path: "/warehouse/leaderboard", permission: "manage_warehouse"),
         AppTab(id: "warehouse-network", label: "Network", icon: "antenna.radiowaves.left.and.right", path: "/warehouse/network", permission: "manage_devices"),
-        AppTab(id: "warehouse-settings", label: "Settings", icon: "gearshape.fill", path: "/warehouse/settings", permission: "manage_warehouse"),
+        AppTab(id: "warehouse-settings", label: "Settings", icon: "gearshape.fill", path: "/warehouse/settings"),
     ], permission: "view_warehouse"),
     // 6. Orders — JPOs, POs, procurement
     AppModule(id: "orders", label: "Orders", icon: "cart.fill", tabs: [

--- a/Weird Parts IOS/Weird Parts IOSTests/WarehouseTabStripRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WarehouseTabStripRegressionTests.swift
@@ -1,6 +1,16 @@
 import XCTest
 
 final class WarehouseTabStripRegressionTests: XCTestCase {
+    func testWarehouseSettingsTabIsReachableForWarehouseDashboardSetupQA() throws {
+        let source = try Self.readNavigationConfigSource()
+        let settingsTab = try Self.lineContaining("id: \"warehouse-settings\"", in: source)
+
+        XCTAssertFalse(
+            settingsTab.contains("permission: \"manage_warehouse\""),
+            "Warehouse Settings must stay reachable to view_warehouse users so QA can open the Warehouse Setup section and both setup wizards."
+        )
+    }
+
     func testModuleHostSubTabPickerAutoScrollsToSelectedTab() throws {
         let source = try Self.readIOSMainViewSource()
 
@@ -21,6 +31,28 @@ final class WarehouseTabStripRegressionTests: XCTestCase {
             source.contains(".id(tab.id)"),
             "Sub-tab chips should provide stable IDs so ScrollViewReader can target the selected tab."
         )
+    }
+
+    private static func lineContaining(_ needle: String, in source: String) throws -> String {
+        guard let line = source.split(separator: "\n").first(where: { $0.contains(needle) }) else {
+            XCTFail("Missing expected source line containing \(needle)")
+            return ""
+        }
+        return String(line)
+    }
+
+    private static func readNavigationConfigSource(
+        file: StaticString = #filePath
+    ) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Navigation")
+            .appendingPathComponent("NavigationConfig.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
     }
 
     private static func readIOSMainViewSource(

--- a/Weird Parts IOS/Weird Parts IOSUITests/WarehouseDashboardScreenshotUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/WarehouseDashboardScreenshotUITests.swift
@@ -30,6 +30,37 @@ final class WarehouseDashboardScreenshotUITests: XCTestCase {
         try writeScreenshot(app.screenshot())
     }
 
+    @MainActor
+    func testWarehouseSettingsSetupSectionIsReachableFromDashboard() throws {
+        let app = XCUIApplication()
+        app.launchEnvironment["WEIRD_PARTS_UI_TEST_PIN"] = Self.uiTestingPIN
+        app.launchArguments += [
+            "-UITesting",
+            "-UITestingWEI936AutoLogin",
+            "-UITestingDispatchBoard",
+            "-UITestingWarehouseDashboard",
+        ]
+        app.launch()
+
+        navigateToWarehouse(in: app)
+        openWarehouseSettingsFromDashboard(in: app)
+
+        XCTAssertTrue(
+            app.staticTexts["Warehouse Setup"].waitForExistence(timeout: 10),
+            "Warehouse Settings page should be reachable from the Warehouse dashboard and show the setup section"
+        )
+        XCTAssertTrue(
+            app.buttons["Floor Plan Setup Wizard"].waitForExistence(timeout: 5)
+                || app.staticTexts["Floor Plan Setup Wizard"].waitForExistence(timeout: 5),
+            "Warehouse setup should expose Floor Plan Setup Wizard"
+        )
+        XCTAssertTrue(
+            app.buttons["Parts-First Setup"].waitForExistence(timeout: 5)
+                || app.staticTexts["Parts-First Setup"].waitForExistence(timeout: 5),
+            "Warehouse setup should expose Parts-First Setup"
+        )
+    }
+
     private func assertKPIExists(
         in app: XCUIApplication,
         identifier: String,
@@ -105,6 +136,45 @@ final class WarehouseDashboardScreenshotUITests: XCTestCase {
         let dashboardSubtab = app.buttons["subtab_warehouse-dashboard"].firstMatch
         if dashboardSubtab.waitForExistence(timeout: timeout) {
             dashboardSubtab.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+            return true
+        }
+
+        return false
+    }
+
+    private func openWarehouseSettingsFromDashboard(in app: XCUIApplication) {
+        let setupBannerSettings = app.buttons["whAction_warehouseSettings"].firstMatch
+        let bannerDeadline = Date().addingTimeInterval(8)
+        while setupBannerSettings.exists && !setupBannerSettings.isHittable && Date() < bannerDeadline {
+            app.swipeUp()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        }
+        if setupBannerSettings.exists && setupBannerSettings.isHittable {
+            setupBannerSettings.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+            return
+        }
+
+        let settingsLink = app.buttons["whSubPage_warehouse-settings"].firstMatch
+        let deadline = Date().addingTimeInterval(12)
+        while (!settingsLink.exists || !settingsLink.isHittable), Date() < deadline {
+            app.swipeUp()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        }
+
+        if settingsLink.exists && settingsLink.isHittable {
+            settingsLink.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        } else {
+            XCTAssertTrue(
+                openWarehouseSettingsSubtab(in: app, timeout: 5),
+                "Warehouse Settings should be reachable from dashboard links or the warehouse subtab strip"
+            )
+        }
+    }
+
+    private func openWarehouseSettingsSubtab(in app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        let settingsSubtab = app.buttons["subtab_warehouse-settings"].firstMatch
+        if settingsSubtab.waitForExistence(timeout: timeout) {
+            settingsSubtab.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
             return true
         }
 


### PR DESCRIPTION
## Summary
- Makes Warehouse Settings reachable for view_warehouse users by removing the extra manage_warehouse tab gate while keeping advanced editable settings hidden unless the user has manage_warehouse.
- Adds a visible 44pt Warehouse Settings entry from the setup banner so the not-configured warehouse dashboard has a reliable user-like path into the setup section.
- Suppresses the legacy module-tour overlay for the WEI936/Warehouse UI-test fixture so automation can interact with the page, matching the existing welcome-overlay suppression.
- Adds regression coverage for the tab permission gate and the phone user-like dashboard → settings → setup wizard flow.

## Verification
- `python3` static RED check confirmed the prior `warehouse-settings` tab line still had `permission: "manage_warehouse"` before the fix.
- `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI936-QA-iPhone-13-mini,OS=26.4.1' -only-testing:"Weird PartsUITests/WarehouseDashboardScreenshotUITests/testWarehouseSettingsSetupSectionIsReachableFromDashboard" test` — passed.
- `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI936-QA-iPhone-13-mini,OS=26.4.1' -only-testing:"Weird Parts IOSTests/WarehouseTabStripRegressionTests/testWarehouseSettingsTabIsReachableForWarehouseDashboardSetupQA" test` — passed.
- `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'generic/platform=iOS Simulator' build` — passed.

Closes #1013
Tracked in WEI-3599.
