### PR TITLE
fix: refresh AI contexts on search changes

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSDailyReportsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSDailyReportsPage.swift
@@ -45,6 +45,7 @@ struct IOSDailyReportsPage: View {
             )
         }
         .searchable(text: $searchText, prompt: "Search jobs...")
+        .onChange(of: searchText) { postAIContext(dateString: isoDate(selectedDate)) }
         .refreshable { loadData() }
         .task { loadData() }
         .onDisappear {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSOrderStagingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSOrderStagingPage.swift
@@ -44,6 +44,7 @@ struct IOSOrderStagingPage: View {
         }
         .navigationTitle("Job Stage Planner")
         .searchable(text: $searchText, prompt: "Search parts...")
+        .onChange(of: searchText) { postAIContext() }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .stageSettings } label: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
@@ -104,6 +104,7 @@ struct IOSPartsOrderManagementPage: View {
         }
         .navigationTitle("Parts Management")
         .searchable(text: $searchText, prompt: "Search parts by name, code, or job...")
+        .onChange(of: searchText) { postAIContext() }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .help } label: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSProcurementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSProcurementPage.swift
@@ -121,6 +121,7 @@ struct IOSProcurementPage: View {
         }
         .navigationTitle("Procurement")
         .searchable(text: $searchText, prompt: "Search parts...")
+        .onChange(of: searchText) { postAIContext() }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .help } label: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSWishlistPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSWishlistPage.swift
@@ -101,6 +101,7 @@ struct IOSWishlistPage: View {
         .task { appCore.onboardingManager?.markCompleted("wishlist-view") }
         .navigationTitle("Wishlist")
         .searchable(text: $searchText, prompt: "Search wishlist...")
+        .onChange(of: searchText) { postAIContext() }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .addItem } label: { Image(systemName: "plus") }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
@@ -135,6 +135,7 @@ struct IOSAuditPage: View {
         }
         .navigationTitle("Warehouse Audit")
         .searchable(text: $searchText, prompt: "Search parts...")
+        .onChange(of: searchText) { postAIContext() }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSOrganizationAuditPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSOrganizationAuditPage.swift
@@ -65,6 +65,7 @@ struct IOSOrganizationAuditPage: View {
         }
         .navigationTitle("Organization Audit")
         .searchable(text: $searchText, prompt: "Search areas...")
+        .onChange(of: searchText) { postAIContext() }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .help } label: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseLeaderboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseLeaderboardPage.swift
@@ -66,6 +66,7 @@ struct IOSWarehouseLeaderboardPage: View {
             sheetContent(for: sheet)
         }
         .searchable(text: $searchText, prompt: "Search users...")
+        .onChange(of: searchText) { postAIContext() }
         .refreshable { loadData() }
         .task { loadData() }
         .onDisappear {


### PR DESCRIPTION
## Summary
- Fixes #881 by reposting AI page context whenever `searchText` changes on affected searchable pages.
- Covers the current stale-context static probe set across Orders, Daily Reports, Warehouse Audit, Organization Audit, and Warehouse Leaderboard.
- Keeps existing load/refresh context posting intact; this only adds search-change invalidation.

## Verification
- Static regression probe: no `postAIContext` + `searchText` + `.searchable(text: $searchText...)` pages remain without `.onChange(of: searchText)`.
- `xcodebuild -workspace 'Wierd Parts.xcworkspace' -scheme 'WiredPart-iOS' -destination 'generic/platform=iOS Simulator' build` — passed.

## Paperclip
- WEI-3803: `[WPR2][GitHub #881] Fix stale searchable page contexts after search text changes`

## CI / local runner note
- Local verification used Xcode simulator build on this Mac.
- Repo CI should run through the WPR2 local self-hosted Mac runner path for iOS/Xcode work rather than GitHub-hosted macOS minutes.
