### PR TITLE
fix: hide deleted tool names in checkout reports

### DIFF
--- a/core/Sources/WiredPartCore/Services/ReportsService.swift
+++ b/core/Sources/WiredPartCore/Services/ReportsService.swift
@@ -1459,7 +1459,7 @@ public final class ReportsService: Sendable {
                            COALESCE(tc.checkout_condition, '') AS condition_out,
                            COALESCE(tc.return_condition, '') AS condition_in
                     FROM tool_checkouts tc
-                    LEFT JOIN tools t ON t.id = tc.tool_id
+                    LEFT JOIN tools t ON t.id = tc.tool_id AND t.deleted_at IS NULL
                     LEFT JOIN users u ON u.id = tc.checked_out_by AND u.deleted_at IS NULL
                     WHERE tc.deleted_at IS NULL
                       AND date(tc.checked_out_at) >= ? AND date(tc.checked_out_at) <= ?

--- a/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
@@ -453,6 +453,39 @@ struct ReportsServiceTests {
         }
     }
 
+    @Test("Tool checkout report hides soft-deleted tool names")
+    func testToolCheckoutReportHidesSoftDeletedToolName() throws {
+        let env = try E2ETestHelpers.setUp()
+        let deletedToolName = "Deleted Torque Wrench"
+        let toolId = try env.db.writer.write { db -> Int64 in
+            try db.execute(sql: """
+                INSERT INTO tools (tool_number, name, category, status, has_kit, created_at, updated_at)
+                VALUES ('T-R002', ?, 'hand_tools', 'available', 0, datetime('now'), datetime('now'))
+                """, arguments: [deletedToolName])
+            return db.lastInsertedRowID
+        }
+
+        try env.tools.checkoutTool(toolId: toolId, userId: env.adminUserId)
+        try env.tools.returnTool(toolId: toolId, userId: env.adminUserId)
+        try env.db.writer.write { db in
+            try db.execute(
+                sql: "UPDATE tools SET deleted_at = datetime('now') WHERE id = ?",
+                arguments: [toolId]
+            )
+        }
+
+        let rows = try env.reports.generateCustomReport(
+            type: "tool_checkouts",
+            columns: ["tool_name", "employee_name"],
+            startDate: Date(timeIntervalSince1970: 0),
+            endDate: Date.distantFuture,
+            filters: [:]
+        )
+
+        #expect(rows.contains { $0.first == "Unknown" })
+        #expect(!rows.contains { $0.first == deletedToolName })
+    }
+
     // MARK: - Job Costs Report (budget_limit fix)
 
     // MARK: - generateCustomReport: Remaining Types


### PR DESCRIPTION
## Summary
- Hide soft-deleted tool names from the custom tool checkout report by only joining active tool rows.
- Preserve historical checkout rows and degrade deleted tool references to the existing `Unknown` placeholder.
- Add a regression test covering an active checkout whose tool is later soft-deleted.

## Tests
- RED: `swift test --filter ReportsServiceTests/testToolCheckoutReportHidesSoftDeletedToolName` failed before the service query change with the deleted tool name still exposed.
- GREEN: `swift test --filter ReportsServiceTests/testToolCheckoutReportHidesSoftDeletedToolName`
- `swift test --filter ReportsServiceTests`
- `swift test`

Paperclip: WEI-3580, parent WEI-3572

Closes #986
