### PR TITLE
docs: codify Copilot PR review gate

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,6 +32,10 @@ rg -n "runs-on:" .github/workflows || grep -R "runs-on:" .github/workflows
 
 The runner API requires a GitHub token with permission to read repository Actions runner state. If API access is unavailable, use the repository Actions UI to inspect runner status and recent runs. Use `runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]` for trusted jobs that need macOS, iOS, Swift, or Xcode, required PR gates, and repo-owned automation jobs. Do not run untrusted fork PR code on the self-hosted runner. If the runner is offline or missing labels, record that exact evidence in the PR/issue comment and name the owner/action needed to restore the runner.
 
+### PR Review Gate
+
+Before any PR is merged, maintainers must request and receive a GitHub Copilot PR review/comment. If Copilot identifies issues, the fix work is routed through normal Codex/Hermes-local or human implementation lanes; Copilot comments are review input, not a local Paperclip provider/tooling path. After fixes, required tests/checks and self-review must pass, and materially changed PRs should be re-submitted for Copilot review/comment. Waiting about 30 minutes between Copilot review/fix cycles is acceptable; branches of branches and PRs of PRs are allowed when they improve quality. This requirement is tracked in Paperclip WEI-3851/WEI-3852 and supersedes older removal churn.
+
 ---
 
 ## 2. Schema Is Canonical

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,17 @@ The runner API requires a GitHub token with permission to read repository Action
 
 This repo is currently under the user's personal GitHub account (`xXKillerNoobYT`), not a GitHub organization. Do not assume organization teams, organization policy pages, organization-level settings, or organization Copilot controls exist. Verify the repo owner before applying GitHub admin instructions. If a requested control is organization-only, document it as not applicable unless/until the user transfers the repo to an organization; use repo-level or user-account-level settings where available. See `docs/github-account-context.md`.
 
+## GitHub Copilot PR Review Gate
+
+Owner direction tracked in Paperclip WEI-3851/WEI-3852 supersedes older attempts to remove GitHub Copilot from the merge path. For every PR before merge:
+
+1. Request a GitHub Copilot PR review/comment through GitHub review tooling the same way you would request a user review.
+2. Do not merge until Copilot has left a review/comment, unless there is explicit owner-approved evidence that Copilot review is unavailable for that PR. Waiting about 30 minutes between review/fix cycles is acceptable.
+3. If Copilot finds issues, route the fix work through the normal Codex/Hermes-local implementation lane or a human. Copilot review comments/suggestions are review input, not permission to use Copilot as a local Paperclip provider/tooling route.
+4. After fixes land, self-review, run required local/CI checks, and re-request/wait for Copilot again when the PR materially changed. Repeat until no blocking issues remain.
+5. Branches of branches and PRs of PRs are allowed when they improve quality or isolate fixes.
+6. Merge readiness now includes: linked Paperclip/GitHub issues resolved, branch current with `main`, required checks green, unresolved review threads resolved, required Copilot review/comment satisfied, and no owner/security/product blocker.
+
 **Rules:**
 
 1. **Find something broken? File it.** Every bug, gap, or missing feature gets a GitHub issue with: title prefix `[Area][Type]`, description of what's wrong, impact, and fix approach.

--- a/docs/paperclip-handoff.md
+++ b/docs/paperclip-handoff.md
@@ -180,10 +180,11 @@ Per `feedback_delegate_to_copilot.md` and `feedback_copilot_delegation_workflow.
 2. Write prescriptive issue prompts
 3. Supervise (don't @copilot in body — let it pick up via assignment)
 4. File-as-a-whole review (single consolidated review comment)
-5. Squash-merge (CI-green is the merge gate)
-6. Sweep (clean up `[gone]` branches)
+5. Request/receive GitHub Copilot PR review/comment before merge; if Copilot finds issues, route fixes through Codex/Hermes-local or human lanes, test/self-review, then re-request/wait as needed (~30 minute cycles are acceptable)
+6. Squash-merge only after CI, required checks, unresolved threads, Paperclip blockers, and the Copilot review gate are clear
+7. Sweep (clean up `[gone]` branches)
 
-Cap: **5 concurrent open Copilot PRs.** Each issue gets its own branch. Merge is the user's; Copilot does not self-merge.
+Cap: **5 concurrent open Copilot PRs.** Each issue gets its own branch. Merge is the user's; Copilot does not self-merge. Paperclip WEI-3851/WEI-3852 supersedes older Copilot-removal churn: keep Copilot as a required GitHub PR reviewer/commenter before merge, but do not use it as a Paperclip local provider/tooling route.
 
 ### The 12 approved automation scanners (queued or partially built)
 


### PR DESCRIPTION
## Summary

- Issue: Paperclip WEI-3852 / WEI-3851 owner direction
- Scope: Codifies the GitHub Copilot PR-review/comment gate in WPR2 project instructions and handoff docs while preserving the boundary that Copilot is not a Paperclip local provider/tooling route.

## Validation

- [x] Tests added/updated as needed — docs/instruction-only change; no product logic tests required.
- [x] Lint/type checks pass — `git diff --check` passed.
- [x] Backward compatibility considered — updates merge SOP only; no runtime behavior changed.

## AI Assistance Disclosure

- [x] AI assistance used in this PR
- Tools used: Hermes / OpenAI Codex gpt-5.5
- AI-assisted areas (files/functions): `CLAUDE.md`, `.github/copilot-instructions.md`, `docs/paperclip-handoff.md`
- Reviewer focus notes for AI-generated/assisted code: Verify the wording correctly requires Copilot PR review/comment before merge and does not re-enable Copilot as a local Paperclip provider/tooling path.

## Copilot-assisted Change Checklist

- [x] Copilot used for this PR: No
- [x] Reviewed Copilot-generated/assisted changes line-by-line
- [x] No secrets, credentials, or customer-sensitive prompt data shared
- [x] Licensing/origin risk checked for non-trivial generated snippets
- [x] Tests added/updated for generated or modified logic — not applicable; documentation/SOP only.
- [x] Manual verification notes added for security/auth/config changes — not applicable; no security/auth/config changes.

## Risk Check

- [x] No secrets or sensitive data were shared with AI tools
- [x] Security-sensitive paths received required reviewer attention — no security-sensitive code paths touched.
- [x] No destructive ops introduced without explicit approval
