### PR TITLE
fix: scan full PR maintenance queue

### DIFF
--- a/scripts/pr-merge-maintenance.sh
+++ b/scripts/pr-merge-maintenance.sh
@@ -17,7 +17,7 @@
 # Environment:
 #   GH_TOKEN                         Required in GitHub Actions.
 #   PR_MAINTENANCE_BASE              Base branch. Default: main.
-#   PR_MAINTENANCE_MAX_PRS           PRs to inspect for candidate. Default: 20.
+#   PR_MAINTENANCE_MAX_PRS           Optional explicit safety cap. Default: inspect all open PRs.
 #   PR_MAINTENANCE_DRY_RUN           Set to 1 to log without side effects.
 #   PR_MAINTENANCE_SKIP_LABELS       Comma-separated labels → manual only.
 #   PR_MAINTENANCE_SKIP_TITLE_REGEX  Extended regex for security/manual titles.
@@ -27,7 +27,7 @@ shopt -s nocasematch
 
 REPO="${1:-${GITHUB_REPOSITORY:-}}"
 BASE="${PR_MAINTENANCE_BASE:-main}"
-MAX_PRS="${PR_MAINTENANCE_MAX_PRS:-20}"
+MAX_PRS="${PR_MAINTENANCE_MAX_PRS:-}"
 DRY_RUN="${PR_MAINTENANCE_DRY_RUN:-0}"
 SKIP_LABELS="${PR_MAINTENANCE_SKIP_LABELS:-security,security-sensitive,manual-review,manual-merge,do-not-merge}"
 SKIP_TITLE_REGEX="${PR_MAINTENANCE_SKIP_TITLE_REGEX:-security|sqlcipher|encryption|auth|payment|credential|secret|keychain}"
@@ -62,21 +62,46 @@ run_or_log() {
   "$@"
 }
 
-echo "==> Scanning up to $MAX_PRS open PRs in $REPO targeting $BASE (one-at-a-time mode)"
+total_open="$(gh api --paginate "repos/$REPO/pulls?state=open&base=$BASE&per_page=100" \
+  --jq '.[] | .number' | wc -l | xargs)"
+
+if [[ "$total_open" -eq 0 ]]; then
+  echo "No open PRs targeting $BASE. Nothing to do."
+  exit 0
+fi
+
+if [[ -n "$MAX_PRS" ]]; then
+  if ! [[ "$MAX_PRS" =~ ^[0-9]+$ ]] || [[ "$MAX_PRS" -lt 1 ]]; then
+    echo "error: PR_MAINTENANCE_MAX_PRS must be a positive integer when set, got '$MAX_PRS'" >&2
+    exit 1
+  fi
+  inspect_limit="$MAX_PRS"
+else
+  inspect_limit="$total_open"
+fi
+
+if [[ "$inspect_limit" -lt "$total_open" ]]; then
+  echo "error: incomplete PR scan refused: total_open=$total_open inspected_limit=$inspect_limit targeting $BASE." >&2
+  echo "Set PR_MAINTENANCE_MAX_PRS to at least $total_open or unset it to inspect the full queue." >&2
+  exit 2
+fi
+
+echo "==> Scanning all $total_open open PRs in $REPO targeting $BASE (one-at-a-time mode)"
+echo "PR scan counts: total_open=$total_open inspected_limit=$inspect_limit"
 
 prs_json="$(gh pr list \
   --repo "$REPO" \
   --base "$BASE" \
   --state open \
-  --limit "$MAX_PRS" \
+  --limit "$inspect_limit" \
   --json number,title,isDraft,labels,headRepositoryOwner,mergeStateStatus,mergeable,autoMergeRequest)"
 
-total="$(jq 'length' <<<"$prs_json")"
-if [[ "$total" -eq 0 ]]; then
-  echo "No open PRs targeting $BASE. Nothing to do."
-  exit 0
+inspected="$(jq 'length' <<<"$prs_json")"
+if [[ "$inspected" -ne "$total_open" ]]; then
+  echo "error: incomplete PR scan: total_open=$total_open inspected=$inspected targeting $BASE." >&2
+  exit 2
 fi
-echo "Found $total open PR(s)."
+echo "Found $total_open open PR(s); inspecting $inspected."
 
 repo_owner="${REPO%%/*}"
 

--- a/tests/pr-merge-maintenance-scan-counts.sh
+++ b/tests/pr-merge-maintenance-scan-counts.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat >"$tmpdir/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${GH_CALL_LOG:?}"
+if [[ "${1:-}" == "api" ]]; then
+  for i in $(seq 1 "${MOCK_OPEN_PR_COUNT:-55}"); do
+    echo "$i"
+  done
+  exit 0
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+  limit=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--limit" ]]; then
+      shift
+      limit="$1"
+      break
+    fi
+    shift
+  done
+  : "${limit:?missing --limit}"
+  python3 - "$limit" <<'PY'
+import json, sys
+limit = int(sys.argv[1])
+print(json.dumps([
+    {
+        "number": i,
+        "title": f"Mock PR {i}",
+        "isDraft": True,
+        "labels": [],
+        "headRepositoryOwner": {"login": "xXKillerNoobYT"},
+        "mergeStateStatus": "CLEAN",
+        "mergeable": "MERGEABLE",
+        "autoMergeRequest": None,
+    }
+    for i in range(1, limit + 1)
+]))
+PY
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 64
+GH
+chmod +x "$tmpdir/gh"
+
+export PATH="$tmpdir:$PATH"
+export GH_CALL_LOG="$tmpdir/gh-calls.log"
+export MOCK_OPEN_PR_COUNT=55
+
+output="$(PR_MAINTENANCE_DRY_RUN=1 "$repo_root/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2)"
+[[ "$output" == *"PR scan counts: total_open=55 inspected_limit=55"* ]]
+[[ "$output" == *"Found 55 open PR(s); inspecting 55."* ]]
+grep -q -- '--limit 55' "$GH_CALL_LOG"
+
+: >"$GH_CALL_LOG"
+set +e
+capped_output="$(PR_MAINTENANCE_DRY_RUN=1 PR_MAINTENANCE_MAX_PRS=50 "$repo_root/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 2>&1)"
+status=$?
+set -e
+[[ "$status" -eq 2 ]]
+[[ "$capped_output" == *"incomplete PR scan refused: total_open=55 inspected_limit=50"* ]]
+if grep -q '^pr list' "$GH_CALL_LOG"; then
+  echo "expected capped incomplete scan to fail before gh pr list" >&2
+  exit 1
+fi
+
+echo "pr-merge-maintenance scan-count smoke test passed"


### PR DESCRIPTION
## Summary
- make `scripts/pr-merge-maintenance.sh` count the full open PR queue for the target base branch before selecting candidates
- remove the silent default 20-PR cap; by default the script now asks `gh pr list` to inspect every open PR it counted
- fail loudly before any candidate action when an explicit `PR_MAINTENANCE_MAX_PRS` cap is smaller than the queue
- add a deterministic shell smoke test that mocks 55 open PRs and verifies both full-scan and capped-incomplete behavior

## Test Plan
- [x] `bash -n scripts/pr-merge-maintenance.sh`
- [x] `bash -n tests/pr-merge-maintenance-scan-counts.sh`
- [x] `tests/pr-merge-maintenance-scan-counts.sh`
- [x] `PR_MAINTENANCE_DRY_RUN=1 scripts/pr-merge-maintenance.sh xXKillerNoobYT/Weird-Part-Run-2 | sed -n '1,20p'`

Paperclip: WEI-3826
Closes #855
