### PR TITLE
fix: include in-progress jobs in notebook picker

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/CreateNotebookSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/CreateNotebookSheet.swift
@@ -1,6 +1,27 @@
 import SwiftUI
 import WiredPartCore
 
+enum CreateNotebookJobPickerLoader {
+    private static let selectableStatuses = ["active", "in_progress"]
+
+    static func loadSelectableJobs(
+        limit: Int = 200,
+        using listJobs: (_ status: String, _ limit: Int) throws -> [JobsService.JobListItem]
+    ) throws -> [JobsService.JobListItem] {
+        var seenJobIds = Set<Int64>()
+        var mergedJobs: [JobsService.JobListItem] = []
+
+        for status in selectableStatuses {
+            let statusJobs = try listJobs(status, limit)
+            for job in statusJobs where seenJobIds.insert(job.id).inserted {
+                mergedJobs.append(job)
+            }
+        }
+
+        return mergedJobs
+    }
+}
+
 /// Sheet for creating a new notebook, optionally from a template.
 struct CreateNotebookSheet: View {
     @EnvironmentObject private var appCore: AppCore
@@ -17,6 +38,7 @@ struct CreateNotebookSheet: View {
     @State private var templates: [NotebooksService.NotebookTemplateItem] = []
     @State private var isSaving = false
     @State private var saveError: String?
+    @State private var jobsLoadError: String?
     @State private var wasAutoFilled = false
 
     private let typeOptions = ["general", "job", "daily_report", "checklist"]
@@ -40,8 +62,17 @@ struct CreateNotebookSheet: View {
 
                 if notebookType == "job" {
                     Section {
-                        if jobs.isEmpty {
-                            Text("No active jobs")
+                        if let jobsLoadError {
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(jobsLoadError)
+                                    .foregroundStyle(.red)
+                                    .font(.caption)
+                                Button("Retry loading jobs") {
+                                    loadJobs()
+                                }
+                            }
+                        } else if jobs.isEmpty {
+                            Text("No active or in-progress jobs")
                                 .foregroundStyle(.secondary)
                         } else {
                             Picker("Job", selection: $selectedJobId) {
@@ -114,10 +145,20 @@ struct CreateNotebookSheet: View {
 
     private func loadJobs() {
         guard let service = appCore.jobsService else {
-            saveError = "Jobs service not available"
+            jobs = []
+            jobsLoadError = "Jobs service not available. Try again after app services finish loading."
             return
         }
-        jobs = (try? service.listJobs(status: "active", limit: 200)) ?? []
+
+        do {
+            jobs = try CreateNotebookJobPickerLoader.loadSelectableJobs { status, limit in
+                try service.listJobs(status: status, limit: limit)
+            }
+            jobsLoadError = nil
+        } catch {
+            jobs = []
+            jobsLoadError = userFriendlyError(error, context: "load jobs")
+        }
     }
 
     private func loadTemplates() {

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -24,7 +24,55 @@ private enum DispatchSheetLoadTestError: Error {
     case employeeLoadFailed
 }
 
+private enum CreateNotebookJobPickerTestError: Error {
+    case loadFailed
+}
+
 struct Weird_Parts_IOSTests {
+
+    private func makeJobListItem(id: Int64, name: String, status: String) -> JobsService.JobListItem {
+        JobsService.JobListItem(
+            id: id,
+            jobNumber: "JOB-\(id)",
+            jobName: name,
+            customerName: nil,
+            status: status,
+            priority: "normal",
+            teamCount: 0,
+            startDate: nil,
+            dueDate: nil
+        )
+    }
+
+    @MainActor
+    @Test func createNotebookJobPickerIncludesInProgressJobsWithoutDuplicates() throws {
+        let activeJob = makeJobListItem(id: 1, name: "Active Job", status: "active")
+        let inProgressJob = makeJobListItem(id: 2, name: "Clocked Job", status: "in_progress")
+        let duplicateActiveJob = makeJobListItem(id: 1, name: "Active Job Duplicate", status: "active")
+
+        let jobs = try CreateNotebookJobPickerLoader.loadSelectableJobs { status, _ in
+            switch status {
+            case "active":
+                return [activeJob, duplicateActiveJob]
+            case "in_progress":
+                return [inProgressJob, duplicateActiveJob]
+            default:
+                return []
+            }
+        }
+
+        #expect(jobs.map(\.id) == [1, 2])
+        #expect(jobs.map(\.status) == ["active", "in_progress"])
+    }
+
+    @MainActor
+    @Test func createNotebookJobPickerPropagatesLoadFailures() throws {
+        #expect(throws: CreateNotebookJobPickerTestError.self) {
+            _ = try CreateNotebookJobPickerLoader.loadSelectableJobs { _, _ in
+                throw CreateNotebookJobPickerTestError.loadFailed
+            }
+        }
+    }
 
     struct LANPeerDiscoveryStartupError: Error, LocalizedError {
         var errorDescription: String? { "port unavailable" }


### PR DESCRIPTION
## Summary
- Includes both active and in-progress jobs in the manual Create Notebook job picker.
- Deduplicates jobs across status queries while preserving picker order.
- Replaces silent job-load failure fallback with a visible, retryable error state.
- Adds targeted Swift Testing coverage for in-progress job inclusion/deduplication and load-failure propagation.

Closes #927
Paperclip: WEI-3766

## Tests
- [x] RED: `xcodebuild test -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/createNotebookJobPickerIncludesInProgressJobsWithoutDuplicates"` failed before implementation with missing `CreateNotebookJobPickerLoader`.
- [x] `xcodebuild test -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/createNotebookJobPickerIncludesInProgressJobsWithoutDuplicates" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/createNotebookJobPickerPropagatesLoadFailures"` -> `** TEST SUCCEEDED **`
- [x] `xcodebuild -scheme "WiredPart-iOS" -destination 'generic/platform=iOS Simulator' build` -> `** BUILD SUCCEEDED **` (pre-existing warnings only)