### PR TITLE
fix: route duplicate job returns safely

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSReceivingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSReceivingPage.swift
@@ -1113,9 +1113,17 @@ private struct IOSJobReturnSortingPage: View {
         jobId: Int64
     ) throws {
         guard let warehouseService = appCore.warehouseService else { return }
-        var remainingItems = holdingItems
+        // Holding items are fetched newest-first, but createJobReturnIntake inserts
+        // items in draft-line order. Route oldest-first so duplicate same-part
+        // lines stay paired with the line the user sorted.
+        var remainingItems = holdingItems.sorted { $0.id < $1.id }
         for line in lines where line.qty > 0 {
-            guard let itemIndex = remainingItems.firstIndex(where: { $0.partId == line.partId }) else { continue }
+            guard let itemIndex = remainingItems.firstIndex(where: { item in
+                item.partId == line.partId
+                    && item.condition == conditionForSubmit(line)
+                    && item.status == expectedInitialStatus(for: line)
+                    && normalizedOptionalText(item.notes) == normalizedOptionalText(line.notes)
+            }) else { continue }
             let item = remainingItems.remove(at: itemIndex)
             switch line.sortAction {
             case .shelf:
@@ -1145,6 +1153,22 @@ private struct IOSJobReturnSortingPage: View {
                 break
             }
         }
+    }
+
+    private func expectedInitialStatus(for line: JobReturnDraftLine) -> String {
+        switch conditionForSubmit(line) {
+        case "damaged":
+            "damaged_review"
+        case "wrong_part":
+            "wrong_part_review"
+        default:
+            "holding"
+        }
+    }
+
+    private func normalizedOptionalText(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func completionSummary() -> String {

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -2275,6 +2275,9 @@ public final class WarehouseService: Sendable {
             guard let item = try Self.fetchJobReturnHoldingItem(id: intakeItemId, dbConn: dbConn) else {
                 throw WarehouseError.jobReturnItemNotFound(intakeItemId)
             }
+            guard item.status == "holding" else {
+                throw WarehouseError.invalidMovementPath(from: "job_return_\(item.status)", to: "warehouse")
+            }
             guard item.qtyRemaining >= qty else {
                 throw WarehouseError.insufficientStock(available: item.qtyRemaining, requested: qty)
             }

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -1543,6 +1543,50 @@ struct WarehouseServiceExtTests {
         #expect(try env.warehouse.getStockQty(partId: wrongPartId, locationType: "warehouse", locationId: 1) == 0)
     }
 
+    @Test("Job Return duplicate same-part mixed outcomes do not shelf review items")
+    func testJobReturnDuplicateSamePartMixedOutcomesDoNotShelfReviewItem() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, name: "Duplicate Mixed Return Part", categoryId: catId)
+        let jobId = try E2ETestHelpers.seedJob(env)
+
+        _ = try env.warehouse.createJobReturnIntake(
+            sourceJobId: jobId,
+            returnSource: "crew_return",
+            returnedBy: env.adminUserId,
+            lines: [
+                .init(partId: partId, qty: 1, condition: "usable", notes: "should shelf"),
+                .init(partId: partId, qty: 1, condition: "damaged", notes: "must stay review"),
+            ]
+        )
+
+        let holdingItems = try env.warehouse.getJobReturnHoldingItems(jobId: jobId, includeRouted: false)
+        guard let damagedReview = holdingItems.first(where: { $0.partId == partId && $0.status == "damaged_review" }),
+              let usableHolding = holdingItems.first(where: { $0.partId == partId && $0.status == "holding" })
+        else {
+            Issue.record("Expected duplicate same-part return to create separate holding and review items")
+            return
+        }
+
+        #expect(throws: WarehouseService.WarehouseError.invalidMovementPath(from: "job_return_damaged_review", to: "warehouse")) {
+            _ = try env.warehouse.confirmJobReturnShelfRoute(
+                intakeItemId: damagedReview.id,
+                qty: 1,
+                performedBy: env.adminUserId
+            )
+        }
+
+        _ = try env.warehouse.confirmJobReturnShelfRoute(
+            intakeItemId: usableHolding.id,
+            qty: 1,
+            performedBy: env.adminUserId
+        )
+
+        let remainingReviewItems = try env.warehouse.getJobReturnHoldingItems(jobId: jobId, includeRouted: false)
+        #expect(remainingReviewItems.contains { $0.id == damagedReview.id && $0.status == "damaged_review" && $0.qtyRemaining == 1 })
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 1)
+    }
+
     @Test("Job Return staging and write-off routes do not affect shelf stock")
     func testJobReturnStagingAndWriteOffDoNotAffectShelfStock() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
Closes #1159

## Summary
- match Job Return immediate routes against the exact created holding item by draft order, part, condition, initial status, and notes instead of part ID only
- prevent direct shelf confirmation for review-status Job Return items
- add regression coverage for duplicate same-part usable + damaged returns

## Verification
- swift test --filter WarehouseServiceExtTests/testJobReturnDuplicateSamePartMixedOutcomesDoNotShelfReviewItem
- swift test --filter WarehouseServiceExtTests

## Local runner path
Local self-hosted Mac runner should validate this trusted repo PR via the existing WPR2 Actions path when checks are queued.