### PR TITLE
Fix job material correction action accessibility

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSJobDetailPage.swift
@@ -727,8 +727,8 @@ struct IOSJobDetailPage: View {
                     .accessibilityIdentifier("job-used-material-return-button-\(part.id)")
                 Button("Correct") { prepareMaterialAction(.correctUsed(part)) }
                     .buttonStyle(.bordered)
-                    .accessibilityLabel("Correct \(part.partName)")
-                    .accessibilityHint("Requires an audit note")
+                    .accessibilityLabel("Correct")
+                    .accessibilityHint("Corrects \(part.partName) and requires an audit note")
                     .accessibilityIdentifier("job-used-material-correct-button-\(part.id)")
                 Spacer()
             }

--- a/Weird Parts IOS/Weird Parts IOSTests/FieldWorkflowActionButtonAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/FieldWorkflowActionButtonAccessibilityTests.swift
@@ -50,6 +50,9 @@ final class FieldWorkflowActionButtonAccessibilityTests: XCTestCase {
         XCTAssertTrue(readyRow.contains(".accessibilityIdentifier(\"job-ready-material-return-button-\\(material.id)\")"))
         XCTAssertTrue(usedRow.contains(".accessibilityIdentifier(\"job-used-material-return-button-\\(part.id)\")"))
         XCTAssertTrue(usedRow.contains(".accessibilityIdentifier(\"job-used-material-correct-button-\\(part.id)\")"))
+        XCTAssertTrue(usedRow.contains(".accessibilityLabel(\"Correct\")"), "The used material correction button must remain discoverable as app.buttons[\"Correct\"] for phone UI tests.")
+        XCTAssertTrue(usedRow.contains(".accessibilityHint(\"Corrects \\(part.partName) and requires an audit note\")"))
+        XCTAssertFalse(usedRow.contains(".accessibilityLabel(\"Correct \\(part.partName)\")"), "Do not replace the visible Correct action label with part-specific accessibility text.")
         XCTAssertTrue(readyRow.contains(".accessibilityElement(children: .combine)"), "Static ready material summary text can still be grouped separately.")
         XCTAssertTrue(usedRow.contains(".accessibilityElement(children: .combine)"), "Static used material summary text can still be grouped separately.")
     }


### PR DESCRIPTION
## Summary

- Issue: Paperclip WEI-3893 — phone Materials > Used row hid the expected `Correct` action from the user-like UI test because the button accessibility label had been replaced with part-specific text.
- Scope: Update the used material row button accessibility label/hint and add regression coverage for button discoverability. This unblocks WEI-3891 QA closeout.

## Validation

- [x] Tests added/updated as needed
- [x] Lint/type checks pass
- [x] Backward compatibility considered

Validation run:

- PASS: `xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -only-testing 'Weird Parts IOSTests/FieldWorkflowActionButtonAccessibilityTests/testJobMaterialRowsKeepUseReturnCorrectButtonsIndependent'`
- PASS: `WEI_3144_ARTIFACT_DIR=/tmp/wei3893-phone-artifacts-1781993793 xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -only-testing 'Weird PartsUITests/Weird_Parts_IOSUITests/testWEI3144JobMaterialsWalkthroughEvidence'`
- PASS: `xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -only-testing 'Weird PartsUITests/Weird_Parts_IOSUITests/testWEI3866WarehouseDashboardNewMovementOpensGuidedWizard'`

## AI Assistance Disclosure

- [x] AI assistance used in this PR
- Tools used: Hermes Agent / OpenAI Codex gpt-5.5, local terminal, Xcode/xcodebuild.
- AI-assisted areas (files/functions): `IOSJobDetailPage.usedMaterialRow`, `FieldWorkflowActionButtonAccessibilityTests.testJobMaterialRowsKeepUseReturnCorrectButtonsIndependent`.
- Reviewer focus notes for AI-generated/assisted code: verify the `Correct` button remains exact-label discoverable for XCTest while part context remains available via the hint.

## Copilot-assisted Change Checklist

- [x] Copilot used for this PR: No
- [x] Reviewed Copilot-generated/assisted changes line-by-line
- [x] No secrets, credentials, or customer-sensitive prompt data shared
- [x] Licensing/origin risk checked for non-trivial generated snippets
- [x] Tests added/updated for generated or modified logic
- [x] Manual verification notes added for security/auth/config changes

## Risk Check

- [x] No secrets or sensitive data were shared with AI tools
- [x] Security-sensitive paths received required reviewer attention
- [x] No destructive ops introduced without explicit approval
