### PR TITLE
fix: expose field workflow action buttons

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
@@ -656,6 +656,8 @@ struct IOSClockPage: View {
                     Text("You are still clocked into \(entry.jobName) since \(formatTime(entry.clockIn)).")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("Active timer recovered. You are still clocked into \(entry.jobName) since \(formatTime(entry.clockIn)).")
                     HStack {
                         Button {
                             recoveredBannerDismissed = true
@@ -663,6 +665,9 @@ struct IOSClockPage: View {
                             Label("Continue Timer", systemImage: "play.circle")
                         }
                         .buttonStyle(.borderedProminent)
+                        .accessibilityLabel("Continue Timer")
+                        .accessibilityHint("Dismisses the recovered timer banner and keeps the active timer running.")
+                        .accessibilityIdentifier("clock-recovered-continue-timer-button")
 
                         Button(role: .destructive) {
                             pendingClockOutEntryId = entry.id
@@ -671,9 +676,11 @@ struct IOSClockPage: View {
                             Label("Clock Out", systemImage: "stop.circle")
                         }
                         .buttonStyle(.bordered)
+                        .accessibilityLabel("Clock Out")
+                        .accessibilityHint("Opens confirmation to clock out of \(entry.jobName).")
+                        .accessibilityIdentifier("clock-recovered-clock-out-button")
                     }
                 }
-                .accessibilityElement(children: .combine)
             }
         }
     }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
@@ -655,19 +655,24 @@ struct IOSJobDetailPage: View {
                     .fontWeight(.semibold)
                     .foregroundStyle(.blue)
             }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(material.partName), \(material.partCode ?? "no part code"), \(material.sourceSummary), \(material.stagedQty) staged")
             HStack {
                 Button("Use") { prepareMaterialAction(.useReady(material)) }
                     .buttonStyle(.borderedProminent)
                     .accessibilityLabel("Use \(material.partName)")
+                    .accessibilityHint("Uses staged material on this job")
+                    .accessibilityIdentifier("job-ready-material-use-button-\(material.id)")
                 Button("Return") { prepareMaterialAction(.returnReady(material)) }
                     .buttonStyle(.bordered)
                     .accessibilityLabel("Return \(material.partName)")
+                    .accessibilityHint("Starts a return for staged material")
+                    .accessibilityIdentifier("job-ready-material-return-button-\(material.id)")
                 Spacer()
             }
             .font(.caption)
         }
         .padding(.vertical, 8)
-        .accessibilityElement(children: .combine)
     }
 
     private var usedMaterialsSegment: some View {
@@ -711,21 +716,26 @@ struct IOSJobDetailPage: View {
                     }
                 }
             }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(part.partName), \(part.partCode ?? "no part code"), \(part.qtyConsumed) used, \(part.qtyReturned) returned, \(netQty) net")
             HStack {
                 Button("Return") { prepareMaterialAction(.returnUsed(part)) }
                     .buttonStyle(.bordered)
                     .disabled(netQty <= 0)
+                    .accessibilityLabel("Return \(part.partName)")
                     .accessibilityHint(netQty > 0 ? "Returns used material to warehouse review" : "All used quantity has already been returned")
+                    .accessibilityIdentifier("job-used-material-return-button-\(part.id)")
                 Button("Correct") { prepareMaterialAction(.correctUsed(part)) }
                     .buttonStyle(.bordered)
+                    .accessibilityLabel("Correct \(part.partName)")
                     .accessibilityHint("Requires an audit note")
+                    .accessibilityIdentifier("job-used-material-correct-button-\(part.id)")
                 Spacer()
             }
             .font(.caption)
         }
         .padding(.vertical, 8)
         .background(highlightedJobPartId == part.id ? Color.green.opacity(0.10) : Color.clear)
