### PR TITLE
WEI-3917: Bound clock location requests

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/LocationManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/LocationManager.swift
@@ -11,6 +11,7 @@ import os.log
 final class LocationManager: NSObject, ObservableObject {
     private let manager = CLLocationManager()
     private var continuation: CheckedContinuation<CLLocation?, Never>?
+    private var timeoutTask: Task<Void, Never>?
     nonisolated let logger = Logger(subsystem: "com.wiredpart.ios", category: "LocationManager")
 
     @Published var authorizationStatus: CLAuthorizationStatus = .notDetermined
@@ -44,17 +45,40 @@ final class LocationManager: NSObject, ObservableObject {
     }
 
     /// Get a single location fix. Returns nil if location services
-    /// are unavailable or denied.
-    func getCurrentLocation() async -> CLLocation? {
+    /// are unavailable, denied, or do not produce a fix before `timeout`.
+    ///
+    /// Simulator location requests can otherwise remain outstanding long enough
+    /// for XCTest to treat navigation into the Clock page as a hung event loop.
+    /// Clock data should still load without GPS; GPS only improves job sorting.
+    func getCurrentLocation(timeout: TimeInterval = 2.0) async -> CLLocation? {
         let status = manager.authorizationStatus
         guard status == .authorizedWhenInUse || status == .authorizedAlways else {
             return nil
         }
 
         return await withCheckedContinuation { cont in
+            // Resolve any stale in-flight request before starting a new one so
+            // overlapping refreshes cannot leak or resume the wrong continuation.
+            finishLocationRequest(nil)
             self.continuation = cont
+            timeoutTask = Task { [weak self] in
+                let nanoseconds = UInt64(max(timeout, 0.1) * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: nanoseconds)
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    self?.logger.warning("[LocationManager] Location request timed out")
+                    self?.finishLocationRequest(nil)
+                }
+            }
             manager.requestLocation()
         }
+    }
+
+    private func finishLocationRequest(_ location: CLLocation?) {
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        continuation?.resume(returning: location)
+        continuation = nil
     }
 }
 
@@ -64,16 +88,14 @@ extension LocationManager: CLLocationManagerDelegate {
     nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         let location = locations.last
         Task { @MainActor in
-            continuation?.resume(returning: location)
-            continuation = nil
+            finishLocationRequest(location)
         }
     }
 
     nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         logger.error("[LocationManager] Error: \(error.localizedDescription)")
         Task { @MainActor in
-            continuation?.resume(returning: nil)
-            continuation = nil
+            finishLocationRequest(nil)
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/LocationManagerRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/LocationManagerRegressionTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+
+/// Regression coverage for WEI-3917.
+///
+/// The Dashboard > Clock route must not block on a simulator GPS request before
+/// rendering Clock In / Out. Location is only used to sort jobs by distance, so
+/// a missing/stalled fix should resolve quickly and let clock data load.
+final class LocationManagerRegressionTests: XCTestCase {
+    func testCurrentLocationRequestHasBoundedTimeout() throws {
+        let source = try Self.readAppSource("LocationManager.swift")
+
+        XCTAssertTrue(
+            source.contains("func getCurrentLocation(timeout: TimeInterval = 2.0) async -> CLLocation?"),
+            "LocationManager.getCurrentLocation must keep a short default timeout so Clock page navigation cannot hang on simulator GPS."
+        )
+        XCTAssertTrue(source.contains("timeoutTask = Task"))
+        XCTAssertTrue(source.contains("Task.sleep(nanoseconds:"))
+        XCTAssertTrue(source.contains("finishLocationRequest(nil)"))
+        XCTAssertTrue(source.contains("manager.requestLocation()"))
+    }
+
+    func testLocationCallbacksUseSingleFinishPath() throws {
+        let source = try Self.readAppSource("LocationManager.swift")
+
+        XCTAssertTrue(source.contains("private func finishLocationRequest(_ location: CLLocation?)"))
+        XCTAssertTrue(source.contains("timeoutTask?.cancel()"))
+        XCTAssertTrue(source.contains("continuation?.resume(returning: location)"))
+        XCTAssertTrue(source.contains("finishLocationRequest(location)"))
+        XCTAssertTrue(source.contains("finishLocationRequest(nil)"))
+        XCTAssertFalse(
+            source.contains("continuation?.resume(returning: nil)\n            continuation = nil"),
+            "Timeout, success, and failure paths should share finishLocationRequest so the timeout is cancelled on all completions."
+        )
+    }
+
+    private static func readAppSource(_ fileName: String, file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("App")
+            .appendingPathComponent(fileName)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes Paperclip WEI-3917 Dashboard > Clock simulator hang by bounding `LocationManager.getCurrentLocation` to a 2s default timeout.
- Resolves stale overlapping location continuations through a single `finishLocationRequest` path so success, failure, and timeout all cancel the timeout task safely.
- Adds regression coverage documenting that Clock page data must load even when simulator GPS never produces a fix.

## Verification
- `xcrun --sdk iphonesimulator swiftc -typecheck -parse-as-library -target arm64-apple-ios26.0-simulator "Weird Parts IOS/Weird Parts IOS/App/LocationManager.swift"`
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'id=145DE584-9492-43FE-8C19-A9573D24DC7F' -derivedDataPath /tmp/wei3917-derived -only-testing:"Weird Parts IOSTests/LocationManagerRegressionTests" -resultBundlePath /tmp/wei3917-location-regression.xcresult`

## Paperclip
- WEI-3917
- Unblocks WEI-3918 review and WEI-3919 QA rerun.
