### PR TITLE
Fix manual backup sidecar copy failures

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
@@ -1,6 +1,49 @@
 import SwiftUI
 import WiredPartCore
 
+enum IOSBackupFileCopier {
+    struct CleanupFailure: LocalizedError {
+        let copyError: Error
+        let cleanupError: Error
+
+        var errorDescription: String? {
+            "Backup failed and the partial backup could not be cleaned up: \(cleanupError.localizedDescription). Original backup error: \(copyError.localizedDescription)"
+        }
+    }
+
+    nonisolated static func copySQLiteSnapshot(from sourceURL: URL, to destURL: URL) throws {
+        var createdURLs: [URL] = []
+
+        do {
+            try FileManager.default.copyItem(at: sourceURL, to: destURL)
+            createdURLs.append(destURL)
+
+            for suffix in ["-wal", "-shm"] {
+                let sourceSidecar = URL(fileURLWithPath: sourceURL.path + suffix)
+                guard FileManager.default.fileExists(atPath: sourceSidecar.path) else { continue }
+
+                let destinationSidecar = URL(fileURLWithPath: destURL.path + suffix)
+                try FileManager.default.copyItem(at: sourceSidecar, to: destinationSidecar)
+                createdURLs.append(destinationSidecar)
+            }
+        } catch {
+            var cleanupError: Error?
+            for createdURL in createdURLs.reversed() {
+                do {
+                    try FileManager.default.removeItem(at: createdURL)
+                } catch let removalError {
+                    cleanupError = removalError
+                }
+            }
+
+            if let cleanupError {
+                throw CleanupFailure(copyError: error, cleanupError: cleanupError)
+            }
+            throw error
+        }
+    }
+}
+
 /// Backup management page for iOS.
 ///
 /// Displays the last backup timestamp, estimated backup size, and
@@ -236,23 +279,7 @@ struct IOSBackupsPage: View {
 
         do {
             let sourceURL = URL(fileURLWithPath: sourcePath)
-            try FileManager.default.copyItem(at: sourceURL, to: destURL)
-
-            // Copy WAL/SHM if they exist
-            let walPath = sourcePath + "-wal"
-            if FileManager.default.fileExists(atPath: walPath) {
-                try? FileManager.default.copyItem(
-                    at: URL(fileURLWithPath: walPath),
-                    to: dir.appendingPathComponent(backupName + "-wal")
-                )
-            }
-            let shmPath = sourcePath + "-shm"
-            if FileManager.default.fileExists(atPath: shmPath) {
-                try? FileManager.default.copyItem(
-                    at: URL(fileURLWithPath: shmPath),
-                    to: dir.appendingPathComponent(backupName + "-shm")
-                )
-            }
+            try IOSBackupFileCopier.copySQLiteSnapshot(from: sourceURL, to: destURL)
 
             backupSuccess = true
             loadData()

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -729,6 +729,48 @@ struct Weird_Parts_IOSTests {
         #expect(source.contains("loadError = userFriendlyError(error, context: \"create supplier channel\")"))
     }
 
+    @Test func manualBackupSidecarCopyFailureIsReportedAndCleanedUp() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("IOSBackupFileCopierTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let sourceURL = tempRoot.appendingPathComponent("wiredpart.sqlite")
+        let sourceWALURL = URL(fileURLWithPath: sourceURL.path + "-wal")
+        let destinationURL = tempRoot.appendingPathComponent("wiredpart-backup.sqlite")
+        let destinationWALURL = URL(fileURLWithPath: destinationURL.path + "-wal")
+
+        try Data("main database".utf8).write(to: sourceURL)
+        try Data("wal sidecar".utf8).write(to: sourceWALURL)
+        try Data("pre-existing destination blocks copy".utf8).write(to: destinationWALURL)
+
+        do {
+            try IOSBackupFileCopier.copySQLiteSnapshot(from: sourceURL, to: destinationURL)
+            Issue.record("Expected WAL copy failure to propagate instead of reporting backup success")
+        } catch {
+            #expect(!FileManager.default.fileExists(atPath: destinationURL.path), "Failed sidecar backups must remove the partial main database copy")
+            #expect(FileManager.default.fileExists(atPath: destinationWALURL.path), "Existing destination files unrelated to this attempt should not be removed")
+        }
+    }
+
+    @Test func manualBackupSidecarCopiesAreNotSwallowedBeforeSuccessState() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let backupsPageURL = repoRoot
+            .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift")
+        let source = try String(contentsOf: backupsPageURL, encoding: .utf8)
+
+        #expect(!source.contains("try? FileManager.default.copyItem"), "Manual backup WAL/SHM copy failures must not be swallowed")
+        #expect(!source.contains("try? FileManager.default.removeItem"), "Failed manual backups must not swallow cleanup failures")
+        #expect(source.contains("try IOSBackupFileCopier.copySQLiteSnapshot"), "Manual backup creation should use the throwing SQLite snapshot copier")
+        #expect(source.contains("createdURLs.reversed()"), "Partial backup cleanup should remove sidecars before the main database")
+        let snapshotCall = try #require(source.range(of: "try IOSBackupFileCopier.copySQLiteSnapshot"))
+        let successState = try #require(source.range(of: "backupSuccess = true"))
+        #expect(snapshotCall.lowerBound < successState.lowerBound, "Success state must only be set after all database sidecars are copied")
+    }
+
     @MainActor
     @Test func shortTermPipelineCallbackFailurePreservesSheetAndFormatsActionError() {
         var reloadCount = 0


### PR DESCRIPTION
## Summary
- Add a throwing SQLite backup file copier for manual backups so WAL/SHM sidecar copy failures propagate instead of being swallowed.
- Clean up files created by the failed backup attempt before surfacing the error.
- Add regression coverage for sidecar failure propagation/cleanup and the success-state ordering guard.

Closes #745

## Verification
- `gh issue view 745 --repo xXKillerNoobYT/Weird-Part-Run-2 --json number,title,state,body,labels,comments,closed,closedAt,url` confirmed GH #745 is still open.
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/manualBackupSidecarCopyFailureIsReportedAndCleanedUp" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/manualBackupSidecarCopiesAreNotSwallowedBeforeSuccessState"` — passed.
- `git diff --check` — passed.
- `python3 scripts/guard-tracked-artifacts.py` — passed.
- `xcodebuild build -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5'` — passed.
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -only-testing:"Weird PartsUITests/Weird_Parts_IOSUITests/testWEI3988BackupRestoreSmokeEvidence"` — passed.

Local runner test path: this PR uses the WPR2 local Mac/iOS validation path with the WEI3988 iPhone simulator; CI should also run on the self-hosted Mac runner for trusted repo events.
