### PR TITLE
Fix flex pool malformed filter fail-open

### DIFF
--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GRDB
+import os.log
 
 /// Scheduling Service — schedule entries, dispatch board, time-off requests,
 /// dispatch templates, and scheduling stats.
@@ -10,6 +11,8 @@ import GRDB
 ///
 /// Ported from: Scheduling & Dispatch feature area (Phases 10, 16)
 public final class SchedulingService: Sendable {
+    private static let logger = Logger(subsystem: "com.wiredpart.core", category: "SchedulingService")
+
     private let db: AppDatabase
     private let auth: AuthService
 
@@ -2394,8 +2397,8 @@ public final class SchedulingService: Sendable {
     ///
     /// A job is visible to a user if:
     /// - `is_flex_pool = 1` and status is not completed/cancelled/on_hold
-    /// - `flex_pool_user_filter` is NULL **or** contains `userId`
-    /// - `flex_pool_team_filter` is NULL **or** the user belongs to one of the listed teams
+    /// - `flex_pool_user_filter` is NULL/blank **or** contains `userId`
+    /// - `flex_pool_team_filter` is NULL/blank **or** the user belongs to one of the listed teams
     ///
     /// Returns an empty array if the `jobs` table is missing (fresh install).
     public func fetchFlexPool(userId: Int64) throws -> [FlexPoolJob] {
@@ -2446,22 +2449,39 @@ public final class SchedulingService: Sendable {
                     let teamFilter: String? = row["flex_pool_team_filter"]
 
                     // User-level filter: if set, userId must appear in the JSON array.
-                    if let uf = userFilter,
-                       let data = uf.data(using: .utf8),
-                       let ids = try? JSONDecoder().decode([Int64].self, from: data),
-                       !ids.contains(userId) {
+                    // Malformed non-empty filters fail closed so corrupt restriction
+                    // data cannot broaden flex-pool visibility.
+                    switch Self.decodeFlexPoolIdFilter(userFilter) {
+                    case .unrestricted:
+                        break
+                    case .invalid:
+                        Self.logger.warning(
+                            "Malformed flex_pool_user_filter for flex-pool job \(id, privacy: .public); failing closed"
+                        )
                         return nil
+                    case .restricted(let ids) where !ids.contains(userId):
+                        return nil
+                    case .restricted:
+                        break
                     }
 
                     // Fix #167: Team-level filter. If the job restricts to specific teams,
                     // the user must belong to at least one of them.
-                    if let tf = teamFilter, !tf.isEmpty,
-                       let data = tf.data(using: .utf8),
-                       let allowedTeams = try? JSONDecoder().decode([Int64].self, from: data),
-                       !allowedTeams.isEmpty {
-                        if userTeamIds.isDisjoint(with: Set(allowedTeams)) {
-                            return nil
-                        }
+                    // Malformed non-empty filters fail closed for the same reason as
+                    // user filters. An empty decoded array preserves the historical
+                    // "no team restriction" behavior used by existing rows.
+                    switch Self.decodeFlexPoolIdFilter(teamFilter) {
+                    case .unrestricted, .restricted([]):
+                        break
+                    case .invalid:
+                        Self.logger.warning(
+                            "Malformed flex_pool_team_filter for flex-pool job \(id, privacy: .public); failing closed"
+                        )
+                        return nil
+                    case .restricted(let allowedTeams) where userTeamIds.isDisjoint(with: Set(allowedTeams)):
+                        return nil
+                    case .restricted:
+                        break
                     }
 
                     return FlexPoolJob(
@@ -2674,6 +2694,25 @@ public final class SchedulingService: Sendable {
     // =========================================================================
     // MARK: - Internal Helpers
     // =========================================================================
+
+    private enum FlexPoolFilter: Sendable {
+        case unrestricted
+        case restricted([Int64])
+        case invalid
+    }
+
+    /// Decode a persisted flex-pool allow-list. NULL/blank means unrestricted;
+    /// malformed non-blank JSON is invalid and must fail closed at call sites.
+    private static func decodeFlexPoolIdFilter(_ rawValue: String?) -> FlexPoolFilter {
+        guard let value = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return .unrestricted
+        }
+        guard let data = value.data(using: .utf8),
+              let ids = try? JSONDecoder().decode([Int64].self, from: data) else {
+            return .invalid
+        }
+        return .restricted(ids)
+    }
 
     /// Normalize a user-entered schedule date without timezone conversion.
     /// Accepts only a trimmed yyyy-MM-dd calendar date string.

--- a/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
@@ -1236,6 +1236,42 @@ struct SchedulingServiceTests {
         #expect(jobs.count == 1)
     }
 
+    @Test("fetchFlexPool excludes jobs with malformed user filter JSON")
+    func testFlexPoolMalformedUserFilterFailsClosed() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-FLEX-BAD-U", name: "Bad User Filter")
+
+        try env.scheduling.markJobFlexPool(jobId: jobId, isFlexPool: true)
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                UPDATE jobs
+                SET flex_pool_user_filter = '[123'
+                WHERE id = ?
+                """, arguments: [jobId])
+        }
+
+        let jobs = try env.scheduling.fetchFlexPool(userId: env.adminUserId)
+        #expect(!jobs.contains(where: { $0.id == jobId }))
+    }
+
+    @Test("fetchFlexPool excludes jobs with malformed team filter JSON")
+    func testFlexPoolMalformedTeamFilterFailsClosed() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-FLEX-BAD-T", name: "Bad Team Filter")
+
+        try env.scheduling.markJobFlexPool(jobId: jobId, isFlexPool: true)
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                UPDATE jobs
+                SET flex_pool_team_filter = '[123'
+                WHERE id = ?
+                """, arguments: [jobId])
+        }
+
+        let jobs = try env.scheduling.fetchFlexPool(userId: env.adminUserId)
+        #expect(!jobs.contains(where: { $0.id == jobId }))
+    }
+
     @Test("claimFlexJob sets worker as lead and removes job from flex pool")
     func testClaimFlexJob() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Fail closed when persisted flex-pool user/team allow-list filters contain malformed non-empty JSON.
- Preserve unrestricted behavior for NULL/blank filters and existing empty team filters.
- Add regression coverage for malformed user and team filters so restricted jobs do not leak into fetchFlexPool results.

Closes #721

## Tests
- `swift test --filter SchedulingServiceTests/testFlexPoolMalformedUserFilterFailsClosed`
- `swift test --filter SchedulingServiceTests`
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `cd core && swift test`

## Notes
- Core service-layer change only; no iOS UI files changed, so no UI smoke/build was required for this fix.
