### PR TITLE
fix: keep staging box numbers monotonic

### DIFF
--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -3049,17 +3049,10 @@ public final class WarehouseService: Sendable {
             let jobNumber = (jobRow["job_number"] as String?) ?? "\(jobId)"
             let jobName = (jobRow["job_name"] as String?) ?? ""
 
-            // Count existing boxes for this job to determine sequence
-            let existingCount = try Int.fetchOne(
-                dbConn,
-                sql: """
-                    SELECT COUNT(*) FROM staging_boxes
-                    WHERE job_id = ? AND deleted_at IS NULL
-                    """,
-                arguments: [jobId]
-            ) ?? 0
-
-            let seq = existingCount + 1
+            // Generate a monotonic per-job sequence from all historical boxes,
+            // including soft-deleted rows. Physical box labels must never be
+            // reused just because an old row was tombstoned.
+            let seq = try nextStagingBoxSequence(dbConn: dbConn, jobId: jobId, jobNumber: jobNumber)
             let seqStr = String(format: "%02d", seq)
             let boxNumber = "\(jobNumber)-\(seqStr)"
 
@@ -3189,14 +3182,10 @@ public final class WarehouseService: Sendable {
                 arguments: [boxId]
             )
 
-            // Create next box (inlined for atomicity — no nested db.writer.write)
-            let existingCount = try Int.fetchOne(
-                dbConn,
-                sql: "SELECT COUNT(*) FROM staging_boxes WHERE job_id = ? AND deleted_at IS NULL",
-                arguments: [jobId]
-            ) ?? 0
-
-            let seq = existingCount + 1
+            // Create next box (inlined for atomicity — no nested db.writer.write).
+            // Use all historical rows so soft-deleted physical box numbers are
+            // not reused.
+            let seq = try nextStagingBoxSequence(dbConn: dbConn, jobId: jobId, jobNumber: jobNumber)
             let seqStr = String(format: "%02d", seq)
             let boxNumber = "\(jobNumber)-\(seqStr)"
             let shortName = buildShortLabel(jobName: jobName)
@@ -3476,6 +3465,24 @@ public final class WarehouseService: Sendable {
             label = candidate
         }
         return label.uppercased()
+    }
+
+    /// Return the next staging-box sequence for a job from every historical
+    /// box number, including soft-deleted rows.
+    private func nextStagingBoxSequence(dbConn: Database, jobId: Int64, jobNumber: String) throws -> Int {
+        let prefix = "\(jobNumber)-"
+        let suffixStart = prefix.count + 1 // SQLite SUBSTR is 1-indexed.
+        let highestSequence = try Int.fetchOne(
+            dbConn,
+            sql: """
+                SELECT MAX(CAST(SUBSTR(box_number, ?) AS INTEGER))
+                FROM staging_boxes
+                WHERE job_id = ? AND SUBSTR(box_number, 1, ?) = ?
+                """,
+            arguments: [suffixStart, jobId, prefix.count, prefix]
+        ) ?? 0
+
+        return highestSequence + 1
     }
 
     // =========================================================================

--- a/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
@@ -421,6 +421,39 @@ struct WarehouseAuditTests {
         #expect(boxes.isEmpty)
     }
 
+    @Test("Staging box numbers do not reuse soft-deleted labels")
+    func testStagingBoxNumberAdvancesAfterSoftDelete() throws {
+        let env = try freshEnv()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-719", name: "Soft Delete Box Job")
+
+        let first = try env.warehouse.createStagingBox(jobId: jobId)
+        let second = try env.warehouse.createStagingBox(jobId: jobId)
+        try env.warehouse.deleteStagingBox(boxId: first.id)
+
+        let third = try env.warehouse.createStagingBox(jobId: jobId)
+        let activeBoxNumbers = try env.warehouse.listStagingBoxes(jobId: jobId).map(\.boxNumber)
+
+        #expect(second.boxNumber == "J-719-02")
+        #expect(third.boxNumber == "J-719-03")
+        #expect(Set(activeBoxNumbers).count == activeBoxNumbers.count)
+    }
+
+    @Test("Marking full creates the next historical staging box number")
+    func testMarkBoxFullAdvancesAfterSoftDelete() throws {
+        let env = try freshEnv()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-719-FULL", name: "Full Box Job")
+
+        let first = try env.warehouse.createStagingBox(jobId: jobId)
+        let second = try env.warehouse.createStagingBox(jobId: jobId)
+        try env.warehouse.deleteStagingBox(boxId: first.id)
+
+        let next = try env.warehouse.markBoxFull(boxId: second.id)
+        let activeBoxNumbers = try env.warehouse.listStagingBoxes(jobId: jobId).map(\.boxNumber)
+
+        #expect(next.boxNumber == "J-719-FULL-03")
+        #expect(Set(activeBoxNumbers).count == activeBoxNumbers.count)
+    }
+
     // MARK: - Trailers
 
     @Test("Trailer lifecycle: create, update, list")


### PR DESCRIPTION
## Summary
- Generate staging box numbers from the highest historical per-job suffix instead of active-row count.
- Apply the same monotonic sequencing when `markBoxFull` auto-creates the successor box.
- Add regression coverage for delete-then-create and delete-then-mark-full flows.

Closes #719

## Verification
- `swift test --filter WarehouseAuditTests/testStagingBoxNumberAdvancesAfterSoftDelete --filter WarehouseAuditTests/testMarkBoxFullAdvancesAfterSoftDelete`
- `swift test --filter WarehouseAuditTests/testStagingBoxes --filter WarehouseAuditTests/testStagingBoxStatus --filter WarehouseAuditTests/testDeleteStagingBox --filter WarehouseAuditTests/testStagingBoxNumberAdvancesAfterSoftDelete --filter WarehouseAuditTests/testMarkBoxFullAdvancesAfterSoftDelete`
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `cd core && swift test` (2168 tests passed)

## CI / local runner note
This is a core-only Swift change with no iOS UI surface. The required WPR2 local Mac Actions runner path remains the repo CI path for PR validation.