### PR TITLE
fix: harden clock supply run status

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
@@ -33,6 +33,7 @@ struct IOSClockPage: View {
 
     // Activity status (working, supply_run, break, lunch_paid, lunch_unpaid)
     @State private var activityStatus: String = "working"
+    @State private var supplyRunStartedAt: Date?
 
     // Break/lunch tracking
     @State private var activeBreakRecord: BreakRecord?
@@ -438,6 +439,28 @@ struct IOSClockPage: View {
                     Text(formatTime(entry.clockIn))
                         .font(.system(.subheadline, design: .monospaced))
                 }
+
+                if activityStatus == "supply_run", let supplyRunStartedAt {
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "car.fill")
+                            .foregroundStyle(.orange)
+                            .accessibilityHidden(true)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Supply run started: \(formatClockTime(supplyRunStartedAt))")
+                                .font(.subheadline)
+                                .fontWeight(.semibold)
+                            Text("\(formatDuration(Date().timeIntervalSince(supplyRunStartedAt))) ago · still billable on this job")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("Supply run started at \(formatClockTime(supplyRunStartedAt)), \(formatDuration(Date().timeIntervalSince(supplyRunStartedAt))) ago. Time is still billable on this job.")
+                }
+
                 Label("Saved on this device · waiting to sync", systemImage: "icloud.and.arrow.up")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -1563,8 +1586,12 @@ struct IOSClockPage: View {
             let newStatus = try service.toggleSupplyRun(laborEntryId: entryId)
             await MainActor.run {
                 activityStatus = newStatus
+                if newStatus != "supply_run" {
+                    supplyRunStartedAt = nil
+                }
                 errorMessage = nil
             }
+            loadData()
         } catch {
             await MainActor.run {
                 errorMessage = userFriendlyError(error, context: "toggle supply run")
@@ -1745,6 +1772,10 @@ struct IOSClockPage: View {
         return String(iso[start..<end])
     }
 
+    private func formatClockTime(_ date: Date) -> String {
+        DateFormatter.localizedString(from: date, dateStyle: .none, timeStyle: .short)
+    }
+
     private func formatDuration(_ interval: TimeInterval) -> String {
         let hours = Int(interval) / 3600
         let minutes = (Int(interval) % 3600) / 60
@@ -1831,9 +1862,11 @@ struct IOSClockPage: View {
 
             // Check activity status from notes (supply_run tracking)
             var currentActivity = "working"
+            var currentSupplyRunStart: Date?
             if let entry {
                 let notes = try? service.getLaborEntryNotes(laborEntryId: entry.id)
-                if JobsService.isOnSupplyRun(notes: notes) {
+                currentSupplyRunStart = JobsService.activeSupplyRunStart(notes: notes)
+                if currentSupplyRunStart != nil {
                     currentActivity = "supply_run"
                 }
             }
@@ -1884,9 +1917,11 @@ struct IOSClockPage: View {
                 lunchPaidMinutes = lunchPaid
                 if let brk = currentBreak {
                     activityStatus = brk.breakType
+                    supplyRunStartedAt = nil
                     startBreakTimer()
                 } else {
                     activityStatus = currentActivity
+                    supplyRunStartedAt = currentSupplyRunStart
                     breakTimer?.invalidate()
                     breakTimer = nil
                     breakElapsedText = ""

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -3637,16 +3637,30 @@ public final class JobsService: Sendable {
 
     /// Checks if the supply run markers in a notes string indicate an active supply run.
     public static func isOnSupplyRun(notes: String?) -> Bool {
-        guard let notes, notes.contains("[supply_run_start:") else { return false }
+        latestUnmatchedSupplyRunStart(notes: notes) != nil
+    }
+
+    /// Returns the latest unmatched supply-run start timestamp, if the notes show an active run.
+    ///
+    /// Supply-run state is tracked in the freeform labor-entry notes using append-only markers.
+    /// The clock page uses this helper to show the field user exactly when the current run
+    /// started and how long they have been out, while keeping the labor entry clocked in.
+    public static func activeSupplyRunStart(notes: String?) -> Date? {
+        guard let timestamp = latestUnmatchedSupplyRunStart(notes: notes) else { return nil }
+        return CoreFormatters.parseDateTime(timestamp)
+    }
+
+    private static func latestUnmatchedSupplyRunStart(notes: String?) -> String? {
+        guard let notes, notes.contains("[supply_run_start:") else { return nil }
         let lastStart = notes.range(of: "[supply_run_start:", options: .backwards)
         let lastEnd = notes.range(of: "[supply_run_end:", options: .backwards)
-        if let start = lastStart {
-            if let end = lastEnd {
-                return start.lowerBound > end.lowerBound
-            }
-            return true
+        guard let start = lastStart, lastEnd.map({ start.lowerBound > $0.lowerBound }) ?? true else {
+            return nil
         }
-        return false
+
+        let valueStart = start.upperBound
+        guard let valueEnd = notes[valueStart...].firstIndex(of: "]") else { return nil }
+        return String(notes[valueStart..<valueEnd])
     }
 
     // =========================================================================

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -1876,6 +1876,19 @@ struct JobsServiceTests {
         #expect(JobsService.isOnSupplyRun(notes: notes))
     }
 
+    @Test("activeSupplyRunStart parses the latest unmatched supply run timestamp")
+    func testActiveSupplyRunStartParsesLatestUnmatchedStart() throws {
+        let notes = "[supply_run_start:2026-04-16T10:00:00Z][supply_run_end:2026-04-16T10:30:00Z] [supply_run_start:2026-04-16T11:15:00Z]"
+        let start = try #require(JobsService.activeSupplyRunStart(notes: notes))
+        #expect(CoreFormatters.iso8601.string(from: start) == "2026-04-16T11:15:00Z")
+    }
+
+    @Test("activeSupplyRunStart is nil when the latest supply run has ended")
+    func testActiveSupplyRunStartNilWhenEnded() {
+        let notes = "[supply_run_start:2026-04-16T10:00:00Z][supply_run_end:2026-04-16T10:30:00Z]"
+        #expect(JobsService.activeSupplyRunStart(notes: notes) == nil)
+    }
+
     @Test("isOnSupplyRun returns false when notes contain no supply run markers")
     func testIsOnSupplyRunNoMarkers() {
         #expect(!JobsService.isOnSupplyRun(notes: "Regular work notes, no supply run"))


### PR DESCRIPTION
## Summary
- Show active supply-run start time and elapsed duration on the iOS clock page while keeping the labor entry billable/clocked in.
- Parse the latest unmatched supply-run marker through JobsService so UI recovery survives reloads and completed runs do not stay active.
- Add focused JobsService coverage for active/ended supply-run marker parsing and keep switch-job/break/lunch/overtime coverage green.

## Paperclip / GitHub traceability
- Paperclip: WEI-3814 (from #904 field-test readiness lane; supersedes initial WEI-3812 intake reference)
- Related intake: WEI-3812
- Closes #71

## Tests
- [x] `swift test --filter JobsServiceTests` (136 tests passed locally on 2026-06-19)
- [x] `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' build CODE_SIGNING_ALLOWED=NO` (BUILD SUCCEEDED locally on 2026-06-19)

## Local Mac runner path
- Verified locally on Isaac's Mac/Xcode path. CI should run on the self-hosted local Mac runner labels for trusted repo checks, not GitHub-hosted macOS minutes.
