### PR TITLE
fix: reload inventory for location type changes

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSInventoryGridPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSInventoryGridPage.swift
@@ -39,6 +39,10 @@ struct IOSInventoryGridPage: View {
         }
     }
 
+    private var selectedLocation: LocationOption {
+        LocationOption(locationType: selectedLocationType, locationId: selectedLocationId)
+    }
+
     private enum StockFilter: String, CaseIterable {
         case lowStock = "Low Stock"
         case outOfStock = "Out of Stock"
@@ -122,9 +126,8 @@ struct IOSInventoryGridPage: View {
         } message: {
             Text(actionError ?? "")
         }
-        .onChange(of: selectedLocationId) {
-            lastLocationType = selectedLocationType
-            lastLocationId = Int(selectedLocationId)
+        .onChange(of: selectedLocation) {
+            persistSelectedLocation()
             loadData()
         }
         .task {
@@ -354,6 +357,11 @@ struct IOSInventoryGridPage: View {
     }
 
     // MARK: - Data Loading
+
+    private func persistSelectedLocation() {
+        lastLocationType = selectedLocationType
+        lastLocationId = Int(selectedLocationId)
+    }
 
     private func loadLocations() {
         guard let service = appCore.warehouseService else {

--- a/Weird Parts IOS/Weird Parts IOSTests/InventoryGridLocationSelectionRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/InventoryGridLocationSelectionRegressionTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+
+final class InventoryGridLocationSelectionRegressionTests: XCTestCase {
+    func testInventoryGridReloadsWhenLocationTypeOrIdChanges() throws {
+        let source = try Self.readInventoryGridPageSource()
+
+        XCTAssertTrue(
+            source.contains("private var selectedLocation: LocationOption"),
+            "Inventory Grid should expose a full location selection value that includes both type and id."
+        )
+        XCTAssertTrue(
+            source.contains(".onChange(of: selectedLocation)"),
+            "Inventory Grid should observe the full location selection so Warehouse #N ↔ Truck #N reloads even when the numeric id is unchanged."
+        )
+        XCTAssertFalse(
+            source.contains(".onChange(of: selectedLocationId)"),
+            "Watching only selectedLocationId misses same-id location type changes and can leave stale inventory visible."
+        )
+        XCTAssertTrue(
+            source.contains("lastLocationType = selectedLocationType"),
+            "The reload trigger should persist the selected location type with the id."
+        )
+        XCTAssertTrue(
+            source.contains("items = try service.getStockAtLocation(locationType: selectedLocationType, locationId: selectedLocationId)"),
+            "Inventory fetches must remain type-aware and id-aware."
+        )
+    }
+
+    private static func readInventoryGridPageSource(
+        file: StaticString = #filePath
+    ) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Warehouse")
+            .appendingPathComponent("IOSInventoryGridPage.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes Warehouse Inventory reload watching the full selected location pair, not just numeric location id.
- Persists the type/id pair through a helper before reloading so Warehouse #N -> Truck #N fetches the selected type/id and does not show stale cross-location stock.
- Adds a regression test that guards against returning to id-only `onChange` behavior.

## Tests
- xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" -derivedDataPath /tmp/wei-3689-derived-data build (passed; existing warnings only)
- xcodebuild -scheme "WiredPart-iOS" -destination "platform=iOS Simulator,name=iPhone 17" -derivedDataPath /tmp/wei-3689-derived-data-test -only-testing:"Weird Parts IOSTests/InventoryGridLocationSelectionRegressionTests" test (passed)

Paperclip: WEI-3689
Closes #1026
