### PR TITLE
fix: reject inactive users in fleet warehouse writes

### DIFF
--- a/core/Sources/WiredPartCore/Services/FleetService.swift
+++ b/core/Sources/WiredPartCore/Services/FleetService.swift
@@ -1132,7 +1132,7 @@ public final class FleetService: Sendable {
                 """, arguments: [vehicleId]) ?? 0) > 0
             guard vehicleExists else { return }
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [userId]) ?? 0) > 0
             guard userExists else { return }
 
@@ -1704,7 +1704,7 @@ public final class FleetService: Sendable {
                 """, arguments: [vehicleId]) ?? 0) > 0
             guard vehicleExists else { throw FleetError.vehicleNotFound(vehicleId) }
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [reportedBy]) ?? 0) > 0
             guard userExists else { throw FleetError.userNotFound(reportedBy) }
 
@@ -1969,7 +1969,7 @@ public final class FleetService: Sendable {
             // Guard: recording user must exist and not be tombstoned — otherwise
             // a spoofed/wrong recordedBy would land in the audit trail unchecked.
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [recordedBy]) ?? 0) > 0
             guard userExists else { throw FleetError.userNotFound(recordedBy) }
 
@@ -2133,7 +2133,7 @@ public final class FleetService: Sendable {
                 """, arguments: [vehicleId]) ?? 0) > 0
             guard vehicleExists else { throw FleetError.vehicleNotFound(vehicleId) }
             let inspectorExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [inspectorId]) ?? 0) > 0
             guard inspectorExists else { throw FleetError.userNotFound(inspectorId) }
             if let tid = trailerId {

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -854,6 +854,7 @@ public final class WarehouseService: Sendable {
         validatePath: Bool = true
     ) throws -> Int64 {
         try db.writer.read { dbConn in
+            try Self.requireActiveUser(performedBy, dbConn: dbConn)
             try ServicePermissionGate.requirePermission(dbConn, userId: performedBy, permissionKey: "move_stock_warehouse")
         }
 

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -876,7 +876,7 @@ public final class WarehouseService: Sendable {
 
             // Guard: performing user must exist and not be tombstoned.
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [performedBy]) ?? 0) > 0
             guard userExists else { throw WarehouseError.userNotFound(performedBy) }
 
@@ -1141,7 +1141,7 @@ public final class WarehouseService: Sendable {
         }
         return try db.writer.write { dbConn in
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [performedBy]) ?? 0) > 0
             guard userExists else { throw WarehouseError.userNotFound(performedBy) }
 
@@ -1497,7 +1497,7 @@ public final class WarehouseService: Sendable {
             // we retain the existing permissive behavior for stockId (tags may
             // outlive their stock row). Only the user-FK is guarded.
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [taggedBy]) ?? 0) > 0
             guard userExists else { throw WarehouseError.userNotFound(taggedBy) }
 
@@ -1655,7 +1655,7 @@ public final class WarehouseService: Sendable {
             // Guard: session-starter must not be tombstoned
             guard let _ = try Row.fetchOne(
                 dbConn,
-                sql: "SELECT id FROM users WHERE id = ? AND deleted_at IS NULL",
+                sql: "SELECT id FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1",
                 arguments: [startedBy]
             ) else {
                 throw WarehouseError.userNotFound(startedBy)
@@ -1880,7 +1880,7 @@ public final class WarehouseService: Sendable {
             // Guard: completing user must not be tombstoned (stock movements will reference them)
             guard let _ = try Row.fetchOne(
                 dbConn,
-                sql: "SELECT id FROM users WHERE id = ? AND deleted_at IS NULL",
+                sql: "SELECT id FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1",
                 arguments: [completedBy]
             ) else {
                 throw WarehouseError.userNotFound(completedBy)
@@ -2661,7 +2661,7 @@ public final class WarehouseService: Sendable {
             // pre-check, an orphan audit session with an unresolvable `started_by`
             // would appear in listAuditSessions' display joins as "Unknown" user.
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [userId]) ?? 0) > 0
             guard userExists else { throw WarehouseError.userNotFound(userId) }
 
@@ -2703,7 +2703,7 @@ public final class WarehouseService: Sendable {
         try db.writer.write { dbConn in
             if let uid = performedBy {
                 let userExists = (try Int.fetchOne(dbConn, sql: """
-                    SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                    SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                     """, arguments: [uid]) ?? 0) > 0
                 guard userExists else { throw WarehouseError.userNotFound(uid) }
                 try ServicePermissionGate.requirePermission(dbConn, userId: uid, permissionKey: "perform_audit")
@@ -2932,7 +2932,7 @@ public final class WarehouseService: Sendable {
 
             // Guard: recording user must exist and not be tombstoned.
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [recordedBy]) ?? 0) > 0
             guard userExists else { throw WarehouseError.userNotFound(recordedBy) }
 
@@ -3823,7 +3823,7 @@ public final class WarehouseService: Sendable {
 
     private static func requireActiveUser(_ userId: Int64, dbConn: Database) throws {
         let exists = (try Int.fetchOne(dbConn, sql: """
-            SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+            SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
             """, arguments: [userId]) ?? 0) > 0
         guard exists else { throw WarehouseError.userNotFound(userId) }
     }
@@ -4526,7 +4526,7 @@ public final class WarehouseService: Sendable {
             guard floorPlanExists else { throw WarehouseError.invalidDimension }
 
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [userId]) ?? 0) > 0
             guard userExists else { throw WarehouseError.userNotFound(userId) }
 
@@ -5753,7 +5753,7 @@ public final class WarehouseService: Sendable {
         guard systemCount >= 0 else { throw WarehouseError.invalidQuantity }
         return try db.writer.write { dbConn in
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [countedBy]) ?? 0) > 0
             guard userExists else { throw WarehouseError.userNotFound(countedBy) }
             let variance = userCount - systemCount
@@ -6005,7 +6005,7 @@ public final class WarehouseService: Sendable {
         guard countedQuantity >= 0 else { throw WarehouseError.invalidQuantity }
         return try db.writer.write { dbConn in
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [verifiedBy]) ?? 0) > 0
             guard userExists else { throw WarehouseError.userNotFound(verifiedBy) }
 
@@ -6056,6 +6056,8 @@ public final class WarehouseService: Sendable {
         targetUnitId: Int64? = nil
     ) throws -> AuditSessionV2 {
         try db.writer.write { dbConn in
+            try Self.requireActiveUser(startedBy, dbConn: dbConn)
+
             var session = AuditSessionV2(
                 id: nil, sessionType: sessionType, startedBy: startedBy,
                 floorPlanId: floorPlanId, targetAreaId: targetAreaId,
@@ -6138,7 +6140,7 @@ public final class WarehouseService: Sendable {
     public func updateUserRating(userId: Int64, action: String, result: String? = nil) throws {
         try db.writer.write { dbConn in
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [userId]) ?? 0) > 0
             guard userExists else { throw WarehouseError.userNotFound(userId) }
 
@@ -6242,7 +6244,7 @@ public final class WarehouseService: Sendable {
             guard areaExists else { throw WarehouseError.areaNotFound(areaId) }
 
             let checkerExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [checkedBy]) ?? 0) > 0
             guard checkerExists else { throw WarehouseError.userNotFound(checkedBy) }
 
@@ -6334,7 +6336,7 @@ public final class WarehouseService: Sendable {
     public func castConsolidationVote(voteId: Int64, userId: Int64, chosenAreaId: Int64) throws {
         try db.writer.write { dbConn in
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [userId]) ?? 0) > 0
             guard userExists else { throw WarehouseError.userNotFound(userId) }
 
@@ -6428,7 +6430,7 @@ public final class WarehouseService: Sendable {
             // Guard: reporter must be a non-tombstoned user — orphan foundBy would
             // produce Unknown-user entries in the misplaced-parts dashboard.
             let userOk = (try Int.fetchOne(dbConn, sql:
-                "SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL",
+                "SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1",
                 arguments: [foundBy]) ?? 0) > 0
             guard userOk else { throw WarehouseError.userNotFound(foundBy) }
             var log = MisplacedPartsLog(
@@ -6479,7 +6481,7 @@ public final class WarehouseService: Sendable {
             // Guard: resolver must be non-tombstoned — a blank resolved_by would
             // make the resolution appear as "Unknown" on the audit dashboard.
             let userOk = (try Int.fetchOne(dbConn, sql:
-                "SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL",
+                "SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1",
                 arguments: [resolvedBy]) ?? 0) > 0
             guard userOk else { throw WarehouseError.userNotFound(resolvedBy) }
             try dbConn.execute(sql: """
@@ -7027,7 +7029,7 @@ public final class WarehouseService: Sendable {
     ) throws -> Int? {
         try db.writer.write { dbConn in
             let userExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL
+                SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [resolvedBy]) ?? 0) > 0
             guard userExists else { throw WarehouseError.userNotFound(resolvedBy) }
             // Get all assignments for this part in this session

--- a/core/Tests/WiredPartCoreTests/FleetServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/FleetServiceTests.swift
@@ -219,6 +219,38 @@ struct FleetServiceTests {
         #expect((previousRow?["end_date"] as String?) != nil, "Previous assignment must have end_date set")
     }
 
+    @Test("assignDriver ignores inactive assignee users")
+    func testAssignDriver_ignoresInactiveAssigneeUser() throws {
+        let env = try E2ETestHelpers.setUp()
+        let vehicleId = try env.fleet.createVehicle(
+            actorId: env.adminUserId,
+            vehicleNumber: "V-ASGN-INACTIVE",
+            vehicleName: "Inactive Driver Truck",
+            vehicleType: "truck",
+            make: nil, model: nil, year: nil, color: nil, vin: nil, licensePlate: nil, notes: nil
+        )
+        let inactiveDriverId = try env.auth.createUser(displayName: "Inactive Fleet Driver", pin: "4444")
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE users SET is_active = 0 WHERE id = ?", arguments: [inactiveDriverId])
+        }
+
+        try env.fleet.assignDriver(
+            actorId: env.adminUserId,
+            vehicleId: vehicleId,
+            userId: inactiveDriverId,
+            assignmentType: "primary",
+            isTakeHome: false
+        )
+
+        let count = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM vehicle_assignments
+                WHERE vehicle_id = ? AND user_id = ? AND deleted_at IS NULL
+                """, arguments: [vehicleId, inactiveDriverId]) ?? 0
+        }
+        #expect(count == 0, "Inactive users must not receive new vehicle assignments")
+    }
+
     @Test("My vehicle stats")
     func testMyVehicleStats() throws {
         let env = try E2ETestHelpers.setUp()
@@ -1127,6 +1159,18 @@ struct FleetServiceTests {
             try env.fleet.reportVehicleIssue(
                 vehicleId: vehicleId, reportedBy: 99_999,
                 severity: "low", description: "fake reporter"
+            )
+        }
+
+        // FK guard: inactive users are treated the same as missing/tombstoned users.
+        let inactiveReporterId = try env.auth.createUser(displayName: "Inactive Fleet Reporter", pin: "5555")
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE users SET is_active = 0 WHERE id = ?", arguments: [inactiveReporterId])
+        }
+        #expect(throws: FleetService.FleetError.userNotFound(inactiveReporterId)) {
+            try env.fleet.reportVehicleIssue(
+                vehicleId: vehicleId, reportedBy: inactiveReporterId,
+                severity: "low", description: "inactive reporter"
             )
         }
 

--- a/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
@@ -823,6 +823,53 @@ struct WarehouseAuditTests {
         #expect((row?["status"] as String?) == "completed")
     }
 
+    @Test("startAuditSession rejects inactive users")
+    func testStartAuditSessionRejectsInactiveUser() throws {
+        let env = try freshEnv()
+        let inactiveUserId = try env.auth.createUser(displayName: "Inactive Audit Starter", pin: "6666")
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE users SET is_active = 0 WHERE id = ?", arguments: [inactiveUserId])
+        }
+
+        #expect(throws: WarehouseService.WarehouseError.userNotFound(inactiveUserId)) {
+            _ = try env.warehouse.startAuditSession(startedBy: inactiveUserId)
+        }
+
+        let sessionCount = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM audit_sessions_v2
+                WHERE started_by = ? AND deleted_at IS NULL
+                """, arguments: [inactiveUserId]) ?? 0
+        }
+        #expect(sessionCount == 0, "Inactive users must not start warehouse audit sessions")
+    }
+
+    @Test("adjustAuditCount rejects inactive performers without stock mutation")
+    func testAdjustAuditCountRejectsInactivePerformer() throws {
+        let env = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10)
+        let inactiveUserId = try env.auth.createUser(displayName: "Inactive Audit Adjuster", pin: "7777")
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE users SET is_active = 0 WHERE id = ?", arguments: [inactiveUserId])
+        }
+
+        #expect(throws: WarehouseService.WarehouseError.userNotFound(inactiveUserId)) {
+            try env.warehouse.adjustAuditCount(
+                partId: partId,
+                locationType: "warehouse",
+                locationId: 1,
+                newQty: 7,
+                reason: "Physical count",
+                performedBy: inactiveUserId
+            )
+        }
+
+        let qty = try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1)
+        #expect(qty == 10, "Inactive-user audit adjustment must not mutate stock")
+    }
+
     @Test("adjustAuditCount updates stock qty and records negative delta adjustment movement")
     func testAdjustAuditCount() throws {
         let env = try freshEnv()

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -1801,6 +1801,38 @@ struct WarehouseServiceExtTests {
         }
     }
 
