### PR TITLE
fix: surface dispatch sheet load failures

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateDispatchSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateDispatchSheet.swift
@@ -1,6 +1,47 @@
 import SwiftUI
 import WiredPartCore
 
+public struct DispatchSheetLoadData {
+    public let jobs: [JobsService.JobListItem]
+    public let employees: [PeopleService.EmployeeListItem]
+    public let jobLoadError: String?
+    public let employeeLoadError: String?
+
+    public var hasLoadFailure: Bool {
+        jobLoadError != nil || employeeLoadError != nil
+    }
+
+    public static func load(
+        jobsProvider: () throws -> [JobsService.JobListItem],
+        employeesProvider: () throws -> [PeopleService.EmployeeListItem],
+        errorFormatter: (Error, String) -> String
+    ) -> DispatchSheetLoadData {
+        var loadedJobs: [JobsService.JobListItem] = []
+        var loadedEmployees: [PeopleService.EmployeeListItem] = []
+        var jobError: String?
+        var employeeError: String?
+
+        do {
+            loadedJobs = try jobsProvider()
+        } catch {
+            jobError = errorFormatter(error, "load active jobs")
+        }
+
+        do {
+            loadedEmployees = try employeesProvider()
+        } catch {
+            employeeError = errorFormatter(error, "load employees")
+        }
+
+        return DispatchSheetLoadData(
+            jobs: loadedJobs,
+            employees: loadedEmployees,
+            jobLoadError: jobError,
+            employeeLoadError: employeeError
+        )
+    }
+}
+
 /// Sheet for creating a new dispatch entry.
 struct CreateDispatchSheet: View {
     @EnvironmentObject private var appCore: AppCore
@@ -15,13 +56,18 @@ struct CreateDispatchSheet: View {
     @State private var selectedUserId: Int64?
     @State private var notes = ""
     @State private var isSaving = false
+    @State private var isLoadingData = false
     @State private var saveError: String?
+    @State private var jobLoadError: String?
+    @State private var employeeLoadError: String?
 
     var body: some View {
         NavigationStack {
             Form {
                 Section("Employee") {
-                    if employees.isEmpty {
+                    if let employeeLoadError {
+                        loadFailureRow(message: employeeLoadError, retryLabel: "Retry loading employees")
+                    } else if employees.isEmpty {
                         Text("No employees found")
                             .foregroundStyle(.secondary)
                     } else {
@@ -35,7 +81,9 @@ struct CreateDispatchSheet: View {
                 }
 
                 Section("Job") {
-                    if jobs.isEmpty {
+                    if let jobLoadError {
+                        loadFailureRow(message: jobLoadError, retryLabel: "Retry loading jobs")
+                    } else if jobs.isEmpty {
                         Text("No active jobs")
                             .foregroundStyle(.secondary)
                     } else {
@@ -74,10 +122,11 @@ struct CreateDispatchSheet: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Create") { saveDispatch() }
-                        .disabled(selectedJobId == nil || selectedUserId == nil || isSaving)
+                        .disabled(selectedJobId == nil || selectedUserId == nil || isSaving || isLoadingData)
                         .fontWeight(.semibold)
                 }
             }
@@ -85,12 +134,58 @@ struct CreateDispatchSheet: View {
         }
     }
 
-    private func loadData() {
-        if let jobService = appCore.jobsService {
-            jobs = (try? jobService.listJobs(status: "active", limit: 200)) ?? []
+    @ViewBuilder
+    private func loadFailureRow(message: String, retryLabel: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Unable to load", systemImage: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+                .font(.subheadline.weight(.semibold))
+            Text(message)
+                .foregroundStyle(.secondary)
+                .font(.caption)
+            Button {
+                loadData()
+            } label: {
+                Label("Retry", systemImage: "arrow.clockwise")
+            }
+            .buttonStyle(.bordered)
+            .accessibilityLabel(retryLabel)
         }
-        if let peopleService = appCore.peopleService {
-            employees = (try? peopleService.listEmployees()) ?? []
+        .accessibilityElement(children: .combine)
+    }
+
+    private func loadData() {
+        isLoadingData = true
+        defer { isLoadingData = false }
+
+        let result = DispatchSheetLoadData.load(
+            jobsProvider: {
+                guard let jobService = appCore.jobsService else {
+                    throw DispatchLoadServiceError.jobsUnavailable
+                }
+                return try jobService.listJobs(status: "active", limit: 200)
+            },
+            employeesProvider: {
+                guard let peopleService = appCore.peopleService else {
+                    throw DispatchLoadServiceError.peopleUnavailable
+                }
+                return try peopleService.listEmployees()
+            },
+            errorFormatter: { error, context in
+                userFriendlyError(error, context: context)
+            }
+        )
+
+        jobs = result.jobs
+        employees = result.employees
+        jobLoadError = result.jobLoadError
+        employeeLoadError = result.employeeLoadError
+
+        if let selectedJobId, !jobs.contains(where: { $0.id == selectedJobId }) {
+            self.selectedJobId = nil
+        }
+        if let selectedUserId, !employees.contains(where: { $0.id == selectedUserId }) {
+            self.selectedUserId = nil
         }
     }
 
@@ -116,5 +211,19 @@ struct CreateDispatchSheet: View {
             saveError = userFriendlyError(error, context: "save data")
         }
         isSaving = false
+    }
+}
+
+private enum DispatchLoadServiceError: LocalizedError {
+    case jobsUnavailable
+    case peopleUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .jobsUnavailable:
+            return "Job service is not available"
+        case .peopleUnavailable:
+            return "People service is not available"
+        }
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -19,6 +19,11 @@ private enum PeerDiscoveryCompanyIdTestError: Error {
     case lookupFailed
 }
 
+private enum DispatchSheetLoadTestError: Error {
+    case jobLoadFailed
+    case employeeLoadFailed
+}
+
 struct Weird_Parts_IOSTests {
 
     struct LANPeerDiscoveryStartupError: Error, LocalizedError {
@@ -340,6 +345,27 @@ struct Weird_Parts_IOSTests {
         )
     }
 
+    @Test func createDispatchSheetShowsActionableLoadFailures() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sheetURL = repoRoot
+            .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateDispatchSheet.swift")
+        let source = try String(contentsOf: sheetURL, encoding: .utf8)
+
+        #expect(!source.contains("try? jobService.listJobs"), "Job load failures must not be swallowed into an empty active-jobs picker state")
+        #expect(!source.contains("try? peopleService.listEmployees"), "Employee load failures must not be swallowed into an empty employee picker state")
+        #expect(source.contains("jobLoadError = result.jobLoadError"), "Job load failures should be tracked separately from empty job results")
+        #expect(source.contains("employeeLoadError = result.employeeLoadError"), "Employee load failures should be tracked separately from empty employee results")
+        #expect(source.contains("userFriendlyError(error, context: context)"), "Service failures should be formatted as user-facing error copy")
+        #expect(source.contains("Text(\"No active jobs\")"), "Legitimate empty job results should still show the empty-state copy")
+        #expect(source.contains("Text(\"No employees found\")"), "Legitimate empty employee results should still show the empty-state copy")
+        #expect(source.contains("Label(\"Retry\", systemImage: \"arrow.clockwise\")"), "Load failures should offer an actionable retry")
+        #expect(source.contains("Retry loading jobs"), "Job retry control needs a specific accessibility label")
+        #expect(source.contains("Retry loading employees"), "Employee retry control needs a specific accessibility label")
+    }
+
     @Test @MainActor func questionnaireBreakAutofillDoesNotSwallowSubmitErrors() throws {
         var autoFillAttempts = 0
 
@@ -415,6 +441,88 @@ struct Weird_Parts_IOSTests {
         let source = try String(contentsOf: suppliersURL, encoding: .utf8)
 
         #expect(source.contains("loadError = userFriendlyError(error, context: \"create supplier channel\")"))
+    }
+
+    @MainActor
+    @Test func dispatchSheetJobLoadFailurePreservesEmployeeResultsAndShowsActionableJobError() throws {
+        let loadedEmployee = PeopleService.EmployeeListItem(
+            id: 42,
+            displayName: "Field Tech",
+            email: "tech@example.com",
+            phone: nil,
+            status: "active",
+            role: "employee",
+            hatNames: nil
+        )
+
+        let result = DispatchSheetLoadData.load(
+            jobsProvider: { throw DispatchSheetLoadTestError.jobLoadFailed },
+            employeesProvider: { [loadedEmployee] },
+            errorFormatter: { _, context in "Couldn't \(context). Retry." }
+        )
+
+        #expect(result.jobs.isEmpty)
+        #expect(result.employees.map(\.displayName) == ["Field Tech"])
+        #expect(result.jobLoadError == "Couldn't load active jobs. Retry.")
+        #expect(result.employeeLoadError == nil)
+        #expect(result.hasLoadFailure)
+    }
+
+    @MainActor
+    @Test func dispatchSheetEmployeeLoadFailurePreservesJobResultsAndShowsActionableEmployeeError() throws {
+        let loadedJob = JobsService.JobListItem(
+            id: 7,
+            jobNumber: "JOB-7",
+            jobName: "Warehouse Upgrade",
+            customerName: nil,
+            status: "active",
+            priority: "medium",
+            teamCount: 0,
+            startDate: nil,
+            dueDate: nil
+        )
+
+        let result = DispatchSheetLoadData.load(
+            jobsProvider: { [loadedJob] },
+            employeesProvider: { throw DispatchSheetLoadTestError.employeeLoadFailed },
+            errorFormatter: { _, context in "Couldn't \(context). Retry." }
+        )
+
+        #expect(result.jobs.map(\.jobName) == ["Warehouse Upgrade"])
+        #expect(result.employees.isEmpty)
+        #expect(result.jobLoadError == nil)
+        #expect(result.employeeLoadError == "Couldn't load employees. Retry.")
+        #expect(result.hasLoadFailure)
+    }
+
+    @MainActor
+    @Test func dispatchSheetBothLoadFailuresExposeBothActionableMessages() throws {
+        let result = DispatchSheetLoadData.load(
+            jobsProvider: { throw DispatchSheetLoadTestError.jobLoadFailed },
+            employeesProvider: { throw DispatchSheetLoadTestError.employeeLoadFailed },
+            errorFormatter: { _, context in "Couldn't \(context). Retry." }
+        )
+
+        #expect(result.jobs.isEmpty)
+        #expect(result.employees.isEmpty)
+        #expect(result.jobLoadError == "Couldn't load active jobs. Retry.")
+        #expect(result.employeeLoadError == "Couldn't load employees. Retry.")
+        #expect(result.hasLoadFailure)
+    }
+
+    @MainActor
+    @Test func dispatchSheetEmptyResultsRemainLegitimateEmptyStatesWithoutLoadFailure() throws {
+        let result = DispatchSheetLoadData.load(
+            jobsProvider: { [] },
+            employeesProvider: { [] },
+            errorFormatter: { _, context in "Couldn't \(context). Retry." }
+        )
+
+        #expect(result.jobs.isEmpty)
+        #expect(result.employees.isEmpty)
+        #expect(result.jobLoadError == nil)
+        #expect(result.employeeLoadError == nil)
+        #expect(!result.hasLoadFailure)
     }
 
     @Test func uiTestingFixturesSeedJPOFlowDataForQASmoke() throws {


### PR DESCRIPTION
## Summary
- Adds explicit dispatch sheet load-state handling for active job and employee picker data.
- Surfaces separate actionable load errors with retry controls instead of degrading thrown service errors into empty picker states.
- Keeps legitimate empty job/employee results as distinct empty-state copy.

## Tests
- PASS: `xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -derivedDataPath .tmp/DerivedData-WEI3579 -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests"`

Paperclip: WEI-3579
Paperclip merge issue: WEI-3637

Closes #997
