### PR TITLE
fix: preserve parts csv text round trips

### DIFF
--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -7212,20 +7212,19 @@ public final class PartsService: Sendable {
 
         func parse(_ csv: String) -> PartsImportParsedSource {
             let hash = service.importSourceHash(Data(csv.utf8))
-            let rows = csv.components(separatedBy: .newlines)
-                .enumerated()
-                .compactMap { offset, line -> PartsImportDraftRow? in
-                    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !trimmed.isEmpty else { return nil }
-                    let rowNumber = offset + 1
-                    return PartsImportDraftRow(
-                        rowNumber: rowNumber,
-                        columns: service.parseImportCSVLine(trimmed),
-                        evidence: [
-                            PartsImportSourceEvidence(kind: .row, rowNumber: rowNumber, text: trimmed)
-                        ]
-                    )
+            let records = service.parseImportCSVRecords(csv)
+            let rows = records.compactMap { record -> PartsImportDraftRow? in
+                guard record.fields.contains(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) else {
+                    return nil
                 }
+                return PartsImportDraftRow(
+                    rowNumber: record.rowNumber,
+                    columns: record.fields,
+                    evidence: [
+                        PartsImportSourceEvidence(kind: .row, rowNumber: record.rowNumber, text: record.text)
+                    ]
+                )
+            }
             let columnCount = rows.map(\.columns.count).max() ?? 0
             let table = PartsImportExtractedTable(
                 id: "csv:table:1",
@@ -7252,23 +7251,78 @@ public final class PartsService: Sendable {
         }
     }
 
-    fileprivate func parseImportCSVLine(_ line: String) -> [String] {
+    fileprivate struct PartsImportCSVRecord {
+        let rowNumber: Int
+        let fields: [String]
+        let text: String
+    }
+
+    fileprivate func parseImportCSVRecords(_ csv: String) -> [PartsImportCSVRecord] {
+        var records: [PartsImportCSVRecord] = []
         var fields: [String] = []
         var current = ""
+        var recordText = ""
         var inQuotes = false
-        var iterator = line.makeIterator()
-        while let char = iterator.next() {
+        var recordStartLine = 1
+        var currentLine = 1
+        var fieldHasQuotedContent = false
+        var index = csv.startIndex
+
+        func finishField() {
+            fields.append(fieldHasQuotedContent ? current : current.trimmingCharacters(in: .whitespacesAndNewlines))
+            current = ""
+            fieldHasQuotedContent = false
+        }
+
+        func finishRecord() {
+            finishField()
+            records.append(PartsImportCSVRecord(rowNumber: recordStartLine, fields: fields, text: recordText))
+            fields.removeAll(keepingCapacity: true)
+            recordText = ""
+            recordStartLine = currentLine
+        }
+
+        while index < csv.endIndex {
+            let char = csv[index]
+            let nextIndex = csv.index(after: index)
+            recordText.append(char)
+
             if char == "\"" {
+                if inQuotes, nextIndex < csv.endIndex, csv[nextIndex] == "\"" {
+                    current.append("\"")
+                    recordText.append("\"")
+                    index = csv.index(after: nextIndex)
+                    continue
+                }
                 inQuotes.toggle()
+                fieldHasQuotedContent = true
             } else if char == "," && !inQuotes {
-                fields.append(current)
-                current = ""
+                finishField()
+            } else if (char == "\n" || char == "\r") && !inQuotes {
+                finishRecord()
+                if char == "\r", nextIndex < csv.endIndex, csv[nextIndex] == "\n" {
+                    index = csv.index(after: nextIndex)
+                    currentLine += 1
+                    recordStartLine = currentLine
+                    continue
+                }
+                currentLine += 1
+                recordStartLine = currentLine
             } else {
                 current.append(char)
+                if char == "\n" { currentLine += 1 }
             }
+            index = nextIndex
         }
-        fields.append(current)
-        return fields
+
+        if !recordText.isEmpty || !current.isEmpty || !fields.isEmpty {
+            finishRecord()
+        }
+        return records
+    }
+
+    fileprivate func parseImportCSVLine(_ line: String) -> [String] {
+        parseImportCSVRecords(line).first?.fields ?? []
     }
 
     // =========================================================================
@@ -8382,12 +8436,24 @@ public final class PartsService: Sendable {
     }
 
     /// Escape a string for CSV output. Wraps in quotes if it contains commas,
-    /// double-quotes, or newlines. Doubles any existing double-quotes.
+    /// double-quotes, newlines, leading/trailing whitespace, or spreadsheet-prone
+    /// text such as numeric-looking codes. Doubles any existing double-quotes.
     private func csvEscape(_ value: String) -> String {
-        if value.contains(",") || value.contains("\"") || value.contains("\n") {
+        if valueRequiresCSVQuoting(value) {
             return "\"\(value.replacingOccurrences(of: "\"", with: "\"\""))\""
         }
         return value
+    }
+
+    private func valueRequiresCSVQuoting(_ value: String) -> Bool {
+        if value.isEmpty { return false }
+        if value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r") {
+            return true
+        }
+        if value != value.trimmingCharacters(in: .whitespacesAndNewlines) {
+            return true
+        }
+        return value.range(of: #"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$"#, options: .regularExpression) != nil
     }
 
     // MARK: - Catalog Search (Full Filters)

--- a/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceAdvancedTests.swift
@@ -310,6 +310,29 @@ struct PartsServiceAdvancedTests {
         #expect(preview.errors.map(\.rowNumber).contains(5))
     }
 
+    @Test("previewPartsImportCSV preserves escaped quotes, commas, multiline text, empty fields, and numeric-looking text")
+    func testPreviewPartsImportCSVPreservesQuotedTextAndStringTypes() throws {
+        let env = try E2ETestHelpers.setUp()
+        let csv = [
+            "name,code,category,brand,cost_price,markup_percent,description,unit_of_measure,shelf_location,bin_location,part_type",
+            "\"Quoted \"\"Widget\"\"\",\"00123\",Round Trip Category,,12.50,40,\"Line one, with comma\nLine two says \"\"keep quotes\"\"\",ea,,\"007\",\"field-kit\""
+        ].joined(separator: "\n")
+
+        let preview = try env.parts.previewPartsImportCSV(csv)
+        let part = try #require(preview.newParts.first)
+
+        #expect(preview.errors.isEmpty)
+        #expect(preview.totalRows == 1)
+        #expect(part.name == "Quoted \"Widget\"")
+        #expect(part.code == "00123")
+        #expect(part.brand == nil)
+        #expect(part.fields["description"] == "Line one, with comma\nLine two says \"keep quotes\"")
+        #expect(part.fields["unit_of_measure"] == "ea")
+        #expect(part.fields["shelf_location"] == nil)
+        #expect(part.fields["bin_location"] == "007")
+        #expect(part.fields["part_type"] == "field-kit")
+    }
+
     @Test("previewPartsImportCSV reports invalid cost_price and markup_percent values with row and column context")
     func testPreviewPartsImportCSVRejectsInvalidNumericValues() throws {
         let env = try E2ETestHelpers.setUp()
@@ -553,6 +576,38 @@ struct PartsServiceAdvancedTests {
         #expect(updated.minStockLevel == 6)
         #expect(updated.targetStockLevel == 24)
         #expect(updated.maxStockLevel == 48)
+    }
+
+    @Test("exportPartsCSV quotes spreadsheet-prone strings so import preserves text types")
+    func testExportPartsCSVQuotesNumericLookingTextForRoundTrip() throws {
+        let env = try E2ETestHelpers.setUp()
+        let categoryId = try E2ETestHelpers.seedCategory(env, name: "Export Round Trip")
+        _ = try env.parts.createPart(
+            categoryId: categoryId,
+            name: "00123",
+            partType: "field-kit",
+            code: "000456",
+            description: "Use \"quoted\" text, commas, and 007 labels",
+            unitOfMeasure: "ea",
+            companyCostPrice: 7.25,
+            companyMarkupPercent: 30,
+            shelfLocation: "001",
+            binLocation: "007"
+        )
+
+        let export = try env.parts.exportPartsCSV(groups: [.hierarchy, .pricing, .details])
+        #expect(export.contains("\"00123\",\"000456\",Export Round Trip"))
+        #expect(export.contains("7.25,,30.0,"))
+        #expect(export.contains("\"Use \"\"quoted\"\" text, commas, and 007 labels\",ea,field-kit,\"001\",\"007\""))
+
+        let preview = try env.parts.previewPartsImportCSV(export)
+        let roundTripped = try #require(preview.conflicts.first?.parsedRow)
+        #expect(roundTripped.name == "00123")
+        #expect(roundTripped.code == "000456")
+        #expect(roundTripped.fields["description"] == "Use \"quoted\" text, commas, and 007 labels")
+        #expect(roundTripped.fields["shelf_location"] == "001")
+        #expect(roundTripped.fields["bin_location"] == "007")
+        #expect(roundTripped.fields["part_type"] == "field-kit")
     }
 
     @Test("previewPartsImportCSV attaches source metadata for audit sessions")


### PR DESCRIPTION
## Summary
- Replace the parts CSV importer line-split parser with a record parser that preserves escaped quotes, embedded commas, multiline quoted text, row numbers, and intentionally empty fields.
- Quote spreadsheet-prone string exports, including numeric-looking text and leading/trailing whitespace, so codes and shelf/bin labels round trip as text.
- Add regression coverage for quoted text, numeric-looking strings, multiline descriptions, empty fields, and exported CSV re-import.

## Test Plan
- [x] swift test --filter PartsServiceAdvancedTests

## Traceability
- Fixes GitHub #713
- Paperclip: WEI-3816
- Local runner path: validated locally with SwiftPM; PR CI should use the self-hosted Mac runner path when repo gates run.