### PR TITLE
fix: apply movement date filters before cap

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
@@ -175,7 +175,7 @@ struct WarehouseMovementsPage: View {
     // MARK: - Smart Card Filters
 
     private var smartCardFilters: some View {
-        let countsByType = Dictionary(grouping: dateFilteredMovements, by: \.movementType)
+        let countsByType = Dictionary(grouping: movements, by: \.movementType)
             .mapValues(\.count)
 
         return ScrollView(.horizontal, showsIndicators: false) {
@@ -187,7 +187,7 @@ struct WarehouseMovementsPage: View {
                             rawValues.reduce(0) { total, rawValue in
                                 total + countsByType[rawValue, default: 0]
                             }
-                        } ?? dateFilteredMovements.count
+                        } ?? movements.count
                     )
                 }
             }
@@ -226,7 +226,7 @@ struct WarehouseMovementsPage: View {
     // MARK: - Filtered Movements
 
     private var filteredMovements: [WarehouseService.MovementRow] {
-        var result = dateFilteredMovements
+        var result = movements
         if let filter = selectedFilter, let movementTypes = filter.movementTypes {
             result = result.filter { movementTypes.contains($0.movementType) }
         }
@@ -235,13 +235,6 @@ struct WarehouseMovementsPage: View {
             result = result.filter { $0.partName.lowercased().contains(query) }
         }
         return result.sorted { ($0.createdAt ?? "") < ($1.createdAt ?? "") }
-    }
-
-    private var dateFilteredMovements: [WarehouseService.MovementRow] {
-        movements.filter { movement in
-            guard let date = movementDate(movement) else { return true }
-            return date >= effectiveStart && date <= effectiveEnd
-        }
     }
 
     // MARK: - Movements List
@@ -387,7 +380,12 @@ struct WarehouseMovementsPage: View {
         isLoading = movements.isEmpty
         loadError = nil
         do {
-            movements = try service.listMovements(limit: 200, sortOrder: .oldestFirst)
+            movements = try service.listMovements(
+                startDate: effectiveStart,
+                endDate: effectiveEnd,
+                limit: 200,
+                sortOrder: .oldestFirst
+            )
             postAIContext()
         } catch {
             loadError = userFriendlyError(error, context: "load movements")

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -171,6 +171,49 @@ struct WarehouseServiceExtTests {
         #expect(active.first?.movementType == "receiving_staged")
     }
 
+    @Test("Movement date filters apply before limit cap")
+    func testMovementDateFiltersApplyBeforeLimitCap() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        let calendar = Calendar(identifier: .gregorian)
+        let oldDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let recentDate = calendar.date(byAdding: .day, value: 30, to: oldDate)!
+
+        for index in 0..<201 {
+            _ = try env.warehouse.createQuickLogMovement(
+                partId: partId,
+                qty: 1,
+                movementType: "received",
+                occurredAt: calendar.date(byAdding: .minute, value: index, to: oldDate)!,
+                toLocationType: "warehouse",
+                toLocationId: 1,
+                reason: "Old capped movement \(index)",
+                performedBy: env.adminUserId
+            )
+        }
+        _ = try env.warehouse.createQuickLogMovement(
+            partId: partId,
+            qty: 2,
+            movementType: "received",
+            occurredAt: recentDate,
+            toLocationType: "warehouse",
+            toLocationId: 1,
+            reason: "Recent filtered movement",
+            performedBy: env.adminUserId
+        )
+
+        let recentMovements = try env.warehouse.listMovements(
+            startDate: calendar.date(byAdding: .day, value: -1, to: recentDate),
+            endDate: calendar.date(byAdding: .day, value: 1, to: recentDate),
+            limit: 200,
+            sortOrder: .oldestFirst
+        )
+
+        #expect(recentMovements.count == 1)
+        #expect(recentMovements.first?.reason == "Recent filtered movement")
+    }
+
     @Test("Quick Log persists happened-at and audit trail fields")
     func testQuickLogPersistence() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Pass the Warehouse Movements page date range into `WarehouseService.listMovements(...)` before the 200-row cap is applied.
- Remove the page-level in-memory date slice from loaded rows so type chips/search operate on the service-filtered result set.
- Add regression coverage with 201 old rows plus one recent row to prove date filters are applied before the limit cap.

## Tests
- `swift test --filter WarehouseServiceExtTests/testMovementDateFiltersApplyBeforeLimitCap` — passed (1 test)
- `swift test --filter WarehouseServiceExtTests` — passed (123 tests)
- `xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" -derivedDataPath /tmp/wpr2-wei3692-dd build` — BUILD SUCCEEDED (existing warnings only)

## Traceability
- Closes #1027
- Paperclip: WEI-3692, WEI-3690
- Local runner path: validated locally on this Mac with SwiftPM and iOS Simulator build; GitHub Actions should use the repo’s self-hosted Mac runner path for required Apple-platform checks.
