### PR TITLE
fix: keep dispatch retry accessibility action separate

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateDispatchSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateDispatchSheet.swift
@@ -137,12 +137,16 @@ struct CreateDispatchSheet: View {
     @ViewBuilder
     private func loadFailureRow(message: String, retryLabel: String) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            Label("Unable to load", systemImage: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
-                .font(.subheadline.weight(.semibold))
-            Text(message)
-                .foregroundStyle(.secondary)
-                .font(.caption)
+            VStack(alignment: .leading, spacing: 4) {
+                Label("Unable to load", systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.subheadline.weight(.semibold))
+                Text(message)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+            .accessibilityElement(children: .combine)
+
             Button {
                 loadData()
             } label: {
@@ -151,7 +155,6 @@ struct CreateDispatchSheet: View {
             .buttonStyle(.bordered)
             .accessibilityLabel(retryLabel)
         }
-        .accessibilityElement(children: .combine)
     }
 
     private func loadData() {

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -362,6 +362,10 @@ struct Weird_Parts_IOSTests {
         #expect(source.contains("Text(\"No active jobs\")"), "Legitimate empty job results should still show the empty-state copy")
         #expect(source.contains("Text(\"No employees found\")"), "Legitimate empty employee results should still show the empty-state copy")
         #expect(source.contains("Label(\"Retry\", systemImage: \"arrow.clockwise\")"), "Load failures should offer an actionable retry")
+        #expect(
+            !source.contains(".accessibilityLabel(retryLabel)\n        }\n        .accessibilityElement(children: .combine)"),
+            "Load-failure rows must not combine the retry button into static failure copy"
+        )
         #expect(source.contains("Retry loading jobs"), "Job retry control needs a specific accessibility label")
         #expect(source.contains("Retry loading employees"), "Employee retry control needs a specific accessibility label")
     }


### PR DESCRIPTION
## Summary
- Keeps the CreateDispatchSheet load-failure message grouped for VoiceOver while moving the Retry button outside the combined accessibility element.
- Preserves the existing context-specific retry labels for failed jobs and employees loads.
- Adds regression coverage to prevent re-combining the retry control into static failure copy.

## Paperclip
- WEI-3762
- Parent: WEI-3539

## Accessibility evidence
- Before the fix, the outer load-failure VStack used `.accessibilityElement(children: .combine)` around both the message and the Retry button, which can make VoiceOver expose the failure text without an independently reachable retry action.
- After the fix, only the warning label/message VStack is combined; the `Button` remains a sibling with `.accessibilityLabel("Retry loading jobs")` or `.accessibilityLabel("Retry loading employees")`, so jobs/employees load failures keep an actionable retry control.

## Tests
- RED: `xcodebuild test -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:"Weird Parts IOSTests"` failed at `Weird_Parts_IOSTests/createDispatchSheetShowsActionableLoadFailures()` after adding the regression assertion; unrelated pre-existing failures also appeared in `SettingsSaveButtonValidationTests.testDailyReportTemplatesPageHasIsDirtyGuard()` and `WarehouseAuditFixtureRegressionTests.testFixtureVerificationItemFallsBackToPendingAssignmentWhenQueueItemMissing()`.
- GREEN: `xcodebuild test -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/createDispatchSheetShowsActionableLoadFailures()"` -> `** TEST SUCCEEDED **`; test case passed.
- BUILD: `xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build` -> `** BUILD SUCCEEDED **` with existing warnings.

Closes #1023
