### PR TITLE
fix: keep timesheet correction history visible

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
@@ -260,20 +260,6 @@ struct IOSTimesheetsPage: View {
                 }
             }
 
-            HStack {
-                Button {
-                    activeSheet = .correction(segment)
-                } label: {
-                    Label("Correct Entry", systemImage: "pencil.and.list.clipboard")
-                }
-                .accessibilityIdentifier("timesheetCorrectEntryButton-\(segment.id)")
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .hideWithoutPermission("manage_labor")
-
-                Spacer()
-            }
-
             let history = correctionHistory.filter { $0.segmentId == segment.id }
             if !history.isEmpty {
                 Divider()
@@ -298,6 +284,20 @@ struct IOSTimesheetsPage: View {
                             .accessibilityIdentifier("timesheetCorrectionHistoryAllocation")
                     }
                 }
+            }
+
+            HStack {
+                Button {
+                    activeSheet = .correction(segment)
+                } label: {
+                    Label("Correct Entry", systemImage: "pencil.and.list.clipboard")
+                }
+                .accessibilityIdentifier("timesheetCorrectEntryButton-\(segment.id)")
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .hideWithoutPermission("manage_labor")
+
+                Spacer()
             }
         }
         .padding(10)


### PR DESCRIPTION
## Summary
- Moves the timesheet correction action below the per-segment correction history so the adjusted allocation/history remains visible after saving on compact phone layouts.
- Keeps the existing `timesheetCorrectionHistoryAllocation` accessibility label path intact for the user-like UI verifier.

## Verification
- `xcodebuild test-without-building -quiet -derivedDataPath /Users/IA/Library/Developer/Xcode/DerivedData/Weird_Parts-djqatanzvyosucelwswjyuzdbytr -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "platform=iOS Simulator,id=7E22D950-7EEA-41D4-A82A-E28C765BA886" -only-testing:"Weird PartsUITests/Weird_Parts_IOSUITests/testWEI3041CorrectionSheetPolicyAllocationEvidence" -resultBundlePath /tmp/wei-3915-artifacts-worktree/phone-test-without-building.xcresult`
- `xcodebuild test-without-building -quiet -derivedDataPath /Users/IA/Library/Developer/Xcode/DerivedData/Weird_Parts-djqatanzvyosucelwswjyuzdbytr -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "platform=iOS Simulator,id=60814A40-7648-4128-9847-A1EAA2686697" -only-testing:"Weird PartsUITests/Weird_Parts_IOSUITests/testWEI3041CorrectionSheetPolicyAllocationEvidence" -resultBundlePath /tmp/wei-3915-artifacts-worktree/tablet-test-without-building.xcresult`
- `swift test --package-path core --filter 'JobsServiceTests|BreakServiceTests|ReportsServiceTests'`

Paperclip: WEI-3915
