### PR TITLE
fix: prevent onboarding setup bypass

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
@@ -42,20 +42,24 @@ struct WiredPartIOSApp: App {
     @AppStorage(OnboardAIFeatureFlag.onboardingMVP) private var onboardAIMVPEnabled = false
 
     init() {
+        Self.migrateLegacyWelcomeFlags()
+    }
+
+    static func migrateLegacyWelcomeFlags(defaults: UserDefaults = .standard) {
         // One-time migration: users who already completed the old welcome flow
         // don't need to re-run the walkthrough or company-setup wizard.
         // Consume hasSeenWelcome immediately so this never re-fires on a
         // subsequent fresh build where the DB is empty but UserDefaults persisted.
-        if UserDefaults.standard.bool(forKey: "hasSeenWelcome") {
-            if !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding") {
-                UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+        if defaults.bool(forKey: "hasSeenWelcome") {
+            if !defaults.bool(forKey: "hasCompletedOnboarding") {
+                defaults.set(true, forKey: "hasCompletedOnboarding")
             }
-            if !UserDefaults.standard.bool(forKey: "hasCompletedCompanySetup") {
-                UserDefaults.standard.set(true, forKey: "hasCompletedCompanySetup")
+            if !defaults.bool(forKey: "hasCompletedCompanySetup") {
+                defaults.set(true, forKey: "hasCompletedCompanySetup")
             }
             // Clear the trigger so a future fresh-DB build doesn't re-apply
             // these flags before bootstrap() can detect the empty database.
-            UserDefaults.standard.removeObject(forKey: "hasSeenWelcome")
+            defaults.removeObject(forKey: "hasSeenWelcome")
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Auth/OnboardingWalkthroughView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/OnboardingWalkthroughView.swift
@@ -584,14 +584,8 @@ struct OnboardingWalkthroughView: View {
     }
 
     private func finishOnboarding() {
+        OnboardingCompletionDefaults.markCompleted(skippedModules: skippedModules)
         hasCompletedOnboarding = true
-        // Also mark these so the older overlays don't re-show
-        UserDefaults.standard.set(true, forKey: "hasSeenWelcome")
-        UserDefaults.standard.set(true, forKey: "hasSeenModuleTour")
-        // Save skipped modules so post-onboarding hints can reference them
-        if let data = try? JSONEncoder().encode(skippedModules) {
-            UserDefaults.standard.set(data, forKey: "onboarding_skipped_modules")
-        }
         // Coordinate with OnboardingProgressManager — mark view tasks complete
         if let manager = appCore.onboardingManager {
             for moduleId in completedModules {
@@ -628,6 +622,21 @@ struct OnboardingWalkthroughView: View {
             UserDefaults.standard.set(data, forKey: "onboarding_skipped_modules")
         }
         UserDefaults.standard.set(currentStep, forKey: "onboarding_current_step")
+    }
+}
+
+enum OnboardingCompletionDefaults {
+    static func markCompleted(
+        skippedModules: Set<String>,
+        defaults: UserDefaults = .standard
+    ) {
+        defaults.set(true, forKey: "hasCompletedOnboarding")
+        // Keep current walkthrough completion separate from the legacy
+        // hasSeenWelcome migration trigger used by WiredPartIOSApp startup.
+        defaults.set(true, forKey: "hasSeenModuleTour")
+        if let data = try? JSONEncoder().encode(skippedModules) {
+            defaults.set(data, forKey: "onboarding_skipped_modules")
+        }
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -92,6 +92,48 @@ struct Weird_Parts_IOSTests {
     }
 
     @MainActor
+    @Test func currentWalkthroughCompletionDoesNotBypassCompanySetupOnRelaunch() throws {
+        let defaults = try temporaryDefaults()
+
+        OnboardingCompletionDefaults.markCompleted(
+            skippedModules: ["dashboard", "settings"],
+            defaults: defaults
+        )
+        WiredPartIOSApp.migrateLegacyWelcomeFlags(defaults: defaults)
+
+        #expect(defaults.bool(forKey: "hasCompletedOnboarding"))
+        #expect(defaults.bool(forKey: "hasSeenModuleTour"))
+        #expect(!defaults.bool(forKey: "hasSeenWelcome"))
+        #expect(!defaults.bool(forKey: "hasCompletedCompanySetup"))
+        #expect(defaults.data(forKey: "onboarding_skipped_modules") != nil)
+    }
+
+    @MainActor
+    @Test func legacyWelcomeMigrationStillCompletesCompanySetupOnce() throws {
+        let defaults = try temporaryDefaults()
+        defaults.set(true, forKey: "hasSeenWelcome")
+
+        WiredPartIOSApp.migrateLegacyWelcomeFlags(defaults: defaults)
+
+        #expect(defaults.bool(forKey: "hasCompletedOnboarding"))
+        #expect(defaults.bool(forKey: "hasCompletedCompanySetup"))
+        #expect(!defaults.bool(forKey: "hasSeenWelcome"))
+    }
+
+    private func temporaryDefaults() throws -> UserDefaults {
+        let suiteName = "WeirdPartsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            throw TestDefaultsError.unavailable
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private enum TestDefaultsError: Error {
+        case unavailable
+    }
+
+    @MainActor
     @Test func shopServerAddressSettingsAreDeviceScoped() async throws {
         #expect(IOSSyncManager.settingSyncScope(for: "sync_server_address") == .device)
         #expect(IOSSyncManager.settingSyncScope(for: "shop_server_address") == .device)


### PR DESCRIPTION
## Summary
- stops current onboarding walkthrough completion from writing the legacy `hasSeenWelcome` startup migration trigger
- exposes the legacy welcome migration as a defaults-injectable helper so the migration can still be tested directly
- adds focused Swift Testing coverage for current walkthrough completion followed by relaunch and for the preserved legacy migration path

## Test Plan
- [x] `xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/currentWalkthroughCompletionDoesNotBypassCompanySetupOnRelaunch" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/legacyWelcomeMigrationStillCompletesCompanySetupOnce"`

Paperclip: WEI-3828
Closes #853