### PR TITLE
fix: refresh AI context for searchable pages

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOCreationPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOCreationPage.swift
@@ -256,6 +256,8 @@ struct IOSJPOCreationPage: View {
             postAIContext()
         }
         .onChange(of: selectedJobId) { postAIContext() }
+        .onChange(of: priority) { postAIContext() }
+        .onChange(of: deliveryOption) { postAIContext() }
         .onDisappear {
             NotificationCenter.default.post(name: .jpoCreationPageInactive, object: nil)
         }
@@ -351,7 +353,10 @@ struct IOSJPOCreationPage: View {
                     .accessibilityHidden(true)
                 TextField("Search parts...", text: $searchText)
                     .textFieldStyle(.plain)
-                    .onChange(of: searchText) { searchParts() }
+                    .onChange(of: searchText) {
+                        searchParts()
+                        postAIContext()
+                    }
                 if !searchText.isEmpty {
                     Button {
                         searchText = ""

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSOrderStagingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSOrderStagingPage.swift
@@ -61,6 +61,7 @@ struct IOSOrderStagingPage: View {
         }
         .refreshable { loadData() }
         .task { await loadInitialData() }
+        .onChange(of: stageFilter) { _, _ in postAIContext() }
         .onDisappear {
             NotificationCenter.default.post(name: .orderStagingPageInactive, object: nil)
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
@@ -150,6 +150,15 @@ struct IOSPartsOrderManagementPage: View {
             }
             loadData()
         }
+        .onChange(of: showDraft) { _, _ in postAIContext() }
+        .onChange(of: showActive) { _, _ in postAIContext() }
+        .onChange(of: showPartial) { _, _ in postAIContext() }
+        .onChange(of: showReceived) { _, _ in postAIContext() }
+        .onChange(of: showCancelled) { _, _ in postAIContext() }
+        .onChange(of: showWaiting) { _, _ in postAIContext() }
+        .onChange(of: showBackorder) { _, _ in postAIContext() }
+        .onChange(of: showReceivedParts) { _, _ in postAIContext() }
+        .onChange(of: selectedPartIds) { _, _ in postAIContext() }
         .onDisappear {
             NotificationCenter.default.post(name: .partsOrderManagementPageInactive, object: nil)
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSProcurementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSProcurementPage.swift
@@ -148,8 +148,20 @@ struct IOSProcurementPage: View {
             loadData()
             appCore.onboardingManager?.markCompleted("procurement-view")
         }
-        .onChange(of: checkedParts) { updateReadyToGenerate() }
-        .onChange(of: selectedSupplier) { updateReadyToGenerate() }
+        .onChange(of: sourceFilter) { _, _ in
+            updateReadyToGenerate()
+            postAIContext()
+        }
+        .onChange(of: checkedParts) { _, _ in
+            updateReadyToGenerate()
+            postAIContext()
+        }
+        .onChange(of: selectedSupplier) { _, _ in
+            updateReadyToGenerate()
+            postAIContext()
+        }
+        .onChange(of: pullDecisions.keys.sorted()) { _, _ in postAIContext() }
+        .onChange(of: poGroupingMode) { _, _ in postAIContext() }
         .onDisappear {
             NotificationCenter.default.post(name: .procurementPageInactive, object: nil)
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSWishlistPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSWishlistPage.swift
@@ -155,6 +155,8 @@ struct IOSWishlistPage: View {
         }
         .refreshable { loadData() }
         .task { loadData() }
+        .onChange(of: searchText) { _, _ in postAIContext() }
+        .onChange(of: selectedStatus) { _, _ in postAIContext() }
         .onDisappear {
             NotificationCenter.default.post(name: .ordersWishlistPageInactive, object: nil)
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
@@ -136,6 +136,7 @@ struct IOSAuditPage: View {
         .navigationTitle("Warehouse Audit")
         .searchable(text: $searchText, prompt: "Search parts...")
         .onChange(of: searchText) { _, _ in postAIContext() }
+        .onChange(of: filter) { _, _ in postAIContext() }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSOrganizationAuditPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSOrganizationAuditPage.swift
@@ -66,6 +66,7 @@ struct IOSOrganizationAuditPage: View {
         .navigationTitle("Organization Audit")
         .searchable(text: $searchText, prompt: "Search areas...")
         .onChange(of: searchText) { _, _ in postAIContext() }
+        .onChange(of: tab) { _, _ in postAIContext() }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .help } label: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseLeaderboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseLeaderboardPage.swift
@@ -279,7 +279,7 @@ struct IOSWarehouseLeaderboardPage: View {
     }
 
     private func postAIContext() {
-        let topUser = leaderboard.first.map { userNames[$0.userId] ?? "User #\($0.userId)" } ?? "none"
+        let topUser = filteredLeaderboard.first.map { userNames[$0.userId] ?? "User #\($0.userId)" } ?? "none"
         let context = """
         Warehouse Leaderboard page. Read-only context.
         Loaded ratings: \(leaderboard.count), visible after search: \(filteredLeaderboard.count), search active: \(!searchText.isEmpty), manager detail access: \(isManager).

--- a/tests/static/test_ai_help_context_coverage.py
+++ b/tests/static/test_ai_help_context_coverage.py
@@ -132,6 +132,43 @@ class AIHelpContextCoverageTests(unittest.TestCase):
                 "onChange(of: selectedFilter)",
                 "onChange(of: activeSheet?.id)",
             ],
+            # Regression coverage for GitHub #881: every searchable page named in the
+            # stale-context report must repost AI context when search text changes.
+            "Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSDailyReportsPage.swift": [
+                "onChange(of: searchText)",
+            ],
+            "Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSOrderStagingPage.swift": [
+                "onChange(of: searchText)",
+                "onChange(of: stageFilter)",
+            ],
+            "Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSProcurementPage.swift": [
+                "onChange(of: searchText)",
+                "onChange(of: sourceFilter)",
+                "onChange(of: selectedSupplier)",
+            ],
+            "Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSWishlistPage.swift": [
+                "onChange(of: searchText)",
+                "onChange(of: selectedStatus)",
+            ],
+            "Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift": [
+                "onChange(of: searchText)",
+                "onChange(of: showDraft)",
+                "onChange(of: showActive)",
+                "onChange(of: showPartial)",
+                "onChange(of: showReceived)",
+                "onChange(of: showCancelled)",
+                "onChange(of: showWaiting)",
+                "onChange(of: showBackorder)",
+                "onChange(of: showReceivedParts)",
+                "onChange(of: selectedPartIds)",
+            ],
+            "Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSOrganizationAuditPage.swift": [
+                "onChange(of: searchText)",
+                "onChange(of: tab)",
+            ],
+            "Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseLeaderboardPage.swift": [
+                "onChange(of: searchText)",
+            ],
         }
         missing = {}
         for path, expected_snippets in freshness_expectations.items():


### PR DESCRIPTION
## Summary
- Repost iOS AI page context when search/filter/tab/selection state changes on affected Orders and Warehouse pages.
- Keep Warehouse Leaderboard top-user context aligned with filtered search results.
- Expand the static AI/help context regression coverage for GitHub #881 so listed searchable pages must keep search/filter context refresh hooks.

Closes #881
Paperclip: WEI-3803

## Test Plan
- [x] python3 tests/static/test_ai_help_context_coverage.py
- [x] python3 static probe for postAIContext + searchText pages missing .onChange(of: searchText) => missing_count=0
- [x] swiftc -parse modified Swift pages

## CI
Repo-owned PR checks should run on the local Mac self-hosted runner path where applicable.