### PR TITLE
fix: isolate AI assistant sessions by context

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
+++ b/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
@@ -359,6 +359,9 @@ struct IOSAIAssistantPanel: View {
 
         ))
         .modifier(ActivePageIdTracker(activePageId: $activePageId))
+        .onReceive(NotificationCenter.default.publisher(for: .appDidLogout)) { _ in
+            resetForLogout()
+        }
     }
 
     // MARK: - Availability Header
@@ -586,6 +589,23 @@ struct IOSAIAssistantPanel: View {
         Task { await aiService.clearConversation() }
         conversationId = UUID().uuidString
         messages = [welcomeMessage()]
+    }
+
+    /// Clear volatile assistant state when the app logs out, without deleting persisted history.
+    private func resetForLogout() {
+        clearConversationError = nil
+        clearConversationRetryId = nil
+        isClearingConversation = false
+        Task { await aiService.clearConversation() }
+        conversationId = UUID().uuidString
+        messages.removeAll()
+        activePageId = nil
+        catalogContext = nil
+        pricingContext = nil
+        suppliersContext = nil
+        companionsContext = nil
+        forecastContext = nil
+        settingsContext = nil
     }
 
     /// Delete all messages from the current conversation (UI + DB) but keep the same conversation ID.

--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -398,6 +398,7 @@ final class AppCore: ObservableObject {
         permissions = []
         onboardingManager = nil
         badgeCountManager.setUserId(nil)
+        NotificationCenter.default.post(name: .appDidLogout, object: self)
     }
 
     /// Run the first-device bootstrap, creating the admin user and default data.

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/NavigationConfig.swift
@@ -206,6 +206,9 @@ extension Notification.Name {
     /// `userInfo` should contain `"moduleId"` (String) and optionally `"tabId"` (String).
     static let navigateToModule = Notification.Name("WiredPart.navigateToModule")
 
+    /// Posted when AppCore logs out the current user so user-scoped UI state can be cleared.
+    static let appDidLogout = Notification.Name("WiredPart.appDidLogout")
+
     /// Posted when the Parts Catalog page appears, with current context for AI.
     static let catalogPageActive = Notification.Name("WiredPart.catalogPageActive")
 

--- a/core/Sources/WiredPartCore/AI/FoundationModelsService.swift
+++ b/core/Sources/WiredPartCore/AI/FoundationModelsService.swift
@@ -96,6 +96,32 @@ public enum AIConversationPersistenceError: LocalizedError, Sendable, Equatable 
     }
 }
 
+/// Identifies the security- and context-bearing inputs used to build a chat session.
+///
+/// Foundation Models sessions capture tool instances and instructions at creation time,
+/// so a cached session is safe to reuse only when every field here is unchanged.
+struct AIChatSessionIdentity: Equatable, Sendable {
+    let conversationId: String
+    let databaseIdentity: String
+    let userId: Int64
+    let permissionKeys: [String]
+    let navigationContext: String
+
+    init(
+        conversationId: String,
+        db: AppDatabase,
+        permissions: [String],
+        userId: Int64,
+        navigationContext: String
+    ) {
+        self.conversationId = conversationId
+        self.databaseIdentity = String(describing: ObjectIdentifier(db))
+        self.userId = userId
+        self.permissionKeys = Array(Set(permissions)).sorted()
+        self.navigationContext = navigationContext
+    }
+}
+
 /// Provides on-device AI text generation via Apple Foundation Models.
 ///
 /// This service wraps `LanguageModelSession` to provide:
