### PR TITLE
fix: preserve bootstrap audit write failures

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -5,6 +5,14 @@ import Security
 import GRDB
 import os.log
 
+protocol AppCoreBackgroundTaskAuditing: Sendable {
+    nonisolated func startTask(name: String, type: String, deviceId: String?) throws -> Int64
+    nonisolated func completeTask(id: Int64, summary: String?, itemsProcessed: Int) throws
+    nonisolated func failTask(id: Int64, error: String) throws
+}
+
+extension BackgroundTaskService: AppCoreBackgroundTaskAuditing {}
+
 /// Shared application state that owns the database and all services.
 ///
 /// Published as an `@EnvironmentObject` so every view in the tree
@@ -274,76 +282,43 @@ final class AppCore: ObservableObject {
 
             // Run scheduled Tools maintenance on launch so expired trades and
             // confidence-score decay are handled even when users do not open a tool detail page.
-            Task.detached { [toolsService, backgroundTaskService] in
-                let taskId = try? backgroundTaskService?.startTask(
+            Task.detached { [toolsService, backgroundTaskService, logger] in
+                Self.runAuditedBootstrapTask(
                     name: "Tools Scheduled Maintenance",
-                    type: "tools_maintenance"
-                )
-                do {
+                    type: "tools_maintenance",
+                    backgroundTaskService: backgroundTaskService,
+                    logger: logger
+                ) {
                     let result = try toolsService?.runScheduledMaintenance()
-                    if let taskId {
-                        let expiredTrades = result?.expiredTrades ?? 0
-                        let updatedScores = result?.updatedConfidenceScores ?? 0
-                        try? backgroundTaskService?.completeTask(
-                            id: taskId,
-                            summary: "Expired \(expiredTrades) trade(s); updated \(updatedScores) confidence score(s)"
-                        )
-                    }
-                } catch {
-                    if let taskId {
-                        try? backgroundTaskService?.failTask(
-                            id: taskId,
-                            error: error.localizedDescription
-                        )
-                    }
+                    let expiredTrades = result?.expiredTrades ?? 0
+                    let updatedScores = result?.updatedConfidenceScores ?? 0
+                    return "Expired \(expiredTrades) trade(s); updated \(updatedScores) confidence score(s)"
                 }
             }
 
             // Run companion auto-discovery cycle in the background (logged)
-            Task.detached { [partsService, backgroundTaskService] in
-                let taskId = try? backgroundTaskService?.startTask(
+            Task.detached { [partsService, backgroundTaskService, logger] in
+                Self.runAuditedBootstrapTask(
                     name: "Companion Auto-Discovery",
-                    type: "companion_discovery"
-                )
-                do {
+                    type: "companion_discovery",
+                    backgroundTaskService: backgroundTaskService,
+                    logger: logger
+                ) {
                     try partsService?.runAutoDiscoveryCycle()
-                    if let taskId {
-                        try? backgroundTaskService?.completeTask(
-                            id: taskId,
-                            summary: "Discovery cycle completed"
-                        )
-                    }
-                } catch {
-                    if let taskId {
-                        try? backgroundTaskService?.failTask(
-                            id: taskId,
-                            error: error.localizedDescription
-                        )
-                    }
+                    return "Discovery cycle completed"
                 }
             }
 
             // Ensure Office chat channel exists (auto-created system channel)
-            Task.detached { [chatService, backgroundTaskService] in
-                let taskId = try? backgroundTaskService?.startTask(
+            Task.detached { [chatService, backgroundTaskService, logger] in
+                Self.runAuditedBootstrapTask(
                     name: "Office Channel Setup",
-                    type: "system_setup"
-                )
-                do {
+                    type: "system_setup",
+                    backgroundTaskService: backgroundTaskService,
+                    logger: logger
+                ) {
                     try chatService?.ensureOfficeChannel()
-                    if let taskId {
-                        try? backgroundTaskService?.completeTask(
-                            id: taskId,
-                            summary: "Office channel ready"
-                        )
-                    }
-                } catch {
-                    if let taskId {
-                        try? backgroundTaskService?.failTask(
-                            id: taskId,
-                            error: error.localizedDescription
-                        )
-                    }
+                    return "Office channel ready"
                 }
             }
         } catch {
@@ -482,6 +457,54 @@ final class AppCore: ObservableObject {
         logger.info(
             "[OnboardAI] bootstrap route=\(result.route.rawValue, privacy: .public) latency_ms=\(latencyMs, privacy: .public) availability=\(result.availabilityLabel, privacy: .public) timeout_budget_ms=\(result.timeoutBudgetMs, privacy: .public) did_timeout=\(result.didTimeout, privacy: .public) fallback_model_unavailable=\(result.usedModelUnavailableFallback, privacy: .public) fallback_low_resource=\(result.usedLowResourceFallback, privacy: .public)"
         )
+    }
+
+    nonisolated static func runAuditedBootstrapTask(
+        name: String,
+        type: String,
+        backgroundTaskService: AppCoreBackgroundTaskAuditing?,
+        logger: Logger,
+        operation: @Sendable () throws -> String
+    ) {
+        var taskId: Int64?
+
+        if let backgroundTaskService {
+            do {
+                taskId = try backgroundTaskService.startTask(
+                    name: name,
+                    type: type,
+                    deviceId: nil
+                )
+            } catch {
+                logger.error("[AppCore] Failed to start background task audit record task_name=\(name, privacy: .public) task_type=\(type, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        let successSummary: String
+        do {
+            successSummary = try operation()
+        } catch {
+            logger.error("[AppCore] Bootstrap background task failed task_name=\(name, privacy: .public) task_type=\(type, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            guard let taskId, let backgroundTaskService else { return }
+
+            do {
+                try backgroundTaskService.failTask(id: taskId, error: error.localizedDescription)
+            } catch {
+                logger.error("[AppCore] Failed to mark background task audit record as failed task_name=\(name, privacy: .public) task_type=\(type, privacy: .public) task_id=\(taskId, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            }
+            return
+        }
+
+        guard let taskId, let backgroundTaskService else { return }
+        do {
+            try backgroundTaskService.completeTask(
+                id: taskId,
+                summary: successSummary,
+                itemsProcessed: 0
+            )
+        } catch {
+            logger.error("[AppCore] Failed to complete background task audit record task_name=\(name, privacy: .public) task_type=\(type, privacy: .public) task_id=\(taskId, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+        }
     }
 
     /// Reload theme settings from the database and apply them.

--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -476,7 +476,8 @@ final class AppCore: ObservableObject {
                     deviceId: nil
                 )
             } catch {
-                logger.error("[AppCore] Failed to start background task audit record task_name=\(name, privacy: .public) task_type=\(type, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+                let nsError = error as NSError
+                logger.error("[AppCore] Failed to start background task audit record task_name=\(name, privacy: .public) task_type=\(type, privacy: .public) error_domain=\(nsError.domain, privacy: .public) error_code=\(nsError.code, privacy: .public) error=\(error.localizedDescription, privacy: .private)")
             }
         }
 
@@ -484,13 +485,15 @@ final class AppCore: ObservableObject {
         do {
             successSummary = try operation()
         } catch {
-            logger.error("[AppCore] Bootstrap background task failed task_name=\(name, privacy: .public) task_type=\(type, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            let nsError = error as NSError
+            logger.error("[AppCore] Bootstrap background task failed task_name=\(name, privacy: .public) task_type=\(type, privacy: .public) error=\(error.localizedDescription, privacy: .private) error_domain=\(nsError.domain, privacy: .public) error_code=\(nsError.code, privacy: .public)")
             guard let taskId, let backgroundTaskService else { return }
 
             do {
                 try backgroundTaskService.failTask(id: taskId, error: error.localizedDescription)
             } catch {
-                logger.error("[AppCore] Failed to mark background task audit record as failed task_name=\(name, privacy: .public) task_type=\(type, privacy: .public) task_id=\(taskId, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+                let nsError = error as NSError
+                logger.error("[AppCore] Failed to mark background task audit record as failed task_name=\(name, privacy: .public) task_type=\(type, privacy: .public) task_id=\(taskId, privacy: .public) error_domain=\(nsError.domain, privacy: .public) error_code=\(nsError.code, privacy: .public) error=\(error.localizedDescription, privacy: .private)")
             }
             return
         }
@@ -503,7 +506,8 @@ final class AppCore: ObservableObject {
                 itemsProcessed: 0
             )
         } catch {
-            logger.error("[AppCore] Failed to complete background task audit record task_name=\(name, privacy: .public) task_type=\(type, privacy: .public) task_id=\(taskId, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            let nsError = error as NSError
+            logger.error("[AppCore] Failed to complete background task audit record task_name=\(name, privacy: .public) task_type=\(type, privacy: .public) task_id=\(taskId, privacy: .public) error_domain=\(nsError.domain, privacy: .public) error_code=\(nsError.code, privacy: .public) error=\(error.localizedDescription, privacy: .private)")
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -21,6 +21,7 @@ private enum BootstrapAuditTestError: Error {
 private final class MockBootstrapTaskAuditor: AppCoreBackgroundTaskAuditing, @unchecked Sendable {
     var startedNames: [String] = []
     var completedIds: [Int64] = []
+    var completedSummaries: [String?] = []
     var failedIds: [Int64] = []
     var startError: Error?
     var completeError: Error?
@@ -38,6 +39,7 @@ private final class MockBootstrapTaskAuditor: AppCoreBackgroundTaskAuditing, @un
             throw completeError
         }
         completedIds.append(id)
+        completedSummaries.append(summary)
     }
 
     func failTask(id: Int64, error: String) throws {
@@ -166,6 +168,24 @@ struct Weird_Parts_IOSTests {
 
         #expect(operation.ran)
         #expect(auditor.startedNames == ["Test Bootstrap Task"])
+        #expect(auditor.failedIds.isEmpty)
+    }
+
+    @Test func auditedBootstrapTaskCompletesAuditRecordOnSuccess() throws {
+        let auditor = MockBootstrapTaskAuditor()
+
+        AppCore.runAuditedBootstrapTask(
+            name: "Test Bootstrap Task",
+            type: "test",
+            backgroundTaskService: auditor,
+            logger: Logger(subsystem: "com.wiredpart.tests", category: "AppCore")
+        ) {
+            "Test complete"
+        }
+
+        #expect(auditor.startedNames == ["Test Bootstrap Task"])
+        #expect(auditor.completedIds == [42])
+        #expect(auditor.completedSummaries == ["Test complete"])
         #expect(auditor.failedIds.isEmpty)
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -9,7 +9,45 @@ import Foundation
 import Security
 import Testing
 import WiredPartCore
+import os.log
 @testable import Weird_Parts
+
+private enum BootstrapAuditTestError: Error {
+    case start
+    case complete
+    case operation
+}
+
+private final class MockBootstrapTaskAuditor: AppCoreBackgroundTaskAuditing, @unchecked Sendable {
+    var startedNames: [String] = []
+    var completedIds: [Int64] = []
+    var failedIds: [Int64] = []
+    var startError: Error?
+    var completeError: Error?
+
+    func startTask(name: String, type: String, deviceId: String?) throws -> Int64 {
+        if let startError {
+            throw startError
+        }
+        startedNames.append(name)
+        return 42
+    }
+
+    func completeTask(id: Int64, summary: String?, itemsProcessed: Int) throws {
+        if let completeError {
+            throw completeError
+        }
+        completedIds.append(id)
+    }
+
+    func failTask(id: Int64, error: String) throws {
+        failedIds.append(id)
+    }
+}
+
+private final class OperationProbe: @unchecked Sendable {
+    var ran = false
+}
 
 private enum QuestionnaireBreakTestError: Error {
     case autoFillFailed
@@ -89,6 +127,62 @@ struct Weird_Parts_IOSTests {
         #expect(QAThreadStatusBuckets.isResolved("closed"))
         #expect(!QAThreadStatusBuckets.isResolved("open"))
         #expect(!QAThreadStatusBuckets.isResolved("escalated"))
+    }
+
+    @Test func auditedBootstrapTaskStillRunsWhenAuditStartFails() throws {
+        let auditor = MockBootstrapTaskAuditor()
+        auditor.startError = BootstrapAuditTestError.start
+        let operation = OperationProbe()
+
+        AppCore.runAuditedBootstrapTask(
+            name: "Test Bootstrap Task",
+            type: "test",
+            backgroundTaskService: auditor,
+            logger: Logger(subsystem: "com.wiredpart.tests", category: "AppCore")
+        ) {
+            operation.ran = true
+            return "Test complete"
+        }
+
+        #expect(operation.ran)
+        #expect(auditor.completedIds.isEmpty)
+        #expect(auditor.failedIds.isEmpty)
+    }
+
+    @Test func auditedBootstrapTaskDoesNotThrowWhenAuditCompletionFails() throws {
+        let auditor = MockBootstrapTaskAuditor()
+        auditor.completeError = BootstrapAuditTestError.complete
+        let operation = OperationProbe()
+
+        AppCore.runAuditedBootstrapTask(
+            name: "Test Bootstrap Task",
+            type: "test",
+            backgroundTaskService: auditor,
+            logger: Logger(subsystem: "com.wiredpart.tests", category: "AppCore")
+        ) {
+            operation.ran = true
+            return "Test complete"
+        }
+
+        #expect(operation.ran)
+        #expect(auditor.startedNames == ["Test Bootstrap Task"])
+        #expect(auditor.failedIds.isEmpty)
+    }
+
+    @Test func auditedBootstrapTaskRecordsOperationFailureWhenPossible() throws {
+        let auditor = MockBootstrapTaskAuditor()
+
+        AppCore.runAuditedBootstrapTask(
+            name: "Test Bootstrap Task",
+            type: "test",
+            backgroundTaskService: auditor,
+            logger: Logger(subsystem: "com.wiredpart.tests", category: "AppCore")
+        ) {
+            throw BootstrapAuditTestError.operation
+        }
+
+        #expect(auditor.completedIds.isEmpty)
+        #expect(auditor.failedIds == [42])
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Replaced silent AppCore bootstrap audit `try?` writes with a shared audited bootstrap helper that preserves primary startup behavior while logging structured audit start/complete/fail write failures.
- Covered Tools Scheduled Maintenance, Companion Auto-Discovery, and Office Channel Setup startup tasks.
- Added focused Swift Testing coverage for audit start failure, completion failure, and operation failure recording.

## Tests
- [x] `xcodebuild test -project \"Weird Parts IOS/Weird Parts.xcodeproj\" -scheme \"Weird Parts\" -destination \"platform=iOS Simulator,name=iPhone 17\" -derivedDataPath .tmp/xcode-derived/WEI-3824 -only-testing:\"Weird Parts IOSTests/Weird_Parts_IOSTests/auditedBootstrapTaskStillRunsWhenAuditStartFails\" -only-testing:\"Weird Parts IOSTests/Weird_Parts_IOSTests/auditedBootstrapTaskDoesNotThrowWhenAuditCompletionFails\" -only-testing:\"Weird Parts IOSTests/Weird_Parts_IOSTests/auditedBootstrapTaskRecordsOperationFailureWhenPossible\"`

Paperclip: WEI-3824
Closes #874