### PR TITLE
Fix grouped PO send toggle-off confirmation

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
@@ -568,6 +568,7 @@ struct POSendToSupplierSheet: View {
                 }
             } catch {
                 await MainActor.run {
+                    guard groupEnabled else { return }
                     let message = "Could not check for other POs for this supplier. Grouped sending is blocked until the sibling lookup succeeds. Error: \(error.localizedDescription)"
                     siblingPOs = []
                     includedSiblingIds = []

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
@@ -267,11 +267,9 @@ struct POSendToSupplierSheet: View {
                 }
             }
             .onChange(of: groupEnabled) { _, on in
+                clearSiblingPOState()
                 if on {
-                    clearSiblingPOState()
                     fetchSiblingPOs()
-                } else {
-                    clearSiblingPOState()
                 }
             }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
@@ -100,7 +100,13 @@ struct POSendToSupplierSheet: View {
 
     private var includedPOs: [Int64] {
         // primary always included
-        [po.id] + Array(includedSiblingIds)
+        guard groupEnabled else { return [po.id] }
+        return [po.id] + Array(includedSiblingIds)
+    }
+
+    private var includedSiblingPOs: [OrdersService.POListItem] {
+        guard groupEnabled else { return [] }
+        return siblingPOs.filter { includedSiblingIds.contains($0.id) }
     }
 
     private var emailSubject: String {
@@ -126,9 +132,7 @@ struct POSendToSupplierSheet: View {
         lines.append("")
 
         // Summary list of included POs
-        let allPoNums = ([po.poNumber] + siblingPOs
-            .filter { includedSiblingIds.contains($0.id) }
-            .map { $0.poNumber })
+        let allPoNums = [po.poNumber] + includedSiblingPOs.map { $0.poNumber }
         if allPoNums.count > 1 {
             lines.append("Included orders:")
             allPoNums.forEach { lines.append("  • \($0)") }
@@ -263,7 +267,14 @@ struct POSendToSupplierSheet: View {
                 }
             }
             .onChange(of: groupEnabled) { _, on in
-                if on { fetchSiblingPOs() }
+                if on {
+                    fetchSiblingPOs()
+                } else {
+                    includedSiblingIds = []
+                    siblingPDFs = [:]
+                    siblingPOsError = nil
+                    siblingPOsLoading = false
+                }
             }
 
             if groupEnabled && siblingPOsLoading {
@@ -511,7 +522,7 @@ struct POSendToSupplierSheet: View {
         var result: [(data: Data, mimeType: String, fileName: String)] = [
             (primaryPDF, "application/pdf", pdfFileName(for: po.poNumber))
         ]
-        for sibling in siblingPOs where includedSiblingIds.contains(sibling.id) {
+        for sibling in includedSiblingPOs {
             if let pdf = siblingPDFs[sibling.id] {
                 result.append((pdf, "application/pdf", pdfFileName(for: sibling.poNumber)))
             }
@@ -588,7 +599,7 @@ struct POSendToSupplierSheet: View {
                 }
 
                 var failedSiblings: [String] = []
-                for sibling in siblingPOs where includedSiblingIds.contains(sibling.id) {
+                for sibling in includedSiblingPOs {
                     do {
                         let detail = try ordersService.getPODetail(id: sibling.id)
                         let gen = POPDFGenerator(po: detail, supplierEmail: primaryEmail, companyName: "WiredPart")
@@ -619,8 +630,8 @@ struct POSendToSupplierSheet: View {
                     // Share sheet fallback — share all PDFs
                     var urls: [URL] = []
                     let tmp = FileManager.default.temporaryDirectory
-                    let allPDFs = [(primaryPDF, po.poNumber)] + sibPDFs.compactMap { (id, data) in
-                        siblingPOs.first(where: { $0.id == id }).map { (data, $0.poNumber) }
+                    let allPDFs = [(primaryPDF, po.poNumber)] + includedSiblingPOs.compactMap { sibling in
+                        sibPDFs[sibling.id].map { ($0, sibling.poNumber) }
                     }
                     do {
                         for (data, num) in allPDFs {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
@@ -268,12 +268,10 @@ struct POSendToSupplierSheet: View {
             }
             .onChange(of: groupEnabled) { _, on in
                 if on {
+                    clearSiblingPOState()
                     fetchSiblingPOs()
                 } else {
-                    includedSiblingIds = []
-                    siblingPDFs = [:]
-                    siblingPOsError = nil
-                    siblingPOsLoading = false
+                    clearSiblingPOState()
                 }
             }
 
@@ -539,6 +537,14 @@ struct POSendToSupplierSheet: View {
         }
     }
 
+    private func clearSiblingPOState() {
+        siblingPOs = []
+        includedSiblingIds = []
+        siblingPDFs = [:]
+        siblingPOsError = nil
+        siblingPOsLoading = false
+    }
+
     private func fetchSiblingPOs() {
         let supplierId = po.supplierId
         guard let svc = appCore.ordersService else {
@@ -553,6 +559,7 @@ struct POSendToSupplierSheet: View {
             do {
                 let results = try svc.listSendablePOs(supplierId: supplierId, excludingId: po.id)
                 await MainActor.run {
+                    guard groupEnabled else { return }
                     siblingPOs = results
                     // Default: select all siblings
                     includedSiblingIds = Set(results.map(\.id))

--- a/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
@@ -135,6 +135,15 @@ final class OrdersSessionUnavailableRegressionTests: XCTestCase {
             "Turning grouped sending off should clear stale sibling selections and generated sibling PDFs."
         )
         XCTAssertTrue(
+            sendSheetSource.contains("if on {\n                    clearSiblingPOState()\n                    fetchSiblingPOs()") &&
+            sendSheetSource.contains("siblingPOs = []"),
+            "Turning grouped sending back on should clear stale sibling rows before the fresh sibling fetch completes."
+        )
+        XCTAssertTrue(
+            sendSheetSource.contains("guard groupEnabled else { return }"),
+            "A stale sibling fetch completing after grouped sending is disabled must not repopulate sibling selections."
+        )
+        XCTAssertTrue(
             sendSheetSource.contains("private var includedSiblingPOs: [OrdersService.POListItem]") &&
             sendSheetSource.contains("guard groupEnabled else { return [] }"),
             "Email body, attachment, and share-sheet paths should use group-aware sibling inclusion instead of raw stale selected ids."

--- a/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
@@ -130,13 +130,25 @@ final class OrdersSessionUnavailableRegressionTests: XCTestCase {
             sendSheetSource.contains("guard groupEnabled else { return [po.id] }"),
             "When grouped sending is off, confirmSent must only mark the primary PO sent even if stale sibling selections exist."
         )
+        guard let clearStateStart = sendSheetSource.range(of: "private func clearSiblingPOState() {") else {
+            XCTFail("Grouped send state reset helper should exist.")
+            return
+        }
+        guard let clearStateEnd = sendSheetSource[clearStateStart.upperBound...].range(of: "    }") else {
+            XCTFail("Grouped send state reset helper should have a closing brace.")
+            return
+        }
+        let clearStateHelper = String(sendSheetSource[clearStateStart.lowerBound..<clearStateEnd.upperBound])
         XCTAssertTrue(
-            sendSheetSource.contains("includedSiblingIds = []") && sendSheetSource.contains("siblingPDFs = [:]"),
-            "Turning grouped sending off should clear stale sibling selections and generated sibling PDFs."
+            clearStateHelper.contains("siblingPOs = []") &&
+            clearStateHelper.contains("includedSiblingIds = []") &&
+            clearStateHelper.contains("siblingPDFs = [:]") &&
+            clearStateHelper.contains("siblingPOsError = nil") &&
+            clearStateHelper.contains("siblingPOsLoading = false"),
+            "Turning grouped sending off should clear stale sibling rows, selections, generated PDFs, errors, and loading state."
         )
         XCTAssertTrue(
-            sendSheetSource.contains("if on {\n                    clearSiblingPOState()\n                    fetchSiblingPOs()") &&
-            sendSheetSource.contains("siblingPOs = []"),
+            sendSheetSource.contains("clearSiblingPOState()\n                if on {\n                    fetchSiblingPOs()"),
             "Turning grouped sending back on should clear stale sibling rows before the fresh sibling fetch completes."
         )
         XCTAssertTrue(

--- a/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
@@ -140,8 +140,8 @@ final class OrdersSessionUnavailableRegressionTests: XCTestCase {
             "Turning grouped sending back on should clear stale sibling rows before the fresh sibling fetch completes."
         )
         XCTAssertTrue(
-            sendSheetSource.contains("guard groupEnabled else { return }"),
-            "A stale sibling fetch completing after grouped sending is disabled must not repopulate sibling selections."
+            sendSheetSource.components(separatedBy: "guard groupEnabled else { return }").count >= 3,
+            "A stale sibling fetch completing after grouped sending is disabled must not repopulate sibling selections or surface stale errors."
         )
         XCTAssertTrue(
             sendSheetSource.contains("private var includedSiblingPOs: [OrdersService.POListItem]") &&

--- a/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
@@ -123,6 +123,32 @@ final class OrdersSessionUnavailableRegressionTests: XCTestCase {
         )
     }
 
+    func testGroupedPOSendToggleOffCannotConfirmSiblingPOs() throws {
+        let sendSheetSource = try Self.readOrdersSource(named: "POSendToSupplierSheet.swift")
+
+        XCTAssertTrue(
+            sendSheetSource.contains("guard groupEnabled else { return [po.id] }"),
+            "When grouped sending is off, confirmSent must only mark the primary PO sent even if stale sibling selections exist."
+        )
+        XCTAssertTrue(
+            sendSheetSource.contains("includedSiblingIds = []") && sendSheetSource.contains("siblingPDFs = [:]"),
+            "Turning grouped sending off should clear stale sibling selections and generated sibling PDFs."
+        )
+        XCTAssertTrue(
+            sendSheetSource.contains("private var includedSiblingPOs: [OrdersService.POListItem]") &&
+            sendSheetSource.contains("guard groupEnabled else { return [] }"),
+            "Email body, attachment, and share-sheet paths should use group-aware sibling inclusion instead of raw stale selected ids."
+        )
+        XCTAssertFalse(
+            sendSheetSource.contains("primary always included\n        [po.id] + Array(includedSiblingIds)"),
+            "includedPOs must not blindly append stale sibling ids after grouped sending has been disabled."
+        )
+        XCTAssertFalse(
+            sendSheetSource.contains("siblingPOs where includedSiblingIds.contains"),
+            "Attachment/PDF generation should use the group-aware includedSiblingPOs helper."
+        )
+    }
+
     private static func readOrdersSource(named filename: String, file: StaticString = #filePath) throws -> String {
         let testFileURL = URL(fileURLWithPath: "\(file)")
         let projectRoot = testFileURL


### PR DESCRIPTION
## Summary
- Makes `POSendToSupplierSheet.includedPOs` ignore stale sibling selections whenever grouped sending is off.
- Clears sibling selections/PDFs/load state when the grouped-send toggle is disabled.
- Routes email body, attachment, PDF generation, and share-sheet sibling lists through a group-aware helper.
- Adds a regression test covering grouped-on, stale-sibling, grouped-off confirmation protection.

Closes #1109

## Tests
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests"`
  - Result: `** TEST SUCCEEDED **` (6 focused tests passed)

## Local runner path
- Verified locally on the Mac/iOS simulator path used by the repo's self-hosted Apple-platform workflow.
