### PR TITLE
docs: dedupe autonomous GitHub issue filing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,9 @@ Errors are learning opportunities. When something breaks:
 
 ## GitHub Issues = Master Todo List
 
-**GitHub Issues is the single source of truth** for all bugs, features, and improvements. Every unfixed problem MUST have a GitHub issue. Every fix should reference and close its issue.
+**GitHub Issues is the single source of truth** for all bugs, features, and improvements. Every unfixed problem MUST be tracked in GitHub, but tracking does not always mean opening a brand-new issue. Before creating an issue, search for existing issues with the same root cause, affected area, or fix shape. If a new finding is another instance of an existing defect class, update the existing issue/umbrella with evidence instead of filing a duplicate.
+
+Use one GitHub issue per coherent fix/PR whenever practical. Prefer umbrella issues for cross-cutting bug classes such as shared validation, repeated silent-error handling, common accessibility defects, or scanner findings that can be fixed by one coordinated pass. File separate issues only when the fix owners, risk, acceptance criteria, or release priority are materially different. Every fix should reference and close its issue or update the umbrella checklist it resolves.
 
 ## WPR2 PR CI: Local Mac Actions Runner
 
@@ -127,13 +129,15 @@ Owner direction tracked in Paperclip WEI-3851/WEI-3852 supersedes older attempts
 
 **Rules:**
 
