### PR TITLE
fix: apply movement date filters before cap

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
@@ -387,7 +387,12 @@ struct WarehouseMovementsPage: View {
         isLoading = movements.isEmpty
         loadError = nil
         do {
-            movements = try service.listMovements(limit: 200, sortOrder: .oldestFirst)
+            movements = try service.listMovements(
+                startDate: effectiveStart,
+                endDate: effectiveEnd,
+                limit: 200,
+                sortOrder: .oldestFirst
+            )
             postAIContext()
         } catch {
             loadError = userFriendlyError(error, context: "load movements")

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -171,6 +171,49 @@ struct WarehouseServiceExtTests {
         #expect(active.first?.movementType == "receiving_staged")
     }
 
+    @Test("Movement date filters are applied before limit")
+    func testMovementDateFiltersApplyBeforeLimit() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+
+        try env.db.writer.write { db in
+            for index in 0..<201 {
+                try db.execute(sql: """
+                    INSERT INTO stock_movements
+                        (part_id, qty, from_location_type, from_location_id, to_location_type, to_location_id,
+                         movement_type, reason, performed_by, created_at)
+                    VALUES (?, 1, NULL, NULL, 'warehouse', 1, 'received', ?, ?, ?)
+                    """, arguments: [
+                    partId,
+                    "Old capped movement \(index)",
+                    env.adminUserId,
+                    "2026-01-01 00:\(String(format: "%02d", index % 60)):00"
+                ])
+            }
+            try db.execute(sql: """
+                INSERT INTO stock_movements
+                    (part_id, qty, from_location_type, from_location_id, to_location_type, to_location_id,
+                     movement_type, reason, performed_by, created_at)
+                VALUES (?, 1, NULL, NULL, 'warehouse', 1, 'received', 'Recent matching movement', ?, '2026-06-15 12:00:00')
+                """, arguments: [partId, env.adminUserId])
+        }
+
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = TimeZone(secondsFromGMT: 0)!
+        let startDate = utc.date(from: DateComponents(year: 2026, month: 6, day: 1))!
+        let endDate = utc.date(from: DateComponents(year: 2026, month: 6, day: 30, hour: 23, minute: 59, second: 59))!
+
+        let filtered = try env.warehouse.listMovements(
+            startDate: startDate,
+            endDate: endDate,
+            limit: 1,
+            sortOrder: .oldestFirst
+        )
+
+        #expect(filtered.map(\.reason) == ["Recent matching movement"])
+    }
+
     @Test("Quick Log persists happened-at and audit trail fields")
     func testQuickLogPersistence() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Passes the Warehouse Movements page date range into `WarehouseService.listMovements` before the 200-row cap is applied.
- Keeps the visible date filter behavior intact while preventing old globally-capped rows from hiding recent matching movement rows.
- Adds a regression test with 201 older movements plus one matching recent movement to prove the service date filter happens before `LIMIT`.

## Tests
- `swift test --filter WarehouseServiceExtTests/testMovementDateFiltersApplyBeforeLimit` — passed
- `xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build` — BUILD SUCCEEDED with existing warnings only

Paperclip: WEI-3690
Closes #1027
