### PR TITLE
WEI-3865: Fix movement wizard keyboard navigation

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
@@ -28,6 +28,7 @@ struct IOSMovementWizard: View {
     @State private var selectedParts: [WizardPart] = []
     @State private var partSearchText = ""
     @State private var partSearchResults: [PartSearchRow] = []
+    @FocusState private var isPartSearchFocused: Bool
 
     // Step 3: Quantities (stored in selectedParts[].qty)
 
@@ -257,7 +258,13 @@ struct IOSMovementWizard: View {
 
                 LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
                     ForEach(locationTypes, id: \.0) { type, label, icon in
-                        locationButton(type: type, label: label, icon: icon, selected: fromLocationType == type) {
+                        locationButton(
+                            type: type,
+                            label: label,
+                            icon: icon,
+                            role: "from",
+                            selected: fromLocationType == type
+                        ) {
                             fromLocationType = type
                             if toLocationType == type { toLocationType = "" }
                         }
@@ -284,6 +291,7 @@ struct IOSMovementWizard: View {
                     ForEach(locationTypes, id: \.0) { type, label, icon in
                         locationButton(
                             type: type, label: label, icon: icon,
+                            role: "to",
                             selected: toLocationType == type,
                             disabled: type == fromLocationType
                         ) {
@@ -316,7 +324,16 @@ struct IOSMovementWizard: View {
     }
 
     @ViewBuilder
-    private func locationButton(type: String, label: String, icon: String, selected: Bool, disabled: Bool = false, action: @escaping () -> Void) -> some View {
+    private func locationButton(
+        type: String,
+        label: String,
+        icon: String,
+        role: String,
+        selected: Bool,
+        disabled: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        let roleLabel = role == "from" ? "From" : "To"
         Button(action: action) {
             VStack(spacing: 6) {
                 Image(systemName: icon)
@@ -339,6 +356,9 @@ struct IOSMovementWizard: View {
         }
         .buttonStyle(.plain)
         .disabled(disabled)
+        .accessibilityIdentifier("movementWizard_\(role)_\(type)")
+        .accessibilityLabel("\(roleLabel) \(label)")
+        .accessibilityHint(disabled ? "Already selected as the other side of this movement" : "Select \(label) as the \(roleLabel.lowercased()) location")
     }
 
     @ViewBuilder
@@ -396,6 +416,7 @@ struct IOSMovementWizard: View {
                 .foregroundStyle(.secondary)
                 .accessibilityHidden(true)
             TextField("Search by name or code…", text: $partSearchText)
+                .focused($isPartSearchFocused)
                 .textInputAutocapitalization(.never)
                 .onChange(of: partSearchText) {
                     searchParts(query: partSearchText)
@@ -438,6 +459,7 @@ struct IOSMovementWizard: View {
         let alreadyAdded = selectedParts.contains(where: { $0.partId == part.id })
         Button {
             addPart(part)
+            isPartSearchFocused = false
         } label: {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
@@ -849,6 +871,9 @@ struct IOSMovementWizard: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .disabled(!canAdvance)
+                .accessibilityIdentifier("movement_wizard_next")
+                .accessibilityLabel("Next")
+                .accessibilityHint("Advance to the next movement wizard step")
             } else if !executeSuccess && executeError == nil {
                 Button {
                     executeMovement()
@@ -913,6 +938,9 @@ struct IOSMovementWizard: View {
             qty: 1,
             availableQty: part.availableQty ?? 0
         ))
+        partSearchText = ""
+        partSearchResults = []
+        isPartSearchFocused = false
     }
 
     private func removePart(_ partId: Int64) {

--- a/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
@@ -54,6 +54,48 @@ final class WarehouseWizardProgressAccessibilityTests: XCTestCase {
         )
     }
 
+    func testMovementWizardLocationTilesExposeStableFromToAccessibilityTargets() throws {
+        let source = try Self.readWarehouseSource("IOSMovementWizard.swift")
+
+        XCTAssertTrue(
+            source.contains("role: \"from\"") && source.contains("role: \"to\""),
+            "Movement wizard must distinguish FROM and TO location tiles for user-like automation and VoiceOver."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityIdentifier(\"movementWizard_\\(role)_\\(type)\")"),
+            "Movement wizard location tiles need stable role+type accessibility identifiers such as movementWizard_from_warehouse."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityLabel(\"\\(roleLabel) \\(label)\")"),
+            "Movement wizard location tiles need unique spoken labels such as From Warehouse and To Truck."
+        )
+        XCTAssertTrue(
+            source.contains("Already selected as the other side of this movement"),
+            "Disabled duplicate-location tiles should explain why they cannot be selected."
+        )
+    }
+
+    func testMovementWizardPartSelectionDismissesKeyboardBeforeNextNavigation() throws {
+        let source = try Self.readWarehouseSource("IOSMovementWizard.swift")
+
+        XCTAssertTrue(
+            source.contains("@FocusState private var isPartSearchFocused"),
+            "Movement wizard must track part-search focus so the iOS keyboard can be dismissed after a part is selected."
+        )
+        XCTAssertTrue(
+            source.contains(".focused($isPartSearchFocused)"),
+            "The part search field must bind to focus state for deterministic keyboard dismissal."
+        )
+        XCTAssertTrue(
+            source.contains("isPartSearchFocused = false") && source.contains("partSearchResults = []"),
+            "Selecting a part should dismiss the keyboard and collapse search results so bottom navigation remains reachable."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityIdentifier(\"movement_wizard_next\")"),
+            "The Next button needs a stable accessibility identifier for user-like UI verification."
+        )
+    }
+
     private static func progressBarSection(in source: String) throws -> String {
         guard let start = source.range(of: "private var progressBar") else {
             XCTFail("Missing progressBar property")


### PR DESCRIPTION
## Paperclip
- Issue: WEI-3865
- Follow-up QA: WEI-3864

## Summary
- Adds stable FROM/TO movement wizard location accessibility identifiers and labels.
- Dismisses/collapses part search focus/results after selecting a part so the iOS keyboard no longer hides the bottom Next navigation.
- Adds a stable movement_wizard_next accessibility target for user-like QA automation.

## Verification
- PASS: xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,id=9064C33E-8312-4D9A-B459-CA785C10AC91' -only-testing:"Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests" -resultBundlePath /tmp/wei3865-warehouse-ax.xcresult
- PASS (QA rerun with WEI-3864 harness patched locally): iPhone 17 Pro iOS 26.4.1 guided inventory movement user-like flow, /tmp/wei3864-mobile-rerun-1781940677.xcresult, log /tmp/wei3864-mobile-rerun-1781940677.log
- BLOCKED separately: iPad Pro 13-inch QA path fails before movement wizard because Warehouse Dashboard tab is not reachable; linked existing WEI-3866.

## Local runner note
Validated locally on the self-hosted Mac/Xcode simulator path.