### PR TITLE
fix: validate job stage template alert names

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSJobStageTemplatesSettingsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSJobStageTemplatesSettingsPage.swift
@@ -31,6 +31,22 @@ struct IOSJobStageTemplatesSettingsPage: View {
         templates.first(where: { $0.id == selectedTemplateId })
     }
 
+    private var trimmedNewTemplateName: String {
+        newTemplateName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedRenameTemplateName: String {
+        renameTemplateName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedDuplicateTemplateName: String {
+        duplicateTemplateName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canCreateTemplate: Bool { !trimmedNewTemplateName.isEmpty }
+    private var canRenameTemplate: Bool { !trimmedRenameTemplateName.isEmpty }
+    private var canDuplicateTemplate: Bool { !trimmedDuplicateTemplateName.isEmpty }
+
     var body: some View {
         Group {
             if isLoading {
@@ -66,20 +82,36 @@ struct IOSJobStageTemplatesSettingsPage: View {
         }
         .alert("Create Template", isPresented: $showingCreateTemplate) {
             TextField("Template name", text: $newTemplateName)
+                .textInputAutocapitalization(.words)
             Button("Create") { createTemplate() }
+                .disabled(!canCreateTemplate)
             Button("Cancel", role: .cancel) { }
         } message: {
-            Text("Creates a workflow with three starter stages. Rename, add, remove, or reorder stages after it is created.")
+            Text(canCreateTemplate
+                ? "Creates a workflow with three starter stages. Rename, add, remove, or reorder stages after it is created."
+                : "Enter a template name before creating this workflow.")
         }
         .alert("Duplicate Template", isPresented: $showingDuplicateTemplate) {
             TextField("New template name", text: $duplicateTemplateName)
+                .textInputAutocapitalization(.words)
             Button("Duplicate") { duplicateTemplate() }
+                .disabled(!canDuplicateTemplate)
             Button("Cancel", role: .cancel) { }
+        } message: {
+            Text(canDuplicateTemplate
+                ? "Creates a copy of the selected workflow using this new template name."
+                : "Enter a new template name before duplicating this workflow.")
         }
         .alert("Rename Template", isPresented: $showingRenameTemplate) {
             TextField("Template name", text: $renameTemplateName)
+                .textInputAutocapitalization(.words)
             Button("Rename") { renameTemplate() }
+                .disabled(!canRenameTemplate)
             Button("Cancel", role: .cancel) { }
+        } message: {
+            Text(canRenameTemplate
+                ? "Renames the selected workflow template. Existing jobs keep their current stage data."
+                : "Enter a template name before renaming this workflow.")
         }
         .confirmationDialog(
             "Archive this template?",
@@ -288,12 +320,14 @@ struct IOSJobStageTemplatesSettingsPage: View {
             errorMessage = "Jobs service unavailable"
             return
         }
+        guard canCreateTemplate else { return }
+        let templateName = trimmedNewTemplateName
         do {
             let templateId = try service.createJobStageTemplate(
-                name: newTemplateName,
+                name: templateName,
                 stageNames: ["Rough-In", "Trim", "Final"]
             )
-            successMessage = "Created \(newTemplateName.trimmingCharacters(in: .whitespacesAndNewlines))."
+            successMessage = "Created \(templateName)."
             errorMessage = nil
             loadTemplates(select: templateId)
         } catch {
@@ -308,8 +342,10 @@ struct IOSJobStageTemplatesSettingsPage: View {
 
     private func renameTemplate() {
         guard let service = appCore.jobsService, let selectedTemplateId else { return }
+        guard canRenameTemplate else { return }
+        let templateName = trimmedRenameTemplateName
         do {
-            try service.renameJobStageTemplate(templateId: selectedTemplateId, name: renameTemplateName)
+            try service.renameJobStageTemplate(templateId: selectedTemplateId, name: templateName)
             successMessage = "Renamed template."
             errorMessage = nil
             loadTemplates(select: selectedTemplateId)
@@ -325,8 +361,10 @@ struct IOSJobStageTemplatesSettingsPage: View {
 
     private func duplicateTemplate() {
         guard let service = appCore.jobsService, let selectedTemplateId else { return }
+        guard canDuplicateTemplate else { return }
+        let templateName = trimmedDuplicateTemplateName
         do {
-            let newId = try service.duplicateJobStageTemplate(templateId: selectedTemplateId, name: duplicateTemplateName)
+            let newId = try service.duplicateJobStageTemplate(templateId: selectedTemplateId, name: templateName)
             successMessage = "Duplicated template."
             errorMessage = nil
             loadTemplates(select: newId)

--- a/Weird Parts IOS/Weird Parts IOSTests/SettingsSaveButtonValidationTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SettingsSaveButtonValidationTests.swift
@@ -136,6 +136,50 @@ final class SettingsSaveButtonValidationTests: XCTestCase {
         )
     }
 
+    // MARK: - IOSJobStageTemplatesSettingsPage
+
+    func testJobStageTemplateAlertsRejectBlankNamesBeforeDismissal() throws {
+        let source = try Self.readSettingsSource("IOSJobStageTemplatesSettingsPage.swift")
+
+        XCTAssertTrue(
+            source.contains("private var trimmedNewTemplateName: String") &&
+                source.contains("private var trimmedRenameTemplateName: String") &&
+                source.contains("private var trimmedDuplicateTemplateName: String"),
+            "Job stage template alerts should centralize whitespace-trimmed names for create, rename, and duplicate actions."
+        )
+        XCTAssertTrue(
+            source.contains("private var canCreateTemplate: Bool { !trimmedNewTemplateName.isEmpty }") &&
+                source.contains("private var canRenameTemplate: Bool { !trimmedRenameTemplateName.isEmpty }") &&
+                source.contains("private var canDuplicateTemplate: Bool { !trimmedDuplicateTemplateName.isEmpty }"),
+            "Job stage template alerts should expose validity flags so blank names cannot be submitted."
+        )
+        XCTAssertTrue(
+            source.contains("Button(\"Create\") { createTemplate() }\n                .disabled(!canCreateTemplate)") &&
+                source.contains("Button(\"Duplicate\") { duplicateTemplate() }\n                .disabled(!canDuplicateTemplate)") &&
+                source.contains("Button(\"Rename\") { renameTemplate() }\n                .disabled(!canRenameTemplate)"),
+            "Create, duplicate, and rename alert actions should stay disabled while their names are blank or whitespace-only."
+        )
+        XCTAssertTrue(
+            source.contains("Enter a template name before creating this workflow.") &&
+                source.contains("Enter a new template name before duplicating this workflow.") &&
+                source.contains("Enter a template name before renaming this workflow."),
+            "Each alert should provide visible validation copy instead of dismissing to a hidden page-level error."
+        )
+        XCTAssertTrue(
+            source.contains("guard canCreateTemplate else { return }") &&
+                source.contains("guard canRenameTemplate else { return }") &&
+                source.contains("guard canDuplicateTemplate else { return }"),
+            "Template actions should keep defensive guards so invalid names never reach JobsService."
+        )
+        XCTAssertTrue(
+            source.contains("name: templateName") &&
+                source.contains("let templateName = trimmedNewTemplateName") &&
+                source.contains("let templateName = trimmedRenameTemplateName") &&
+                source.contains("let templateName = trimmedDuplicateTemplateName"),
+            "Template actions should pass trimmed names to JobsService after validation."
+        )
+    }
+
     // MARK: - IOSAuditSettingsPage
 
     func testAuditSettingsPageHasBothIsDirtyAndValidSettingsGuard() throws {


### PR DESCRIPTION
## Summary
- Disables Create, Duplicate, and Rename alert submit buttons while job stage template names are blank or whitespace-only.
- Adds visible alert validation copy so the user stays in the edit context instead of dismissing to a hidden page-level error.
- Trims template names before calling `JobsService`, with defensive guards for all three actions.
- Adds a regression test covering the alert validation guards/copy/trimmed service calls.

Closes #1001

## Tests
- [x] `xcodebuild test -quiet -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/wei3577-derived-1781473887 -only-testing:'Weird Parts IOSTests/SettingsSaveButtonValidationTests/testJobStageTemplateAlertsRejectBlankNamesBeforeDismissal'`
- [x] `git diff --check`
- [x] diff conflict/secret scan

## CI / local runner path
This iOS UI fix is intended for the repo's local Mac runner path when CI runs: `[self-hosted, macOS, ARM64, xcode, ios, local-mac]`.
