### PR TITLE
fix: ignore completed supply-run toggles

### DIFF
--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -3614,7 +3614,13 @@ public final class JobsService: Sendable {
         try db.writer.write { conn in
             guard let row = try Row.fetchOne(
                 conn,
-                sql: "SELECT notes FROM labor_entries WHERE id = ? AND deleted_at IS NULL",
+                sql: """
+                    SELECT notes FROM labor_entries
+                    WHERE id = ?
+                      AND status = 'clocked_in'
+                      AND clock_out IS NULL
+                      AND deleted_at IS NULL
+                    """,
                 arguments: [laborEntryId]
             ) else { return "working" }
 
@@ -3632,7 +3638,14 @@ public final class JobsService: Sendable {
             }
 
             try conn.execute(
-                sql: "UPDATE labor_entries SET notes = ? WHERE id = ? AND deleted_at IS NULL",
+                sql: """
+                    UPDATE labor_entries
+                    SET notes = ?
+                    WHERE id = ?
+                      AND status = 'clocked_in'
+                      AND clock_out IS NULL
+                      AND deleted_at IS NULL
+                    """,
                 arguments: [note, laborEntryId]
             )
 

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -2356,6 +2356,26 @@ struct JobsServiceTests {
             "Soft-deleted labor entry notes must not gain supply_run markers")
     }
 
+    @Test("toggleSupplyRun is a no-op on a completed labor entry")
+    func testToggleSupplyRun_noOpOnCompletedEntry() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let entryId = try env.jobs.clockIn(userId: env.adminUserId, jobId: jobId)
+        try env.jobs.clockOut(laborEntryId: entryId)
+
+        // Stale supply-run toggle on a completed entry should not mutate audited time data.
+        let result = try env.jobs.toggleSupplyRun(laborEntryId: entryId)
+        #expect(result == "working",
+            "toggleSupplyRun on completed entry must return 'working' (no-op early exit)")
+
+        let row = try env.db.writer.read { db in
+            try Row.fetchOne(db, sql: "SELECT notes FROM labor_entries WHERE id = ?", arguments: [entryId])
+        }
+        let notes: String? = row?["notes"]
+        #expect(notes == nil || (notes?.contains("supply_run_start") == false),
+            "Completed labor entry notes must not gain supply_run markers")
+    }
+
     @Test("activeSupplyRunStart returns the latest unmatched supply run start")
     func testActiveSupplyRunStart_returnsLatestUnmatchedStart() throws {
         let notes = """


### PR DESCRIPTION
## Summary
- restrict `JobsService.toggleSupplyRun(laborEntryId:)` to active clocked-in labor rows only
- leave completed or clocked-out labor entries unchanged and return the existing no-op `working` state
- add regression coverage for stale toggles against completed labor entries

Closes #1118
Paperclip: WEI-4109 (from WEI-4107)

## Verification
- `git diff --check`
- `cd core && swift test --filter JobsServiceTests` — 142 tests passed
- `cd core && swift test` — 2154 tests / 65 suites passed

## CI / runner note
This is Swift core-only. Local verification passed on the Mac development machine; GitHub checks should use the repo local self-hosted Mac path where required.