### PR TITLE
fix: require warehouse service for job return routing

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSReceivingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSReceivingPage.swift
@@ -1082,7 +1082,12 @@ private struct IOSJobReturnSortingPage: View {
 
             let holdingItems = try warehouseService.getJobReturnHoldingItems(jobId: job.id, includeRouted: false)
                 .filter { $0.intakeId == intakeId }
-            try applyImmediateRoutes(holdingItems: holdingItems, userId: userId, jobId: job.id)
+            try applyImmediateRoutes(
+                holdingItems: holdingItems,
+                warehouseService: warehouseService,
+                userId: userId,
+                jobId: job.id
+            )
 
             await MainActor.run {
                 completionMessage = completionSummary()
@@ -1109,10 +1114,10 @@ private struct IOSJobReturnSortingPage: View {
 
     private func applyImmediateRoutes(
         holdingItems: [WarehouseService.JobReturnHoldingItem],
+        warehouseService: WarehouseService,
         userId: Int64,
         jobId: Int64
     ) throws {
-        guard let warehouseService = appCore.warehouseService else { return }
         // Holding items are fetched newest-first, but createJobReturnIntake inserts
         // items in draft-line order. Route oldest-first so duplicate same-part
         // lines stay paired with the line the user sorted.

--- a/Weird Parts IOS/Weird Parts IOSTests/JobReturnImmediateRoutesServiceRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/JobReturnImmediateRoutesServiceRegressionTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+
+/// Regression coverage for GH#1123: job-return immediate routes must not silently
+/// succeed if the warehouse service disappears between return intake and routing.
+final class JobReturnImmediateRoutesServiceRegressionTests: XCTestCase {
+    func testImmediateRoutesUseAlreadyUnwrappedWarehouseService() throws {
+        let source = try Self.readWarehouseSource(named: "IOSReceivingPage.swift")
+
+        let helperSection = try Self.extractFunctionSection(named: "applyImmediateRoutes", from: source)
+        XCTAssertTrue(
+            helperSection.contains("warehouseService: WarehouseService"),
+            "Immediate route helper should require the already-unwrapped WarehouseService from submitJobReturn."
+        )
+        XCTAssertFalse(
+            helperSection.contains("guard let warehouseService = appCore.warehouseService else { return }"),
+            "Immediate route helper must not silently return after the return intake has been created."
+        )
+
+        let submitBody = try Self.extractFunctionBody(named: "submitJobReturn", from: source)
+        XCTAssertTrue(
+            submitBody.contains("guard let warehouseService = appCore.warehouseService else"),
+            "Job Return submit should still fail visibly before creating an intake when the warehouse service is unavailable."
+        )
+        XCTAssertTrue(
+            submitBody.contains("warehouseService: warehouseService"),
+            "Job Return submit should pass the unwrapped service into immediate routing so success is only shown after routing attempts run."
+        )
+    }
+
+    private static func extractFunctionBody(named functionName: String, from source: String) throws -> String {
+        return try extractFunctionSection(named: functionName, from: source)
+    }
+
+    private static func extractFunctionSection(named functionName: String, from source: String) throws -> String {
+        guard let signatureRange = source.range(of: "private func \(functionName)") else {
+            XCTFail("Missing function \(functionName)")
+            return ""
+        }
+        let section = String(source[signatureRange.lowerBound...])
+        let body = try extractBlock(startingAt: "{", in: section)
+        guard let bodyRange = section.range(of: body) else { return section }
+        return String(section[..<bodyRange.upperBound])
+    }
+
+    private static func extractBlock(startingAt marker: String, in source: String) throws -> String {
+        guard let markerRange = source.range(of: marker),
+              let openBraceIndex = source[markerRange.lowerBound...].firstIndex(of: "{") else {
+            XCTFail("Missing block marker \(marker)")
+            return ""
+        }
+
+        var depth = 0
+        var cursor = openBraceIndex
+        while cursor < source.endIndex {
+            let char = source[cursor]
+            if char == "{" { depth += 1 }
+            if char == "}" {
+                depth -= 1
+                if depth == 0 {
+                    return String(source[openBraceIndex...cursor])
+                }
+            }
+            cursor = source.index(after: cursor)
+        }
+
+        XCTFail("Unterminated block for marker \(marker)")
+        return ""
+    }
+
+    private static func readWarehouseSource(named filename: String, file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Warehouse")
+            .appendingPathComponent(filename)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/JobReturnImmediateRoutesServiceRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/JobReturnImmediateRoutesServiceRegressionTests.swift
@@ -12,8 +12,8 @@ final class JobReturnImmediateRoutesServiceRegressionTests: XCTestCase {
             "Immediate route helper should require the already-unwrapped WarehouseService from submitJobReturn."
         )
         XCTAssertFalse(
-            helperSection.contains("guard let warehouseService = appCore.warehouseService else { return }"),
-            "Immediate route helper must not silently return after the return intake has been created."
+            helperSection.contains("appCore.warehouseService"),
+            "Immediate route helper must not re-read appCore.warehouseService or silently return after the return intake has been created."
         )
 
         let submitBody = try Self.extractFunctionBody(named: "submitJobReturn", from: source)
@@ -32,7 +32,7 @@ final class JobReturnImmediateRoutesServiceRegressionTests: XCTestCase {
     }
 
     private static func extractFunctionSection(named functionName: String, from source: String) throws -> String {
-        guard let signatureRange = source.range(of: "private func \(functionName)") else {
+        guard let signatureRange = source.range(of: "func \(functionName)") else {
             XCTFail("Missing function \(functionName)")
             return ""
         }


### PR DESCRIPTION
## Summary
- Fixes Job Return immediate routing so the route helper uses the already-unwrapped `WarehouseService` from `submitJobReturn` instead of re-reading `appCore.warehouseService` and silently returning.
- Keeps the existing visible pre-intake service-unavailable failure path, so success is only shown after immediate shelf/stage/write-off route attempts run.
- Adds an iOS regression source test that prevents `applyImmediateRoutes` from reintroducing a silent `guard ... else { return }` and verifies the helper requires an explicit `WarehouseService`.

Closes #1123

## Tests
- `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -only-testing:"Weird Parts IOSTests/JobReturnImmediateRoutesServiceRegressionTests/testImmediateRoutesUseAlreadyUnwrappedWarehouseService" test` — passed
- `swift test --filter WarehouseServiceExtTests/testJobReturn` from `core/` — passed, 4 tests
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed

## CI / local runner path
- This PR should use the repo self-hosted Mac runner path for trusted iOS/Xcode CI: `IA-Mac-WPR2` with labels `self-hosted, macOS, ARM64, xcode, ios, local-mac`.
