### PR TITLE
WEI-3904: Cover Stage 5 time core break attachment

### DIFF
--- a/core/Sources/WiredPartCore/Services/BreakService.swift
+++ b/core/Sources/WiredPartCore/Services/BreakService.swift
@@ -159,8 +159,9 @@ public final class BreakService: Sendable {
         let isPaid = (breakType != "lunch_unpaid")
         do {
             return try db.writer.write { dbConn in
+                let resolvedLaborEntryId = try laborEntryId ?? Self.activeClockEntryId(dbConn: dbConn, userId: userId)
                 var record = BreakRecord(
-                    id: nil, userId: userId, laborEntryId: laborEntryId,
+                    id: nil, userId: userId, laborEntryId: resolvedLaborEntryId,
                     breakType: breakType, startedAt: Self.nowString(),
                     endedAt: nil, durationMinutes: nil, isPaid: isPaid,
                     autoFilled: false, timerDurationMinutes: timerMinutes,
@@ -455,6 +456,18 @@ public final class BreakService: Sendable {
 
     private static func parseDateTime(_ str: String) -> Date? {
         CoreFormatters.parseDateTime(str)
+    }
+
+    private static func activeClockEntryId(dbConn: Database, userId: Int64) throws -> Int64? {
+        try Int64.fetchOne(dbConn, sql: """
+            SELECT id
+            FROM labor_entries
+            WHERE user_id = ?
+              AND status = 'clocked_in'
+              AND deleted_at IS NULL
+            ORDER BY clock_in DESC, id DESC
+            LIMIT 1
+            """, arguments: [userId])
     }
 
     /// Add minutes to a time string like "10:00" → "10:15".

--- a/core/Tests/WiredPartCoreTests/BreakServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/BreakServiceTests.swift
@@ -129,6 +129,22 @@ struct BreakServiceTests {
         #expect(active?.breakType == "rest")
     }
 
+    @Test("Start break attaches to active clock entry when laborEntryId is omitted")
+    func testStartBreakAttachesToActiveClockEntryByDefault() throws {
+        let env = try freshEnv()
+        let breakService = BreakService(db: env.db)
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-BREAK-ACTIVE", name: "Break Active Job")
+        let laborEntryId = try env.jobs.clockIn(userId: env.adminUserId, jobId: jobId)
+
+        let record = try breakService.startBreak(
+            userId: env.adminUserId,
+            breakType: "lunch_unpaid",
+            timerMinutes: 30
+        )
+
+        #expect(record.laborEntryId == laborEntryId)
+    }
+
     @Test("Get break records for day")
     func testGetBreakRecordsForDay() throws {
         let env = try freshEnv()

--- a/core/Tests/WiredPartCoreTests/DatabaseTests.swift
+++ b/core/Tests/WiredPartCoreTests/DatabaseTests.swift
@@ -108,9 +108,9 @@ struct DatabaseTests {
         #expect(tables == ["part_import_row_evidence", "part_import_sessions"])
     }
 
-    @Test("Schema version is 103")
+    @Test("Schema version is 105")
     func testSchemaVersion() throws {
-        #expect(AppDatabase.schemaVersion == 103)
+        #expect(AppDatabase.schemaVersion == 105)
     }
 
     @Test("Migration 095 normalizes duplicate legacy stage sort orders and category maps")

--- a/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
@@ -48,6 +48,38 @@ struct ReportsServiceTests {
         #expect(data.count >= 1)
     }
 
+    @Test("Timesheet segments include breaks started from active clock entry")
+    func testTimesheetSegmentsIncludeBreaksStartedFromActiveClockEntry() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-ACTIVE-BREAK", name: "Active Break Summary Job")
+        let breakService = BreakService(db: env.db)
+        let clockIn = try Date("2026-03-05T08:00:00Z", strategy: .iso8601)
+        let clockOut = try Date("2026-03-05T17:00:00Z", strategy: .iso8601)
+        let laborEntryId = try env.jobs.clockIn(userId: env.adminUserId, jobId: jobId, at: clockIn)
+
+        let breakRecord = try breakService.startBreak(
+            userId: env.adminUserId,
+            breakType: "lunch_unpaid",
+            timerMinutes: 30
+        )
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                UPDATE break_records
+                SET started_at = '2026-03-05T12:00:00Z',
+                    ended_at = '2026-03-05T12:30:00Z',
+                    duration_minutes = 30
+                WHERE id = ?
+                """, arguments: [breakRecord.id])
+        }
+        try env.jobs.clockOut(laborEntryId: laborEntryId, at: clockOut)
+
+        let segments = try env.reports.getTimesheetSegments(startDate: "2026-03-05", endDate: "2026-03-05", userId: env.adminUserId)
+        let segment = segments.first { $0.id == laborEntryId }
+
+        #expect(segment?.unpaidLunchMinutes == 30)
+        #expect(segment?.regularHours == 8.0)
+    }
+
     @Test("Timesheet segments prefer is_paid over break_type for unpaid correction buckets")
     func testTimesheetSegmentsUseIsPaidForContradictoryBreakRows() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Implements the Stage 5 break/lunch attachment gap: `BreakService.startBreak` now resolves the user's active local labor entry when callers omit `laborEntryId`, so break rows remain tied to the clock segment for local-first summaries.
- Adds regression coverage for both the service-level active-clock attachment and the timesheet summary path that consumes the attached break row.
- Updates the schema-version migration assertion to the current `AppDatabase.schemaVersion == 105`, unblocking full package verification on this branch.
- Confirms the existing Stage 5 time core foundation covers clock in/out, job switching, breaks/lunch, overtime allocation, correction audit history, and timesheet-ready summaries; this PR repairs the remaining attachment contract without pulling Stage 6 parts-on-jobs scope.

## Tests
- `swift test --filter ReportsServiceTests/testTimesheetSegmentsIncludeBreaksStartedFromActiveClockEntry`
- `swift test --filter 'JobsServiceTests|BreakServiceTests|ReportsServiceTests'` — 205 tests passed
- `swift test --filter DatabaseTests/testSchemaVersion`
- `swift test` — 2147 tests passed

## UI integration contract
- Existing UI callers may continue calling `BreakService.startBreak(userId:breakType:timerMinutes:)` without passing a labor entry id. The backend will attach the break to the currently active `labor_entries` row when one exists.
- If there is no active clock entry, behavior remains unchanged: the break is created without `labor_entry_id`, which lets non-clocked/admin break records remain possible.

## Paperclip
- WEI-3904
- Stage 5 goal: `53055fd4-d775-4971-85d4-5fcd481ff505`
- Duplicate WEI-3908 should remain cancelled/superseded by this canonical chain.
