### PR TITLE
fix: harden database backup restore safety

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Cipher.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Cipher.swift
@@ -281,7 +281,7 @@ extension AppDatabase {
                 try fm.moveItem(atPath: tempPath, toPath: path)
             } catch {
                 if fm.fileExists(atPath: bakPath), !fm.fileExists(atPath: path) {
-                    try? fm.moveItem(atPath: bakPath, toPath: path)
+                    try fm.moveItem(atPath: bakPath, toPath: path)
                 }
                 throw error
             }

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Cipher.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Cipher.swift
@@ -256,9 +256,18 @@ extension AppDatabase {
         // --- Step 5: Atomic rename ---
         // Original → .unencrypted.bak (preserved; deleted after 7 days by cleanupStaleBackup).
         // Temp encrypted → canonical path.
+        try replacePlaintextDatabaseWithEncryptedTemp(atPath: path, tempPath: tempPath, backupPath: bakPath)
+    }
+
+    static func replacePlaintextDatabaseWithEncryptedTemp(
+        atPath path: String,
+        tempPath: String,
+        backupPath bakPath: String,
+        fileManager fm: FileManager = .default
+    ) throws {
         do {
             for suffix in ["-wal", "-shm"] { try? fm.removeItem(atPath: path + suffix) }
-            try? fm.removeItem(atPath: bakPath)      // Remove stale backup if present.
+            for suffix in ["", "-wal", "-shm"] { try? fm.removeItem(atPath: bakPath + suffix) }
             try fm.moveItem(atPath: path, toPath: bakPath)
             // Touch the backup so the 7-day retention window is measured from the time
             // of migration, not from the original DB file's last-modified timestamp.
@@ -268,9 +277,15 @@ extension AppDatabase {
             } catch {
                 Self.cipherLogger.warning("Failed to touch backup file (7-day window may be inaccurate): \(error.localizedDescription, privacy: .public)")
             }
-            try fm.moveItem(atPath: tempPath, toPath: path)
+            do {
+                try fm.moveItem(atPath: tempPath, toPath: path)
+            } catch {
+                if fm.fileExists(atPath: bakPath), !fm.fileExists(atPath: path) {
+                    try? fm.moveItem(atPath: bakPath, toPath: path)
+                }
+                throw error
+            }
         } catch {
-            // Rename failed — temp is orphaned; clean it up. Original is still at `path`.
             for p in [tempPath, tempPath + "-wal", tempPath + "-shm"] {
                 try? fm.removeItem(atPath: p)
             }

--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -122,9 +122,10 @@ public final class AppDatabase: Sendable {
         }
 
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd_HHmmss"
+        dateFormatter.dateFormat = "yyyy-MM-dd_HHmmss_SSS"
         let timestamp = dateFormatter.string(from: Date())
-        let backupPath = backupDir + "/pre-migration-\(timestamp).sqlite"
+        let uniqueId = UUID().uuidString.prefix(8)
+        let backupPath = backupDir + "/pre-migration-\(timestamp)-\(uniqueId).sqlite"
 
         do {
             // Only back up if the source file exists
@@ -165,18 +166,50 @@ public final class AppDatabase: Sendable {
     /// Restore database from a backup file.
     public static func restoreDatabase(from backupPath: String, to dbPath: String) throws {
         let fileManager = FileManager.default
-        // Remove current DB files
-        try? fileManager.removeItem(atPath: dbPath)
-        try? fileManager.removeItem(atPath: dbPath + "-wal")
-        try? fileManager.removeItem(atPath: dbPath + "-shm")
-        // Copy backup into place
-        try fileManager.copyItem(atPath: backupPath, toPath: dbPath)
-        // Restore WAL/SHM if they exist
+        let restoreId = UUID().uuidString
+        let stagedPath = dbPath + ".restore-\(restoreId).tmp"
+        let rollbackPath = dbPath + ".restore-\(restoreId).rollback"
+
+        func removeDatabaseFiles(at path: String) {
+            try? fileManager.removeItem(atPath: path)
+            try? fileManager.removeItem(atPath: path + "-wal")
+            try? fileManager.removeItem(atPath: path + "-shm")
+        }
+
+        func moveDatabaseFiles(from source: String, to destination: String) throws {
+            if fileManager.fileExists(atPath: source) {
+                try fileManager.moveItem(atPath: source, toPath: destination)
+            }
+            for suffix in ["-wal", "-shm"] where fileManager.fileExists(atPath: source + suffix) {
+                try fileManager.moveItem(atPath: source + suffix, toPath: destination + suffix)
+            }
+        }
+
+        removeDatabaseFiles(at: stagedPath)
+        removeDatabaseFiles(at: rollbackPath)
+        defer {
+            removeDatabaseFiles(at: stagedPath)
+            removeDatabaseFiles(at: rollbackPath)
+        }
+
+        // Stage the backup bundle before touching the live database. This preserves
+        // the current DB when the backup path is stale, missing, or unreadable.
+        try fileManager.copyItem(atPath: backupPath, toPath: stagedPath)
         for suffix in ["-wal", "-shm"] {
             let src = backupPath + suffix
             if fileManager.fileExists(atPath: src) {
-                try? fileManager.copyItem(atPath: src, toPath: dbPath + suffix)
+                try fileManager.copyItem(atPath: src, toPath: stagedPath + suffix)
             }
+        }
+
+        do {
+            try moveDatabaseFiles(from: dbPath, to: rollbackPath)
+            try moveDatabaseFiles(from: stagedPath, to: dbPath)
+        } catch {
+            if !fileManager.fileExists(atPath: dbPath), fileManager.fileExists(atPath: rollbackPath) {
+                try? moveDatabaseFiles(from: rollbackPath, to: dbPath)
+            }
+            throw error
         }
     }
 }

--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -165,6 +165,14 @@ public final class AppDatabase: Sendable {
 
     /// Restore database from a backup file.
     public static func restoreDatabase(from backupPath: String, to dbPath: String) throws {
+        try restoreDatabase(from: backupPath, to: dbPath, willPromoteStagedBackup: nil)
+    }
+
+    static func restoreDatabase(
+        from backupPath: String,
+        to dbPath: String,
+        willPromoteStagedBackup: (() throws -> Void)?
+    ) throws {
         let fileManager = FileManager.default
         let restoreId = UUID().uuidString
         let stagedPath = dbPath + ".restore-\(restoreId).tmp"
@@ -204,9 +212,13 @@ public final class AppDatabase: Sendable {
 
         do {
             try moveDatabaseFiles(from: dbPath, to: rollbackPath)
+            try willPromoteStagedBackup?()
             try moveDatabaseFiles(from: stagedPath, to: dbPath)
         } catch {
-            if !fileManager.fileExists(atPath: dbPath), fileManager.fileExists(atPath: rollbackPath) {
+            if fileManager.fileExists(atPath: rollbackPath)
+                || fileManager.fileExists(atPath: rollbackPath + "-wal")
+                || fileManager.fileExists(atPath: rollbackPath + "-shm") {
+                removeDatabaseFiles(at: dbPath)
                 try? moveDatabaseFiles(from: rollbackPath, to: dbPath)
             }
             throw error

--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -122,6 +122,9 @@ public final class AppDatabase: Sendable {
         }
 
         let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         dateFormatter.dateFormat = "yyyy-MM-dd_HHmmss_SSS"
         let timestamp = dateFormatter.string(from: Date())
         let uniqueId = UUID().uuidString.prefix(8)
@@ -177,6 +180,7 @@ public final class AppDatabase: Sendable {
         let restoreId = UUID().uuidString
         let stagedPath = dbPath + ".restore-\(restoreId).tmp"
         let rollbackPath = dbPath + ".restore-\(restoreId).rollback"
+        var shouldCleanRollback = true
 
         func removeDatabaseFiles(at path: String) {
             try? fileManager.removeItem(atPath: path)
@@ -197,7 +201,9 @@ public final class AppDatabase: Sendable {
         removeDatabaseFiles(at: rollbackPath)
         defer {
             removeDatabaseFiles(at: stagedPath)
-            removeDatabaseFiles(at: rollbackPath)
+            if shouldCleanRollback {
+                removeDatabaseFiles(at: rollbackPath)
+            }
         }
 
         // Stage the backup bundle before touching the live database. This preserves
@@ -219,7 +225,12 @@ public final class AppDatabase: Sendable {
                 || fileManager.fileExists(atPath: rollbackPath + "-wal")
                 || fileManager.fileExists(atPath: rollbackPath + "-shm") {
                 removeDatabaseFiles(at: dbPath)
-                try? moveDatabaseFiles(from: rollbackPath, to: dbPath)
+                do {
+                    try moveDatabaseFiles(from: rollbackPath, to: dbPath)
+                } catch {
+                    shouldCleanRollback = false
+                    throw error
+                }
             }
             throw error
         }

--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -197,6 +197,15 @@ public final class AppDatabase: Sendable {
             }
         }
 
+        func removeDestinationFilesForRollbackBundle() {
+            if fileManager.fileExists(atPath: rollbackPath) {
+                try? fileManager.removeItem(atPath: dbPath)
+            }
+            for suffix in ["-wal", "-shm"] where fileManager.fileExists(atPath: rollbackPath + suffix) {
+                try? fileManager.removeItem(atPath: dbPath + suffix)
+            }
+        }
+
         removeDatabaseFiles(at: stagedPath)
         removeDatabaseFiles(at: rollbackPath)
         defer {
@@ -224,7 +233,7 @@ public final class AppDatabase: Sendable {
             if fileManager.fileExists(atPath: rollbackPath)
                 || fileManager.fileExists(atPath: rollbackPath + "-wal")
                 || fileManager.fileExists(atPath: rollbackPath + "-shm") {
-                removeDatabaseFiles(at: dbPath)
+                removeDestinationFilesForRollbackBundle()
                 do {
                     try moveDatabaseFiles(from: rollbackPath, to: dbPath)
                 } catch {

--- a/core/Tests/WiredPartCoreTests/AppDatabaseCipherTests.swift
+++ b/core/Tests/WiredPartCoreTests/AppDatabaseCipherTests.swift
@@ -328,4 +328,39 @@ struct AppDatabaseCipherTests {
         #expect(checkCount == origCount, "Row count must be unchanged after failed migration")
         #expect(sentinel == "original_value", "Sentinel row must be intact in original DB")
     }
+
+    @Test("testRenamePromotionFailureRestoresOriginalDB — failed encrypted temp promotion rolls plaintext DB back")
+    func testRenamePromotionFailureRestoresOriginalDB() throws {
+        let path = tmpPath("promotion-rollback")
+        let missingTempPath = path + ".encrypted-tmp"
+        defer { cleanup(path) }
+
+        let plainDB = try AppDatabase.openDatabase(atPath: path)
+        try plainDB.writer.write { db in
+            try db.execute(sql: """
+                INSERT OR REPLACE INTO settings (key, value, category)
+                VALUES ('promotion_rollback_sentinel', 'original_value', 'test')
+            """)
+        }
+        try (plainDB.writer as? DatabasePool)?.close()
+
+        do {
+            try AppDatabase.replacePlaintextDatabaseWithEncryptedTemp(
+                atPath: path,
+                tempPath: missingTempPath,
+                backupPath: path + ".unencrypted.bak"
+            )
+            Issue.record("Promotion should throw when the encrypted temp database is missing")
+        } catch {
+            #expect(FileManager.default.fileExists(atPath: path), "Original plaintext DB must be restored to the canonical path")
+            #expect(!FileManager.default.fileExists(atPath: path + ".unencrypted.bak"), "Rollback should not leave the only good copy stranded at the backup path")
+
+            let checkPool = try DatabasePool(path: path)
+            let sentinel: String? = try checkPool.read { db in
+                try String.fetchOne(db, sql: "SELECT value FROM settings WHERE key = 'promotion_rollback_sentinel'")
+            }
+            try checkPool.close()
+            #expect(sentinel == "original_value", "Sentinel row must survive failed promotion rollback")
+        }
+    }
 }

--- a/core/Tests/WiredPartCoreTests/BackupRestoreDataSafetyTests.swift
+++ b/core/Tests/WiredPartCoreTests/BackupRestoreDataSafetyTests.swift
@@ -5,6 +5,51 @@ import GRDB
 
 @Suite("Backup Restore Data Safety Tests", .serialized)
 struct BackupRestoreDataSafetyTests {
+    @Test("Restore from a missing backup leaves the current database file untouched")
+    func testRestoreMissingBackupLeavesCurrentDatabaseUntouched() throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("wei-1103-restore-missing-backup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let targetPath = directory.appendingPathComponent("live.sqlite").path
+        let missingBackupPath = directory.appendingPathComponent("missing-backup.sqlite").path
+        let liveBytes = Data("live database bytes".utf8)
+        try liveBytes.write(to: URL(fileURLWithPath: targetPath))
+
+        do {
+            try AppDatabase.restoreDatabase(from: missingBackupPath, to: targetPath)
+            Issue.record("Restore should throw when the backup file is missing")
+        } catch {
+            let preservedBytes = try Data(contentsOf: URL(fileURLWithPath: targetPath))
+            #expect(preservedBytes == liveBytes)
+        }
+    }
+
+    @Test("Repeated rapid backups all create usable snapshots")
+    func testRapidRepeatedBackupsDoNotCollide() throws {
+        let fixture = try Self.makeCriticalFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let sourceSnapshot = try Self.snapshot(at: fixture.databasePath)
+        var backupPaths: [String] = []
+        for index in 0..<20 {
+            let backupPath = try #require(AppDatabase.backupDatabase(atPath: fixture.databasePath))
+            backupPaths.append(backupPath)
+            #expect(FileManager.default.fileExists(atPath: backupPath))
+
+            let restoredPath = fixture.directory.appendingPathComponent("rapid-restore-\(index).sqlite").path
+            try AppDatabase.restoreDatabase(from: backupPath, to: restoredPath)
+            let restoredSnapshot = try Self.snapshot(at: restoredPath)
+            #expect(restoredSnapshot == sourceSnapshot)
+        }
+
+        #expect(Set(backupPaths).count == backupPaths.count)
+        for backupPath in backupPaths.suffix(5) {
+            #expect(FileManager.default.fileExists(atPath: backupPath))
+        }
+    }
+
     @Test("Production backup and restore preserves critical beta records")
     func testProductionBackupRestorePreservesCriticalBetaRecords() throws {
         let fixture = try Self.makeCriticalFixture()

--- a/core/Tests/WiredPartCoreTests/BackupRestoreDataSafetyTests.swift
+++ b/core/Tests/WiredPartCoreTests/BackupRestoreDataSafetyTests.swift
@@ -81,9 +81,10 @@ struct BackupRestoreDataSafetyTests {
         }
 
         #expect(Set(backupPaths).count == backupPaths.count)
-        for backupPath in backupPaths.suffix(5) {
-            #expect(FileManager.default.fileExists(atPath: backupPath))
-        }
+        let backupDir = fixture.directory.appendingPathComponent("Backups").path
+        let retainedBackups = try FileManager.default.contentsOfDirectory(atPath: backupDir)
+            .filter { $0.hasPrefix("pre-migration-") && $0.hasSuffix(".sqlite") }
+        #expect(retainedBackups.count == 5)
     }
 
     @Test("Production backup and restore preserves critical beta records")

--- a/core/Tests/WiredPartCoreTests/BackupRestoreDataSafetyTests.swift
+++ b/core/Tests/WiredPartCoreTests/BackupRestoreDataSafetyTests.swift
@@ -26,6 +26,42 @@ struct BackupRestoreDataSafetyTests {
         }
     }
 
+    @Test("Restore rolls back the whole live bundle when staged sidecar promotion fails")
+    func testRestoreRollbackAfterPartialStagedPromotionFailure() throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("wei-1103-restore-partial-promotion-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let targetPath = directory.appendingPathComponent("live.sqlite").path
+        let backupPath = directory.appendingPathComponent("backup.sqlite").path
+        let liveBytes = Data("live database bytes".utf8)
+        let liveWalBytes = Data("live wal bytes".utf8)
+        let liveShmBytes = Data("live shm bytes".utf8)
+        let backupBytes = Data("backup database bytes".utf8)
+        let backupWalBytes = Data("backup wal bytes".utf8)
+
+        try liveBytes.write(to: URL(fileURLWithPath: targetPath))
+        try liveWalBytes.write(to: URL(fileURLWithPath: targetPath + "-wal"))
+        try liveShmBytes.write(to: URL(fileURLWithPath: targetPath + "-shm"))
+        try backupBytes.write(to: URL(fileURLWithPath: backupPath))
+        try backupWalBytes.write(to: URL(fileURLWithPath: backupPath + "-wal"))
+
+        do {
+            try AppDatabase.restoreDatabase(from: backupPath, to: targetPath) {
+                // The live bundle has already been moved to rollback storage. Place
+                // an incompatible item at the WAL destination so the staged base DB
+                // can be promoted first, then sidecar promotion throws.
+                try FileManager.default.createDirectory(atPath: targetPath + "-wal", withIntermediateDirectories: false)
+            }
+            Issue.record("Restore should throw when staged sidecar promotion fails")
+        } catch {
+            #expect(try Data(contentsOf: URL(fileURLWithPath: targetPath)) == liveBytes)
+            #expect(try Data(contentsOf: URL(fileURLWithPath: targetPath + "-wal")) == liveWalBytes)
+            #expect(try Data(contentsOf: URL(fileURLWithPath: targetPath + "-shm")) == liveShmBytes)
+        }
+    }
+
     @Test("Repeated rapid backups all create usable snapshots")
     func testRapidRepeatedBackupsDoNotCollide() throws {
         let fixture = try Self.makeCriticalFixture()


### PR DESCRIPTION
## Summary
- Fix pre-migration backup filename collisions by adding millisecond precision plus a short UUID suffix.
- Make restore stage backups before touching the live database, then roll back the original files if promotion fails.
- Make SQLCipher plaintext-to-encrypted promotion restore the original database when the second rename fails.
- Add regression coverage for rapid backup creation, missing-backup restore safety, and encrypted promotion rollback.

Closes #1096
Closes #1103
Closes #1104
Closes #1107

## Tests
- `cd core && swift test --filter BackupRestoreDataSafetyTests`
- `cd core && swift test --filter AppDatabaseCipherTests`

## CI / runner note
Apple-platform PR validation should run on the repo local self-hosted Mac runner path (`runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]`) per the WPR2 runner policy.
