### PR TITLE
Fix Flex Pool missing-session user fallback

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSFlexPoolPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSFlexPoolPage.swift
@@ -30,8 +30,8 @@ struct IOSFlexPoolPage: View {
     @State private var claimedJobId: Int64?
     @State private var pendingApprovalIds: Set<Int64> = []
 
-    private var currentUserId: Int64 {
-        appCore.currentUser?.id ?? 0
+    private var currentUserId: Int64? {
+        appCore.currentUser?.id
     }
 
     var body: some View {
@@ -197,9 +197,13 @@ struct IOSFlexPoolPage: View {
             claimError = "Scheduling service not available"
             return
         }
+        guard let userId = currentUserId else {
+            claimError = "User session unavailable. Sign in again."
+            return
+        }
 
         do {
-            try service.claimFlexJob(jobId: job.id, userId: currentUserId)
+            try service.claimFlexJob(jobId: job.id, userId: userId)
 
             if job.isApprovalRequired {
                 // Show "Pending Approval" state instead of removing
@@ -222,11 +226,18 @@ struct IOSFlexPoolPage: View {
             loadError = "Scheduling service not available."
             return
         }
+        guard let userId = currentUserId else {
+            flexJobs = []
+            pendingApprovalIds = []
+            isLoading = false
+            loadError = "User session unavailable. Sign in again."
+            return
+        }
         isLoading = flexJobs.isEmpty
         loadError = nil
 
         do {
-            flexJobs = try service.fetchFlexPool(userId: currentUserId)
+            flexJobs = try service.fetchFlexPool(userId: userId)
         } catch {
             loadError = userFriendlyError(error, context: "load flex pool")
         }

--- a/Weird Parts IOS/Weird Parts IOSTests/FlexPoolPageSessionRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/FlexPoolPageSessionRegressionTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+
+final class FlexPoolPageSessionRegressionTests: XCTestCase {
+    func testFlexPoolDoesNotFallBackToSyntheticUserZero() throws {
+        let source = try Self.readFlexPoolPageSource()
+
+        XCTAssertFalse(
+            source.contains("appCore.currentUser?.id ?? 0"),
+            "Flex Pool must not substitute user id 0 for a missing session."
+        )
+        XCTAssertTrue(
+            source.contains("private var currentUserId: Int64?"),
+            "Flex Pool should model the current user id as optional so missing-session state is explicit."
+        )
+        XCTAssertTrue(
+            source.contains("guard let userId = currentUserId else"),
+            "Flex Pool fetch and claim flows should fail closed until a real current user id exists."
+        )
+        XCTAssertTrue(
+            source.contains("loadError = \"User session unavailable. Sign in again.\""),
+            "Flex Pool should show a visible session error instead of loading jobs for user 0."
+        )
+        XCTAssertTrue(
+            source.contains("claimError = \"User session unavailable. Sign in again.\""),
+            "Flex Pool claim attempts should surface a session error instead of calling claimFlexJob with user 0."
+        )
+        XCTAssertTrue(
+            source.contains("try service.fetchFlexPool(userId: userId)")
+                && source.contains("try service.claimFlexJob(jobId: job.id, userId: userId)"),
+            "Flex Pool service calls should use the unwrapped real user id."
+        )
+    }
+
+    private static func readFlexPoolPageSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Scheduling")
+            .appendingPathComponent("IOSFlexPoolPage.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes Flex Pool missing-session handling so the page no longer substitutes user id 0 when `appCore.currentUser` is unavailable.
- Fails closed with a visible session message before flex-pool fetches or claim attempts.
- Adds focused regression coverage to prevent reintroducing the `currentUser?.id ?? 0` fallback.

Fixes #732

## Verification
- `xcodebuild test -project "Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -only-testing:"Weird Parts IOSTests/FlexPoolPageSessionRegressionTests"`

## CI / local runner note
- Local Mac runner path remains the intended PR validation route for required WPR2 iOS checks: self-hosted macOS/ARM64/Xcode/iOS/local-mac runner.
