### PR TITLE
fix: improve panel schedule circuit accessibility

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
@@ -10,6 +10,32 @@ import WiredPartCore
 struct WiredPartIOSApp: App {
     @StateObject private var appCore = AppCore()
     @StateObject private var tabPrefs = TabBarPreferences()
+    @State private var uiTestingPanelSchedule = PanelSchedule(
+        panelName: "QA Panel A",
+        panelType: .loadCenter,
+        totalSpaces: 8,
+        mainBreakerAmps: 200,
+        voltage: 240,
+        phase: 1,
+        location: "Shop east wall",
+        circuits: [
+            CircuitEntry(
+                spaceNumber: 1,
+                breakerAmps: 20,
+                breakerType: .single,
+                circuitDescription: "Office lighting",
+                isSpare: false,
+                isFedFrom: "MDP"
+            ),
+            CircuitEntry(
+                spaceNumber: 2,
+                breakerAmps: 30,
+                breakerType: .double,
+                circuitDescription: "Compressor",
+                isSpare: false
+            ),
+        ]
+    )
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @AppStorage("hasCompletedCompanySetup") private var hasCompletedCompanySetup = false
     @AppStorage("hasSeenOnboardAIMVPEntry") private var hasSeenOnboardAIMVPEntry = false
@@ -54,6 +80,10 @@ struct WiredPartIOSApp: App {
         ProcessInfo.processInfo.arguments.contains("-UITestingWEI3144JobMaterials")
     }
 
+    private var shouldShowPanelScheduleFixture: Bool {
+        ProcessInfo.processInfo.arguments.contains("-UITestingPanelScheduleBuilderFixture")
+    }
+
     private var stage8ReportsUITestTarget: Stage8ReportsUITestTarget? {
         Stage8ReportsUITestTarget(processArguments: ProcessInfo.processInfo.arguments)
     }
@@ -85,7 +115,15 @@ struct WiredPartIOSApp: App {
     var body: some Scene {
         WindowGroup {
             Group {
-                if shouldShowWEI3140ImportPreviewFixture {
+                if shouldShowPanelScheduleFixture {
+                    NavigationStack {
+                        PanelScheduleBuilder(schedule: $uiTestingPanelSchedule) { saved in
+                            uiTestingPanelSchedule = saved
+                        }
+                        .navigationTitle("Panel Schedule")
+                        .navigationBarTitleDisplayMode(.inline)
+                    }
+                } else if shouldShowWEI3140ImportPreviewFixture {
                     #if DEBUG
                     WEI3140ImportPreviewFixtureView()
                     #else

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
@@ -107,7 +107,8 @@ struct PanelScheduleBuilder: View {
 
                     Rectangle()
                         .fill(.gray)
-                        .frame(width: 4, height: 36)
+                        .frame(width: 4, height: 44)
+                        .accessibilityHidden(true)
 
                     circuitCell(spaceNumber: rightSpace, circuit: rightCircuit, isLeft: false)
                 }
@@ -148,10 +149,48 @@ struct PanelScheduleBuilder: View {
             }
             .padding(.horizontal, 4)
             .padding(.vertical, 6)
-            .frame(height: 36)
+            .frame(minHeight: 44)
             .background(circuitBackground(circuit))
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(circuitAccessibilityLabel(spaceNumber: spaceNumber, circuit: circuit))
+        .accessibilityValue(circuitAccessibilityValue(circuit))
+        .accessibilityHint("Opens the editor for circuit \(spaceNumber).")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private func circuitDisplayName(_ circuit: CircuitEntry?) -> String {
+        let description = circuit?.circuitDescription.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return description.isEmpty ? "SPARE" : description
+    }
+
+    private func circuitAccessibilityLabel(spaceNumber: Int, circuit: CircuitEntry?) -> String {
+        "Circuit \(spaceNumber), \(circuitDisplayName(circuit))"
+    }
+
+    private func circuitAccessibilityValue(_ circuit: CircuitEntry?) -> String {
+        guard let circuit, !circuit.isSpare else {
+            return "Spare circuit, no breaker assigned"
+        }
+
+        var details: [String] = []
+        if let amps = circuit.breakerAmps {
+            details.append("\(amps) amp")
+        } else {
+            details.append("No amp rating")
+        }
+        details.append("\(circuit.breakerType.rawValue) breaker")
+
+        let description = circuit.circuitDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !description.isEmpty {
+            details.append(description)
+        }
+        if let fedFrom = circuit.isFedFrom?.trimmingCharacters(in: .whitespacesAndNewlines), !fedFrom.isEmpty {
+            details.append("fed from \(fedFrom)")
+        }
+        return details.joined(separator: ", ")
     }
 
     private func circuitBackground(_ circuit: CircuitEntry?) -> Color {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
@@ -119,10 +119,7 @@ struct PanelScheduleBuilder: View {
 
     private func circuitCell(spaceNumber: Int, circuit: CircuitEntry?, isLeft: Bool) -> some View {
         Button {
-            selectedCircuit = circuit ?? CircuitEntry(
-                spaceNumber: spaceNumber
-            )
-            activeSheet = .circuitEditor
+            openCircuitEditor(spaceNumber: spaceNumber, circuit: circuit)
         } label: {
             HStack(spacing: 2) {
                 if isLeft {
@@ -154,11 +151,15 @@ struct PanelScheduleBuilder: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityElement(children: .ignore)
         .accessibilityLabel(circuitAccessibilityLabel(spaceNumber: spaceNumber, circuit: circuit))
         .accessibilityValue(circuitAccessibilityValue(circuit))
         .accessibilityHint("Opens the editor for circuit \(spaceNumber).")
-        .accessibilityAddTraits(.isButton)
+        .accessibilityIdentifier("panel-schedule-circuit-\(spaceNumber)")
+    }
+
+    private func openCircuitEditor(spaceNumber: Int, circuit: CircuitEntry?) {
+        selectedCircuit = circuit ?? CircuitEntry(spaceNumber: spaceNumber)
+        activeSheet = .circuitEditor
     }
 
     private func circuitDisplayName(_ circuit: CircuitEntry?) -> String {

--- a/Weird Parts IOS/Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests.swift
@@ -25,12 +25,17 @@ final class PanelScheduleBuilderAccessibilityTests: XCTestCase {
             source.contains(".contentShape(Rectangle())"),
             "The full 44pt row should be tappable, not just visible text."
         )
+        XCTAssertFalse(
+            source.contains(".accessibilityElement(children: .ignore)"),
+            "Do not wrap the Button in a separate explicit accessibility element; XCTest taps can hit that wrapper without firing the button action."
+        )
         XCTAssertTrue(
-            source.contains(".accessibilityElement(children: .ignore)") &&
+            source.contains("openCircuitEditor(spaceNumber: spaceNumber, circuit: circuit)") &&
                 source.contains(".accessibilityLabel(circuitAccessibilityLabel(spaceNumber: spaceNumber, circuit: circuit))") &&
                 source.contains(".accessibilityValue(circuitAccessibilityValue(circuit))") &&
-                source.contains(".accessibilityHint(\"Opens the editor for circuit \\(spaceNumber).\")"),
-            "Each circuit button should expose a single label/value/hint that explains it opens the editor."
+                source.contains(".accessibilityHint(\"Opens the editor for circuit \\(spaceNumber).\")") &&
+                source.contains(".accessibilityIdentifier(\"panel-schedule-circuit-\\(spaceNumber)\")"),
+            "Each real circuit button should expose label/value/hint/identifier directly while preserving its editor action."
         )
         XCTAssertTrue(
             source.contains("private func circuitAccessibilityLabel(spaceNumber: Int, circuit: CircuitEntry?) -> String") &&

--- a/Weird Parts IOS/Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+/// Regression coverage for GitHub #998 / WEI-3578.
+///
+/// Panel schedule circuit rows are touch/edit controls in dense field documentation.
+/// They must keep a 44pt target and expose a single meaningful accessibility element
+/// instead of fragmented text from the row labels.
+final class PanelScheduleBuilderAccessibilityTests: XCTestCase {
+    func testCircuitCellsExposeMinimumTargetAndEditorAccessibility() throws {
+        let source = try Self.readNotebookSource("PanelScheduleBuilder.swift")
+
+        XCTAssertFalse(
+            source.contains(".frame(height: 36)"),
+            "Circuit cells must not use the old 36pt tap target."
+        )
+        XCTAssertTrue(
+            source.contains(".frame(minHeight: 44)"),
+            "Circuit cells should provide at least a 44pt tap target while preserving dense row content."
+        )
+        XCTAssertTrue(
+            source.contains(".frame(width: 4, height: 44)"),
+            "The center separator should match the expanded 44pt circuit-row height."
+        )
+        XCTAssertTrue(
+            source.contains(".contentShape(Rectangle())"),
+            "The full 44pt row should be tappable, not just visible text."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityElement(children: .ignore)") &&
+                source.contains(".accessibilityLabel(circuitAccessibilityLabel(spaceNumber: spaceNumber, circuit: circuit))") &&
+                source.contains(".accessibilityValue(circuitAccessibilityValue(circuit))") &&
+                source.contains(".accessibilityHint(\"Opens the editor for circuit \\(spaceNumber).\")"),
+            "Each circuit button should expose a single label/value/hint that explains it opens the editor."
+        )
+        XCTAssertTrue(
+            source.contains("private func circuitAccessibilityLabel(spaceNumber: Int, circuit: CircuitEntry?) -> String") &&
+                source.contains("\"Circuit \\(spaceNumber), \\(circuitDisplayName(circuit))\"") &&
+                source.contains("private func circuitAccessibilityValue(_ circuit: CircuitEntry?) -> String"),
+            "PanelScheduleBuilder should build explicit accessible names and values for empty and populated circuits."
+        )
+        XCTAssertTrue(
+            source.contains("Spare circuit, no breaker assigned") &&
+                source.contains("\\(amps) amp") &&
+                source.contains("\\(circuit.breakerType.rawValue) breaker") &&
+                source.contains("fed from \\(fedFrom)"),
+            "Accessibility values should distinguish spare circuits from populated circuits and include useful breaker/source context."
+        )
+    }
+
+    private static func readNotebookSource(_ filename: String, file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Notebooks")
+            .appendingPathComponent(filename)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -144,6 +144,42 @@ final class Weird_Parts_IOSUITests: XCTestCase {
         app = nil
     }
 
+    // MARK: - Panel Schedule Accessibility
+
+    @MainActor
+    func testPanelScheduleAccessibleCircuitButtonOpensEditor() throws {
+        relaunchForPanelScheduleBuilderFixture()
+
+        let accessibleCircuit = app.buttons["Circuit 1, Office lighting"]
+        XCTAssertTrue(
+            accessibleCircuit.waitForExistence(timeout: 20),
+            "Panel schedule fixture should expose populated circuit 1 as the user-facing accessibility button."
+        )
+        XCTAssertFalse(
+            app.buttons["1, 20, Office lighting"].exists,
+            "The visible row text must not remain as a nested second button competing with the accessible circuit control."
+        )
+
+        accessibleCircuit.tap()
+
+        XCTAssertTrue(
+            app.navigationBars["Circuit 1"].waitForExistence(timeout: 5) || app.staticTexts["Circuit 1"].waitForExistence(timeout: 5),
+            "Tapping the accessible circuit control should open the same circuit editor as a visual/user tap."
+        )
+        XCTAssertTrue(
+            app.textFields["Description (e.g. Kitchen Outlets)"].waitForExistence(timeout: 5),
+            "Circuit editor should show the description field after the accessible button is activated."
+        )
+    }
+
+    private func relaunchForPanelScheduleBuilderFixture() {
+        app?.terminate()
+        app = XCUIApplication()
+        configureUITestingEnvironment(app)
+        app.launchArguments += ["-UITestingPanelScheduleBuilderFixture"]
+        app.launch()
+    }
+
     // MARK: - Login Accessibility
 
 


### PR DESCRIPTION
## Summary
- Expands panel schedule circuit edit controls from the old 36pt row height to a minimum 44pt touch target.
- Keeps the full row tappable with a rectangular content shape and hides the center separator from accessibility.
- Adds explicit accessibility label, value, hint, and button trait for empty/spare and populated circuit rows, including breaker/source context.
- Adds a focused regression test for the 44pt target and accessibility label/value/hint contract.

Closes #998
Paperclip: WEI-3578; QA follow-up: WEI-3582

## Tests
- [x] `xcodebuild test -quiet -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/wei3578-derived-1781474403 -only-testing:'Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests/testCircuitCellsExposeMinimumTargetAndEditorAccessibility'`
- [x] `git diff --cached --check`
- [x] staged diff conflict/secret scan

## CI / local runner path
This iOS accessibility fix is intended for the repo's local Mac runner path when CI runs: `[self-hosted, macOS, ARM64, xcode, ios, local-mac]`.

## Verification note
Static regression coverage is included here; user-like UI/AX verification remains routed through Paperclip QA issue WEI-3582.