@@ -133,6 +159,9 @@ public actor FoundationModelsService {
 
     /// Conversation ID that the current active session belongs to.
     private var activeChatConversationId: String?
+
+    /// Security/context identity that the current active session was built with.
+    private var activeChatSessionIdentity: AIChatSessionIdentity?
 
     /// In-memory message history for the current conversation.
     private var messageHistory: [AIConversationMessage] = []
@@ -415,8 +444,16 @@ public actor FoundationModelsService {
                     \(navigationContext)
                     """
 
-                let session = getOrCreateChatSession(
+                let sessionIdentity = AIChatSessionIdentity(
                     conversationId: conversationId,
+                    db: db,
+                    permissions: permissions,
+                    userId: userId,
+                    navigationContext: navigationContext
+                )
+
+                let session = getOrCreateChatSession(
+                    identity: sessionIdentity,
                     tools: tools,
                     instructions: chatInstructions
                 )
@@ -453,22 +490,23 @@ public actor FoundationModelsService {
 
     // MARK: - Session Management
 
-    /// Returns the existing `LanguageModelSession` if the conversation ID matches,
+    /// Returns the existing `LanguageModelSession` if the full session identity matches,
     /// otherwise creates a new session and caches it.
     #if canImport(FoundationModels)
     @available(macOS 26.0, iOS 26.0, *)
     private func getOrCreateChatSession(
-        conversationId: String,
+        identity: AIChatSessionIdentity,
         tools: [any FoundationModels.Tool],
         instructions: String
     ) -> LanguageModelSession {
-        if conversationId == activeChatConversationId,
+        if identity == activeChatSessionIdentity,
            let existing = activeChatSession as? LanguageModelSession {
             return existing
         }
         let session = LanguageModelSession(tools: tools, instructions: instructions)
         activeChatSession = session
-        activeChatConversationId = conversationId
+        activeChatConversationId = identity.conversationId
+        activeChatSessionIdentity = identity
         messageHistory.removeAll()
         return session
     }
@@ -481,6 +519,7 @@ public actor FoundationModelsService {
         activeChatSession = nil
         #endif
         activeChatConversationId = nil
+        activeChatSessionIdentity = nil
         messageHistory.removeAll()
     }
 

--- a/core/Tests/WiredPartCoreTests/FoundationModelsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/FoundationModelsServiceTests.swift
@@ -128,6 +128,64 @@ struct FoundationModelsServiceTests {
         #expect(history.isEmpty)
     }
 
+    @Test("chat session identity covers user permissions database and navigation context")
+    func testChatSessionIdentity_coversSecurityAndContextInputs() throws {
+        let env = try E2ETestHelpers.setUp()
+        let otherEnv = try E2ETestHelpers.setUp()
+        let baseline = AIChatSessionIdentity(
+            conversationId: "conversation-1",
+            db: env.db,
+            permissions: ["view_jobs", "admin", "view_jobs"],
+            userId: 42,
+            navigationContext: "Page A"
+        )
+
+        let reorderedPermissions = AIChatSessionIdentity(
+            conversationId: "conversation-1",
+            db: env.db,
+            permissions: ["admin", "view_jobs"],
+            userId: 42,
+            navigationContext: "Page A"
+        )
+        #expect(baseline == reorderedPermissions)
+
+        #expect(baseline != AIChatSessionIdentity(
+            conversationId: "conversation-2",
+            db: env.db,
+            permissions: ["view_jobs", "admin"],
+            userId: 42,
+            navigationContext: "Page A"
+        ))
+        #expect(baseline != AIChatSessionIdentity(
+            conversationId: "conversation-1",
+            db: otherEnv.db,
+            permissions: ["view_jobs", "admin"],
+            userId: 42,
+            navigationContext: "Page A"
+        ))
+        #expect(baseline != AIChatSessionIdentity(
+            conversationId: "conversation-1",
+            db: env.db,
+            permissions: ["view_jobs"],
+            userId: 42,
+            navigationContext: "Page A"
+        ))
+        #expect(baseline != AIChatSessionIdentity(
+            conversationId: "conversation-1",
+            db: env.db,
+            permissions: ["view_jobs", "admin"],
+            userId: 43,
+            navigationContext: "Page A"
+        ))
+        #expect(baseline != AIChatSessionIdentity(
+            conversationId: "conversation-1",
+            db: env.db,
+            permissions: ["view_jobs", "admin"],
+            userId: 42,
+            navigationContext: "Page B"
+        ))
+    }
+
     // MARK: - DB Persistence (static methods, fully testable)
 
     @Test("saveMessage then loadConversation round-trips message content")


### PR DESCRIPTION
## Summary
- Add an AI chat session identity covering conversation id, database instance, user id, sorted permission keys, and navigation context so cached Foundation Models sessions are reused only when their captured tools/instructions are still current.
- Clear the cached AI session identity alongside `clearConversation()`.
- Broadcast logout from `AppCore` and have the iOS assistant panel clear volatile assistant state when logout occurs.
- Add a regression test that proves identity changes for user, permissions, database, conversation, and navigation context changes while normalizing permission ordering/duplicates.

Closes #1194

## Verification
- `gh issue view 1194 --repo xXKillerNoobYT/Weird-Part-Run-2 --json number,title,state,body,labels,comments,url` confirmed #1194 is still OPEN before implementation.
- `gh pr list --repo xXKillerNoobYT/Weird-Part-Run-2 --state open --search "1194" --json number,title,headRefName,state,body,url` returned `[]`; no newer open PR already covered it.
- `swift test --filter FoundationModelsServiceTests` passed: 28 tests.
- `swift test` passed: 2154 tests.
- `git diff --check` passed.
- `python3 scripts/guard-tracked-artifacts.py` passed: No tracked Paperclip/Xcode runtime artifacts found.
- `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' build` passed: **BUILD SUCCEEDED**.
- Initial iOS smoke build attempt with `name=iPhone 16` failed because that simulator is not installed; available local test path was `WEI3988-iPhone` on the local Mac simulator.

## Paperclip
- WEI-4140
