### PR TITLE
Fix fail-safe database restore and SQLCipher promotion

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Cipher.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Cipher.swift
@@ -113,7 +113,6 @@ extension AppDatabase {
         }
 
         let tempPath = path + ".encrypted-tmp"
-        let bakPath  = path + ".unencrypted.bak"
 
         // Remove any leftover temp file from a previous failed attempt.
         for p in [tempPath, tempPath + "-wal", tempPath + "-shm"] {
@@ -255,7 +254,23 @@ extension AppDatabase {
 
         // --- Step 5: Atomic rename ---
         // Original → .unencrypted.bak (preserved; deleted after 7 days by cleanupStaleBackup).
-        // Temp encrypted → canonical path.
+        // Temp encrypted → canonical path. If the temp promotion fails after the original
+        // was moved aside, rollback restores `.unencrypted.bak` to the canonical path.
+        try replacePlaintextDatabaseWithEncryptedTemp(atPath: path, tempPath: tempPath)
+    }
+
+    /// Promote an encrypted temp DB over a plaintext canonical DB with rollback.
+    ///
+    /// Internal for regression testing of the narrow failure window after `path` has
+    /// been moved to `.unencrypted.bak` but before `tempPath` reaches `path`.
+    static func replacePlaintextDatabaseWithEncryptedTemp(
+        atPath path: String,
+        tempPath: String,
+        beforePromotingTemp: (() throws -> Void)? = nil
+    ) throws {
+        let fm = FileManager.default
+        let bakPath = path + ".unencrypted.bak"
+
         do {
             for suffix in ["-wal", "-shm"] { try? fm.removeItem(atPath: path + suffix) }
             try? fm.removeItem(atPath: bakPath)      // Remove stale backup if present.
@@ -268,11 +283,16 @@ extension AppDatabase {
             } catch {
                 Self.cipherLogger.warning("Failed to touch backup file (7-day window may be inaccurate): \(error.localizedDescription, privacy: .public)")
             }
+            try beforePromotingTemp?()
             try fm.moveItem(atPath: tempPath, toPath: path)
         } catch {
-            // Rename failed — temp is orphaned; clean it up. Original is still at `path`.
-            for p in [tempPath, tempPath + "-wal", tempPath + "-shm"] {
+            // Rename failed after the original may have been moved aside. Remove any
+            // partial encrypted output and restore the plaintext backup before throwing.
+            for p in [path, path + "-wal", path + "-shm", tempPath, tempPath + "-wal", tempPath + "-shm"] {
                 try? fm.removeItem(atPath: p)
+            }
+            if fm.fileExists(atPath: bakPath) {
+                try? fm.moveItem(atPath: bakPath, toPath: path)
             }
             throw CipherMigrationError.renameFailed(error)
         }

--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -165,18 +165,73 @@ public final class AppDatabase: Sendable {
     /// Restore database from a backup file.
     public static func restoreDatabase(from backupPath: String, to dbPath: String) throws {
         let fileManager = FileManager.default
-        // Remove current DB files
-        try? fileManager.removeItem(atPath: dbPath)
-        try? fileManager.removeItem(atPath: dbPath + "-wal")
-        try? fileManager.removeItem(atPath: dbPath + "-shm")
-        // Copy backup into place
-        try fileManager.copyItem(atPath: backupPath, toPath: dbPath)
-        // Restore WAL/SHM if they exist
-        for suffix in ["-wal", "-shm"] {
-            let src = backupPath + suffix
-            if fileManager.fileExists(atPath: src) {
-                try? fileManager.copyItem(atPath: src, toPath: dbPath + suffix)
+
+        // Stage the backup into the destination directory before touching the live DB.
+        // A missing/unreadable backup must fail here while the current DB is still intact.
+        let stagingPath = dbPath + ".restore-staging-\(UUID().uuidString)"
+        let rollbackPath = dbPath + ".restore-rollback-\(UUID().uuidString)"
+        var stagedPaths = [stagingPath]
+        var rollbackPaths: [(current: String, rollback: String)] = []
+        var promotedStagedMain = false
+
+        do {
+            try fileManager.copyItem(atPath: backupPath, toPath: stagingPath)
+
+            // Stage WAL/SHM before modifying live sidecar files.
+            for suffix in ["-wal", "-shm"] {
+                let src = backupPath + suffix
+                if fileManager.fileExists(atPath: src) {
+                    let staged = stagingPath + suffix
+                    try fileManager.copyItem(atPath: src, toPath: staged)
+                    stagedPaths.append(staged)
+                }
             }
+
+            // Move current files aside so a later promotion failure can roll back.
+            for suffix in ["", "-wal", "-shm"] {
+                let current = dbPath + suffix
+                guard fileManager.fileExists(atPath: current) else { continue }
+                let rollback = rollbackPath + suffix
+                try fileManager.moveItem(atPath: current, toPath: rollback)
+                rollbackPaths.append((current: current, rollback: rollback))
+            }
+
+            // Promote the staged backup files into the canonical paths.
+            try fileManager.moveItem(atPath: stagingPath, toPath: dbPath)
+            promotedStagedMain = true
+            for suffix in ["-wal", "-shm"] {
+                let staged = stagingPath + suffix
+                if fileManager.fileExists(atPath: staged) {
+                    try fileManager.moveItem(atPath: staged, toPath: dbPath + suffix)
+                }
+            }
+
+            // Restore succeeded; remove rollback copies of the former live database.
+            for pair in rollbackPaths {
+                try? fileManager.removeItem(atPath: pair.rollback)
+            }
+        } catch {
+            // Clean up any partial restore output and put the original DB files back.
+            // If staging failed before moving current files aside, do not touch dbPath.
+            if !rollbackPaths.isEmpty || promotedStagedMain {
+                for suffix in ["", "-wal", "-shm"] {
+                    try? fileManager.removeItem(atPath: dbPath + suffix)
+                }
+            }
+            for pair in rollbackPaths.reversed() {
+                if fileManager.fileExists(atPath: pair.rollback) {
+                    try? fileManager.moveItem(atPath: pair.rollback, toPath: pair.current)
+                }
+            }
+            for path in stagedPaths {
+                try? fileManager.removeItem(atPath: path)
+            }
+            throw error
+        }
+
+        // Remove any staged sidecar that was not promoted due to an older backup shape.
+        for suffix in ["-wal", "-shm"] {
+            try? fileManager.removeItem(atPath: stagingPath + suffix)
         }
     }
 }

--- a/core/Tests/WiredPartCoreTests/AppDatabaseCipherTests.swift
+++ b/core/Tests/WiredPartCoreTests/AppDatabaseCipherTests.swift
@@ -328,4 +328,34 @@ struct AppDatabaseCipherTests {
         #expect(checkCount == origCount, "Row count must be unchanged after failed migration")
         #expect(sentinel == "original_value", "Sentinel row must be intact in original DB")
     }
+
+    @Test("testRenamePromotionFailureRestoresOriginalDB — failed temp promotion rolls back backup")
+    func testRenamePromotionFailureRestoresOriginalDB() throws {
+        let path = tmpPath("rename-promotion-rollback")
+        let tempPath = path + ".encrypted-tmp"
+        defer { cleanup(path) }
+
+        try "original plaintext sentinel".write(toFile: path, atomically: true, encoding: .utf8)
+        try "encrypted temp sentinel".write(toFile: tempPath, atomically: true, encoding: .utf8)
+
+        var didThrow = false
+        do {
+            try AppDatabase.replacePlaintextDatabaseWithEncryptedTemp(
+                atPath: path,
+                tempPath: tempPath,
+                beforePromotingTemp: {
+                    struct SimulatedPromotionFailure: Error {}
+                    throw SimulatedPromotionFailure()
+                }
+            )
+        } catch CipherMigrationError.renameFailed {
+            didThrow = true
+        }
+
+        #expect(didThrow, "Promotion helper must surface a rename failure")
+        #expect(FileManager.default.fileExists(atPath: path), "Canonical DB path must be restored after promotion failure")
+        #expect(!FileManager.default.fileExists(atPath: path + ".unencrypted.bak"), "Rollback should consume the temporary plaintext backup")
+        let restoredContents = try String(contentsOfFile: path, encoding: .utf8)
+        #expect(restoredContents == "original plaintext sentinel")
+    }
 }

--- a/core/Tests/WiredPartCoreTests/BackupRestoreDataSafetyTests.swift
+++ b/core/Tests/WiredPartCoreTests/BackupRestoreDataSafetyTests.swift
@@ -22,6 +22,27 @@ struct BackupRestoreDataSafetyTests {
         Self.assertCriticalSnapshot(restoredSnapshot)
     }
 
+    @Test("Missing backup restore leaves current database untouched")
+    func testRestoreMissingBackupLeavesCurrentDatabaseUntouched() throws {
+        let fixture = try Self.makeCriticalFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let beforeSnapshot = try Self.snapshot(at: fixture.databasePath)
+        let missingBackupPath = fixture.directory.appendingPathComponent("missing-backup.sqlite").path
+
+        var didThrow = false
+        do {
+            try AppDatabase.restoreDatabase(from: missingBackupPath, to: fixture.databasePath)
+        } catch {
+            didThrow = true
+        }
+
+        #expect(didThrow, "Restore must report an error when the backup file is missing")
+        #expect(FileManager.default.fileExists(atPath: fixture.databasePath), "Current DB must still exist after failed restore")
+        let afterSnapshot = try Self.snapshot(at: fixture.databasePath)
+        #expect(afterSnapshot == beforeSnapshot, "Current DB contents must be unchanged after failed restore")
+    }
+
     private struct Fixture {
         let directory: URL
         let databasePath: String


### PR DESCRIPTION
## Summary
- stages backup restore files before touching the live database and rolls back the current DB if restore promotion fails
- extracts SQLCipher plaintext-to-encrypted promotion into a rollback-safe helper that restores `.unencrypted.bak` if temp promotion fails
- adds regressions for missing backup restore and failed SQLCipher promotion rollback

Closes #1103
Closes #1104
Paperclip: WEI-4135

## Tests
- `git diff --check -- core/Sources/WiredPartCore/Database/AppDatabase.swift core/Sources/WiredPartCore/Database/AppDatabase+Cipher.swift core/Tests/WiredPartCoreTests/BackupRestoreDataSafetyTests.swift core/Tests/WiredPartCoreTests/AppDatabaseCipherTests.swift`
- `swift test --filter 'BackupRestoreDataSafetyTests|AppDatabaseCipherTests'` (14 tests / 2 suites passed)
- `swift test` (2156 tests / 65 suites passed)

## CI / local runner path
This repo uses the trusted local self-hosted Mac runner path for iOS/macOS/Xcode gates when CI runs are required: `[self-hosted, macOS, ARM64, xcode, ios, local-mac]`.
