### PR TITLE
fix: preserve stock thresholds in parts CSV import

### DIFF
--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -6385,6 +6385,22 @@ public final class PartsService: Sendable {
                     }
                 }
             }
+            for stockHeader in ["min_stock", "target_stock", "max_stock"] {
+                if let raw = fields[stockHeader] {
+                    guard let value = Int(raw) else {
+                        let message = "Invalid integer for \(stockHeader): \(raw)"
+                        preview.errors.append(PartsImportError(rowNumber: rowNumber, message: message))
+                        errorsByRowNumber[rowNumber, default: []].append(message)
+                        continue
+                    }
+                    if value < 0 {
+                        let message = "\(stockHeader) cannot be negative"
+                        preview.errors.append(PartsImportError(rowNumber: rowNumber, message: message))
+                        errorsByRowNumber[rowNumber, default: []].append(message)
+                        continue
+                    }
+                }
+            }
             if let messages = errorsByRowNumber[rowNumber] {
                 preview.decisions.append(PartsImportPreviewRowDecision(
                     rowNumber: rowNumber,
@@ -6792,6 +6808,19 @@ public final class PartsService: Sendable {
                     return value
                 }
 
+                func parseImportInteger(_ rawValue: String?, header: String, rowNumber: Int) throws -> Int? {
+                    guard let rawValue else { return nil }
+                    let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { return nil }
+                    guard let value = Int(trimmed) else {
+                        throw PartsError.invalidInput("Invalid integer for \(header) at row \(rowNumber): \(rawValue)")
+                    }
+                    if value < 0 {
+                        throw PartsError.invalidInput("\(header) cannot be negative at row \(rowNumber)")
+                    }
+                    return value
+                }
+
                 func findOrCreateCategoryInTransaction(_ name: String) throws -> Int64 {
                     if let existing = try Row.fetchOne(dbConn, sql: "SELECT id FROM part_categories WHERE name = ? AND deleted_at IS NULL", arguments: [name]) {
                         return existing["id"]
@@ -6822,21 +6851,28 @@ public final class PartsService: Sendable {
                     let brandId = try findOrCreateBrandInTransaction(row.brand)
                     let cost = try parseImportNumeric(row.fields["cost_price"], header: "cost_price", rowNumber: row.rowNumber) ?? 0
                     let markup = try parseImportNumeric(row.fields["markup_percent"], header: "markup_percent", rowNumber: row.rowNumber) ?? 0
+                    let minStock = try parseImportInteger(row.fields["min_stock"], header: "min_stock", rowNumber: row.rowNumber)
+                    let targetStock = try parseImportInteger(row.fields["target_stock"], header: "target_stock", rowNumber: row.rowNumber)
+                    let maxStock = try parseImportInteger(row.fields["max_stock"], header: "max_stock", rowNumber: row.rowNumber)
                     let partType = row.fields["part_type"] ?? "general"
 
                     try Validators.requireName(row.name, field: "Part name")
                     try Validators.requireText(row.code, field: "Part code", limit: Validators.Limits.code)
                     try Validators.requireNonNegative(cost, field: "Cost price")
                     try Validators.requireNonNegative(markup, field: "Markup percent")
+                    if let minStock { try Validators.requireNonNegative(minStock, field: "Min stock") }
+                    if let targetStock { try Validators.requireNonNegative(targetStock, field: "Target stock") }
+                    if let maxStock { try Validators.requireNonNegative(maxStock, field: "Max stock") }
 
                     try dbConn.execute(sql: """
                         INSERT INTO parts (
                             category_id, brand_id, part_type, code, name, description,
                             unit_of_measure, company_cost_price, weighted_avg_cost,
-                            company_markup_percent, shelf_location, bin_location,
+                            company_markup_percent, min_stock_level, target_stock_level,
+                            max_stock_level, shelf_location, bin_location,
                             auto_add_to_wishlist_when_low, is_deprecated, is_qr_tagged,
                             is_active, created_at, updated_at
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 1, datetime('now'), datetime('now'))
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 1, datetime('now'), datetime('now'))
                         """, arguments: [
                             categoryId,
                             brandId,
@@ -6848,6 +6884,9 @@ public final class PartsService: Sendable {
                             cost,
                             cost,
                             markup,
+                            minStock,
+                            targetStock,
+                            maxStock,
                             row.fields["shelf_location"],
                             row.fields["bin_location"]
                         ])
@@ -6860,6 +6899,9 @@ public final class PartsService: Sendable {
                     let brandId = try findOrCreateBrandInTransaction(row.brand)
                     let cost = try parseImportNumeric(row.fields["cost_price"], header: "cost_price", rowNumber: row.rowNumber)
                     let markup = try parseImportNumeric(row.fields["markup_percent"], header: "markup_percent", rowNumber: row.rowNumber)
+                    let minStock = try parseImportInteger(row.fields["min_stock"], header: "min_stock", rowNumber: row.rowNumber)
+                    let targetStock = try parseImportInteger(row.fields["target_stock"], header: "target_stock", rowNumber: row.rowNumber)
+                    let maxStock = try parseImportInteger(row.fields["max_stock"], header: "max_stock", rowNumber: row.rowNumber)
 
                     var clauses = [
                         "name = ?",
@@ -6874,6 +6916,9 @@ public final class PartsService: Sendable {
                     if let unit = row.fields["unit_of_measure"] { clauses.append("unit_of_measure = ?"); args.append(unit) }
                     if let cost { clauses.append("company_cost_price = ?"); args.append(cost) }
                     if let markup { clauses.append("company_markup_percent = ?"); args.append(markup) }
+                    if let minStock { clauses.append("min_stock_level = ?"); args.append(minStock) }
+                    if let targetStock { clauses.append("target_stock_level = ?"); args.append(targetStock) }
+                    if let maxStock { clauses.append("max_stock_level = ?"); args.append(maxStock) }
                     if let shelf = row.fields["shelf_location"] { clauses.append("shelf_location = ?"); args.append(shelf) }
                     if let bin = row.fields["bin_location"] { clauses.append("bin_location = ?"); args.append(bin) }
                     clauses.append("updated_at = datetime('now')")

--- a/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
@@ -486,6 +486,73 @@ struct PartsServiceAdvancedTests {
         #expect(export.contains("Round Trip Cost Part,ROUND-COST-001,18.75,18.75,40.0,26.25"))
     }
 
+    @Test("commitPartsImportCSV preserves imported stock thresholds for new parts")
+    func testCommitPartsImportCSVPreservesStockThresholdsForNewParts() throws {
+        let env = try E2ETestHelpers.setUp()
+        let preview = try env.parts.previewPartsImportCSV("""
+        name,code,category,min_stock,target_stock,max_stock
+        Round Trip Stock Part,ROUND-STOCK-001,Round Trip Stock,5,20,40
+        """)
+
+        _ = try env.parts.commitPartsImportCSV(preview)
+
+        let imported = try #require(try env.parts.findPartByCode("ROUND-STOCK-001"))
+        #expect(imported.minStockLevel == 5)
+        #expect(imported.targetStockLevel == 20)
+        #expect(imported.maxStockLevel == 40)
+
+        let export = try env.parts.exportPartsCSV(groups: [.stockLevels])
+        #expect(export.contains("Round Trip Stock Part,ROUND-STOCK-001,5,20,40,0"))
+    }
+
+    @Test("commitPartsImportCSV updates existing stock thresholds when conflict is accepted")
+    func testCommitPartsImportCSVUpdatesExistingStockThresholds() throws {
+        let env = try E2ETestHelpers.setUp()
+        let categoryId = try E2ETestHelpers.seedCategory(env, name: "Stock Update")
+        _ = try env.parts.createPart(
+            categoryId: categoryId,
+            name: "Existing Stock Part",
+            code: "STOCK-UPD-001",
+            minStockLevel: 1,
+            maxStockLevel: 3,
+            targetStockLevel: 2
+        )
+
+        var preview = try env.parts.previewPartsImportCSV("""
+        name,code,category,min_stock,target_stock,max_stock
+        Existing Stock Part,STOCK-UPD-001,Stock Update,7,14,21
+        """)
+        preview.conflicts = preview.conflicts.map { conflict in
+            var editable = conflict
+            editable.resolution = .update
+            return editable
+        }
+
+        _ = try env.parts.commitPartsImportCSV(preview)
+
+        let updated = try #require(try env.parts.findPartByCode("STOCK-UPD-001"))
+        #expect(updated.minStockLevel == 7)
+        #expect(updated.targetStockLevel == 14)
+        #expect(updated.maxStockLevel == 21)
+    }
+
+    @Test("previewPartsImportCSV rejects invalid stock threshold values")
+    func testPreviewPartsImportCSVRejectsInvalidStockThresholdValues() throws {
+        let env = try E2ETestHelpers.setUp()
+        let csv = """
+        name,code,category,min_stock,target_stock,max_stock
+        Bad Stock Part,BAD-STOCK-001,Stock Validation,N/A,2.5,-3
+        """
+
+        let preview = try env.parts.previewPartsImportCSV(csv)
+
+        #expect(preview.newParts.isEmpty)
+        #expect(preview.errors.count == 3)
+        #expect(preview.errors.contains { $0.rowNumber == 2 && $0.message == "Invalid integer for min_stock: N/A" })
+        #expect(preview.errors.contains { $0.rowNumber == 2 && $0.message == "Invalid integer for target_stock: 2.5" })
+        #expect(preview.errors.contains { $0.rowNumber == 2 && $0.message == "max_stock cannot be negative" })
+    }
+
     @Test("previewPartsImportCSV attaches source metadata for audit sessions")
     func testPreviewPartsImportCSVAttachesSourceMetadata() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Parse and validate imported `min_stock`, `target_stock`, and `max_stock` CSV fields as non-negative integers during parts import preview.
- Persist validated stock thresholds on both new part creation and accepted conflict updates.
- Add regression coverage for new-part round trip, conflict update preservation, and invalid stock-threshold reporting.

## Paperclip
- WEI-3809

## Test Plan
- [x] `cd core && swift test --filter 'PartsServiceAdvancedTests/testCommitPartsImportCSVPreservesStockThresholdsForNewParts|PartsServiceAdvancedTests/testCommitPartsImportCSVUpdatesExistingStockThresholds|PartsServiceAdvancedTests/testPreviewPartsImportCSVRejectsInvalidStockThresholdValues'`
- [x] `cd core && swift test --filter PartsServiceAdvancedTests`
- [x] `cd core && swift test`

Closes #739