### PR TITLE
fix: expose tablet warehouse dashboard navigation targets

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
@@ -28,6 +28,7 @@ struct IOSMovementWizard: View {
     @State private var selectedParts: [WizardPart] = []
     @State private var partSearchText = ""
     @State private var partSearchResults: [PartSearchRow] = []
+    @FocusState private var isPartSearchFocused: Bool
 
     // Step 3: Quantities (stored in selectedParts[].qty)
 
@@ -257,7 +258,13 @@ struct IOSMovementWizard: View {
 
                 LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
                     ForEach(locationTypes, id: \.0) { type, label, icon in
-                        locationButton(type: type, label: label, icon: icon, selected: fromLocationType == type) {
+                        locationButton(
+                            type: type,
+                            label: label,
+                            icon: icon,
+                            role: "from",
+                            selected: fromLocationType == type
+                        ) {
                             fromLocationType = type
                             if toLocationType == type { toLocationType = "" }
                         }
@@ -284,6 +291,7 @@ struct IOSMovementWizard: View {
                     ForEach(locationTypes, id: \.0) { type, label, icon in
                         locationButton(
                             type: type, label: label, icon: icon,
+                            role: "to",
                             selected: toLocationType == type,
                             disabled: type == fromLocationType
                         ) {
@@ -316,7 +324,16 @@ struct IOSMovementWizard: View {
     }
 
     @ViewBuilder
-    private func locationButton(type: String, label: String, icon: String, selected: Bool, disabled: Bool = false, action: @escaping () -> Void) -> some View {
+    private func locationButton(
+        type: String,
+        label: String,
+        icon: String,
+        role: String,
+        selected: Bool,
+        disabled: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        let roleLabel = role == "from" ? "From" : "To"
         Button(action: action) {
             VStack(spacing: 6) {
                 Image(systemName: icon)
@@ -339,6 +356,9 @@ struct IOSMovementWizard: View {
         }
         .buttonStyle(.plain)
         .disabled(disabled)
+        .accessibilityIdentifier("movementWizard_\(role)_\(type)")
+        .accessibilityLabel("\(roleLabel) \(label)")
+        .accessibilityHint(disabled ? "Already selected as the other side of this movement" : "Select \(label) as the \(roleLabel.lowercased()) location")
     }
 
     @ViewBuilder
@@ -396,6 +416,7 @@ struct IOSMovementWizard: View {
                 .foregroundStyle(.secondary)
                 .accessibilityHidden(true)
             TextField("Search by name or code…", text: $partSearchText)
+                .focused($isPartSearchFocused)
                 .textInputAutocapitalization(.never)
                 .onChange(of: partSearchText) {
                     searchParts(query: partSearchText)
@@ -438,6 +459,7 @@ struct IOSMovementWizard: View {
         let alreadyAdded = selectedParts.contains(where: { $0.partId == part.id })
         Button {
             addPart(part)
+            isPartSearchFocused = false
         } label: {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
@@ -849,6 +871,9 @@ struct IOSMovementWizard: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .disabled(!canAdvance)
+                .accessibilityIdentifier("movement_wizard_next")
+                .accessibilityLabel("Next")
+                .accessibilityHint("Advance to the next movement wizard step")
             } else if !executeSuccess && executeError == nil {
                 Button {
                     executeMovement()
@@ -913,6 +938,9 @@ struct IOSMovementWizard: View {
             qty: 1,
             availableQty: part.availableQty ?? 0
         ))
+        partSearchText = ""
+        partSearchResults = []
+        isPartSearchFocused = false
     }
 
     private func removePart(_ partId: Int64) {

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
@@ -509,6 +509,11 @@ struct IOSMainView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityIdentifier("tab_\(module.id)")
+        .accessibilityLabel(module.label)
+        .accessibilityHint(tabCount > 1 ? "Show \(module.label) sections" : "Open \(module.label)")
     }
 
     @ViewBuilder
@@ -559,6 +564,11 @@ struct IOSMainView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityIdentifier("subtab_\(tab.id)")
+        .accessibilityLabel(tab.label)
+        .accessibilityHint("Open the \(tab.label) section")
     }
 
     @ViewBuilder
@@ -820,6 +830,11 @@ struct ModuleHostView: View {
                             sidebarRow(tab: tab, selected: tab.id == selectedTabId)
                         }
                         .buttonStyle(.plain)
+                        .contentShape(Rectangle())
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityIdentifier("subtab_\(tab.id)")
+                        .accessibilityLabel(tab.label)
+                        .accessibilityHint("Open the \(tab.label) warehouse section")
                     }
                 }
                 .padding(.vertical, DS.Space.sm)
@@ -890,6 +905,7 @@ struct ModuleHostView: View {
                         // give automation a plain, explicitly-sized hit region.
                         .buttonStyle(.plain)
                         .contentShape(Rectangle())
+                        .accessibilityElement(children: .ignore)
                         .accessibilityIdentifier("subtab_\(tab.id)")
                         .accessibilityLabel(tab.label)
                         .id(tab.id)

--- a/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
@@ -54,6 +54,48 @@ final class WarehouseWizardProgressAccessibilityTests: XCTestCase {
         )
     }
 
+    func testMovementWizardLocationTilesExposeStableFromToAccessibilityTargets() throws {
+        let source = try Self.readWarehouseSource("IOSMovementWizard.swift")
+
+        XCTAssertTrue(
+            source.contains("role: \"from\"") && source.contains("role: \"to\""),
+            "Movement wizard must distinguish FROM and TO location tiles for user-like automation and VoiceOver."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityIdentifier(\"movementWizard_\\(role)_\\(type)\")"),
+            "Movement wizard location tiles need stable role+type accessibility identifiers such as movementWizard_from_warehouse."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityLabel(\"\\(roleLabel) \\(label)\")"),
+            "Movement wizard location tiles need unique spoken labels such as From Warehouse and To Truck."
+        )
+        XCTAssertTrue(
+            source.contains("Already selected as the other side of this movement"),
+            "Disabled duplicate-location tiles should explain why they cannot be selected."
+        )
+    }
+
+    func testMovementWizardPartSelectionDismissesKeyboardBeforeNextNavigation() throws {
+        let source = try Self.readWarehouseSource("IOSMovementWizard.swift")
+
+        XCTAssertTrue(
+            source.contains("@FocusState private var isPartSearchFocused"),
+            "Movement wizard must track part-search focus so the iOS keyboard can be dismissed after a part is selected."
+        )
+        XCTAssertTrue(
+            source.contains(".focused($isPartSearchFocused)"),
+            "The part search field must bind to focus state for deterministic keyboard dismissal."
+        )
+        XCTAssertTrue(
+            source.contains("isPartSearchFocused = false") && source.contains("partSearchResults = []"),
+            "Selecting a part should dismiss the keyboard and collapse search results so bottom navigation remains reachable."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityIdentifier(\"movement_wizard_next\")"),
+            "The Next button needs a stable accessibility identifier for user-like UI verification."
+        )
+    }
+
     private static func progressBarSection(in source: String) throws -> String {
         guard let start = source.range(of: "private var progressBar") else {
             XCTFail("Missing progressBar property")

--- a/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
@@ -96,6 +96,43 @@ final class WarehouseWizardProgressAccessibilityTests: XCTestCase {
         )
     }
 
+    func testModuleSidebarTabsExposeSameStableSubtabIdentifiersAsTopTabs() throws {
+        let source = try Self.readNavigationSource("IOSMainView.swift")
+        let sidebarStart = try XCTUnwrap(source.range(of: "private var sidebarLayout"))
+        let sidebarTail = source[sidebarStart.lowerBound...]
+        let sidebarEnd = sidebarTail.range(of: "/// Sidebar width adapts")?.lowerBound ?? sidebarTail.endIndex
+        let sidebarSource = String(sidebarTail[..<sidebarEnd])
+        let fullSidebarStart = try XCTUnwrap(source.range(of: "private func fullSidebarTabRow"))
+        let fullSidebarTail = source[fullSidebarStart.lowerBound...]
+        let fullSidebarEnd = fullSidebarTail.range(of: "private var fullSidebarActions")?.lowerBound ?? fullSidebarTail.endIndex
+        let fullSidebarSource = String(fullSidebarTail[..<fullSidebarEnd])
+
+        XCTAssertTrue(
+            sidebarSource.contains(".accessibilityElement(children: .ignore)"),
+            "Sidebar module navigation should expose the button itself as the automation target instead of its child label/icon."
+        )
+        XCTAssertTrue(
+            sidebarSource.contains(".accessibilityIdentifier(\"subtab_\\(tab.id)\")"),
+            "iPad/sidebar module navigation must expose the same stable subtab_<id> identifiers as the horizontal sub-tab picker."
+        )
+        XCTAssertTrue(
+            fullSidebarSource.contains(".accessibilityElement(children: .ignore)"),
+            "Full-sidebar module navigation should expose the button itself as the automation target instead of its child label/icon."
+        )
+        XCTAssertTrue(
+            fullSidebarSource.contains(".accessibilityIdentifier(\"subtab_\\(tab.id)\")"),
+            "Full-sidebar iPad navigation must expose the same stable subtab_<id> identifiers as the horizontal sub-tab picker."
+        )
+        XCTAssertTrue(
+            sidebarSource.contains(".accessibilityLabel(tab.label)") && fullSidebarSource.contains(".accessibilityLabel(tab.label)"),
+            "Sidebar module navigation needs the same readable labels as top tabs for VoiceOver and UI tests."
+        )
+        XCTAssertTrue(
+            sidebarSource.contains(".contentShape(Rectangle())") && fullSidebarSource.contains(".contentShape(Rectangle())"),
+            "Sidebar module navigation needs an explicit tappable hit region for user-like tests."
+        )
+    }
+
     private static func progressBarSection(in source: String) throws -> String {
         guard let start = source.range(of: "private var progressBar") else {
             XCTFail("Missing progressBar property")
@@ -118,6 +155,21 @@ final class WarehouseWizardProgressAccessibilityTests: XCTestCase {
             .appendingPathComponent("Weird Parts IOS")
             .appendingPathComponent("Features")
             .appendingPathComponent("Warehouse")
+            .appendingPathComponent(fileName)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    private static func readNavigationSource(
+        _ fileName: String,
+        file: StaticString = #filePath
+    ) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Navigation")
             .appendingPathComponent(fileName)
         return try String(contentsOf: sourceURL, encoding: .utf8)
     }

--- a/Weird Parts IOS/Weird Parts IOSUITests/WarehouseDashboardScreenshotUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/WarehouseDashboardScreenshotUITests.swift
@@ -109,6 +109,12 @@ final class WarehouseDashboardScreenshotUITests: XCTestCase {
 
         let warehouseTab = app.buttons["tab_warehouse"].firstMatch
         if warehouseTab.waitForExistence(timeout: 8) {
+            // Full-sidebar iPad launches can already be deep-linked to Warehouse.
+            // Tapping an already-expanded Warehouse row collapses its subtabs, so
+            // first give the requested dashboard subtab/content a chance to settle.
+            if openWarehouseDashboardSubtab(in: app, timeout: 5) {
+                return
+            }
             warehouseTab.tap()
         } else if openMoreTab(in: app) {
             let warehouse = app.buttons["Warehouse"].firstMatch
@@ -124,6 +130,12 @@ final class WarehouseDashboardScreenshotUITests: XCTestCase {
             warehouse.tap()
         } else {
             XCTFail("Warehouse module tab should be reachable")
+        }
+
+        if !openWarehouseDashboardSubtab(in: app, timeout: 10), warehouseTab.exists {
+            // If the first tap collapsed the full-sidebar row, tap once more to
+            // re-expand and expose the stable warehouse subtabs.
+            warehouseTab.tap()
         }
 
         XCTAssertTrue(
@@ -165,7 +177,8 @@ final class WarehouseDashboardScreenshotUITests: XCTestCase {
         // page rather than a separate horizontal chip. Treat a visible KPI as the
         // same successful user state: the Warehouse Dashboard is reachable.
         if app.descendants(matching: .any)["warehouseKPIAuditScore"].firstMatch.exists
-            || app.descendants(matching: .any)["warehouseKPITotalStock"].firstMatch.exists {
+            || app.descendants(matching: .any)["warehouseKPITotalStock"].firstMatch.exists
+            || app.buttons["whAction_newMovement"].firstMatch.exists {
             return true
         }
 

--- a/Weird Parts IOS/Weird Parts IOSUITests/WarehouseDashboardScreenshotUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/WarehouseDashboardScreenshotUITests.swift
@@ -139,6 +139,15 @@ final class WarehouseDashboardScreenshotUITests: XCTestCase {
             return true
         }
 
+        // Full-sidebar iPad launches can already be deep-linked to the dashboard,
+        // in which case the dashboard subtab may be represented by the active
+        // page rather than a separate horizontal chip. Treat a visible KPI as the
+        // same successful user state: the Warehouse Dashboard is reachable.
+        if app.descendants(matching: .any)["warehouseKPIAuditScore"].firstMatch.exists
+            || app.descendants(matching: .any)["warehouseKPITotalStock"].firstMatch.exists {
+            return true
+        }
+
         return false
     }
 


### PR DESCRIPTION
## Summary
- expose stable accessibility identifiers for full-sidebar module headers and subtabs on iPad/tablet layouts
- keep sidebar subtab targets aligned with the existing horizontal subtab identifiers
- let the warehouse dashboard UI test treat an already-visible dashboard KPI state as successful dashboard reachability on full-sidebar iPad launches

## Verification
- PASS: xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,id=9064C33E-8312-4D9A-B459-CA785C10AC91' -only-testing:"Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests/testModuleSidebarTabsExposeSameStableSubtabIdentifiersAsTopTabs" -resultBundlePath /tmp/wei3869-sidebar-fullsidebar-ax.xcresult
- PASS: xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,id=60814A40-7648-4128-9847-A1EAA2686697' -only-testing:"Weird PartsUITests/WarehouseDashboardScreenshotUITests/testWarehouseDashboardScreenshot" -resultBundlePath /tmp/wei3869-ipad-dashboard-1781943378.xcresult

Stacked on PR #1073 / WEI-3865 because the full guided movement tablet rerun also needs the movement-wizard keyboard/navigation fix.