-        .accessibilityElement(children: .combine)
     }
 
     private var returnsMaterialsSegment: some View {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
@@ -1645,15 +1645,18 @@ private struct MisplacedPartSheet: View {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(alignment: .top) {
                     lookupPartText(selectedPart)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityAddTraits(.isSelected)
                     Spacer()
                     Button("Change") {
                         self.selectedPart = nil
                         homeOptions = []
                         homeAreaId = nil
                     }
+                    .accessibilityLabel("Change selected part")
+                    .accessibilityHint("Clears the selected misplaced part so you can choose a different part.")
+                    .accessibilityIdentifier("misplaced-selected-part-change-button")
                 }
-                .accessibilityElement(children: .combine)
-                .accessibilityAddTraits(.isSelected)
             }
         } else {
             validationText("Select the part you found.")
@@ -1665,13 +1668,16 @@ private struct MisplacedPartSheet: View {
         if let selectedArea {
             HStack(alignment: .top) {
                 lookupAreaText(selectedArea, showsHomeBadge: false)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityAddTraits(.isSelected)
                 Spacer()
                 Button("Change") {
                     self.selectedArea = nil
                 }
+                .accessibilityLabel("Change selected area")
+                .accessibilityHint("Clears the selected misplaced part location so you can choose a different area.")
+                .accessibilityIdentifier("misplaced-selected-area-change-button")
             }
-            .accessibilityElement(children: .combine)
-            .accessibilityAddTraits(.isSelected)
         } else {
             validationText("Select where you found it.")
         }

--- a/Weird Parts IOS/Weird Parts IOSTests/FieldWorkflowActionButtonAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/FieldWorkflowActionButtonAccessibilityTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+
+/// Regression coverage for GitHub #1029 / WEI-3751 / WEI-3752.
+///
+/// Field workflow rows can group static summary text for VoiceOver, but any
+/// visible workflow action buttons must remain real, separately discoverable
+/// controls. Do not put `.accessibilityElement(children: .combine)` on parent
+/// rows that also contain `Button`s for these field-critical actions.
+final class FieldWorkflowActionButtonAccessibilityTests: XCTestCase {
+    func testRecoveredClockBannerKeepsTimerActionsIndependent() throws {
+        let source = try Self.readJobSource("IOSClockPage.swift")
+        let section = try Self.section(
+            named: "private func clockRecoverySection",
+            in: source,
+            endingBefore: "private func activeBreakTitle"
+        )
+
+        XCTAssertFalse(
+            section.contains(".accessibilityElement(children: .combine)\n            }"),
+            "The recovered timer banner must not combine the parent container around Continue Timer and Clock Out buttons."
+        )
+        XCTAssertTrue(section.contains(".accessibilityIdentifier(\"clock-recovered-continue-timer-button\")"))
+        XCTAssertTrue(section.contains(".accessibilityIdentifier(\"clock-recovered-clock-out-button\")"))
+        XCTAssertTrue(section.contains(".accessibilityHint(\"Dismisses the recovered timer banner"))
+        XCTAssertTrue(section.contains(".accessibilityHint(\"Opens confirmation to clock out"))
+    }
+
+    func testJobMaterialRowsKeepUseReturnCorrectButtonsIndependent() throws {
+        let source = try Self.readJobSource("IOSJobDetailPage.swift")
+        let readyRow = try Self.section(
+            named: "private func readyMaterialRow",
+            in: source,
+            endingBefore: "private var usedMaterialsSegment"
+        )
+        let usedRow = try Self.section(
+            named: "private func usedMaterialRow",
+            in: source,
+            endingBefore: "private var returnsMaterialsSegment"
+        )
+
+        XCTAssertFalse(
+            readyRow.trimmingCharacters(in: .whitespacesAndNewlines).hasSuffix(".accessibilityElement(children: .combine)"),
+            "The ready material row parent must not combine Use and Return buttons."
+        )
+        XCTAssertFalse(
+            usedRow.trimmingCharacters(in: .whitespacesAndNewlines).hasSuffix(".accessibilityElement(children: .combine)"),
+            "The used material row parent must not combine Return and Correct buttons."
+        )
+        XCTAssertTrue(readyRow.contains(".accessibilityIdentifier(\"job-ready-material-use-button-\\(material.id)\")"))
+        XCTAssertTrue(readyRow.contains(".accessibilityIdentifier(\"job-ready-material-return-button-\\(material.id)\")"))
+        XCTAssertTrue(usedRow.contains(".accessibilityIdentifier(\"job-used-material-return-button-\\(part.id)\")"))
+        XCTAssertTrue(usedRow.contains(".accessibilityIdentifier(\"job-used-material-correct-button-\\(part.id)\")"))
+        XCTAssertTrue(readyRow.contains(".accessibilityElement(children: .combine)"), "Static ready material summary text can still be grouped separately.")
+        XCTAssertTrue(usedRow.contains(".accessibilityElement(children: .combine)"), "Static used material summary text can still be grouped separately.")
+    }
+
+    func testMisplacedPartSelectionSummariesKeepChangeButtonsIndependent() throws {
+        let source = try Self.readWarehouseSource("IOSAuditPage.swift")
+        let partSummary = try Self.section(
+            named: "private var selectedPartSummary",
+            in: source,
+            endingBefore: "private var selectedAreaSummary"
+        )
+        let areaSummary = try Self.section(
+            named: "private var selectedAreaSummary",
+            in: source,
+            endingBefore: "private var partResultsView"
+        )
+
+        XCTAssertFalse(
+            partSummary.contains("Button(\"Change\") {\n                        self.selectedPart = nil\n                        homeOptions = []\n                        homeAreaId = nil\n                    }\n                }\n                .accessibilityElement(children: .combine)"),
+            "The selected part HStack must not combine the Change button into a static parent row."
+        )
+        XCTAssertFalse(
+            areaSummary.contains("Button(\"Change\") {\n                    self.selectedArea = nil\n                }\n            }\n            .accessibilityElement(children: .combine)"),
+            "The selected area HStack must not combine the Change button into a static parent row."
+        )
+        XCTAssertTrue(partSummary.contains(".accessibilityIdentifier(\"misplaced-selected-part-change-button\")"))
+        XCTAssertTrue(areaSummary.contains(".accessibilityIdentifier(\"misplaced-selected-area-change-button\")"))
+        XCTAssertTrue(partSummary.contains(".accessibilityLabel(\"Change selected part\")"))
+        XCTAssertTrue(areaSummary.contains(".accessibilityLabel(\"Change selected area\")"))
+    }
+
+    private static func section(named startMarker: String, in source: String, endingBefore endMarker: String) throws -> String {
+        guard let start = source.range(of: startMarker) else {
+            XCTFail("Missing section starting with \(startMarker)")
+            return source
+        }
+        let afterStart = source[start.lowerBound...]
+        guard let end = afterStart.range(of: endMarker) else {
+            XCTFail("Missing section ending before \(endMarker)")
+            return String(afterStart)
+        }
+        return String(afterStart[..<end.lowerBound])
+    }
+
+    private static func readJobSource(_ fileName: String, file: StaticString = #filePath) throws -> String {
+        try readFeatureSource(fileName, folder: "Jobs", file: file)
+    }
+
+    private static func readWarehouseSource(_ fileName: String, file: StaticString = #filePath) throws -> String {
+        try readFeatureSource(fileName, folder: "Warehouse", file: file)
+    }
+
+    private static func readFeatureSource(
+        _ fileName: String,
+        folder: String,
+        file: StaticString = #filePath
+    ) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent(folder)
+            .appendingPathComponent(fileName)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Split static summary accessibility grouping away from workflow action buttons in the recovered timer banner, job material rows, and misplaced-part audit selections.
- Added explicit labels, hints, and stable accessibility identifiers for Continue Timer, Clock Out, Use, Return, Correct, and Change controls.
- Added source-level regression coverage for GitHub #1029 / Paperclip WEI-3751 / WEI-3752 under the WEI-3539 hygiene lane.

Closes #1029
Paperclip: WEI-3751, WEI-3752, parent WEI-3539

## Test Plan
- [x] xcodebuild test -project "Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:"Weird Parts IOSTests/FieldWorkflowActionButtonAccessibilityTests"
- [x] Source scan verified the old combined-parent patterns no longer wrap the #1029 action rows.
- [x] Diff scan found no conflict markers or secret-looking additions.

## Local runner / CI note
This PR is intended for the local Mac runner path for trusted iOS/Xcode validation if CI runs: [self-hosted, macOS, ARM64, xcode, ios, local-mac].

## Follow-up QA
Because the fix changes accessibility exposure in field-critical UI flows, I am requesting UIExpertVerifier follow-up in Paperclip for user-like desktop/tablet/mobile/ARIA-oriented evidence before merge.