### PR TITLE
fix: make geofence job switch atomic

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/GeofenceAlertView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/GeofenceAlertView.swift
@@ -251,9 +251,16 @@ struct GeofenceAlertView: View {
                 break
 
             case .anotherJob:
-                if let newJobId = targetJobId, let entryId = activeEntryId {
-                    try service.clockOut(laborEntryId: entryId, gpsLat: exitLat, gpsLng: exitLng)
-                    try service.clockIn(userId: userId, jobId: newJobId, gpsLat: exitLat, gpsLng: exitLng)
+                if let newJobId = targetJobId {
+                    try service.switchClockedInJob(
+                        userId: userId,
+                        nextJobId: newJobId,
+                        at: Date(),
+                        clockOutGpsLat: exitLat,
+                        clockOutGpsLng: exitLng,
+                        clockInGpsLat: exitLat,
+                        clockInGpsLng: exitLng
+                    )
                 }
 
             case .lunch, .breakTime, .doneForDay:

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -436,6 +436,40 @@ struct JobsServiceTests {
         }
     }
 
+    @Test("Switching jobs keeps current entry active when target job is not clockable")
+    func testSwitchClockedInJobRollsBackWhenTargetIsNotClockable() throws {
+        try withMountainTimeZone {
+            let env = try E2ETestHelpers.setUp()
+            let firstJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-SW-STAY", name: "Switch Stays Active")
+            let closedJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-SW-CLOSED", name: "Closed Switch Target")
+
+            let firstEntryId = try env.jobs.clockIn(
+                userId: env.adminUserId,
+                jobId: firstJobId,
+                at: try Self.localToday(hour: 7, minute: 0)
+            )
+            try env.jobs.updateJob(id: closedJobId, status: "completed")
+
+            #expect(throws: JobsService.JobsError.jobNotClockable(closedJobId)) {
+                try env.jobs.switchClockedInJob(
+                    userId: env.adminUserId,
+                    nextJobId: closedJobId,
+                    at: try Self.localToday(hour: 12, minute: 15)
+                )
+            }
+
+            let entries = try env.jobs.listLaborEntries(userId: env.adminUserId)
+            let originalEntry = try #require(entries.first { $0.id == firstEntryId })
+            let active = try env.jobs.getActiveClockEntry(userId: env.adminUserId)
+
+            #expect(entries.count == 1)
+            #expect(originalEntry.status == "clocked_in")
+            #expect(originalEntry.clockOut == nil)
+            #expect(active?.id == firstEntryId)
+            #expect(active?.jobId == firstJobId)
+        }
+    }
+
     @Test("Clock out subtracts unpaid breaks but keeps paid breaks compensable")
     func testClockOutBreakPayTreatmentIsDeterministic() throws {
         try withMountainTimeZone {


### PR DESCRIPTION
## Summary
- Route the geofence “Another Job” confirmation through `JobsService.switchClockedInJob(...)` instead of separate clock-out/clock-in writes.
- Preserve the existing geofence response UX and error path, so a failed target clock-in leaves the original timer active.
- Add a regression test proving a non-clockable target rolls back and keeps the original active entry clocked in.

## Tests
- `swift test --filter JobsServiceTests/testSwitchClockedInJobRollsBackWhenTargetIsNotClockable` — passed (1 test)
- `swift test --filter JobsServiceTests` — passed (134 tests)
- `xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" -derivedDataPath /tmp/wpr2-wei3688-dd3 build` — BUILD SUCCEEDED

## Traceability
- Closes #1025
- Paperclip: WEI-3688
- Local runner path: validated locally on this Mac with SwiftPM and iOS Simulator build; GitHub Actions should use the repo’s self-hosted Mac runner path for required Apple-platform checks.