-1. **Find something broken? File it.** Every bug, gap, or missing feature gets a GitHub issue with: title prefix `[Area][Type]`, description of what's wrong, impact, and fix approach.
-2. **Fix something? Close the issue.** When you fix a bug, close the corresponding issue with a comment describing what was done.
-3. **Ask before filing ambiguous issues.** If you're unsure whether something is a bug or intended behavior, ask the user first. Get the right info before filing.
-4. **Keep issues up to date.** As work progresses, update issue descriptions, add comments with progress, and close completed items. Stale issues are worse than no issues.
-5. **Check existing issues first.** Before filing a new issue, search to make sure it's not already tracked. Reference related issues with `#number`.
-6. **Issue format:** Use `[Area]` prefix (e.g., `[Parts]`, `[Orders]`, `[Scheduling]`) and `[Type]` (e.g., `[Bug]`, `[Feature]`, `[UX]`). Include a "Status" line: `OPEN`, `IN PROGRESS`, or `FIXED`.
-7. **Program Review issues (#52-#66)** are the parent tracking issues for each feature area. New issues should reference their parent when applicable.
+1. **Find something broken? Track it without spraying.** Every bug, gap, or missing feature gets GitHub tracking with: title prefix `[Area][Type]`, description of what's wrong, impact, and fix approach. Search first. If the finding shares a root cause/fix with existing issues, comment/update the existing issue or umbrella checklist instead of creating another issue.
+2. **Group duplicate-class findings.** When one PR can reasonably fix multiple findings, create or update one umbrella issue and list the affected files/flows as checklist items. Cross-cutting examples: `.whitespaces` vs `.whitespacesAndNewlines`, repeated silent `try?`/guard-return failures, common accessibility label gaps, repeated empty-state defects, or scanner findings with the same remediation pattern.
+3. **Split only for real independence.** File separate issues only when findings need different owners, plans, risk decisions, release priority, or PRs. Area differences alone are not enough if the same central validator/helper/audit pass will fix them.
+4. **Fix something? Close or check off the tracker.** When you fix a bug, close the corresponding issue with a comment describing what was done, or update the umbrella checklist/comment with the resolved sub-findings.
+5. **Ask before filing ambiguous issues.** If you're unsure whether something is a bug or intended behavior, ask the user first. Get the right info before filing.
+6. **Keep issues up to date.** As work progresses, update issue descriptions, add comments with progress, and close completed items. Stale issues are worse than no issues.
+7. **Check existing issues first.** Before filing a new issue, search to make sure it's not already tracked. Reference related issues with `#number`.
+8. **Issue format:** Use `[Area]` prefix (e.g., `[Parts]`, `[Orders]`, `[Scheduling]`) and `[Type]` (e.g., `[Bug]`, `[Feature]`, `[UX]`). Include a "Status" line: `OPEN`, `IN PROGRESS`, or `FIXED`.
+9. **Program Review issues (#52-#66)** are the parent tracking issues for each feature area. New issues should reference their parent when applicable.
 
 ---
 

--- a/docs/paperclip-handoff.md
+++ b/docs/paperclip-handoff.md
@@ -28,7 +28,7 @@
 - **Plans before prompts.** ALL design decisions go to `docs/plans/*.md` BEFORE any code is generated. CLAUDE.md §"Plan Filing & History" is the rule. If you find yourself coding without a plan, stop and ask the user (Q&A workflow in §7).
 - **Goal -> plan -> issue -> PR loop.** For Paperclip/GitHub routing, read `docs/plans/paperclip-agentic-execution-loop.md`. It defines the required fields for GitHub issues, Paperclip child issues, branch/worktree hygiene, PR evidence, and closeout comments.
 - **Slow, focused, one-area-at-a-time.** AUTO GO's soul (`docs/auto-go-soul.md`) is the canonical statement. Convergence over breadth. 25-minute cap per iteration. No spraying.
-- **No finding gets lost.** Anything you notice that's out-of-scope for the current check goes to a GitHub issue with the right area label and tier (T1/T2/T3) BEFORE you continue. See `feedback_issue_ordering.md`.
+- **No finding gets lost, but no issue spraying.** Anything you notice that's out-of-scope for the current check gets GitHub tracking before you continue, but first search existing issues and umbrella trackers. If the finding shares a root cause or likely PR with an existing tracker, add it there instead of opening a new issue. See `feedback_issue_ordering.md`.
 - **Per-POV Q&A.** Each `Answer: _pending_` line in `docs/dev-qa.md` waits for a role-specific answer (Owner / Manager / Developer / User). Never collapse. See `feedback_qa_workflow.md`.
 - **Tests are non-negotiable.** Every new public service method gets a test in the same iteration that introduces it. C4 + C5 must pass before an area graduates.
 - **The user does not read code.** Reports come back as dashboards / plain-English / per-POV breakdowns. See `user_background.md`.

--- a/docs/plans/paperclip-agentic-execution-loop.md
+++ b/docs/plans/paperclip-agentic-execution-loop.md
@@ -42,6 +42,8 @@ The operating rule is: field-test beta work comes first. Process or infrastructu
 
 Every new or materially updated GitHub issue created from Paperclip, QA, or autonomous findings must include:
 
+- **Dedupe evidence:** the exact GitHub search/query or existing issue review performed before filing. If a matching root-cause issue exists, update it instead of opening another issue.
+- **Grouping decision:** why this should be a standalone issue, or the umbrella issue/checklist item it belongs under. Prefer one issue per coherent fix/PR; repeated instances of the same scanner/root-cause class should become one umbrella with affected files/flows listed.
 - **Field-test relevance:** why the issue matters before beta, or why it is explicitly deferred.
 - **Area label:** one of the product areas used by the beta checklist, plus severity/tier labels when applicable.
 - **Acceptance criteria:** observable behavior, not only "update docs" or "investigate".

--- a/xcode-ai/skills/usability-hunter/SKILL.md
+++ b/xcode-ai/skills/usability-hunter/SKILL.md
@@ -279,9 +279,9 @@ done
 
 ### Priority Order
 1. **CRITICAL** — Fix immediately. Dismiss bugs causing stuck sheets, data loss from silent saves, dead-end navigation. Direct Swift edit, test, commit.
-2. **HIGH** — Fix if under 30 minutes. Missing feedback, validation gaps, guard-let-service-return. Otherwise file GitHub issue.
-3. **MODERATE** — File GitHub issue with `usability-hunter` + `bug` labels. Include file path, line number, pattern category.
-4. **LOW** — File GitHub issue with `usability-hunter` + `enhancement` labels.
+2. **HIGH** — Fix if under 30 minutes. Missing feedback, validation gaps, guard-let-service-return. Otherwise update an existing GitHub issue/umbrella or file one if no tracker exists after search.
+3. **MODERATE** — Update or file GitHub tracking with `usability-hunter` + `bug` labels. Include file path, line number, pattern category. Group repeated instances with the same root cause into one umbrella issue/checklist instead of one issue per file.
+4. **LOW** — Update or file GitHub tracking with `usability-hunter` + `enhancement` labels; prefer umbrella/checklist tracking for repeated scanner classes.
 
 ### Per-Fix Steps
 1. Read the file and understand root cause


### PR DESCRIPTION
## Summary
- Tightens CLAUDE.md so Paperclip tracks every finding without opening a brand-new issue for duplicate root-cause classes.
- Adds dedupe evidence and grouping-decision requirements to the Paperclip agentic execution loop.
- Updates Paperclip handoff and usability-hunter guidance to prefer umbrella/checklist tracking for repeated scanner classes.

Closes #1168

## GitHub cleanup already performed
- Created #1166 as the umbrella for 24 newline/whitespace validation duplicate-class findings and closed the individual duplicate issues with consolidation comments.
- Created #1167 as the umbrella for 5 repeated silent-failure findings and closed the individual duplicate issues with consolidation comments.

## Verification
- `git diff --check` — passed.
- Markdown/process-only change; no app build required.

## Paperclip traceability
- Owner request: reduce aggressive autonomous GitHub issue spraying while preserving successful bug discovery.
- GitHub issue fixed: #1168
