### PR TITLE
fix: scope warehouse drafts per user

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
@@ -1009,8 +1009,6 @@ struct IOSMovementWizard: View {
 
     // MARK: - Draft Persistence (#148)
 
-    private static let draftKey = "movementWizardDraft"
-
     private struct WizardDraftPayload: Codable {
         var currentStep: Int
         var fromLocationType: String
@@ -1036,13 +1034,13 @@ struct IOSMovementWizard: View {
             referenceNumber: referenceNumber
         )
         if let data = try? JSONEncoder().encode(draft) {
-            UserDefaults.standard.set(data, forKey: Self.draftKey)
+            MovementWizardDraftStore.save(data, userId: appCore.currentUser?.id)
         }
         dismiss()
     }
 
     private func restoreDraft() {
-        guard let data = UserDefaults.standard.data(forKey: Self.draftKey),
+        guard let data = MovementWizardDraftStore.loadData(userId: appCore.currentUser?.id),
               let draft = try? JSONDecoder().decode(WizardDraftPayload.self, from: data) else { return }
         currentStep = draft.currentStep
         fromLocationType = draft.fromLocationType
@@ -1057,7 +1055,28 @@ struct IOSMovementWizard: View {
     }
 
     private func clearDraft() {
-        UserDefaults.standard.removeObject(forKey: Self.draftKey)
+        MovementWizardDraftStore.clear(userId: appCore.currentUser?.id)
+    }
+}
+
+enum MovementWizardDraftStore {
+    static let baseKey = "movementWizardDraft"
+
+    static func key(userId: Int64?) -> String {
+        guard let userId else { return "\(baseKey)_anonymous" }
+        return "\(baseKey)_user_\(userId)"
+    }
+
+    static func save(_ data: Data, userId: Int64?) {
+        UserDefaults.standard.set(data, forKey: key(userId: userId))
+    }
+
+    static func loadData(userId: Int64?) -> Data? {
+        UserDefaults.standard.data(forKey: key(userId: userId))
+    }
+
+    static func clear(userId: Int64?) {
+        UserDefaults.standard.removeObject(forKey: key(userId: userId))
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/PartsFlowWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/PartsFlowWizard.swift
@@ -5,22 +5,27 @@ enum PartsFlowDraftStore {
     static let countsKey = "partsFlow_counts"
     static let locationsKey = "partsFlow_locations"
 
-    static func loadCounts() -> [Int64: String] {
-        loadDictionary(forKey: countsKey)
+    static func scopedKey(_ baseKey: String, userId: Int64?) -> String {
+        guard let userId else { return "\(baseKey)_anonymous" }
+        return "\(baseKey)_user_\(userId)"
     }
 
-    static func loadLocations() -> [Int64: String] {
-        loadDictionary(forKey: locationsKey)
+    static func loadCounts(userId: Int64?) -> [Int64: String] {
+        loadDictionary(forKey: scopedKey(countsKey, userId: userId))
     }
 
-    static func save(counts: [Int64: String], locations: [Int64: String]) {
-        saveDictionary(counts, forKey: countsKey)
-        saveDictionary(locations, forKey: locationsKey)
+    static func loadLocations(userId: Int64?) -> [Int64: String] {
+        loadDictionary(forKey: scopedKey(locationsKey, userId: userId))
     }
 
-    static func clear() {
-        UserDefaults.standard.removeObject(forKey: countsKey)
-        UserDefaults.standard.removeObject(forKey: locationsKey)
+    static func save(counts: [Int64: String], locations: [Int64: String], userId: Int64?) {
+        saveDictionary(counts, forKey: scopedKey(countsKey, userId: userId))
+        saveDictionary(locations, forKey: scopedKey(locationsKey, userId: userId))
+    }
+
+    static func clear(userId: Int64?) {
+        UserDefaults.standard.removeObject(forKey: scopedKey(countsKey, userId: userId))
+        UserDefaults.standard.removeObject(forKey: scopedKey(locationsKey, userId: userId))
     }
 
     private static func loadDictionary(forKey key: String) -> [Int64: String] {
@@ -403,8 +408,9 @@ struct PartsFlowWizard: View {
     private func loadParts() {
         isLoading = true
         loadError = nil
-        partCounts = PartsFlowDraftStore.loadCounts()
-        partLocations = PartsFlowDraftStore.loadLocations()
+        let userId = appCore.currentUser?.id
+        partCounts = PartsFlowDraftStore.loadCounts(userId: userId)
+        partLocations = PartsFlowDraftStore.loadLocations(userId: userId)
 
         guard let partsService = appCore.partsService else {
             parts = []
@@ -442,7 +448,8 @@ struct PartsFlowWizard: View {
         isSaving = true
         saveErrorMessage = nil
 
-        PartsFlowDraftStore.save(counts: partCounts, locations: partLocations)
+        let userId = appCore.currentUser?.id
+        PartsFlowDraftStore.save(counts: partCounts, locations: partLocations, userId: userId)
 
         guard let service = appCore.partsService else {
             isSaving = false
@@ -486,12 +493,12 @@ struct PartsFlowWizard: View {
             }
             savedCount = count
             if !failedParts.isEmpty {
-                PartsFlowDraftStore.save(counts: counts, locations: locations)
+                PartsFlowDraftStore.save(counts: counts, locations: locations, userId: userId)
                 let preview = failedParts.prefix(3).joined(separator: ", ")
                 let suffix = failedParts.count > 3 ? " and \(failedParts.count - 3) more" : ""
                 saveErrorMessage = "Failed to save \(failedParts.count) part(s): \(preview)\(suffix). Your draft is still saved on this device."
             } else if clearDraft {
-                PartsFlowDraftStore.clear()
+                PartsFlowDraftStore.clear(userId: userId)
             }
             isSaving = false
             if andDismiss && saveErrorMessage == nil {

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -98,6 +98,50 @@ struct Weird_Parts_IOSTests {
     }
 
     @MainActor
+    @Test func partsFlowDraftsAreScopedPerAuthenticatedUser() throws {
+        let userA: Int64 = 101
+        let userB: Int64 = 202
+        PartsFlowDraftStore.clear(userId: userA)
+        PartsFlowDraftStore.clear(userId: userB)
+        UserDefaults.standard.removeObject(forKey: PartsFlowDraftStore.countsKey)
+        UserDefaults.standard.removeObject(forKey: PartsFlowDraftStore.locationsKey)
+        defer {
+            PartsFlowDraftStore.clear(userId: userA)
+            PartsFlowDraftStore.clear(userId: userB)
+        }
+
+        UserDefaults.standard.set(Data("legacy".utf8), forKey: PartsFlowDraftStore.countsKey)
+        PartsFlowDraftStore.save(counts: [1: "7"], locations: [1: "Aisle 4"], userId: userA)
+
+        #expect(PartsFlowDraftStore.scopedKey(PartsFlowDraftStore.countsKey, userId: userA) != PartsFlowDraftStore.countsKey)
+        #expect(PartsFlowDraftStore.loadCounts(userId: userA) == [1: "7"])
+        #expect(PartsFlowDraftStore.loadLocations(userId: userA) == [1: "Aisle 4"])
+        #expect(PartsFlowDraftStore.loadCounts(userId: userB).isEmpty)
+        #expect(PartsFlowDraftStore.loadLocations(userId: userB).isEmpty)
+    }
+
+    @MainActor
+    @Test func movementWizardDraftsAreScopedPerAuthenticatedUser() throws {
+        let userA: Int64 = 303
+        let userB: Int64 = 404
+        MovementWizardDraftStore.clear(userId: userA)
+        MovementWizardDraftStore.clear(userId: userB)
+        UserDefaults.standard.removeObject(forKey: MovementWizardDraftStore.baseKey)
+        defer {
+            MovementWizardDraftStore.clear(userId: userA)
+            MovementWizardDraftStore.clear(userId: userB)
+        }
+
+        let draftData = Data("user-a-draft".utf8)
+        UserDefaults.standard.set(Data("legacy".utf8), forKey: MovementWizardDraftStore.baseKey)
+        MovementWizardDraftStore.save(draftData, userId: userA)
+
+        #expect(MovementWizardDraftStore.key(userId: userA) != MovementWizardDraftStore.baseKey)
+        #expect(MovementWizardDraftStore.loadData(userId: userA) == draftData)
+        #expect(MovementWizardDraftStore.loadData(userId: userB) == nil)
+    }
+
+    @MainActor
     @Test func autoSyncTimerTickStopsWhenStoredOptOutBecomesFalse() async throws {
         let db = try AppDatabase.openInMemoryDatabase()
         let settings = SettingsService(db: db)
@@ -652,20 +696,22 @@ struct Weird_Parts_IOSTests {
 struct PartsFlowDraftStoreTests {
     @MainActor
     @Test func preservesAndClearsDraftCountsAndLocations() async throws {
-        PartsFlowDraftStore.clear()
-        defer { PartsFlowDraftStore.clear() }
+        let userId: Int64 = 505
+        PartsFlowDraftStore.clear(userId: userId)
+        defer { PartsFlowDraftStore.clear(userId: userId) }
 
         PartsFlowDraftStore.save(
             counts: [101: "7", 202: ""],
-            locations: [101: "Shelf A", 303: "Van 2"]
+            locations: [101: "Shelf A", 303: "Van 2"],
+            userId: userId
         )
 
-        #expect(PartsFlowDraftStore.loadCounts() == [101: "7", 202: ""])
-        #expect(PartsFlowDraftStore.loadLocations() == [101: "Shelf A", 303: "Van 2"])
+        #expect(PartsFlowDraftStore.loadCounts(userId: userId) == [101: "7", 202: ""])
+        #expect(PartsFlowDraftStore.loadLocations(userId: userId) == [101: "Shelf A", 303: "Van 2"])
 
-        PartsFlowDraftStore.clear()
+        PartsFlowDraftStore.clear(userId: userId)
 
-        #expect(PartsFlowDraftStore.loadCounts().isEmpty)
-        #expect(PartsFlowDraftStore.loadLocations().isEmpty)
+        #expect(PartsFlowDraftStore.loadCounts(userId: userId).isEmpty)
+        #expect(PartsFlowDraftStore.loadLocations(userId: userId).isEmpty)
     }
 }


### PR DESCRIPTION
## Summary
- Keeps `shop_server_address` device-scoped in both iOS sync scope classification and core settings sync filtering.
- Moves warehouse parts-flow count/location drafts from shared global UserDefaults keys to authenticated-user-scoped keys.
- Moves movement wizard draft payloads from the shared `movementWizardDraft` key to authenticated-user-scoped keys.
- Adds regression coverage proving User B cannot restore User A's parts-flow or movement wizard draft data, and that legacy global draft keys are not used for authenticated scoped reads.

## Test Plan
- [x] `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/shopServerAddressSettingsAreDeviceScoped" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/partsFlowDraftsAreScopedPerAuthenticatedUser" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/movementWizardDraftsAreScopedPerAuthenticatedUser" -only-testing:"Weird Parts IOSTests/PartsFlowDraftStoreTests/preservesAndClearsDraftCountsAndLocations"`
- [x] `swift test --filter SettingsServiceTests` from `core/`
- [x] Local runner path available for CI: repo-owned iOS/macOS checks should run on Isaac's self-hosted Mac runner labels, not hosted billing minutes.

Closes #880
Closes #848
Closes #846

Paperclip: WEI-3799