+    @Test("createMovement permission gate rejects inactive performing users without writing movement rows")
+    func testCreateMovement_permissionGateRejectsInactivePerformedByUser() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        let inactiveUserId = try env.auth.createUser(displayName: "Inactive Warehouse Mover", pin: "6666")
+        try env.db.writer.write { db in
+            try db.execute(
+                sql: "INSERT INTO user_hats (user_id, hat_id, is_active) SELECT ?, id, 1 FROM hats WHERE name = 'Admin'",
+                arguments: [inactiveUserId]
+            )
+            try db.execute(sql: "UPDATE users SET is_active = 0 WHERE id = ?", arguments: [inactiveUserId])
+        }
+
+        #expect(throws: ServicePermissionGate.GateError.insufficientPermissions(required: "move_stock_warehouse")) {
+            _ = try env.warehouse.createMovement(
+                partId: partId, qty: 1,
+                fromLocationType: nil, fromLocationId: nil,
+                toLocationType: "warehouse", toLocationId: 1,
+                movementType: "add_stock", performedBy: inactiveUserId
+            )
+        }
+
+        let count = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM stock_movements
+                WHERE part_id = ? AND performed_by = ? AND deleted_at IS NULL
+                """, arguments: [partId, inactiveUserId]) ?? 0
+        }
+        #expect(count == 0, "Inactive users must not create stock movement audit rows")
+    }
+
     @Test("createStagingBox rejects tombstoned job")
     func testCreateStagingBox_rejectsTombstonedJob() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -1801,8 +1801,8 @@ struct WarehouseServiceExtTests {
         }
     }
 
-    @Test("createMovement permission gate rejects inactive performing users without writing movement rows")
-    func testCreateMovement_permissionGateRejectsInactivePerformedByUser() throws {
+    @Test("createMovement rejects inactive performing users before permission checks without writing movement rows")
+    func testCreateMovement_rejectsInactivePerformedByUserBeforePermissionChecks() throws {
         let env = try E2ETestHelpers.setUp()
         let catId = try E2ETestHelpers.seedCategory(env)
         let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
@@ -1815,7 +1815,7 @@ struct WarehouseServiceExtTests {
             try db.execute(sql: "UPDATE users SET is_active = 0 WHERE id = ?", arguments: [inactiveUserId])
         }
 
-        #expect(throws: ServicePermissionGate.GateError.insufficientPermissions(required: "move_stock_warehouse")) {
+        #expect(throws: WarehouseService.WarehouseError.userNotFound(inactiveUserId)) {
             _ = try env.warehouse.createMovement(
                 partId: partId, qty: 1,
                 fromLocationType: nil, fromLocationId: nil,


### PR DESCRIPTION
## Summary
- Require `users.is_active = 1` in Fleet write-path user guards for driver assignment, vehicle issue reporting, trailer location history, and inspection saving.
- Require active users in Warehouse user guards for stock movement, receiving/audit/trailer/floor-plan/misplaced-part write paths and shared active-user helper.
- Add inactive-user regression coverage for fleet assignments, fleet issue reports, warehouse movements, audit session start, and audit adjustments.

Closes #729

## Verification
- `swift test --filter FleetServiceTests/testAssignDriver_ignoresInactiveAssigneeUser --filter FleetServiceTests/testReportVehicleIssue --filter WarehouseServiceExtTests/testCreateMovement_rejectsInactivePerformedByUser --filter WarehouseAuditTests/testStartAuditSessionRejectsInactiveUser --filter WarehouseAuditTests/testAdjustAuditCountRejectsInactivePerformer` — passed (5 Swift Testing tests).
- `git diff --check` — passed.
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`).
- `cd core && swift test` — passed with exit 0: 2172 Swift Testing tests in 65 suites plus XCTest tests.

## Local runner / CI path
- Core-only backend change; no iOS UI smoke required.
- PR CI should use the WPR2 local self-hosted Mac runner path documented for this repo (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`) if GitHub Actions gates run for this PR.
