### PR TITLE
fix: respect auto-sync opt-out on timer ticks

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -122,9 +122,23 @@ final class IOSSyncManager {
         syncTimer?.invalidate()
         syncTimer = Timer.scheduledTimer(withTimeInterval: syncIntervalSeconds, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
-                await self?.syncNow()
+                await self?.handleAutoSyncTimerTick()
             }
         }
+    }
+
+    /// Handles one scheduled auto-sync tick.
+    ///
+    /// Re-check persisted auto-sync opt-in at execution time so a timer that was
+    /// scheduled while enabled cannot keep syncing after another settings path
+    /// stores `auto_sync = false`.
+    func handleAutoSyncTimerTick() async {
+        guard isSyncAvailable else { return }
+        guard isAutoSyncEnabled else {
+            stopAutoSync()
+            return
+        }
+        await syncNow()
     }
 
     /// Stop automatic sync.

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -98,6 +98,36 @@ struct Weird_Parts_IOSTests {
     }
 
     @MainActor
+    @Test func autoSyncTimerTickStopsWhenStoredOptOutBecomesFalse() async throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        let settings = SettingsService(db: db)
+        try settings.upsertSetting(key: "shop_server_address", value: "http://127.0.0.1:9", category: "sync")
+        try settings.upsertSetting(key: "auto_sync", value: "false", category: "sync")
+        let manager = IOSSyncManager()
+        manager.configure(db: db, settingsService: settings)
+        manager.startAutoSync(intervalSeconds: 60)
+
+        await manager.handleAutoSyncTimerTick()
+
+        #expect(manager.syncStatus == .idle)
+        #expect(manager.syncStatusDescription == "Ready")
+    }
+
+    @MainActor
+    @Test func autoSyncTimerTickRunsWhenStoredOptInStaysTrue() async throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        let settings = SettingsService(db: db)
+        try settings.upsertSetting(key: "shop_server_address", value: "http://127.0.0.1:9", category: "sync")
+        try settings.upsertSetting(key: "auto_sync", value: "true", category: "sync")
+        let manager = IOSSyncManager()
+        manager.configure(db: db, settingsService: settings)
+
+        await manager.handleAutoSyncTimerTick()
+
+        #expect(manager.syncStatus != .idle)
+    }
+
+    @MainActor
     @Test func lanPeerDiscoveryStartupFailureSurfacesErrorAndStopsLanOnlyScan() async throws {
         let manager = IOSSyncManager()
         manager.isScanning = true


### PR DESCRIPTION
## Summary
- Re-check persisted `auto_sync` before each scheduled auto-sync timer tick.
- Stop the existing timer when the stored opt-out is false so a previously scheduled timer cannot continue syncing.
- Add iOS regression coverage for stored opt-out and opt-in timer tick behavior.

## Paperclip
- WEI-3767

## Tests
- [x] `xcodebuild -scheme "WiredPart-iOS" -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/autoSyncTimerTickStopsWhenStoredOptOutBecomesFalse" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/autoSyncTimerTickRunsWhenStoredOptInStaysTrue" test`
- [x] `xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build` (succeeded with existing warnings)

Closes #922