### PR TITLE
fix: align timesheet break bucket paid state

### DIFF
--- a/core/Sources/WiredPartCore/Services/ReportsService.swift
+++ b/core/Sources/WiredPartCore/Services/ReportsService.swift
@@ -340,9 +340,23 @@ public final class ReportsService: Sendable {
                            COALESCE(le.regular_hours, 0) AS regular_hours,
                            COALESCE(le.overtime_hours, 0) AS overtime_hours,
                            COALESCE(le.status, CASE WHEN le.clock_out IS NULL THEN 'open' ELSE 'completed' END) AS status,
-                           COALESCE(SUM(CASE WHEN br.break_type = 'break' THEN COALESCE(br.duration_minutes, 0) ELSE 0 END), 0) AS paid_break_minutes,
-                           COALESCE(SUM(CASE WHEN br.break_type = 'lunch_paid' THEN COALESCE(br.duration_minutes, 0) ELSE 0 END), 0) AS paid_lunch_minutes,
-                           COALESCE(SUM(CASE WHEN br.break_type = 'lunch_unpaid' THEN COALESCE(br.duration_minutes, 0) ELSE 0 END), 0) AS unpaid_lunch_minutes
+                           COALESCE(SUM(CASE
+                               WHEN br.break_type = 'break'
+                                    AND COALESCE(br.is_paid, 1) = 1
+                               THEN COALESCE(br.duration_minutes, 0)
+                               ELSE 0
+                           END), 0) AS paid_break_minutes,
+                           COALESCE(SUM(CASE
+                               WHEN br.break_type IN ('lunch_paid', 'lunch_unpaid')
+                                    AND COALESCE(br.is_paid, CASE WHEN br.break_type = 'lunch_unpaid' THEN 0 ELSE 1 END) = 1
+                               THEN COALESCE(br.duration_minutes, 0)
+                               ELSE 0
+                           END), 0) AS paid_lunch_minutes,
+                           COALESCE(SUM(CASE
+                               WHEN COALESCE(br.is_paid, CASE WHEN br.break_type = 'lunch_unpaid' THEN 0 ELSE 1 END) = 0
+                               THEN COALESCE(br.duration_minutes, 0)
+                               ELSE 0
+                           END), 0) AS unpaid_lunch_minutes
                     FROM labor_entries le
                     LEFT JOIN users u ON u.id = le.user_id AND u.deleted_at IS NULL
                     LEFT JOIN jobs j ON j.id = le.job_id AND j.deleted_at IS NULL

--- a/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
@@ -48,6 +48,37 @@ struct ReportsServiceTests {
         #expect(data.count >= 1)
     }
 
+    @Test("Timesheet segments prefer is_paid over break_type for unpaid correction buckets")
+    func testTimesheetSegmentsUseIsPaidForContradictoryBreakRows() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-SEG", name: "Segment Bucket Job")
+        let laborEntryId = try env.db.writer.write { db -> Int64 in
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, '2026-03-05T08:00:00Z', '2026-03-05T16:00:00Z', 7.5, 0.0, 'completed', datetime('now'))
+                """, arguments: [env.adminUserId, jobId])
+            let entryId = db.lastInsertedRowID
+            try db.execute(sql: """
+                INSERT INTO break_records
+                    (user_id, labor_entry_id, break_type, started_at, ended_at, duration_minutes, is_paid, auto_filled)
+                VALUES (?, ?, 'break', '2026-03-05T12:00:00Z', '2026-03-05T12:30:00Z', 30, 0, 0)
+                """, arguments: [env.adminUserId, entryId])
+            return entryId
+        }
+
+        let segments = try env.reports.getTimesheetSegments(
+            startDate: "2026-03-05",
+            endDate: "2026-03-05",
+            userId: env.adminUserId
+        )
+
+        let segment = segments.first { $0.id == laborEntryId }
+        #expect(segment?.paidBreakMinutes == 0)
+        #expect(segment?.paidLunchMinutes == 0)
+        #expect(segment?.unpaidLunchMinutes == 30)
+    }
+
     @Test("Timesheet data buckets UTC evening clock-in into local work day")
     func testTimesheetUsesLocalOperationalDayForUtcClockIn() throws {
         try withDenverTimeZone {


### PR DESCRIPTION
## Summary
- Align ReportsService timesheet segment break buckets with correction math by preferring `break_records.is_paid` for paid/unpaid classification.
- Keep legacy `break_type = 'lunch_unpaid'` handling for rows where `is_paid` is absent/null while allowing explicit `is_paid` values to override break type.
- Add a regression covering contradictory `break_type = 'break'`, `is_paid = 0` rows so manager review no longer reports them as paid break minutes.

Closes #1024
Paperclip: WEI-3743
Parent hygiene gate: WEI-3539

## Tests
- [x] `cd core && swift test --filter ReportsServiceTests`

## CI / runner note
- Focused Swift Package tests were run locally in `core/`. Repo-owned macOS/iOS CI should use the local self-hosted Mac runner path per WPR2 policy.