### PR TITLE
fix: remove duplicate WEI-3866 UI test

### DIFF
--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -360,31 +360,6 @@ final class Weird_Parts_IOSUITests: XCTestCase {
     }
 
     @MainActor
-    func testWEI3866WarehouseDashboardNewMovementOpensGuidedWizard() throws {
-        app.terminate()
-        app = XCUIApplication()
-        configureUITestingEnvironment(app)
-        app.launchArguments += [
-            "-UITestingWEI936AutoLogin",
-            "-UITestingWarehouseDashboard"
-        ]
-        app.launch()
-
-        openWarehouseDashboard()
-
-        let newMovement = app.buttons["whAction_newMovement"].firstMatch
-        XCTAssertTrue(newMovement.waitForExistence(timeout: 20), "Warehouse Dashboard should expose a stable New Movement quick action")
-        XCTAssertTrue(newMovement.isHittable, "Warehouse Dashboard New Movement action should be immediately hittable on iPhone")
-        newMovement.tap()
-
-        XCTAssertTrue(
-            app.staticTexts["Where is stock moving?"].waitForExistence(timeout: 10) ||
-                app.navigationBars["New Movement"].waitForExistence(timeout: 10),
-            "Tapping the Warehouse Dashboard New Movement action should open the guided movement wizard."
-        )
-    }
-
-    @MainActor
     func testWEI3144JobMaterialsWalkthroughEvidence() throws {
         let artifactDirectory = wei3144ArtifactDirectory
         try FileManager.default.createDirectory(at: artifactDirectory, withIntermediateDirectories: true)


### PR DESCRIPTION
## Summary
- Removes the duplicate `testWEI3866WarehouseDashboardNewMovementOpensGuidedWizard()` declaration from the UI test bundle.
- Keeps the later WEI-3866 implementation that includes the coordinate fallback for non-hittable quick action controls.

## Verification
- `python3 - <<'PY' ...` confirmed only one `testWEI3866WarehouseDashboardNewMovementOpensGuidedWizard()` remains.
- `xcodebuild test -project "Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "platform=iOS Simulator,name=WEI3988-iPhone" -only-testing:"Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests" -only-testing:"Weird Parts IOSTests/WarehouseStickerProgressScopeRegressionTests" CODE_SIGNING_ALLOWED=NO` from `Weird Parts IOS/` succeeded.

Closes #1126

Paperclip: WEI-4078
