### PR TITLE
fix: block inactive user clock-ins

### DIFF
--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -1370,6 +1370,8 @@ public final class JobsService: Sendable {
     ) throws -> Int64 {
         let clockInTimestamp = Self.sqliteTimestamp(clockInAt)
         return try db.writer.write { dbConn in
+            try Self.requireActiveUser(dbConn, userId: userId)
+
             let existing = try Int.fetchOne(
                 dbConn,
                 sql: """
@@ -3386,6 +3388,8 @@ public final class JobsService: Sendable {
         gpsLat: Double?,
         gpsLng: Double?
     ) throws -> Int64 {
+        try requireActiveUser(dbConn, userId: userId)
+
         guard let jobRow = try Row.fetchOne(
             dbConn,
             sql: "SELECT status FROM jobs WHERE id = ? AND deleted_at IS NULL",

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -417,6 +417,57 @@ struct JobsServiceTests {
         #expect(stableId.flatMap(UUID.init(uuidString:)) != nil)
     }
 
+    @Test("Inactive users cannot clock into jobs")
+    func testInactiveUsersCannotClockIntoJobs() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-INACTIVE", name: "Inactive User Job")
+        let inactiveUserId = try env.auth.createUser(displayName: "Inactive Clock User", pin: "7788")
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE users SET is_active = 0 WHERE id = ?", arguments: [inactiveUserId])
+        }
+
+        #expect(throws: JobsService.JobsError.userNotActive(inactiveUserId)) {
+            _ = try env.jobs.clockIn(userId: inactiveUserId, jobId: jobId)
+        }
+
+        let openEntryCount = try env.db.writer.read { db in
+            try Int.fetchOne(
+                db,
+                sql: """
+                    SELECT COUNT(*) FROM labor_entries
+                    WHERE user_id = ? AND status = 'clocked_in' AND deleted_at IS NULL
+                    """,
+                arguments: [inactiveUserId]
+            ) ?? 0
+        }
+        #expect(openEntryCount == 0)
+    }
+
+    @Test("Inactive users cannot clock into shop warehouse")
+    func testInactiveUsersCannotClockIntoShopWarehouse() throws {
+        let env = try E2ETestHelpers.setUp()
+        let inactiveUserId = try env.auth.createUser(displayName: "Inactive Shop User", pin: "7789")
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE users SET is_active = 0 WHERE id = ?", arguments: [inactiveUserId])
+        }
+
+        #expect(throws: JobsService.JobsError.userNotActive(inactiveUserId)) {
+            _ = try env.jobs.clockInToWarehouse(userId: inactiveUserId)
+        }
+
+        let openEntryCount = try env.db.writer.read { db in
+            try Int.fetchOne(
+                db,
+                sql: """
+                    SELECT COUNT(*) FROM labor_entries
+                    WHERE user_id = ? AND status = 'clocked_in' AND deleted_at IS NULL
+                    """,
+                arguments: [inactiveUserId]
+            ) ?? 0
+        }
+        #expect(openEntryCount == 0)
+    }
+
     @Test("Labor summary after clock in/out")
     func testLaborSummary() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Add active-user validation before job clock-in insertion.
- Add active-user validation before Shop / Warehouse clock-in insertion.
- Add regression coverage proving inactive users cannot create active labor entries through either path.

Closes #1111
Paperclip: WEI-4090

## Verification
- `cd core && git diff --check`
- `cd core && swift test --filter JobsServiceTests` — 143 tests passed
- `cd core && swift test` — 2155 tests / 65 suites passed

## CI / runner note
Apple-platform PR validation should use the WPR2 local self-hosted Mac runner path (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`) per repo policy.

## Copilot review gate
GitHub Copilot PR review/comment requested per repo policy; if reviewer assignment is unavailable, a fallback `@github-copilot please review` comment will be posted.