### PR TITLE
Block invalid manual catalog pricing

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
@@ -1267,9 +1267,21 @@ private struct QuickEditSheet: View {
         costPrice != originalCostPrice || markupPercent != originalMarkup
     }
 
-    private var sellPrice: Double {
-        let cost = Double(costPrice) ?? 0
-        let markup = Double(markupPercent) ?? 0
+    private var pricingValidationMessage: String? {
+        do {
+            _ = try ManualPricingInputValidator.parseMoney(costPrice, fieldName: "Cost")
+            _ = try ManualPricingInputValidator.parsePercent(markupPercent, fieldName: "Markup")
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    private var sellPrice: Double? {
+        guard let cost = try? ManualPricingInputValidator.parseMoney(costPrice, fieldName: "Cost"),
+              let markup = try? ManualPricingInputValidator.parsePercent(markupPercent, fieldName: "Markup") else {
+            return nil
+        }
         return cost * (1 + markup / 100)
     }
 
@@ -1311,8 +1323,14 @@ private struct QuickEditSheet: View {
                         Text("%")
                     }
                     .frame(minHeight: 44)
-                    LabeledContent("Sell Price", value: String(format: "$%.2f", sellPrice))
+                    LabeledContent("Sell Price", value: sellPrice.map { String(format: "$%.2f", $0) } ?? "—")
                         .foregroundStyle(.secondary)
+                    if let pricingValidationMessage {
+                        Label(pricingValidationMessage, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                            .font(.caption)
+                            .accessibilityIdentifier("manual-pricing-validation-error")
+                    }
                 }
 
                 Section("Stock") {
@@ -1331,7 +1349,7 @@ private struct QuickEditSheet: View {
                     Button("Save") {
                         Task { await save() }
                     }
-                    .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty || isSaving)
+                    .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty || pricingValidationMessage != nil || isSaving)
                 }
             }
             .interactiveDismissDisabled(isDirty || isSaving)
@@ -1364,9 +1382,17 @@ private struct QuickEditSheet: View {
             return
         }
 
+        let cost: Double
+        let markup: Double
+        do {
+            cost = try ManualPricingInputValidator.parseMoney(costPrice, fieldName: "Cost")
+            markup = try ManualPricingInputValidator.parsePercent(markupPercent, fieldName: "Markup")
+        } catch {
+            saveError = error.localizedDescription
+            return
+        }
+
         isSaving = true
-        let cost = Double(costPrice) ?? 0
-        let markup = Double(markupPercent) ?? 0
 
         do {
             try service.updatePart(
@@ -1409,6 +1435,16 @@ private struct PartFormSheet: View {
     @State private var isSaving = false
 
     private let partTypes = ["standard", "special_order", "custom"]
+
+    private var pricingValidationMessage: String? {
+        do {
+            _ = try ManualPricingInputValidator.parseMoney(costPrice, fieldName: "Cost Price")
+            _ = try ManualPricingInputValidator.parsePercent(markupPercent, fieldName: "Markup")
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
 
     var body: some View {
         NavigationStack {
@@ -1456,6 +1492,12 @@ private struct PartFormSheet: View {
                         Text("%")
                     }
                     .frame(minHeight: 44)
+                    if let pricingValidationMessage {
+                        Label(pricingValidationMessage, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                            .font(.caption)
+                            .accessibilityIdentifier("manual-pricing-validation-error")
+                    }
                 }
 
                 if appCore.hasPermission("edit_parts_catalog") {
@@ -1487,7 +1529,7 @@ private struct PartFormSheet: View {
                                 }
                             }
                         }
-                        .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty || selectedCategoryId == 0)
+                        .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty || selectedCategoryId == 0 || pricingValidationMessage != nil)
                     }
                 }
             }
@@ -1517,8 +1559,15 @@ private struct PartFormSheet: View {
     private func save() async {
         let trimmedName = name.trimmingCharacters(in: .whitespaces)
         guard !trimmedName.isEmpty, selectedCategoryId > 0 else { return }
-        let cost = Double(costPrice) ?? 0
-        let markup = Double(markupPercent) ?? 0
+        let cost: Double
+        let markup: Double
+        do {
+            cost = try ManualPricingInputValidator.parseMoney(costPrice, fieldName: "Cost Price")
+            markup = try ManualPricingInputValidator.parsePercent(markupPercent, fieldName: "Markup")
+        } catch {
+            saveError = error.localizedDescription
+            return
+        }
         guard let service = appCore.partsService else {
             saveError = "Service not available"
             return

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsPricingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsPricingPage.swift
@@ -1082,11 +1082,26 @@ struct PricingEditSheet: View {
     @State private var supplierCosts: [PartsService.PartSupplierCost] = []
     @State private var loadError: String?
 
+    private var pricingValidationMessage: String? {
+        do {
+            if useFixedPrice {
+                _ = try ManualPricingInputValidator.parseMoney(fixedPriceText, fieldName: "Fixed Price")
+            } else if pricingMode == "markup" {
+                _ = try ManualPricingInputValidator.parsePercent(markupText, fieldName: "Markup")
+            } else {
+                _ = try ManualPricingInputValidator.parsePercent(marginText, fieldName: "Margin")
+            }
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
     private var previewSellPrice: Double {
-        if useFixedPrice, let fixed = Double(fixedPriceText), fixed > 0 {
+        if useFixedPrice, let fixed = try? ManualPricingInputValidator.parseMoney(fixedPriceText, fieldName: "Fixed Price") {
             return max(fixed, row.weightedAvgCost) // never below cost
         }
-        let markup = Double(markupText) ?? 0
+        let markup = (try? ManualPricingInputValidator.parsePercent(markupText, fieldName: "Markup")) ?? row.effectiveMarkup
         return row.weightedAvgCost * (1 + max(markup, 0) / 100)
     }
 
@@ -1231,6 +1246,13 @@ struct PricingEditSheet: View {
                             }
                         }
                     }
+
+                    if let pricingValidationMessage {
+                        Label(pricingValidationMessage, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                            .font(.caption)
+                            .accessibilityIdentifier("manual-pricing-validation-error")
+                    }
                 }
 
                 // Preview
@@ -1293,7 +1315,7 @@ struct PricingEditSheet: View {
                     } label: {
                         if isSaving { ProgressView() } else { Text("Save") }
                     }
-                    .disabled(isSaving)
+                    .disabled(isSaving || pricingValidationMessage != nil)
                 }
             }
             .interactiveDismissDisabled(isSaving)
@@ -1347,13 +1369,13 @@ struct PricingEditSheet: View {
             }
 
             if useFixedPrice {
-                let fixed = Double(fixedPriceText) ?? 0
+                let fixed = try ManualPricingInputValidator.parseMoney(fixedPriceText, fieldName: "Fixed Price")
                 _ = try service.setPricingTier(partId: row.id, fixedSellPrice: max(fixed, row.weightedAvgCost))
             } else if pricingMode == "markup" {
-                let markup = max(Double(markupText) ?? 0, 0)
+                let markup = try ManualPricingInputValidator.parsePercent(markupText, fieldName: "Markup")
                 _ = try service.setPricingTier(partId: row.id, markupPercent: markup)
             } else {
-                let margin = max(Double(marginText) ?? 0, 0)
+                let margin = try ManualPricingInputValidator.parsePercent(marginText, fieldName: "Margin")
                 _ = try service.setPricingTier(partId: row.id, marginPercent: margin)
             }
 

--- a/core/Sources/WiredPartCore/ManualPricingInputValidator.swift
+++ b/core/Sources/WiredPartCore/ManualPricingInputValidator.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Validates human-entered catalog pricing fields before they reach persistence.
+///
+/// Manual SwiftUI `TextField` values must not use `Double(text) ?? 0` because
+/// malformed drafts such as `abc`, `$12`, or a blank field become zero and can
+/// silently overwrite real catalog prices.
+public enum ManualPricingInputValidator {
+    public enum ValidationError: LocalizedError, Equatable {
+        case required(fieldName: String)
+        case invalidNumber(fieldName: String)
+        case negative(fieldName: String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .required(let fieldName):
+                return "\(fieldName) is required. Keep your entered value and fix it before saving."
+            case .invalidNumber(let fieldName):
+                return "\(fieldName) must be a valid number. Keep your entered value and fix it before saving."
+            case .negative(let fieldName):
+                return "\(fieldName) must be zero or greater. Keep your entered value and fix it before saving."
+            }
+        }
+    }
+
+    public static func parseMoney(_ rawValue: String, fieldName: String) throws -> Double {
+        try parseNonNegativeDecimal(rawValue, fieldName: fieldName)
+    }
+
+    public static func parsePercent(_ rawValue: String, fieldName: String) throws -> Double {
+        try parseNonNegativeDecimal(rawValue, fieldName: fieldName)
+    }
+
+    private static func parseNonNegativeDecimal(_ rawValue: String, fieldName: String) throws -> Double {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw ValidationError.required(fieldName: fieldName)
+        }
+        guard let value = Double(trimmed), value.isFinite else {
+            throw ValidationError.invalidNumber(fieldName: fieldName)
+        }
+        guard value >= 0 else {
+            throw ValidationError.negative(fieldName: fieldName)
+        }
+        return value
+    }
+}

--- a/core/Tests/WiredPartCoreTests/ManualPricingInputValidatorTests.swift
+++ b/core/Tests/WiredPartCoreTests/ManualPricingInputValidatorTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import WiredPartCore
+
+final class ManualPricingInputValidatorTests: XCTestCase {
+    func testInvalidManualCostIsRejectedInsteadOfCoercedToZero() {
+        XCTAssertThrowsError(
+            try ManualPricingInputValidator.parseMoney("abc", fieldName: "Cost")
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Cost must be a valid number. Keep your entered value and fix it before saving."
+            )
+        }
+    }
+
+    func testBlankManualCostIsRejectedInsteadOfCoercedToZero() {
+        XCTAssertThrowsError(
+            try ManualPricingInputValidator.parseMoney("   ", fieldName: "Cost")
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Cost is required. Keep your entered value and fix it before saving."
+            )
+        }
+    }
+
+    func testNegativeManualCostIsRejected() {
+        XCTAssertThrowsError(
+            try ManualPricingInputValidator.parseMoney("-1.25", fieldName: "Cost")
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Cost must be zero or greater. Keep your entered value and fix it before saving."
+            )
+        }
+    }
+
+    func testValidManualMarkupAllowsZeroAndPositiveValues() throws {
+        XCTAssertEqual(try ManualPricingInputValidator.parsePercent("0", fieldName: "Markup"), 0)
+        XCTAssertEqual(try ManualPricingInputValidator.parsePercent("12.5", fieldName: "Markup"), 12.5)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a shared manual pricing input validator so invalid, blank, or negative values cannot be coerced to zero.
- Applies validation to the catalog quick edit, add/edit part form, and pricing edit sheet with visible draft-safe errors and disabled saves while invalid.
- Adds regression coverage for invalid manual cost/markup parsing.

## Verification
- RED reproduced: `swift test --filter ManualPricingInputValidatorTests` initially failed because `ManualPricingInputValidator` did not exist.
- PASS: `swift test --filter ManualPricingInputValidatorTests` — 4 tests passed.
- PASS: `swift test --filter 'ManualPricingInputValidatorTests|PartsServiceCoverageTests'` — 59 tests passed.

Refs xXKillerNoobYT/Weird-Part-Run-2#737
Refs xXKillerNoobYT/Weird-Part-Run-2#904
Refs WEI-3818
Refs WEI-3815
