### PR TITLE
fix: keep callback sheets open on action failure

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSShortTermPipelinePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSShortTermPipelinePage.swift
@@ -4,6 +4,31 @@ import os
 
 private let pipelineLog = Logger(subsystem: "com.wiredpart", category: "scheduling.pipeline")
 
+struct IOSShortTermPipelineCallbackActionResult: Equatable {
+    let errorMessage: String?
+    let shouldDismissSheet: Bool
+}
+
+enum IOSShortTermPipelineCallbackActionHandler {
+    static func perform(
+        context: String,
+        operation: () throws -> Void,
+        reload: () -> Void,
+        errorFormatter: (Error, String) -> String
+    ) -> IOSShortTermPipelineCallbackActionResult {
+        do {
+            try operation()
+            reload()
+            return IOSShortTermPipelineCallbackActionResult(errorMessage: nil, shouldDismissSheet: true)
+        } catch {
+            return IOSShortTermPipelineCallbackActionResult(
+                errorMessage: errorFormatter(error, context),
+                shouldDismissSheet: false
+            )
+        }
+    }
+}
+
 /// Short-term pipeline page showing jobs ready or near-ready for scheduling.
 ///
 /// Categories: Start Anytime (target: 3), Schedule Needed (target: 2),
@@ -321,13 +346,18 @@ struct IOSShortTermPipelinePage: View {
             loadError = "Service not available"
             return
         }
-        do {
-            try service.markCallbackComplete(jobId: jobId, notes: notes)
-            loadData()
-        } catch {
-            loadError = userFriendlyError(error, context: "load pipeline data")
+        let result = IOSShortTermPipelineCallbackActionHandler.perform(
+            context: "complete callback",
+            operation: {
+                try service.markCallbackComplete(jobId: jobId, notes: notes)
+            },
+            reload: loadData,
+            errorFormatter: userFriendlyError
+        )
+        loadError = result.errorMessage
+        if result.shouldDismissSheet {
+            activeSheet = nil
         }
-        activeSheet = nil
     }
 
     private func snoozeCallback(jobId: Int64, days: Int) {
@@ -336,13 +366,18 @@ struct IOSShortTermPipelinePage: View {
             return
         }
         let target = Calendar.current.date(byAdding: .day, value: days, to: Date()) ?? Date()
-        do {
-            try service.snoozeCallback(jobId: jobId, until: Formatters.localDateFormatter.string(from: target))
-            loadData()
-        } catch {
-            loadError = userFriendlyError(error, context: "load pipeline data")
+        let result = IOSShortTermPipelineCallbackActionHandler.perform(
+            context: "snooze callback",
+            operation: {
+                try service.snoozeCallback(jobId: jobId, until: Formatters.localDateFormatter.string(from: target))
+            },
+            reload: loadData,
+            errorFormatter: userFriendlyError
+        )
+        loadError = result.errorMessage
+        if result.shouldDismissSheet {
+            activeSheet = nil
         }
-        activeSheet = nil
     }
 
     private func movePipelineItem(jobId: Int64, to category: String) {

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -28,6 +28,10 @@ private enum CreateNotebookJobPickerTestError: Error {
     case loadFailed
 }
 
+private enum ShortTermPipelineCallbackActionTestError: Error {
+    case operationFailed
+}
+
 struct Weird_Parts_IOSTests {
 
     private func makeJobListItem(id: Int64, name: String, status: String) -> JobsService.JobListItem {
@@ -567,6 +571,48 @@ struct Weird_Parts_IOSTests {
         let source = try String(contentsOf: suppliersURL, encoding: .utf8)
 
         #expect(source.contains("loadError = userFriendlyError(error, context: \"create supplier channel\")"))
+    }
+
+    @MainActor
+    @Test func shortTermPipelineCallbackFailurePreservesSheetAndFormatsActionError() {
+        var reloadCount = 0
+
+        let result = IOSShortTermPipelineCallbackActionHandler.perform(
+            context: "complete callback",
+            operation: {
+                throw ShortTermPipelineCallbackActionTestError.operationFailed
+            },
+            reload: {
+                reloadCount += 1
+            },
+            errorFormatter: { _, context in "Could not \(context). Try again." }
+        )
+
+        #expect(result.errorMessage == "Could not complete callback. Try again.")
+        #expect(!result.shouldDismissSheet)
+        #expect(reloadCount == 0)
+    }
+
+    @MainActor
+    @Test func shortTermPipelineCallbackSuccessReloadsAndDismissesSheet() {
+        var reloadCount = 0
+        var operationCount = 0
+
+        let result = IOSShortTermPipelineCallbackActionHandler.perform(
+            context: "snooze callback",
+            operation: {
+                operationCount += 1
+            },
+            reload: {
+                reloadCount += 1
+            },
+            errorFormatter: { _, context in "Could not \(context). Try again." }
+        )
+
+        #expect(result.errorMessage == nil)
+        #expect(result.shouldDismissSheet)
+        #expect(operationCount == 1)
+        #expect(reloadCount == 1)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Keep Short-Term Pipeline callback sheets open when complete/snooze service actions fail.
- Use action-specific error context for complete callback and snooze callback failures.
- Add focused regression coverage for failed action retention and successful dismiss/reload behavior.

## Paperclip Traceability
- Paperclip: WEI-3821
- Closes #878

## Test Plan
- [x] `xcodebuild test -project "Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/shortTermPipelineCallbackFailurePreservesSheetAndFormatsActionError" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/shortTermPipelineCallbackSuccessReloadsAndDismissesSheet"`

## CI / Runner Notes
- Local Mac/Xcode verification used for the focused iOS regression path.
- Repo CI should run on the configured self-hosted local Mac runner for trusted iOS checks where applicable.
