### PR TITLE
test: guard schema version migration bookkeeping

### DIFF
--- a/core/Tests/WiredPartCoreTests/DatabaseTests.swift
+++ b/core/Tests/WiredPartCoreTests/DatabaseTests.swift
@@ -75,6 +75,7 @@ struct DatabaseTests {
             "estimation_question_accuracy_reviews", // 082
             "warehouse_walking_paths", // 083
             "warehouse_walking_path_stops", // 083
+            "audit_session_events", // 085
             // Tools detail (048-050)
             "tool_checkouts",    // 048
             // Vehicle & trailer (051-053)
@@ -109,9 +110,41 @@ struct DatabaseTests {
         #expect(tables == ["part_import_row_evidence", "part_import_sessions"])
     }
 
+    @Test("Migration 085 creates audit session event table and lookup index")
+    func testMigration085CreatesAuditSessionEvents() throws {
+        var config = Configuration()
+        config.foreignKeysEnabled = true
+        let queue = try DatabaseQueue(configuration: config)
+        var migrator = DatabaseMigrator()
+        AppDatabase.registerMigrations(&migrator)
+        try migrator.migrate(queue, upTo: "085_audit_session_events")
+
+        let result = try queue.read { db -> (tableExists: Bool, indexExists: Bool) in
+            let tableExists = try db.tableExists("audit_session_events")
+            let indexExists = try String.fetchOne(db, sql: """
+                SELECT name FROM sqlite_master
+                WHERE type = 'index' AND name = 'idx_audit_session_events_session'
+                """) != nil
+            return (tableExists, indexExists)
+        }
+
+        #expect(result.tableExists)
+        #expect(result.indexExists)
+    }
+
     @Test("Schema version is 105")
     func testSchemaVersion() throws {
         #expect(AppDatabase.schemaVersion == 105)
+    }
+
+    @Test("Persisted schema version matches AppDatabase schemaVersion")
+    func testPersistedSchemaVersionMatchesAppDatabaseSchemaVersion() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        let persistedVersion = try db.writer.read { db in
+            try String.fetchOne(db, sql: "SELECT value FROM settings WHERE key = 'db_schema_version'")
+        }
+
+        #expect(persistedVersion == "\(AppDatabase.schemaVersion)")
     }
 
     @Test("Migration 095 normalizes duplicate legacy stage sort orders and category maps")


### PR DESCRIPTION
## Summary
- Confirm current `AppDatabase.schemaVersion` and `DatabaseTests.testSchemaVersion` are already aligned at 105 on current `main`.
- Add explicit migration 085 coverage for the `audit_session_events` table and lookup index.
- Add a persisted schema-version regression guard so the `settings.db_schema_version` bookkeeping must match `AppDatabase.schemaVersion` after migrations run.

Closes #733

## Verification
- `swift test --filter 'DatabaseTests/testSchemaVersion|DatabaseTests/testMigration085CreatesAuditSessionEvents|DatabaseTests/testPersistedSchemaVersionMatchesAppDatabaseSchemaVersion|DatabaseTests/testAllMigrationsApply'` — passed (4 Swift Testing tests).
- `git diff --check` — passed.
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`).
- `cd core && swift test` — passed with exit 0: 2174 Swift Testing tests in 65 suites plus 4 XCTest tests.

## Local runner / CI path
- Core-only backend test change; no iOS UI smoke required.
- PR CI should use the WPR2 local self-hosted Mac runner path documented for this repo (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`) if GitHub Actions gates run for this PR.
