### PR TITLE
WEI-3884 Add local-first job record foundation

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -144,6 +144,7 @@ extension AppDatabase {
         registerMigration102PartImportSavedMappings(&migrator)
         registerMigration103TimesheetCorrectionAudit(&migrator)
         registerMigration104AuthTokenSessionDeviceId(&migrator)
+        registerMigration105JobRecordsLocalFirst(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -5857,6 +5858,31 @@ extension AppDatabase {
                           on: "auth_token_sessions",
                           columns: ["parent_refresh_id"],
                           ifNotExists: true)
+        }
+    }
+
+    private static func registerMigration105JobRecordsLocalFirst(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("105_job_records_local_first") { db in
+            try addColumnIfMissing(db, table: "jobs", column: "stable_id", type: .text)
+            try addColumnIfMissing(db, table: "jobs", column: "site_name", type: .text)
+            try db.execute(sql: """
+                UPDATE jobs
+                SET stable_id = lower(hex(randomblob(4))) || '-' ||
+                    lower(hex(randomblob(2))) || '-' ||
+                    lower(hex(randomblob(2))) || '-' ||
+                    lower(hex(randomblob(2))) || '-' ||
+                    lower(hex(randomblob(6)))
+                WHERE stable_id IS NULL OR trim(stable_id) = ''
+                """)
+            try db.execute(sql: """
+                UPDATE jobs
+                SET site_name = address_line1
+                WHERE (site_name IS NULL OR trim(site_name) = '')
+                  AND address_line1 IS NOT NULL
+                  AND trim(address_line1) != ''
+                """)
+            try db.create(index: "idx_jobs_stable_id", on: "jobs", columns: ["stable_id"], unique: true, ifNotExists: true)
+            try db.create(index: "idx_jobs_site_name", on: "jobs", columns: ["site_name"], ifNotExists: true)
         }
     }
 }

--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -14,8 +14,8 @@ public final class AppDatabase: Sendable {
     }
 
     /// The total number of registered migrations. Update when adding new migrations.
