### PR TITLE
fix: keep schedule config sheets open on failures

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleConfigPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleConfigPage.swift
@@ -120,6 +120,7 @@ struct IOSScheduleConfigPage: View {
             ShiftTemplateEditSheet(
                 existing: existing,
                 hats: allHats,
+                actionError: saveError,
                 onSave: { saveShiftTemplate($0) },
                 onDelete: existing.map { tpl in { deleteShiftTemplate(tpl.id) } }
             )
@@ -127,6 +128,7 @@ struct IOSScheduleConfigPage: View {
         case .editHoliday(let existing):
             HolidayEditSheet(
                 existing: existing,
+                actionError: saveError,
                 onSave: { saveHoliday($0) },
                 onDelete: existing.map { hol in { deleteHoliday(hol.id) } }
             )
@@ -476,12 +478,12 @@ struct IOSScheduleConfigPage: View {
 
     // MARK: - Template & Holiday Actions
 
-    private func saveShiftTemplate(_ data: ShiftTemplateEditSheet.TemplateData) {
+    private func saveShiftTemplate(_ data: ShiftTemplateEditSheet.TemplateData) -> Bool {
         guard let svc = appCore.schedulingService else {
             saveError = "Scheduling service not available"
-            activeSheet = nil
-            return
+            return false
         }
+        saveError = nil
         do {
             try svc.saveShiftTemplate(
                 id: data.existingId, name: data.name, hatId: data.hatId,
@@ -490,58 +492,66 @@ struct IOSScheduleConfigPage: View {
                 overtimeRule: data.overtimeRule
             )
             shiftTemplates = (try? svc.getShiftTemplates()) ?? []
+            activeSheet = nil
+            return true
         } catch {
             saveError = userFriendlyError(error, context: "save shift template")
+            return false
         }
-        activeSheet = nil
     }
 
-    private func deleteShiftTemplate(_ id: Int64) {
+    private func deleteShiftTemplate(_ id: Int64) -> Bool {
         guard let svc = appCore.schedulingService else {
             saveError = "Scheduling service not available"
-            activeSheet = nil
-            return
+            return false
         }
+        saveError = nil
         do {
             try svc.deleteShiftTemplate(id: id)
             shiftTemplates = (try? svc.getShiftTemplates()) ?? []
+            activeSheet = nil
+            return true
         } catch {
             saveError = userFriendlyError(error, context: "delete shift template")
+            return false
         }
-        activeSheet = nil
     }
 
-    private func saveHoliday(_ data: HolidayEditSheet.HolidayData) {
+    private func saveHoliday(_ data: HolidayEditSheet.HolidayData) -> Bool {
         guard let svc = appCore.schedulingService else {
             saveError = "Scheduling service not available"
-            activeSheet = nil
-            return
+            return false
         }
+        saveError = nil
         do {
             try svc.saveHoliday(
                 id: data.existingId, name: data.name, date: data.date,
                 isPaid: data.isPaid, isRecurring: data.isRecurring
             )
             holidays = (try? svc.getHolidays()) ?? []
+            activeSheet = nil
+            return true
         } catch {
             saveError = userFriendlyError(error, context: "save holiday")
+            return false
         }
-        activeSheet = nil
     }
 
-    private func deleteHoliday(_ id: Int64) {
+    private func deleteHoliday(_ id: Int64) -> Bool {
         guard let svc = appCore.schedulingService else {
             saveError = "Scheduling service not available"
-            activeSheet = nil
-            return
+            return false
         }
+        saveError = nil
         do {
             try svc.deleteHoliday(id: id)
             holidays = (try? svc.getHolidays()) ?? []
+            activeSheet = nil
+            return true
         } catch {
             saveError = userFriendlyError(error, context: "delete holiday")
+            return false
         }
-        activeSheet = nil
     }
 }
 
@@ -623,8 +633,9 @@ struct ShiftTemplateEditSheet: View {
 
     let existing: SchedulingService.ShiftTemplateRow?
     let hats: [PeopleService.HatListItem]
-    let onSave: (TemplateData) -> Void
-    let onDelete: (() -> Void)?
+    let actionError: String?
+    let onSave: (TemplateData) -> Bool
+    let onDelete: (() -> Bool)?
 
     @State private var name = ""
     @State private var selectedHatId: Int64 = 0
@@ -707,6 +718,15 @@ struct ShiftTemplateEditSheet: View {
                     }
                 }
 
+                if let actionError {
+                    Section {
+                        Label(actionError, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .font(.callout)
+                            .accessibilityIdentifier("shiftTemplateActionError")
+                    }
+                }
+
                 if onDelete != nil {
                     Section {
                         Button(role: .destructive) {
@@ -733,8 +753,9 @@ struct ShiftTemplateEditSheet: View {
             .onAppear { populateFromExisting() }
             .confirmationDialog("Delete this template?", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
                 Button("Delete Template", role: .destructive) {
-                    onDelete?()
-                    dismiss()
+                    if onDelete?() == true {
+                        dismiss()
+                    }
                 }
                 Button("Cancel", role: .cancel) {}
             } message: {
@@ -765,7 +786,7 @@ struct ShiftTemplateEditSheet: View {
         let daysArray = dayOrder.filter { selectedDays.contains($0) }
         let daysJSON = (try? JSONEncoder().encode(daysArray)).flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
 
-        onSave(TemplateData(
+        if onSave(TemplateData(
             existingId: existing?.id,
             name: name.trimmingCharacters(in: .whitespaces),
             hatId: selectedHatId == 0 ? nil : selectedHatId,
@@ -775,7 +796,9 @@ struct ShiftTemplateEditSheet: View {
             breakMinutes: breakMinutes,
             breakPaid: breakPaid,
             overtimeRule: overtimeRule
-        ))
+        )) {
+            dismiss()
+        }
     }
 }
 
@@ -793,8 +816,9 @@ struct HolidayEditSheet: View {
     }
 
     let existing: SchedulingService.HolidayRow?
-    let onSave: (HolidayData) -> Void
-    let onDelete: (() -> Void)?
+    let actionError: String?
+    let onSave: (HolidayData) -> Bool
+    let onDelete: (() -> Bool)?
 
     @State private var name = ""
     @State private var selectedDate = Date()
@@ -817,6 +841,15 @@ struct HolidayEditSheet: View {
                 Section("Options") {
                     Toggle("Paid Holiday", isOn: $isPaid)
                     Toggle("Recurring Annually", isOn: $isRecurring)
+                }
+
+                if let actionError {
+                    Section {
+                        Label(actionError, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .font(.callout)
+                            .accessibilityIdentifier("holidayActionError")
+                    }
                 }
 
                 if onDelete != nil {
@@ -845,8 +878,9 @@ struct HolidayEditSheet: View {
             .onAppear { populateFromExisting() }
             .confirmationDialog("Delete this holiday?", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
                 Button("Delete Holiday", role: .destructive) {
-                    onDelete?()
-                    dismiss()
+                    if onDelete?() == true {
+                        dismiss()
+                    }
                 }
                 Button("Cancel", role: .cancel) {}
             } message: {
@@ -865,12 +899,14 @@ struct HolidayEditSheet: View {
     }
 
     private func save() {
-        onSave(HolidayData(
+        if onSave(HolidayData(
             existingId: existing?.id,
             name: name.trimmingCharacters(in: .whitespaces),
             date: Formatters.localDateFormatter.string(from: selectedDate),
             isPaid: isPaid,
             isRecurring: isRecurring
-        ))
+        )) {
+            dismiss()
+        }
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/ScheduleConfigSheetFailureRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/ScheduleConfigSheetFailureRegressionTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+
+/// Regression coverage for GH#877: failed Schedule Config sheet actions must not dismiss edit context.
+final class ScheduleConfigSheetFailureRegressionTests: XCTestCase {
+    func testShiftTemplateAndHolidayActionsDismissSheetsOnlyAfterSuccessfulServiceCalls() throws {
+        let source = try Self.readSchedulingSource(named: "IOSScheduleConfigPage.swift")
+
+        try Self.assertDismissesOnlyOnSuccess(in: source, functionName: "saveShiftTemplate")
+        try Self.assertDismissesOnlyOnSuccess(in: source, functionName: "deleteShiftTemplate")
+        try Self.assertDismissesOnlyOnSuccess(in: source, functionName: "saveHoliday")
+        try Self.assertDismissesOnlyOnSuccess(in: source, functionName: "deleteHoliday")
+    }
+
+    func testFailurePathsSurfaceInlineSaveErrorWithoutClearingActiveSheet() throws {
+        let source = try Self.readSchedulingSource(named: "IOSScheduleConfigPage.swift")
+
+        XCTAssertTrue(
+            source.contains("actionError: saveError"),
+            "Schedule Config edit sheets should receive saveError so failures remain visible without dismissing the sheet."
+        )
+        XCTAssertTrue(
+            source.contains("accessibilityIdentifier(\"shiftTemplateActionError\")") &&
+                source.contains("accessibilityIdentifier(\"holidayActionError\")"),
+            "Shift template and holiday sheets should expose inline action-error labels for failed saves/deletes."
+        )
+
+        try Self.assertCatchKeepsSheetOpen(in: source, functionName: "saveShiftTemplate", context: "save shift template")
+        try Self.assertCatchKeepsSheetOpen(in: source, functionName: "deleteShiftTemplate", context: "delete shift template")
+        try Self.assertCatchKeepsSheetOpen(in: source, functionName: "saveHoliday", context: "save holiday")
+        try Self.assertCatchKeepsSheetOpen(in: source, functionName: "deleteHoliday", context: "delete holiday")
+    }
+
+    func testSheetsDismissThemselvesOnlyWhenCallbacksSucceed() throws {
+        let source = try Self.readSchedulingSource(named: "IOSScheduleConfigPage.swift")
+
+        XCTAssertTrue(
+            source.contains("if onSave(TemplateData(") && source.contains("if onSave(HolidayData("),
+            "Save buttons must keep entered sheet values in place when the parent save callback reports failure."
+        )
+        XCTAssertTrue(
+            source.components(separatedBy: "if onDelete?() == true").count >= 3,
+            "Delete confirmation buttons must dismiss only after the parent delete callback reports success."
+        )
+    }
+
+    private static func assertDismissesOnlyOnSuccess(
+        in source: String,
+        functionName: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let functionBody = try extractFunctionBody(named: functionName, from: source)
+        let doBody = try extractBlock(startingAt: "do {", in: functionBody)
+
+        XCTAssertTrue(
+            doBody.contains("activeSheet = nil"),
+            "\(functionName) should dismiss the active edit/confirm sheet from its success path only.",
+            file: file,
+            line: line
+        )
+        XCTAssertFalse(
+            sourceAfterDoCatch(in: functionBody).contains("activeSheet = nil"),
+            "\(functionName) must not unconditionally dismiss the sheet after catch; failures need preserved context/input.",
+            file: file,
+            line: line
+        )
+    }
+
+    private static func assertCatchKeepsSheetOpen(
+        in source: String,
+        functionName: String,
+        context: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let functionBody = try extractFunctionBody(named: functionName, from: source)
+        let catchBody = try extractBlock(startingAt: "catch {", in: functionBody)
+
+        XCTAssertTrue(
+            catchBody.contains("saveError = userFriendlyError(error, context: \"\(context)\")"),
+            "\(functionName) should surface the failure near the sheet action.",
+            file: file,
+            line: line
+        )
+        XCTAssertFalse(
+            catchBody.contains("activeSheet = nil"),
+            "\(functionName) catch path must keep the edit/confirm sheet open after failure.",
+            file: file,
+            line: line
+        )
+    }
+
+    private static func sourceAfterDoCatch(in functionBody: String) -> String {
+        guard let catchRange = functionBody.range(of: "catch {") else { return functionBody }
+        let afterCatchStart = functionBody[catchRange.lowerBound...]
+        guard let catchBody = try? extractBlock(startingAt: "catch {", in: String(afterCatchStart)),
+              let catchBodyRange = afterCatchStart.range(of: catchBody) else {
+            return String(afterCatchStart)
+        }
+        return String(afterCatchStart[catchBodyRange.upperBound...])
+    }
+
+    private static func extractFunctionBody(named functionName: String, from source: String) throws -> String {
+        guard let signatureRange = source.range(of: "private func \(functionName)") else {
+            XCTFail("Missing function \(functionName)")
+            return ""
+        }
+        return try extractBlock(startingAt: "{", in: String(source[signatureRange.lowerBound...]))
+    }
+
+    private static func extractBlock(startingAt marker: String, in source: String) throws -> String {
+        guard let markerRange = source.range(of: marker),
+              let openBraceIndex = source[markerRange.lowerBound...].firstIndex(of: "{") else {
+            XCTFail("Missing block marker \(marker)")
+            return ""
+        }
+
+        var depth = 0
+        var cursor = openBraceIndex
+        while cursor < source.endIndex {
+            let char = source[cursor]
+            if char == "{" { depth += 1 }
+            if char == "}" {
+                depth -= 1
+                if depth == 0 {
+                    return String(source[openBraceIndex...cursor])
+                }
+            }
+            cursor = source.index(after: cursor)
+        }
+
+        XCTFail("Unterminated block for marker \(marker)")
+        return ""
+    }
+
+    private static func readSchedulingSource(named filename: String, file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Scheduling")
+            .appendingPathComponent(filename)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary

- Issue: Schedule Config save/delete failures for shift templates and holidays closed the active edit/confirm sheet even though `saveError` was set.
- Scope: Keep edit context open on failed save/delete, preserve entered values, show inline action errors in the active sheet, and add focused regression coverage.

Paperclip: WEI-3822
GitHub: Closes #877

## Validation

- [x] Tests added/updated as needed
- [x] Lint/type checks pass
- [x] Backward compatibility considered

Verification run:
- [x] `python3` source regression check: success-path-only dismissals, no catch/unconditional `activeSheet = nil`, inline error identifiers present
- [x] `swiftc -parse "Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleConfigPage.swift" "Weird Parts IOS/Weird Parts IOSTests/ScheduleConfigSheetFailureRegressionTests.swift"`
- [x] `xcodebuild build -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO`
- [x] `xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:"Weird Parts IOSTests/ScheduleConfigSheetFailureRegressionTests" CODE_SIGNING_ALLOWED=NO`

## AI Assistance Disclosure

- [x] AI assistance used in this PR
- Tools used: Hermes FrontendCoder using OpenAI Codex/GPT-5.5; local shell, git, gh, xcodebuild
- AI-assisted areas (files/functions): `IOSScheduleConfigPage.swift` sheet callbacks/error rendering; `ScheduleConfigSheetFailureRegressionTests.swift`
- Reviewer focus notes for AI-generated/assisted code: Confirm the source-level regression test is acceptable for this target and that sheet dismissal remains consistent for both save and delete success/failure paths.

## Copilot-assisted Change Checklist

- [x] Copilot used for this PR: No
- [x] Reviewed Copilot-generated/assisted changes line-by-line (not applicable; Copilot was not used)
- [x] No secrets, credentials, or customer-sensitive prompt data shared
- [x] Licensing/origin risk checked for non-trivial generated snippets
- [x] Tests added/updated for generated or modified logic
- [x] Manual verification notes added for security/auth/config changes (not security/auth/config; verification commands listed above)

## Risk Check

- [x] No secrets or sensitive data were shared with AI tools
- [x] Security-sensitive paths received required reviewer attention (not security-sensitive)
- [x] No destructive ops introduced without explicit approval

Closes #877
