### PR TITLE
[WEI-3862] Add guided inventory ledger movements

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
@@ -83,6 +83,13 @@ struct WarehouseDashboardPage: View {
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 HStack(spacing: 12) {
+                    Button { activeSheet = .newMovement } label: {
+                        Image(systemName: "arrow.left.arrow.right.circle.fill")
+                    }
+                    .accessibilityLabel("New Movement")
+                    .accessibilityHint("Opens the guided movement wizard")
+                    .accessibilityIdentifier("whAction_newMovement")
+
                     CartBadgeButton(cartManager: cartManager)
                     Button { activeSheet = .help } label: {
                         Image(systemName: "questionmark.circle")
@@ -121,10 +128,8 @@ struct WarehouseDashboardPage: View {
     private func sheetContent(for sheet: ActiveSheet) -> some View {
         switch sheet {
         case .newMovement:
-            NavigationStack {
-                IOSMovementWizard()
-                    .environmentObject(appCore)
-            }
+            IOSMovementWizard()
+                .environmentObject(appCore)
         case .qrScanner:
             QRScanSheet(expectedType: .bin) { result in
                 activeSheet = nil

--- a/Weird Parts IOS/Weird Parts IOSUITests/WarehouseDashboardScreenshotUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/WarehouseDashboardScreenshotUITests.swift
@@ -61,6 +61,27 @@ final class WarehouseDashboardScreenshotUITests: XCTestCase {
         )
     }
 
+    @MainActor
+    func testWarehouseDashboardNewMovementQuickActionOpensWizard() throws {
+        let app = XCUIApplication()
+        app.launchEnvironment["WEIRD_PARTS_UI_TEST_PIN"] = Self.uiTestingPIN
+        app.launchArguments += [
+            "-UITesting",
+            "-UITestingWEI936AutoLogin",
+            "-UITestingDispatchBoard",
+            "-UITestingWarehouseDashboard",
+        ]
+        app.launch()
+
+        navigateToWarehouse(in: app)
+        openNewMovementFromDashboard(in: app)
+
+        XCTAssertTrue(
+            app.staticTexts["Where is stock moving?"].waitForExistence(timeout: 10),
+            "Tapping the Warehouse Dashboard New Movement quick action should open the guided movement wizard."
+        )
+    }
+
     private func assertKPIExists(
         in app: XCUIApplication,
         identifier: String,
@@ -140,6 +161,19 @@ final class WarehouseDashboardScreenshotUITests: XCTestCase {
         }
 
         return false
+    }
+
+    private func openNewMovementFromDashboard(in app: XCUIApplication) {
+        let newMovement = app.buttons["whAction_newMovement"].firstMatch
+        XCTAssertTrue(
+            newMovement.waitForExistence(timeout: 10),
+            "Warehouse Dashboard should expose a stable New Movement entry point"
+        )
+        XCTAssertTrue(
+            newMovement.isHittable,
+            "Warehouse Dashboard New Movement entry point should be hittable immediately after opening the dashboard"
+        )
+        newMovement.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
     }
 
     private func openWarehouseSettingsFromDashboard(in app: XCUIApplication) {

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -357,6 +357,8 @@ public final class WarehouseService: Sendable {
         "truck→warehouse", "trailer→warehouse",
         "pulled→warehouse",
         "warehouse→job",
+        "job→return", "truck→return", "trailer→return",
+        "return→warehouse", "return→truck", "return→trailer",
     ]
 
     /// Paths that require a photo.
@@ -862,6 +864,8 @@ public final class WarehouseService: Sendable {
         guard !movementType.trimmingCharacters(in: .whitespaces).isEmpty else {
             throw WarehouseError.requiredFieldEmpty
         }
+        try Self.validateLocationEndpointCompleteness(locationType: fromLocationType, locationId: fromLocationId)
+        try Self.validateLocationEndpointCompleteness(locationType: toLocationType, locationId: toLocationId)
         return try db.writer.write { dbConn in
             // Guard: part must exist and not be tombstoned — otherwise the INSERT
             // would create an orphan stock_movement against a soft-deleted part.
@@ -986,7 +990,7 @@ public final class WarehouseService: Sendable {
         gpsLat: Double? = nil,
         gpsLng: Double? = nil
     ) throws -> Int64 {
-        try createMovement(
+        return try createMovement(
             partId: partId,
             qty: qty,
             fromLocationType: fromLocationType,
@@ -1007,6 +1011,79 @@ public final class WarehouseService: Sendable {
 
     /// Input spec for a single movement in a batch. Mirrors `createMovement` parameters
     /// minus `performedBy` (passed once at the batch level).
+    public enum GuidedMovementLocationType: String, Sendable, CaseIterable {
+        case warehouse
+        case pulled
+        case truck
+        case trailer
+        case job
+        case returnHolding = "return"
+    }
+
+    public struct GuidedMovementInput: Sendable {
+        public let partId: Int64
+        public let qty: Int
+        public let fromLocationType: GuidedMovementLocationType
+        public let fromLocationId: Int64
+        public let toLocationType: GuidedMovementLocationType
+        public let toLocationId: Int64
+        public let performedBy: Int64
+        public let jobId: Int64?
+        public let reason: String?
+        public let notes: String?
+        public let photoPath: String?
+        public let referenceNumber: String?
+        public let unitCostAtMove: Double?
+        public let unitSellAtMove: Double?
+        public let occurredAt: Date?
+        public let verifiedBy: Int64?
+        public let scanConfirmed: Bool
+        public let gpsLat: Double?
+        public let gpsLng: Double?
+
+        public init(
+            partId: Int64,
+            qty: Int,
+            fromLocationType: GuidedMovementLocationType,
+            fromLocationId: Int64,
+            toLocationType: GuidedMovementLocationType,
+            toLocationId: Int64,
+            performedBy: Int64,
+            jobId: Int64? = nil,
+            reason: String? = nil,
+            notes: String? = nil,
+            photoPath: String? = nil,
+            referenceNumber: String? = nil,
+            unitCostAtMove: Double? = nil,
+            unitSellAtMove: Double? = nil,
+            occurredAt: Date? = nil,
+            verifiedBy: Int64? = nil,
+            scanConfirmed: Bool = false,
+            gpsLat: Double? = nil,
+            gpsLng: Double? = nil
+        ) {
+            self.partId = partId
+            self.qty = qty
+            self.fromLocationType = fromLocationType
+            self.fromLocationId = fromLocationId
+            self.toLocationType = toLocationType
+            self.toLocationId = toLocationId
+            self.performedBy = performedBy
+            self.jobId = jobId
+            self.reason = reason
+            self.notes = notes
+            self.photoPath = photoPath
+            self.referenceNumber = referenceNumber
+            self.unitCostAtMove = unitCostAtMove
+            self.unitSellAtMove = unitSellAtMove
+            self.occurredAt = occurredAt
+            self.verifiedBy = verifiedBy
+            self.scanConfirmed = scanConfirmed
+            self.gpsLat = gpsLat
+            self.gpsLng = gpsLng
+        }
+    }
+
     public struct MovementInput: Sendable {
         public let partId: Int64
         public let qty: Int
@@ -1059,6 +1136,8 @@ public final class WarehouseService: Sendable {
             guard !m.movementType.trimmingCharacters(in: .whitespaces).isEmpty else {
                 throw WarehouseError.requiredFieldEmpty
             }
+            try Self.validateLocationEndpointCompleteness(locationType: m.fromLocationType, locationId: m.fromLocationId)
+            try Self.validateLocationEndpointCompleteness(locationType: m.toLocationType, locationId: m.toLocationId)
         }
         return try db.writer.write { dbConn in
             let userExists = (try Int.fetchOne(dbConn, sql: """
@@ -1141,6 +1220,55 @@ public final class WarehouseService: Sendable {
             }
             return ids
         }
+    }
+
+    /// Execute a guided movement wizard commit through the same ledger-backed
+    /// movement writer used by manual warehouse operations. The wizard API keeps
+    /// every warehouse/pulled/truck/job/return transition auditable by deriving
+    /// the movement type from the endpoints and committing stock + history in one
+    /// database transaction.
+    @discardableResult
+    public func executeGuidedMovement(_ input: GuidedMovementInput) throws -> Int64 {
+        let fromType = input.fromLocationType.rawValue
+        let toType = input.toLocationType.rawValue
+        let validation = try validateMovement(
+            partId: input.partId,
+            qty: input.qty,
+            fromLocationType: fromType,
+            fromLocationId: input.fromLocationId,
+            toLocationType: toType,
+            toLocationId: input.toLocationId
+        )
+        guard validation.isValid else {
+            if let stockMessage = validation.errors.first(where: { $0.hasPrefix("Insufficient stock:") }) {
+                let numbers = stockMessage.split { !$0.isNumber }.compactMap { Int($0) }
+                throw WarehouseError.insufficientStock(available: numbers.first ?? 0, requested: numbers.dropFirst().first ?? input.qty)
+            }
+            throw WarehouseError.invalidMovementPath(from: fromType, to: toType)
+        }
+
+        return try createMovement(
+            partId: input.partId,
+            qty: input.qty,
+            fromLocationType: fromType,
+            fromLocationId: input.fromLocationId,
+            toLocationType: toType,
+            toLocationId: input.toLocationId,
+            movementType: Self.determineMovementType(from: fromType, to: toType),
+            reason: input.reason,
+            notes: input.notes,
+            performedBy: input.performedBy,
+            jobId: input.jobId,
+            photoPath: input.photoPath,
+            referenceNumber: input.referenceNumber,
+            unitCostAtMove: input.unitCostAtMove,
+            unitSellAtMove: input.unitSellAtMove,
+            occurredAt: input.occurredAt,
+            verifiedBy: input.verifiedBy,
+            scanConfirmed: input.scanConfirmed,
+            gpsLat: input.gpsLat,
+            gpsLng: input.gpsLng
+        )
     }
 
     /// Execute a validated movement with automatic type determination.
@@ -2333,7 +2461,11 @@ public final class WarehouseService: Sendable {
         performedBy: Int64,
         isDamaged: Bool = false
     ) throws -> Int64 {
-        try createMovement(
+        try Self.validateReturnMutationPath(
+            fromLocationType: fromLocationType,
+            toLocationType: toLocationType
+        )
+        return try createMovement(
             partId: partId,
             qty: qty,
             fromLocationType: fromLocationType,
@@ -4017,10 +4149,10 @@ public final class WarehouseService: Sendable {
 
     /// Determine the movement_type based on from/to location types.
     private static func determineMovementType(from: String, to: String) -> String {
-        if to == "warehouse" && (from == "truck" || from == "trailer") {
+        if to == "warehouse" && (from == "truck" || from == "trailer" || from == "return") {
             return StockMovement.MovementType.stockReturn.rawValue
         }
-        if from == "job" {
+        if to == "return" || from == "job" || from == "return" {
             return StockMovement.MovementType.stockReturn.rawValue
         }
         return StockMovement.MovementType.transfer.rawValue
@@ -4031,6 +4163,22 @@ public final class WarehouseService: Sendable {
         let pathKey = "\(fromLocationType)→\(toLocationType)"
         guard validPaths.contains(pathKey) else {
             throw WarehouseError.invalidMovementPath(from: fromLocationType, to: toLocationType)
+        }
+    }
+
+    private static func validateReturnMutationPath(fromLocationType: String, toLocationType: String) throws {
+        let allowedSourceTypes = Set(["warehouse", "pulled", "truck", "trailer", "job"])
+        guard toLocationType == "warehouse", allowedSourceTypes.contains(fromLocationType) else {
+            throw WarehouseError.invalidMovementPath(from: fromLocationType, to: toLocationType)
+        }
+    }
+
+    private static func validateLocationEndpointCompleteness(locationType: String?, locationId: Int64?) throws {
+        switch (locationType, locationId) {
+        case (nil, nil), (.some, .some):
+            return
+        case (.some, nil), (nil, .some):
+            throw WarehouseError.requiredFieldEmpty
         }
     }
 
@@ -4047,6 +4195,8 @@ public final class WarehouseService: Sendable {
             return "Job \(id)"
         case "pulled":
             return "Pulled Staging"
+        case "return":
+            return "Return Holding \(id)"
         default:
             return "\(type) #\(id)"
         }

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -1229,6 +1229,8 @@ public final class WarehouseService: Sendable {
     /// database transaction.
     @discardableResult
     public func executeGuidedMovement(_ input: GuidedMovementInput) throws -> Int64 {
+        guard input.qty > 0 else { throw WarehouseError.invalidQuantity }
+
         let fromType = input.fromLocationType.rawValue
         let toType = input.toLocationType.rawValue
         let validation = try validateMovement(

--- a/core/Tests/WiredPartCoreTests/GuidedInventoryMovementTests.swift
+++ b/core/Tests/WiredPartCoreTests/GuidedInventoryMovementTests.swift
@@ -159,6 +159,32 @@ struct GuidedInventoryMovementTests {
         #expect(try movementCount(env, partId: partId) == beforeCount)
     }
 
+    @Test("guided zero quantity fails as invalid quantity without stock or ledger side effects")
+    func guidedZeroQuantityFailsWithoutSideEffects() throws {
+        let env = try E2ETestHelpers.setUp()
+        let partId = try seedPartWithWarehouseStock(env, qty: 2)
+        let beforeCount = try movementCount(env, partId: partId)
+
+        #expect(throws: WarehouseService.WarehouseError.invalidQuantity) {
+            try env.warehouse.executeGuidedMovement(
+                WarehouseService.GuidedMovementInput(
+                    partId: partId,
+                    qty: 0,
+                    fromLocationType: .warehouse,
+                    fromLocationId: 1,
+                    toLocationType: .truck,
+                    toLocationId: 9,
+                    performedBy: env.adminUserId,
+                    reason: "Should fail before movement commit"
+                )
+            )
+        }
+
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 2)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "truck", locationId: 9) == 0)
+        #expect(try movementCount(env, partId: partId) == beforeCount)
+    }
+
     private func seedPartWithWarehouseStock(_ env: E2ETestHelpers.TestEnvironment, qty: Int) throws -> Int64 {
         let categoryId = try E2ETestHelpers.seedCategory(env, name: "WEI-3862 Inventory")
         let partId = try E2ETestHelpers.seedPart(env, name: "WEI-3862 Ledger Part", categoryId: categoryId)

--- a/core/Tests/WiredPartCoreTests/GuidedInventoryMovementTests.swift
+++ b/core/Tests/WiredPartCoreTests/GuidedInventoryMovementTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+import GRDB
+@testable import WiredPartCore
+
+@Suite("Guided Inventory Movement Ledger Tests")
+struct GuidedInventoryMovementTests {
+    @Test("guided warehouse to truck movement writes one ledger row and updates both locations")
+    func guidedWarehouseToTruckWritesLedger() throws {
+        let env = try E2ETestHelpers.setUp()
+        let partId = try seedPartWithWarehouseStock(env, qty: 10)
+
+        let movementId = try env.warehouse.executeGuidedMovement(
+            WarehouseService.GuidedMovementInput(
+                partId: partId,
+                qty: 4,
+                fromLocationType: .warehouse,
+                fromLocationId: 1,
+                toLocationType: .truck,
+                toLocationId: 7,
+                performedBy: env.adminUserId,
+                reason: "Load service truck",
+                notes: "WEI-3862 guided move",
+                scanConfirmed: true
+            )
+        )
+
+        #expect(movementId > 0)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 6)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "truck", locationId: 7) == 4)
+
+        let ledger = try #require(try env.warehouse.getInventoryLedger(partId: partId))
+        #expect(ledger.totalQty == 10)
+        #expect(ledger.movements.contains { movement in
+            movement.id == movementId &&
+            movement.fromLocationType == "warehouse" &&
+            movement.toLocationType == "truck" &&
+            movement.movementType == StockMovement.MovementType.transfer.rawValue &&
+            movement.scanConfirmed
+        })
+    }
+
+    @Test("guided warehouse to job movement links the job and preserves quantity history")
+    func guidedWarehouseToJobLinksJob() throws {
+        let env = try E2ETestHelpers.setUp()
+        let partId = try seedPartWithWarehouseStock(env, qty: 8)
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "WEI-3862-JOB", name: "Ledger Job")
+
+        let movementId = try env.warehouse.executeGuidedMovement(
+            WarehouseService.GuidedMovementInput(
+                partId: partId,
+                qty: 3,
+                fromLocationType: .warehouse,
+                fromLocationId: 1,
+                toLocationType: .job,
+                toLocationId: jobId,
+                performedBy: env.adminUserId,
+                jobId: jobId,
+                reason: "Issue to job"
+            )
+        )
+
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 5)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "job", locationId: jobId) == 3)
+
+        let row = try env.db.writer.read { db in
+            try Row.fetchOne(db, sql: "SELECT job_id, qty, movement_type FROM stock_movements WHERE id = ?", arguments: [movementId])
+        }
+        #expect((row?["job_id"] as Int64?) == jobId)
+        #expect((row?["qty"] as Int?) == 3)
+        #expect((row?["movement_type"] as String?) == StockMovement.MovementType.transfer.rawValue)
+    }
+
+    @Test("guided job return moves stock into return holding before restock to warehouse")
+    func guidedJobReturnAndRestockUseReturnLocation() throws {
+        let env = try E2ETestHelpers.setUp()
+        let partId = try seedPartWithWarehouseStock(env, qty: 5)
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "WEI-3862-RET", name: "Return Job")
+
+        _ = try env.warehouse.executeGuidedMovement(
+            WarehouseService.GuidedMovementInput(
+                partId: partId,
+                qty: 2,
+                fromLocationType: .warehouse,
+                fromLocationId: 1,
+                toLocationType: .job,
+                toLocationId: jobId,
+                performedBy: env.adminUserId,
+                jobId: jobId,
+                reason: "Issue to job"
+            )
+        )
+
+        let returnMovementId = try env.warehouse.executeGuidedMovement(
+            WarehouseService.GuidedMovementInput(
+                partId: partId,
+                qty: 1,
+                fromLocationType: .job,
+                fromLocationId: jobId,
+                toLocationType: .returnHolding,
+                toLocationId: jobId,
+                performedBy: env.adminUserId,
+                jobId: jobId,
+                reason: "Usable return from job"
+            )
+        )
+        let restockMovementId = try env.warehouse.executeGuidedMovement(
+            WarehouseService.GuidedMovementInput(
+                partId: partId,
+                qty: 1,
+                fromLocationType: .returnHolding,
+                fromLocationId: jobId,
+                toLocationType: .warehouse,
+                toLocationId: 1,
+                performedBy: env.adminUserId,
+                jobId: jobId,
+                reason: "Restock usable return"
+            )
+        )
+
+        #expect(returnMovementId > 0)
+        #expect(restockMovementId > 0)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "job", locationId: jobId) == 1)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "return", locationId: jobId) == 0)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 4)
+
+        let returnRows = try env.warehouse.listMovements(movementType: StockMovement.MovementType.stockReturn.rawValue)
+        #expect(returnRows.contains { $0.id == returnMovementId && $0.toLocationType == "return" })
+        #expect(returnRows.contains { $0.id == restockMovementId && $0.fromLocationType == "return" })
+    }
+
+    @Test("guided invalid movement rolls back without stock or ledger side effects")
+    func guidedInvalidMovementRollsBack() throws {
+        let env = try E2ETestHelpers.setUp()
+        let partId = try seedPartWithWarehouseStock(env, qty: 2)
+        let beforeCount = try movementCount(env, partId: partId)
+
+        do {
+            _ = try env.warehouse.executeGuidedMovement(
+                WarehouseService.GuidedMovementInput(
+                    partId: partId,
+                    qty: 5,
+                    fromLocationType: .warehouse,
+                    fromLocationId: 1,
+                    toLocationType: .truck,
+                    toLocationId: 9,
+                    performedBy: env.adminUserId,
+                    reason: "Should fail"
+                )
+            )
+            Issue.record("Expected insufficient stock to fail")
+        } catch WarehouseService.WarehouseError.insufficientStock(let available, let requested) {
+            #expect(available == 2)
+            #expect(requested == 5)
+        }
+
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 2)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "truck", locationId: 9) == 0)
+        #expect(try movementCount(env, partId: partId) == beforeCount)
+    }
+
+    private func seedPartWithWarehouseStock(_ env: E2ETestHelpers.TestEnvironment, qty: Int) throws -> Int64 {
+        let categoryId = try E2ETestHelpers.seedCategory(env, name: "WEI-3862 Inventory")
+        let partId = try E2ETestHelpers.seedPart(env, name: "WEI-3862 Ledger Part", categoryId: categoryId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: qty)
+        return partId
+    }
+
+    private func movementCount(_ env: E2ETestHelpers.TestEnvironment, partId: Int64) throws -> Int {
+        try env.db.writer.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM stock_movements WHERE part_id = ? AND deleted_at IS NULL",
+                arguments: [partId]
+            ) ?? 0
+        }
+    }
+}

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -359,6 +359,143 @@ struct WarehouseServiceExtTests {
         #expect(ledger.movements.count == 1)
     }
 
+    @Test("Guided warehouse pulled truck job route writes durable ledger history")
+    func testGuidedWarehousePulledTruckJobRouteWritesDurableLedgerHistory() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, name: "Guided Ledger Part", categoryId: catId)
+        let jobId = try E2ETestHelpers.seedJob(env)
+
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 12, locationType: "warehouse", locationId: 1)
+        _ = try env.warehouse.executeMovement(
+            partId: partId,
+            qty: 5,
+            fromLocationType: "warehouse",
+            fromLocationId: 1,
+            toLocationType: "pulled",
+            toLocationId: jobId,
+            reason: "Stage for guided load",
+            performedBy: env.adminUserId,
+            jobId: jobId
+        )
+        _ = try env.warehouse.executeMovement(
+            partId: partId,
+            qty: 5,
+            fromLocationType: "pulled",
+            fromLocationId: jobId,
+            toLocationType: "truck",
+            toLocationId: 42,
+            reason: "Load guided truck",
+            performedBy: env.adminUserId,
+            jobId: jobId
+        )
+        _ = try env.warehouse.executeMovement(
+            partId: partId,
+            qty: 2,
+            fromLocationType: "truck",
+            fromLocationId: 42,
+            toLocationType: "job",
+            toLocationId: jobId,
+            reason: "Install at job",
+            performedBy: env.adminUserId,
+            jobId: jobId
+        )
+
+        let ledger = try #require(try env.warehouse.getInventoryLedger(partId: partId))
+        #expect(ledger.totalQty == 12)
+        #expect(ledger.locations.contains { $0.locationType == "warehouse" && $0.locationId == 1 && $0.qty == 7 })
+        #expect(ledger.locations.contains { $0.locationType == "truck" && $0.locationId == 42 && $0.qty == 3 })
+        #expect(ledger.locations.contains { $0.locationType == "job" && $0.locationId == jobId && $0.qty == 2 })
+        #expect(ledger.movements.count == 4)
+        #expect(ledger.movements.contains { $0.fromLocationType == "warehouse" && $0.toLocationType == "pulled" && $0.qty == 5 })
+        #expect(ledger.movements.contains { $0.fromLocationType == "pulled" && $0.toLocationType == "truck" && $0.qty == 5 })
+        #expect(ledger.movements.contains { $0.fromLocationType == "truck" && $0.toLocationType == "job" && $0.qty == 2 })
+    }
+
+    @Test("Guided movement rejects incomplete locations without mutating stock or history")
+    func testGuidedMovementRejectsIncompleteLocationsWithoutMutation() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 8, locationType: "warehouse", locationId: 1)
+
+        #expect(throws: WarehouseService.WarehouseError.requiredFieldEmpty) {
+            try env.warehouse.createMovement(
+                partId: partId,
+                qty: 3,
+                fromLocationType: "warehouse",
+                fromLocationId: 1,
+                toLocationType: "truck",
+                toLocationId: nil,
+                movementType: "transfer",
+                reason: "Incomplete destination",
+                performedBy: env.adminUserId
+            )
+        }
+
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 8)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "truck", locationId: 42) == 0)
+        let ledger = try #require(try env.warehouse.getInventoryLedger(partId: partId))
+        #expect(ledger.movements.count == 1)
+        #expect(!ledger.movements.contains { $0.reason == "Incomplete destination" })
+    }
+
+    @Test("Return movement rejects invalid shortcuts and rolls back")
+    func testReturnMovementRejectsInvalidShortcutAndRollsBack() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 4, locationType: "supplier", locationId: 7)
+
+        #expect(throws: WarehouseService.WarehouseError.invalidMovementPath(from: "supplier", to: "warehouse")) {
+            try env.warehouse.processReturn(
+                partId: partId,
+                qty: 2,
+                fromLocationType: "supplier",
+                fromLocationId: 7,
+                toLocationType: "warehouse",
+                toLocationId: 1,
+                reason: "Invalid direct return",
+                performedBy: env.adminUserId
+            )
+        }
+
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "supplier", locationId: 7) == 4)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 0)
+        let ledger = try #require(try env.warehouse.getInventoryLedger(partId: partId))
+        #expect(ledger.movements.count == 1)
+        #expect(!ledger.movements.contains { $0.reason == "Invalid direct return" })
+    }
+
+    @Test("Return movement from truck to warehouse writes stock and audit history")
+    func testReturnMovementFromTruckToWarehouseWritesStockAndAuditHistory() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 6, locationType: "truck", locationId: 42)
+
+        _ = try env.warehouse.processReturn(
+            partId: partId,
+            qty: 4,
+            fromLocationType: "truck",
+            fromLocationId: 42,
+            toLocationType: "warehouse",
+            toLocationId: 1,
+            reason: "Return unused truck stock",
+            performedBy: env.adminUserId
+        )
+
+        let ledger = try #require(try env.warehouse.getInventoryLedger(partId: partId))
+        #expect(ledger.locations.contains { $0.locationType == "truck" && $0.locationId == 42 && $0.qty == 2 })
+        #expect(ledger.locations.contains { $0.locationType == "warehouse" && $0.locationId == 1 && $0.qty == 4 })
+        #expect(ledger.movements.contains {
+            $0.fromLocationType == "truck" &&
+                $0.toLocationType == "warehouse" &&
+                $0.movementType == StockMovement.MovementType.stockReturn.rawValue &&
+                $0.qty == 4
+        })
+    }
+
     @Test("Movement service returns empty defaults when movement table is missing")
     func testMovementMissingTableDefaults() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary

- Issue: Paperclip WEI-3862 — Stage 3 inventory ledger and guided movement workflow foundation; goal cb2684a4-19d0-40a3-ba67-c17046e2e03c.
- Scope: Adds a guided movement commit API that routes warehouse/pulled/truck/job/return inventory movements through ledger-backed stock movement creation, extends return-holding path support, and hardens rollback/endpoint validation so guided flows cannot silently mutate stock.

## Validation

- [x] Tests added/updated as needed
  - Added `GuidedInventoryMovementTests` for warehouse -> truck, warehouse -> job, job -> return holding -> warehouse, and invalid/rollback paths.
  - Added WarehouseService extended regressions for durable guided route history, incomplete location rejection, valid truck returns, and invalid return shortcut rollback.
- [x] Lint/type checks pass
  - `swift test --filter GuidedInventoryMovementTests` — passed, 5 tests.
  - `swift test --filter WarehouseServiceExtTests` — passed, 127 tests.
  - `swift test` — passed, 2141 tests / 64 suites.
- [x] Backward compatibility considered
  - Existing `createMovement`, `executeMovement`, and batch movement APIs stay in place; new guided API delegates to the existing ledger writer.
  - Endpoint completeness validation only rejects partial location endpoints that previously could create ambiguous/non-auditable movement rows.

## AI Assistance Disclosure

- [x] AI assistance used in this PR
- Tools used: Hermes BackendCoder using OpenAI/Codex-route assistance; GitHub Copilot was not used to generate this change.
- AI-assisted areas (files/functions):
  - `core/Sources/WiredPartCore/Services/WarehouseService.swift`
  - `core/Tests/WiredPartCoreTests/GuidedInventoryMovementTests.swift`
  - `core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift`
- Reviewer focus notes for AI-generated/assisted code:
  - Please focus on whether the new return-holding path set matches field workflow language.
  - Please verify the endpoint-completeness guard is acceptable for all existing stock movement callers.
  - GitHub Copilot review was attempted via `gh pr edit --add-reviewer github-copilot`; GitHub did not expose Copilot as a normal reviewer for this personal-account repo, so a PR comment records the unavailable request.

## Copilot-assisted Change Checklist

- [x] Copilot used for this PR: No
- [x] Reviewed Copilot-generated/assisted changes line-by-line
- [x] No secrets, credentials, or customer-sensitive prompt data shared
- [x] Licensing/origin risk checked for non-trivial generated snippets
- [x] Tests added/updated for generated or modified logic
- [x] Manual verification notes added for security/auth/config changes

## Risk Check

- [x] No secrets or sensitive data were shared with AI tools
- [x] Security-sensitive paths received required reviewer attention
- [x] No destructive ops introduced without explicit approval

## CI / local Mac runner notes

Local self-hosted Mac runner path is the intended PR verification path for this repo; local Swift package tests above were run on the Mac worktree before opening this PR.

Closes WEI-3862