-    /// Migrations are 000-103.
-    public static let schemaVersion = 103
+    /// Migrations are 000-105.
+    public static let schemaVersion = 105
 
     /// Initialize with an existing database writer and run all migrations.
     public init(_ writer: any DatabaseWriter) throws {

--- a/core/Sources/WiredPartCore/Services/JobsService+Records.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService+Records.swift
@@ -98,6 +98,7 @@ extension JobsService {
             jobName: jobName,
             customerName: customerName,
             addressLine1: siteName,
+            siteName: siteName,
             status: status,
             priority: priority,
             jobType: jobType,
@@ -105,42 +106,53 @@ extension JobsService {
             createdBy: draft.createdBy
         )
 
-        if siteName != nil {
-            try writeDatabase { dbConn in
-                try dbConn.execute(
-                    sql: "UPDATE jobs SET site_name = ?, updated_at = datetime('now') WHERE id = ? AND deleted_at IS NULL",
-                    arguments: [siteName, jobId]
-                )
-            }
-        }
         return try getJobRecord(id: jobId)
     }
 
     @discardableResult
     public func updateJobRecord(id: Int64, _ update: JobRecordUpdate) throws -> JobRecord {
-        try updateJob(
-            id: id,
-            jobName: try update.jobName.map(Self.requiredTrimmed(_:)),
-            customerName: Self.optionalTrimmed(update.customerName),
-            addressLine1: nil,
-            status: try update.status.map(Self.requiredTrimmed(_:)),
-            priority: try update.priority.map(Self.requiredTrimmed(_:)),
-            jobType: try update.jobType.map(Self.requiredTrimmed(_:)),
-            notes: Self.optionalTrimmed(update.notes)
-        )
-
         try writeDatabase { dbConn in
-            try Self.ensureJobStableId(dbConn: dbConn, jobId: id)
+            var setClauses: [String] = []
+            var args: [DatabaseValueConvertible?] = []
+
+            if let jobName = try update.jobName.map(Self.requiredTrimmed(_:)) {
+                setClauses.append("job_name = ?")
+                args.append(jobName)
+            }
+            if update.customerName != nil {
+                setClauses.append("customer_name = ?")
+                args.append(Self.optionalTrimmed(update.customerName))
+            }
+            if let status = try update.status.map(Self.requiredTrimmed(_:)) {
+                setClauses.append("status = ?")
+                args.append(status)
+            }
+            if let priority = try update.priority.map(Self.requiredTrimmed(_:)) {
+                setClauses.append("priority = ?")
+                args.append(priority)
+            }
+            if let jobType = try update.jobType.map(Self.requiredTrimmed(_:)) {
+                setClauses.append("job_type = ?")
+                args.append(jobType)
+            }
+            if update.notes != nil {
+                setClauses.append("notes = ?")
+                args.append(Self.optionalTrimmed(update.notes))
+            }
             if update.siteName != nil {
                 let siteName = Self.optionalTrimmed(update.siteName)
-                try dbConn.execute(
-                    sql: """
-                        UPDATE jobs
-                        SET site_name = ?, address_line1 = ?, updated_at = datetime('now')
-                        WHERE id = ? AND deleted_at IS NULL
-                        """,
-                    arguments: [siteName, siteName, id]
-                )
+                setClauses.append("site_name = ?")
+                args.append(siteName)
+                setClauses.append("address_line1 = ?")
+                args.append(siteName)
+            }
+
+            try Self.ensureJobStableId(dbConn: dbConn, jobId: id)
+            if !setClauses.isEmpty {
+                setClauses.append("updated_at = datetime('now')")
+                args.append(id)
+                let sql = "UPDATE jobs SET \(setClauses.joined(separator: ", ")) WHERE id = ? AND deleted_at IS NULL"
+                try dbConn.execute(sql: sql, arguments: StatementArguments(args))
             }
         }
         return try getJobRecord(id: id)

--- a/core/Sources/WiredPartCore/Services/JobsService+Records.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService+Records.swift
@@ -117,14 +117,11 @@ extension JobsService {
 
     @discardableResult
     public func updateJobRecord(id: Int64, _ update: JobRecordUpdate) throws -> JobRecord {
-        if let jobName = update.jobName, try Self.requiredTrimmed(jobName).isEmpty { throw JobsError.requiredFieldEmpty }
-        if let status = update.status, try Self.requiredTrimmed(status).isEmpty { throw JobsError.requiredFieldEmpty }
-
         try updateJob(
             id: id,
             jobName: try update.jobName.map(Self.requiredTrimmed(_:)),
             customerName: Self.optionalTrimmed(update.customerName),
-            addressLine1: Self.optionalTrimmed(update.siteName),
+            addressLine1: nil,
             status: try update.status.map(Self.requiredTrimmed(_:)),
             priority: try update.priority.map(Self.requiredTrimmed(_:)),
             jobType: try update.jobType.map(Self.requiredTrimmed(_:)),
@@ -134,9 +131,14 @@ extension JobsService {
         try db.writer.write { dbConn in
             try Self.ensureJobStableId(dbConn: dbConn, jobId: id)
             if update.siteName != nil {
+                let siteName = Self.optionalTrimmed(update.siteName)
                 try dbConn.execute(
-                    sql: "UPDATE jobs SET site_name = ?, updated_at = datetime('now') WHERE id = ? AND deleted_at IS NULL",
-                    arguments: [Self.optionalTrimmed(update.siteName), id]
+                    sql: """
+                        UPDATE jobs
+                        SET site_name = ?, address_line1 = ?, updated_at = datetime('now')
+                        WHERE id = ? AND deleted_at IS NULL
+                        """,
+                    arguments: [siteName, siteName, id]
                 )
             }
         }

--- a/core/Sources/WiredPartCore/Services/JobsService+Records.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService+Records.swift
@@ -1,0 +1,223 @@
+import Foundation
+import GRDB
+
+extension JobsService {
+    /// Local-first job record used by job-detail flows and future sync paths.
+    /// `stableId` is generated locally and survives reloads/sync reconciliation,
+    /// while `id` remains the SQLite row id for local joins.
+    public struct JobRecord: Sendable, Identifiable, Equatable {
+        public let id: Int64
+        public let stableId: String
+        public let jobNumber: String
+        public let jobName: String
+        public let customerName: String?
+        public let siteName: String?
+        public let status: String
+        public let priority: String
+        public let jobType: String
+        public let notes: String?
+        public let createdAt: String?
+        public let updatedAt: String?
+    }
+
+    public struct JobRecordDraft: Sendable, Equatable {
+        public let jobNumber: String
+        public let jobName: String
+        public let customerName: String?
+        public let siteName: String?
+        public let status: String
+        public let priority: String
+        public let jobType: String
+        public let notes: String?
+        public let createdBy: Int64?
+
+        public init(
+            jobNumber: String,
+            jobName: String,
+            customerName: String? = nil,
+            siteName: String? = nil,
+            status: String = "active",
+            priority: String = "normal",
+            jobType: String = "service",
+            notes: String? = nil,
+            createdBy: Int64? = nil
+        ) {
+            self.jobNumber = jobNumber
+            self.jobName = jobName
+            self.customerName = customerName
+            self.siteName = siteName
+            self.status = status
+            self.priority = priority
+            self.jobType = jobType
+            self.notes = notes
+            self.createdBy = createdBy
+        }
+    }
+
+    public struct JobRecordUpdate: Sendable, Equatable {
+        public let jobName: String?
+        public let customerName: String?
+        public let siteName: String?
+        public let status: String?
+        public let priority: String?
+        public let jobType: String?
+        public let notes: String?
+
+        public init(
+            jobName: String? = nil,
+            customerName: String? = nil,
+            siteName: String? = nil,
+            status: String? = nil,
+            priority: String? = nil,
+            jobType: String? = nil,
+            notes: String? = nil
+        ) {
+            self.jobName = jobName
+            self.customerName = customerName
+            self.siteName = siteName
+            self.status = status
+            self.priority = priority
+            self.jobType = jobType
+            self.notes = notes
+        }
+    }
+
+    @discardableResult
+    public func createJobRecord(_ draft: JobRecordDraft) throws -> JobRecord {
+        let jobNumber = try Self.requiredTrimmed(draft.jobNumber)
+        let jobName = try Self.requiredTrimmed(draft.jobName)
+        let status = try Self.requiredTrimmed(draft.status)
+        let priority = try Self.requiredTrimmed(draft.priority)
+        let jobType = try Self.requiredTrimmed(draft.jobType)
+        let customerName = Self.optionalTrimmed(draft.customerName)
+        let siteName = Self.optionalTrimmed(draft.siteName)
+        let notes = Self.optionalTrimmed(draft.notes)
+
+        let jobId = try createJob(
+            jobNumber: jobNumber,
+            jobName: jobName,
+            customerName: customerName,
+            addressLine1: siteName,
+            status: status,
+            priority: priority,
+            jobType: jobType,
+            notes: notes,
+            createdBy: draft.createdBy
+        )
+
+        try db.writer.write { dbConn in
+            try Self.ensureJobStableId(dbConn: dbConn, jobId: jobId)
+            try dbConn.execute(
+                sql: "UPDATE jobs SET site_name = ?, updated_at = datetime('now') WHERE id = ? AND deleted_at IS NULL",
+                arguments: [siteName, jobId]
+            )
+        }
+        return try getJobRecord(id: jobId)
+    }
+
+    @discardableResult
+    public func updateJobRecord(id: Int64, _ update: JobRecordUpdate) throws -> JobRecord {
+        if let jobName = update.jobName, try Self.requiredTrimmed(jobName).isEmpty { throw JobsError.requiredFieldEmpty }
+        if let status = update.status, try Self.requiredTrimmed(status).isEmpty { throw JobsError.requiredFieldEmpty }
+
+        try updateJob(
+            id: id,
+            jobName: try update.jobName.map(Self.requiredTrimmed(_:)),
+            customerName: Self.optionalTrimmed(update.customerName),
+            addressLine1: Self.optionalTrimmed(update.siteName),
+            status: try update.status.map(Self.requiredTrimmed(_:)),
+            priority: try update.priority.map(Self.requiredTrimmed(_:)),
+            jobType: try update.jobType.map(Self.requiredTrimmed(_:)),
+            notes: Self.optionalTrimmed(update.notes)
+        )
+
+        try db.writer.write { dbConn in
+            try Self.ensureJobStableId(dbConn: dbConn, jobId: id)
+            if update.siteName != nil {
+                try dbConn.execute(
+                    sql: "UPDATE jobs SET site_name = ?, updated_at = datetime('now') WHERE id = ? AND deleted_at IS NULL",
+                    arguments: [Self.optionalTrimmed(update.siteName), id]
+                )
+            }
+        }
+        return try getJobRecord(id: id)
+    }
+
+    public func getJobRecord(id: Int64) throws -> JobRecord {
+        let record = try db.writer.read { dbConn -> JobRecord? in
+            guard let row = try Row.fetchOne(dbConn, sql: Self.jobRecordSelectSQL + " WHERE id = ? AND deleted_at IS NULL", arguments: [id]) else {
+                return nil
+            }
+            return try Self.jobRecord(from: row)
+        }
+        guard let record else { throw JobsError.jobNotFound(id) }
+        return record
+    }
+
+    public func listJobRecords(search: String? = nil, status: String? = nil, limit: Int = 50, offset: Int = 0) throws -> [JobRecord] {
+        try db.writer.read { dbConn in
+            var clauses = ["deleted_at IS NULL"]
+            var args: [DatabaseValueConvertible?] = []
+            if let search = Self.optionalTrimmed(search) {
+                clauses.append("(job_name LIKE ? OR job_number LIKE ? OR customer_name LIKE ? OR site_name LIKE ?)")
+                let pattern = "%\(search)%"
+                args += [pattern, pattern, pattern, pattern]
+            }
+            if let status = Self.optionalTrimmed(status) {
+                clauses.append("status = ?")
+                args.append(status)
+            }
+            args += [max(1, limit), max(0, offset)]
+            let rows = try Row.fetchAll(
+                dbConn,
+                sql: Self.jobRecordSelectSQL + " WHERE \(clauses.joined(separator: " AND ")) ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?",
+                arguments: StatementArguments(args)
+            )
+            return try rows.map(Self.jobRecord(from:))
+        }
+    }
+
+    static func ensureJobStableId(dbConn: Database, jobId: Int64) throws {
+        guard try dbConn.columns(in: "jobs").contains(where: { $0.name == "stable_id" }) else { return }
+        let existing = try String.fetchOne(dbConn, sql: "SELECT stable_id FROM jobs WHERE id = ?", arguments: [jobId])
+        guard Self.optionalTrimmed(existing) == nil else { return }
+        try dbConn.execute(sql: "UPDATE jobs SET stable_id = ? WHERE id = ?", arguments: [UUID().uuidString, jobId])
+    }
+
+    private static let jobRecordSelectSQL = """
+        SELECT id, stable_id, job_number, job_name, customer_name, site_name, address_line1,
+               status, priority, job_type, notes, created_at, updated_at
+        FROM jobs
+        """
+
+    private static func jobRecord(from row: Row) throws -> JobRecord {
+        let id: Int64 = row["id"] ?? 0
+        let stableId = try requiredTrimmed((row["stable_id"] as String?) ?? "")
+        return JobRecord(
+            id: id,
+            stableId: stableId,
+            jobNumber: row["job_number"] ?? "",
+            jobName: row["job_name"] ?? "",
+            customerName: row["customer_name"],
+            siteName: (row["site_name"] as String?) ?? (row["address_line1"] as String?),
+            status: row["status"] ?? "active",
+            priority: row["priority"] ?? "normal",
+            jobType: row["job_type"] ?? "service",
+            notes: row["notes"],
+            createdAt: row["created_at"],
+            updatedAt: row["updated_at"]
+        )
+    }
+
+    private static func requiredTrimmed(_ value: String) throws -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw JobsError.requiredFieldEmpty }
+        return trimmed
+    }
+
+    private static func optionalTrimmed(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/core/Sources/WiredPartCore/Services/JobsService+Records.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService+Records.swift
@@ -184,7 +184,7 @@ extension JobsService {
         guard try dbConn.columns(in: "jobs").contains(where: { $0.name == "stable_id" }) else { return }
         let existing = try String.fetchOne(dbConn, sql: "SELECT stable_id FROM jobs WHERE id = ? AND deleted_at IS NULL", arguments: [jobId])
         guard Self.optionalTrimmed(existing) == nil else { return }
-        try dbConn.execute(sql: "UPDATE jobs SET stable_id = ? WHERE id = ? AND deleted_at IS NULL", arguments: [UUID().uuidString, jobId])
+        try dbConn.execute(sql: "UPDATE jobs SET stable_id = ? WHERE id = ? AND deleted_at IS NULL", arguments: [UUID().uuidString.lowercased(), jobId])
     }
 
     private static let jobRecordSelectSQL = """

--- a/core/Sources/WiredPartCore/Services/JobsService+Records.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService+Records.swift
@@ -105,12 +105,13 @@ extension JobsService {
             createdBy: draft.createdBy
         )
 
-        try db.writer.write { dbConn in
-            try Self.ensureJobStableId(dbConn: dbConn, jobId: jobId)
-            try dbConn.execute(
-                sql: "UPDATE jobs SET site_name = ?, updated_at = datetime('now') WHERE id = ? AND deleted_at IS NULL",
-                arguments: [siteName, jobId]
-            )
+        if siteName != nil {
+            try db.writer.write { dbConn in
+                try dbConn.execute(
+                    sql: "UPDATE jobs SET site_name = ?, updated_at = datetime('now') WHERE id = ? AND deleted_at IS NULL",
+                    arguments: [siteName, jobId]
+                )
+            }
         }
         return try getJobRecord(id: jobId)
     }

--- a/core/Sources/WiredPartCore/Services/JobsService+Records.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService+Records.swift
@@ -106,7 +106,7 @@ extension JobsService {
         )
 
         if siteName != nil {
-            try db.writer.write { dbConn in
+            try writeDatabase { dbConn in
                 try dbConn.execute(
                     sql: "UPDATE jobs SET site_name = ?, updated_at = datetime('now') WHERE id = ? AND deleted_at IS NULL",
                     arguments: [siteName, jobId]
@@ -129,7 +129,7 @@ extension JobsService {
             notes: Self.optionalTrimmed(update.notes)
         )
 
-        try db.writer.write { dbConn in
+        try writeDatabase { dbConn in
             try Self.ensureJobStableId(dbConn: dbConn, jobId: id)
             if update.siteName != nil {
                 let siteName = Self.optionalTrimmed(update.siteName)
@@ -147,7 +147,7 @@ extension JobsService {
     }
 
     public func getJobRecord(id: Int64) throws -> JobRecord {
-        let record = try db.writer.read { dbConn -> JobRecord? in
+        let record = try readDatabase { dbConn -> JobRecord? in
             guard let row = try Row.fetchOne(dbConn, sql: Self.jobRecordSelectSQL + " WHERE id = ? AND deleted_at IS NULL", arguments: [id]) else {
                 return nil
             }
@@ -158,13 +158,13 @@ extension JobsService {
     }
 
     public func listJobRecords(search: String? = nil, status: String? = nil, limit: Int = 50, offset: Int = 0) throws -> [JobRecord] {
-        try db.writer.read { dbConn in
+        try readDatabase { dbConn in
             var clauses = ["deleted_at IS NULL"]
             var args: [DatabaseValueConvertible?] = []
             if let search = Self.optionalTrimmed(search) {
-                clauses.append("(job_name LIKE ? OR job_number LIKE ? OR customer_name LIKE ? OR site_name LIKE ?)")
+                clauses.append("(job_name LIKE ? OR job_number LIKE ? OR customer_name LIKE ? OR site_name LIKE ? OR address_line1 LIKE ?)")
                 let pattern = "%\(search)%"
-                args += [pattern, pattern, pattern, pattern]
+                args += [pattern, pattern, pattern, pattern, pattern]
             }
             if let status = Self.optionalTrimmed(status) {
                 clauses.append("status = ?")
@@ -182,9 +182,9 @@ extension JobsService {
 
     static func ensureJobStableId(dbConn: Database, jobId: Int64) throws {
         guard try dbConn.columns(in: "jobs").contains(where: { $0.name == "stable_id" }) else { return }
-        let existing = try String.fetchOne(dbConn, sql: "SELECT stable_id FROM jobs WHERE id = ?", arguments: [jobId])
+        let existing = try String.fetchOne(dbConn, sql: "SELECT stable_id FROM jobs WHERE id = ? AND deleted_at IS NULL", arguments: [jobId])
         guard Self.optionalTrimmed(existing) == nil else { return }
-        try dbConn.execute(sql: "UPDATE jobs SET stable_id = ? WHERE id = ?", arguments: [UUID().uuidString, jobId])
+        try dbConn.execute(sql: "UPDATE jobs SET stable_id = ? WHERE id = ? AND deleted_at IS NULL", arguments: [UUID().uuidString, jobId])
     }
 
     private static let jobRecordSelectSQL = """

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -810,6 +810,7 @@ public final class JobsService: Sendable {
         jobName: String,
         customerName: String? = nil,
         addressLine1: String? = nil,
+        siteName: String? = nil,
         addressLine2: String? = nil,
         city: String? = nil,
         state: String? = nil,
@@ -842,7 +843,7 @@ public final class JobsService: Sendable {
                 sql: """
                     INSERT INTO jobs
                     (job_number, job_name, customer_name,
-                     address_line1, address_line2, city, state, zip,
+                     address_line1, site_name, address_line2, city, state, zip,
                      gps_lat, gps_lng, status, priority, job_type,
                      bill_rate_type_id, billing_rate, estimated_hours,
                      lead_user_id, on_call_type,
@@ -851,11 +852,11 @@ public final class JobsService: Sendable {
                      budget_limit, budget_alert_percent, created_by,
                      job_classification,
                      created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
                     """,
                 arguments: [
                     jobNumber, jobName, customerName,
-                    addressLine1, addressLine2, city, state, zip,
+                    addressLine1, siteName, addressLine2, city, state, zip,
                     gpsLat, gpsLng, status, priority, jobType,
                     billRateTypeId, billingRate, estimatedHours,
                     leadUserId, onCallType,

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -3290,7 +3290,9 @@ public final class JobsService: Sendable {
                 "Internal time bucket for Shop / Warehouse clock entries."
             ]
         )
-        return dbConn.lastInsertedRowID
+        let jobId = dbConn.lastInsertedRowID
+        try ensureJobStableId(dbConn: dbConn, jobId: jobId)
+        return jobId
     }
 
     /// List active/in-progress jobs, optionally excluding a specific job ID.

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -10,12 +10,20 @@ import GRDB
 ///
 /// Ported from: Jobs & Labor feature area (Phases 4, 4.5, 15)
 public final class JobsService: Sendable {
-    let db: AppDatabase
+    private let db: AppDatabase
     private static let warehouseClockJobNumber = "__SHOP_WAREHOUSE__"
     private static let warehouseClockJobName = "Shop / Warehouse"
 
     public init(db: AppDatabase) {
         self.db = db
+    }
+
+    func readDatabase<T>(_ block: (Database) throws -> T) throws -> T {
+        try db.writer.read(block)
+    }
+
+    func writeDatabase<T>(_ block: (Database) throws -> T) throws -> T {
+        try db.writer.write(block)
     }
 
     // =========================================================================

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -10,7 +10,7 @@ import GRDB
 ///
 /// Ported from: Jobs & Labor feature area (Phases 4, 4.5, 15)
 public final class JobsService: Sendable {
-    private let db: AppDatabase
+    let db: AppDatabase
     private static let warehouseClockJobNumber = "__SHOP_WAREHOUSE__"
     private static let warehouseClockJobName = "Shop / Warehouse"
 
@@ -858,6 +858,7 @@ public final class JobsService: Sendable {
                 ]
             )
             let jobId = dbConn.lastInsertedRowID
+            try Self.ensureJobStableId(dbConn: dbConn, jobId: jobId)
             if let defaultTemplateId = try Int64.fetchOne(dbConn, sql: """
                 SELECT id FROM job_stage_templates
                 WHERE is_default = 1 AND archived_at IS NULL

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -29,6 +29,84 @@ struct JobsServiceTests {
         #expect(jobs.contains(where: { $0.jobNumber == "J-TEST" }))
     }
 
+    @Test("local-first job records create update list and survive service reload")
+    func testLocalFirstJobRecordsCRUDAndReload() throws {
+        let env = try E2ETestHelpers.setUp()
+        let created = try env.jobs.createJobRecord(
+            JobsService.JobRecordDraft(
+                jobNumber: "  J-LOCAL-001  ",
+                jobName: "  Local First Job  ",
+                customerName: "  Alpine Electric  ",
+                siteName: "  Alpine City Hall  ",
+                status: "active",
+                priority: "high",
+                notes: "  First site note  ",
+                createdBy: env.adminUserId
+            )
+        )
+        #expect(created.id > 0)
+        #expect(!created.stableId.isEmpty)
+        #expect(UUID(uuidString: created.stableId) != nil)
+        #expect(created.jobNumber == "J-LOCAL-001")
+        #expect(created.jobName == "Local First Job")
+        #expect(created.customerName == "Alpine Electric")
+        #expect(created.siteName == "Alpine City Hall")
+        #expect(created.notes == "First site note")
+
+        let reloadedService = JobsService(db: env.db)
+        let reloaded = try reloadedService.getJobRecord(id: created.id)
+        #expect(reloaded.stableId == created.stableId)
+
+        let updated = try reloadedService.updateJobRecord(
+            id: created.id,
+            JobsService.JobRecordUpdate(
+                jobName: "  Local First Job - Updated  ",
+                customerName: "  Alpine Public Works  ",
+                siteName: "  Council Chambers  ",
+                status: "in_progress",
+                priority: "critical",
+                notes: "  Updated field note  "
+            )
+        )
+        #expect(updated.stableId == created.stableId)
+        #expect(updated.jobName == "Local First Job - Updated")
+        #expect(updated.customerName == "Alpine Public Works")
+        #expect(updated.siteName == "Council Chambers")
+        #expect(updated.status == "in_progress")
+        #expect(updated.priority == "critical")
+        #expect(updated.notes == "Updated field note")
+
+        let listed = try reloadedService.listJobRecords(status: "in_progress")
+        #expect(listed.contains { $0.id == created.id && $0.stableId == created.stableId })
+    }
+
+    @Test("local-first job records reject invalid input and expose empty state")
+    func testLocalFirstJobRecordsInvalidInputAndEmptyState() throws {
+        let env = try E2ETestHelpers.setUp()
+        #expect(try env.jobs.listJobRecords(status: "cancelled").isEmpty)
+        #expect(throws: JobsService.JobsError.requiredFieldEmpty) {
+            _ = try env.jobs.createJobRecord(
+                JobsService.JobRecordDraft(jobNumber: " ", jobName: "Blank Number", createdBy: env.adminUserId)
+            )
+        }
+        #expect(throws: JobsService.JobsError.requiredFieldEmpty) {
+            _ = try env.jobs.createJobRecord(
+                JobsService.JobRecordDraft(jobNumber: "J-BLANK-NAME", jobName: " ", createdBy: env.adminUserId)
+            )
+        }
+    }
+
+    @Test("jobs migration backfills stable ids for existing rows")
+    func testJobsMigrationBackfillsStableIds() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-BACKFILL", name: "Backfilled Job")
+        let row = try env.db.writer.read { db in
+            try Row.fetchOne(db, sql: "SELECT stable_id FROM jobs WHERE id = ?", arguments: [jobId])
+        }
+        let stableId = try #require(row?["stable_id"] as String?)
+        #expect(UUID(uuidString: stableId) != nil)
+    }
+
     @Test("createJob creates a linked job notebook")
     func testCreateJobCreatesLinkedNotebook() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -106,8 +106,8 @@ struct JobsServiceTests {
         }
     }
 
-    @Test("jobs migration backfills stable ids for existing rows")
-    func testJobsMigrationBackfillsStableIds() throws {
+    @Test("seeded jobs receive stable ids after local-first schema is available")
+    func testSeededJobsReceiveStableIds() throws {
         let env = try E2ETestHelpers.setUp()
         let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-BACKFILL", name: "Backfilled Job")
         let row = try env.db.writer.read { db in

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -78,6 +78,16 @@ struct JobsServiceTests {
 
         let listed = try reloadedService.listJobRecords(status: "in_progress")
         #expect(listed.contains { $0.id == created.id && $0.stableId == created.stableId })
+
+        let clearedSite = try reloadedService.updateJobRecord(
+            id: created.id,
+            JobsService.JobRecordUpdate(siteName: "   ")
+        )
+        #expect(clearedSite.siteName == nil)
+        let addressLine1 = try env.db.writer.read { db in
+            try String.fetchOne(db, sql: "SELECT address_line1 FROM jobs WHERE id = ?", arguments: [created.id])
+        }
+        #expect(addressLine1 == nil)
     }
 
     @Test("local-first job records reject invalid input and expose empty state")
@@ -336,6 +346,15 @@ struct JobsServiceTests {
         #expect(laborEntryId > 0)
         #expect(active?.id == laborEntryId)
         #expect(active?.jobName == "Shop / Warehouse")
+
+        let stableId = try env.db.writer.read { db in
+            try String.fetchOne(
+                db,
+                sql: "SELECT stable_id FROM jobs WHERE job_number = ? AND deleted_at IS NULL",
+                arguments: ["__SHOP_WAREHOUSE__"]
+            )
+        }
+        #expect(stableId.flatMap(UUID.init(uuidString:)) != nil)
     }
 
     @Test("Labor summary after clock in/out")


### PR DESCRIPTION
## Summary
- Add a local-first JobRecord API with stable UUID-backed identifiers for create/read/update/list job record flows.
- Add migration 105 to backfill jobs.stable_id, preserve site metadata, and index stable/site lookups.
- Keep existing createJob path assigning stable IDs so legacy callers participate in the local-first model.

## Verification
- RED: swift test --filter JobsServiceTests/testLocalFirstJobRecordsCRUDAndReload failed before implementation with missing createJobRecord/getJobRecord/updateJobRecord/listJobRecords APIs.
- GREEN: swift test --filter JobsServiceTests passed (137 tests).
- Regression: swift test passed locally before branch push (2144 tests, 64 suites).

## Paperclip
- WEI-3884

## QA notes
- Backend/local-first only; no UI entry points touched.
- Stage 3 inventory/job material paths covered through JobsServiceTests and full core test suite.