### PR TITLE
Fix full database export WAL snapshot

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
@@ -1,5 +1,29 @@
 import SwiftUI
 import WiredPartCore
+import GRDB
+
+enum IOSDatabaseExportSnapshotter {
+    nonisolated static func exportSQLiteSnapshot(from source: any DatabaseWriter, to destURL: URL) throws {
+        for url in [destURL, URL(fileURLWithPath: destURL.path + "-wal"), URL(fileURLWithPath: destURL.path + "-shm")] {
+            if FileManager.default.fileExists(atPath: url.path) {
+                try FileManager.default.removeItem(at: url)
+            }
+        }
+
+        let destination = try DatabaseQueue(path: destURL.path)
+        try source.backup(to: destination)
+    }
+
+    nonisolated static func userFriendlyExportError(raw: String) -> String {
+        if raw.contains("database is locked") {
+            return "The database is busy. Please try again in a moment."
+        }
+        if raw.contains("disk I/O error") || raw.contains("disk full") {
+            return "Storage problem. Check your device has enough space."
+        }
+        return "Couldn't export data. Pull down to retry."
+    }
+}
 
 /// Data export page for iOS.
 ///
@@ -280,8 +304,8 @@ struct IOSDataExportPage: View {
         isExporting = true
         errorMessage = nil
 
-        guard let dbPath = try? AppCore.databasePath() else {
-            errorMessage = "Cannot locate database."
+        guard let database = appCore.db else {
+            errorMessage = "Database is not available."
             isExporting = false
             return
         }
@@ -292,16 +316,22 @@ struct IOSDataExportPage: View {
         let dateStr = formatter.string(from: Date())
         let destURL = tmpDir.appendingPathComponent("wiredpart-full-\(dateStr).sqlite")
 
-        do {
-            // Remove previous temp if exists
-            try? FileManager.default.removeItem(at: destURL)
-            try FileManager.default.copyItem(at: URL(fileURLWithPath: dbPath), to: destURL)
-            exportURLs = [destURL]
-            exportSuccess = true
-            showShareSheet = true
-        } catch {
-            errorMessage = userFriendlyError(error, context: "export data")
+        Task.detached(priority: .userInitiated) {
+            do {
+                try IOSDatabaseExportSnapshotter.exportSQLiteSnapshot(from: database.writer, to: destURL)
+                await MainActor.run {
+                    exportURLs = [destURL]
+                    exportSuccess = true
+                    showShareSheet = true
+                    isExporting = false
+                }
+            } catch {
+                let message = IOSDatabaseExportSnapshotter.userFriendlyExportError(raw: error.localizedDescription)
+                await MainActor.run {
+                    errorMessage = message
+                    isExporting = false
+                }
+            }
         }
-        isExporting = false
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import GRDB
 import Security
 import Testing
 import WiredPartCore
@@ -769,6 +770,51 @@ struct Weird_Parts_IOSTests {
         let snapshotCall = try #require(source.range(of: "try IOSBackupFileCopier.copySQLiteSnapshot"))
         let successState = try #require(source.range(of: "backupSuccess = true"))
         #expect(snapshotCall.lowerBound < successState.lowerBound, "Success state must only be set after all database sidecars are copied")
+    }
+
+    @Test func fullDatabaseExportUsesGRDBSnapshotAndIncludesWALChanges() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("IOSDatabaseExportSnapshotterTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let sourceURL = tempRoot.appendingPathComponent("wiredpart-live.sqlite")
+        let destinationURL = tempRoot.appendingPathComponent("wiredpart-export.sqlite")
+        let source = try DatabasePool(path: sourceURL.path)
+        try source.write { db in
+            try db.execute(sql: "PRAGMA journal_mode = WAL")
+            try db.execute(sql: "PRAGMA wal_autocheckpoint = 0")
+            try db.execute(sql: "CREATE TABLE export_probe(id INTEGER PRIMARY KEY, value TEXT NOT NULL)")
+            try db.execute(sql: "INSERT INTO export_probe(value) VALUES (?)", arguments: ["committed-in-wal"])
+        }
+
+        #expect(FileManager.default.fileExists(atPath: sourceURL.path + "-wal"), "Test fixture should keep committed data in a WAL sidecar")
+
+        try IOSDatabaseExportSnapshotter.exportSQLiteSnapshot(from: source, to: destinationURL)
+
+        let exported = try DatabaseQueue(path: destinationURL.path)
+        let exportedValue = try exported.read { db in
+            try String.fetchOne(db, sql: "SELECT value FROM export_probe WHERE id = 1")
+        }
+        #expect(exportedValue == "committed-in-wal")
+    }
+
+    @Test func fullDatabaseExportDoesNotCopyMainDatabaseFileDirectly() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let exportPageURL = repoRoot
+            .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift")
+        let source = try String(contentsOf: exportPageURL, encoding: .utf8)
+
+        #expect(!source.contains("copyItem(at: URL(fileURLWithPath: dbPath), to: destURL)"), "Full database export must not copy only the main SQLite file")
+        #expect(source.contains("try IOSDatabaseExportSnapshotter.exportSQLiteSnapshot"), "Full database export should use the GRDB snapshot helper")
+        #expect(source.contains("Task.detached(priority: .userInitiated)"), "Full database export should run the snapshot off the main actor so large exports do not freeze Settings")
+        #expect(source.contains("await MainActor.run"), "Full database export should return success and error state updates to the main actor")
+        let snapshotCall = try #require(source.range(of: "try IOSDatabaseExportSnapshotter.exportSQLiteSnapshot"))
+        let successState = try #require(source.range(of: "exportSuccess = true", range: snapshotCall.lowerBound..<source.endIndex))
+        #expect(snapshotCall.lowerBound < successState.lowerBound, "Success state must only be set after the GRDB snapshot is complete")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- replace Settings full database export main-file copying with a GRDB backup snapshot from the live `AppDatabase` writer
- run the full-database snapshot off the main actor and marshal success/error state back to the main actor so large exports do not freeze Settings
- remove stale temp export artifacts before creating the snapshot
- add iOS regression coverage proving committed WAL-only rows are present in the exported SQLite artifact and guarding against reintroducing main-file-only or main-thread export logic

Closes #746

## Tests
- `xcodebuild -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/fullDatabaseExportUsesGRDBSnapshotAndIncludesWALChanges" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/fullDatabaseExportDoesNotCopyMainDatabaseFileDirectly" test` — passed
- `cd core && swift build && swift test` — passed (2174 Swift Testing tests + XCTest package tests)
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`)
- `xcodebuild -scheme "WiredPart-iOS" -destination 'generic/platform=iOS Simulator' build | grep -E "error:|warning:|BUILD SUCCEEDED|BUILD FAILED"` — passed (`** BUILD SUCCEEDED **`; pre-existing warnings remain)

## Notes
- The focused regression uses a WAL-mode `DatabasePool` with `wal_autocheckpoint = 0` to keep committed data in the WAL sidecar before snapshot export.
- Copilot review comments were addressed: snapshot work now runs in `Task.detached(priority: .userInitiated)`, and the core build/test gate is reported above.