### PR TITLE
WEI-3866: Stabilize warehouse movement entry

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
@@ -84,6 +84,11 @@ struct WarehouseDashboardPage: View {
             ToolbarItem(placement: .primaryAction) {
                 HStack(spacing: 12) {
                     CartBadgeButton(cartManager: cartManager)
+                    Button { activeSheet = .newMovement } label: {
+                        Image(systemName: "arrow.left.arrow.right.circle.fill")
+                    }
+                    .accessibilityLabel("New Movement")
+                    .accessibilityIdentifier("whAction_newMovement")
                     Button { activeSheet = .help } label: {
                         Image(systemName: "questionmark.circle")
                     }
@@ -121,10 +126,8 @@ struct WarehouseDashboardPage: View {
     private func sheetContent(for sheet: ActiveSheet) -> some View {
         switch sheet {
         case .newMovement:
-            NavigationStack {
-                IOSMovementWizard()
-                    .environmentObject(appCore)
-            }
+            IOSMovementWizard()
+                .environmentObject(appCore)
         case .qrScanner:
             QRScanSheet(expectedType: .bin) { result in
                 activeSheet = nil
@@ -667,6 +670,8 @@ struct WarehouseDashboardPage: View {
             quickActionButton(title: action.title, icon: action.icon, color: action.color)
         }
             .buttonStyle(.plain)
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .contentShape(Rectangle())
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(action.title)
             .accessibilityAddTraits(.isButton)
@@ -709,7 +714,9 @@ struct WarehouseDashboardPage: View {
                 .minimumScaleFactor(0.85)
         }
         .frame(maxWidth: .infinity)
+        .frame(minHeight: 44)
         .padding(.vertical, 16)
+        .contentShape(Rectangle())
         .background(Color(.secondarySystemGroupedBackground))
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
@@ -105,14 +105,17 @@ struct WarehouseMovementsPage: View {
                     Image(systemName: "qrcode.viewfinder")
                 }
                 .accessibilityLabel("Scan QR code")
+                .accessibilityIdentifier("whMovement_scanQR")
                 Button { activeSheet = .quickLog } label: {
                     Image(systemName: "square.and.pencil")
                 }
                 .accessibilityLabel("Quick log movement")
+                .accessibilityIdentifier("whMovement_quickLog")
                 Button { activeSheet = .newMovement } label: {
                     Image(systemName: "plus")
                 }
                 .accessibilityLabel("New movement")
+                .accessibilityIdentifier("whMovement_openWizard")
             }
             ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .help } label: {
@@ -363,7 +366,9 @@ struct WarehouseMovementsPage: View {
             message: searchText.isEmpty && selectedFilter == nil
                 ? "Stock movements will appear here as parts are transferred."
                 : "No movements match your criteria.",
-            actionLabel: "New Movement"
+            actionLabel: "New Movement",
+            actionIcon: "plus",
+            actionAccessibilityIdentifier: "whMovement_emptyNewMovement"
         ) {
             activeSheet = .newMovement
         }

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -348,6 +348,31 @@ final class Weird_Parts_IOSUITests: XCTestCase {
     }
 
     @MainActor
+    func testWEI3866WarehouseDashboardNewMovementOpensGuidedWizard() throws {
+        app.terminate()
+        app = XCUIApplication()
+        configureUITestingEnvironment(app)
+        app.launchArguments += [
+            "-UITestingWEI936AutoLogin",
+            "-UITestingWarehouseDashboard"
+        ]
+        app.launch()
+
+        openWarehouseDashboard()
+
+        let newMovement = app.buttons["whAction_newMovement"].firstMatch
+        XCTAssertTrue(newMovement.waitForExistence(timeout: 20), "Warehouse Dashboard should expose a stable New Movement quick action")
+        XCTAssertTrue(newMovement.isHittable, "Warehouse Dashboard New Movement action should be immediately hittable on iPhone")
+        newMovement.tap()
+
+        XCTAssertTrue(
+            app.staticTexts["Where is stock moving?"].waitForExistence(timeout: 10) ||
+                app.navigationBars["New Movement"].waitForExistence(timeout: 10),
+            "Tapping the Warehouse Dashboard New Movement action should open the guided movement wizard."
+        )
+    }
+
+    @MainActor
     func testWEI3144JobMaterialsWalkthroughEvidence() throws {
         let artifactDirectory = wei3144ArtifactDirectory
         try FileManager.default.createDirectory(at: artifactDirectory, withIntermediateDirectories: true)


### PR DESCRIPTION
## Summary
- Add an immediately hittable Warehouse Dashboard toolbar New Movement entry using the production `whAction_newMovement` accessibility identifier.
- Keep dashboard quick-action tiles hittable with 44pt minimum target/content shape, and expose stable movement-page toolbar/empty-state fallback identifiers.
- Remove the extra wrapper NavigationStack around `IOSMovementWizard` in the dashboard sheet; the wizard already owns its NavigationStack.
- Add a focused XCUITest that verifies the dashboard New Movement entry is immediately hittable and opens the guided movement wizard.

## Paperclip
- Paperclip issue: WEI-3866
- Goal: Stage 3 — Inventory ledger and guided movement workflow

## Tests
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "platform=iOS Simulator,id=9064C33E-8312-4D9A-B459-CA785C10AC91" -only-testing:"Weird PartsUITests/Weird_Parts_IOSUITests/testWEI3866WarehouseDashboardNewMovementOpensGuidedWizard" -resultBundlePath docs/testing/artifacts/wei-3866/current/warehouse-wei3866-iphone.xcresult`
- Result: `TEST SUCCEEDED`; `testWEI3866WarehouseDashboardNewMovementOpensGuidedWizard` passed on iPhone 17 Pro simulator in 25.257s.
- Local runner path: verified locally on this Mac/iOS Simulator path; PR CI should use the self-hosted macOS/Xcode runner for trusted repo events.
