### PR TITLE
fix(warehouse): expose packout front face controls

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
@@ -921,19 +921,6 @@ private struct AddStorageUnitSheet: View {
                     typeSummaryRow(catalogItem)
                 }
 
-                Section("Dimensions") {
-                    Stepper("Width: \(widthInches)\"", value: $widthInches, in: 6...240, step: 6)
-                    Stepper("Depth: \(depthInches)\"", value: $depthInches, in: 6...120, step: 6)
-                    Stepper("Height: \(heightInches)\"", value: $heightInches, in: 12...240, step: 6)
-                }
-
-                Section("Grid Placement") {
-                    Stepper("X: \(gridX)", value: $gridX, in: 0...100)
-                    Stepper("Y: \(gridY)", value: $gridY, in: 0...100)
-                    Stepper("Width: \(gridWidth) cells", value: $gridWidth, in: 1...10)
-                    Stepper("Height: \(gridHeight) cells", value: $gridHeight, in: 1...10)
-                }
-
                 Section {
                     Picker("Front Face", selection: $frontFace) {
                         ForEach(faceOptions, id: \.self) { Text($0.capitalized) }
@@ -945,6 +932,19 @@ private struct AddStorageUnitSheet: View {
                         .foregroundStyle(.secondary)
                 } header: {
                     Text("Orientation")
+                }
+
+                Section("Dimensions") {
+                    Stepper("Width: \(widthInches)\"", value: $widthInches, in: 6...240, step: 6)
+                    Stepper("Depth: \(depthInches)\"", value: $depthInches, in: 6...120, step: 6)
+                    Stepper("Height: \(heightInches)\"", value: $heightInches, in: 12...240, step: 6)
+                }
+
+                Section("Grid Placement") {
+                    Stepper("X: \(gridX)", value: $gridX, in: 0...100)
+                    Stepper("Y: \(gridY)", value: $gridY, in: 0...100)
+                    Stepper("Width: \(gridWidth) cells", value: $gridWidth, in: 1...10)
+                    Stepper("Height: \(gridHeight) cells", value: $gridHeight, in: 1...10)
                 }
 
                 Section("Structure") {


### PR DESCRIPTION
## Summary
- Moves the Add Packout Set sheet's Front Face orientation picker above the lower dimensions/grid sections.
- Keeps the existing `warehouse-add-unit-front-face` accessibility identifier and makes the East/West segmented controls visible immediately after opening the sheet on the warehouse locations direct route.

## Test Plan
- [x] RED: `xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'id=88221D6D-FF1C-43A0-9CE6-970876D1EBAB' -derivedDataPath /tmp/DerivedData-WEI3763-red -only-testing:"Weird PartsUITests/Weird_Parts_IOSUITests/testWEI2475WarehouseLocationsDirectRouteReachesSeededFloorPlan"` failed on `Add Packout Set sheet should expose Front Face controls`.
- [x] GREEN: same targeted iPhone 17/iOS 26.4 simulator command with `/tmp/DerivedData-WEI3763-green` passed: `Executed 1 test, with 0 failures`.

Local runner/CI note: this is an iOS UI change; PR CI should use the repo self-hosted Mac runner path for trusted app checks.

Paperclip: WEI-3763
Closes #956
