### PR TITLE
Fix pre-migration WAL rollback backup sidecars

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase.swift
@@ -136,12 +136,14 @@ public final class AppDatabase: Sendable {
 
             try fileManager.copyItem(atPath: path, toPath: backupPath)
 
-            // Also copy WAL and SHM files if they exist
+            // Also copy WAL and SHM files if they exist. These sidecars are part
+            // of the durable SQLite snapshot while WAL mode is enabled; silently
+            // skipping one can make the pre-migration rollback backup stale.
             for suffix in ["-wal", "-shm"] {
                 let src = path + suffix
                 let dst = backupPath + suffix
                 if fileManager.fileExists(atPath: src) {
-                    try? fileManager.copyItem(atPath: src, toPath: dst)
+                    try fileManager.copyItem(atPath: src, toPath: dst)
                 }
             }
 

--- a/core/Tests/WiredPartCoreTests/BackupRestoreDataSafetyTests.swift
+++ b/core/Tests/WiredPartCoreTests/BackupRestoreDataSafetyTests.swift
@@ -87,6 +87,40 @@ struct BackupRestoreDataSafetyTests {
         #expect(retainedBackups.count == 5)
     }
 
+    @Test("Backup and restore preserves committed rows that still live in the WAL sidecar")
+    func testBackupRestorePreservesWalOnlyCommittedRows() throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("wei-4157-wal-backup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("live.sqlite").path
+        var config = Configuration()
+        config.prepareDatabase { db in
+            try db.execute(sql: "PRAGMA journal_mode = WAL")
+            try db.execute(sql: "PRAGMA wal_autocheckpoint = 0")
+        }
+
+        let queue = try DatabaseQueue(path: databasePath, configuration: config)
+        try queue.write { db in
+            try db.execute(sql: "CREATE TABLE wal_only_records(id INTEGER PRIMARY KEY, value TEXT NOT NULL)")
+            try db.execute(sql: "INSERT INTO wal_only_records(value) VALUES ('committed-only-in-wal')")
+        }
+
+        #expect(FileManager.default.fileExists(atPath: databasePath + "-wal"))
+
+        let backupPath = try #require(AppDatabase.backupDatabase(atPath: databasePath))
+        #expect(FileManager.default.fileExists(atPath: backupPath + "-wal"))
+
+        let restoredPath = directory.appendingPathComponent("restored.sqlite").path
+        try AppDatabase.restoreDatabase(from: backupPath, to: restoredPath)
+
+        let restoredValue = try DatabaseQueue(path: restoredPath).read { db in
+            try String.fetchOne(db, sql: "SELECT value FROM wal_only_records WHERE id = 1")
+        }
+        #expect(restoredValue == "committed-only-in-wal")
+    }
+
     @Test("Production backup and restore preserves critical beta records")
     func testProductionBackupRestorePreservesCriticalBetaRecords() throws {
         let fixture = try Self.makeCriticalFixture()


### PR DESCRIPTION
## Summary
- Make pre-migration database backups fail loudly if WAL/SHM sidecar copies fail instead of silently producing stale rollback bundles.
- Add a regression test that creates a WAL-mode SQLite database with committed data still in the WAL, backs it up, restores it, and verifies the row survives.

Closes #747

## Verification
- `gh issue view 747 --repo xXKillerNoobYT/Weird-Part-Run-2 --json number,state,title,labels,body,comments,closedAt` → issue is still OPEN and no comments indicate a newer PR already covers it.
- `gh pr list --repo xXKillerNoobYT/Weird-Part-Run-2 --state open --search '747' --json number,title,state,headRefName,baseRefName,url,body` → `[]`.
- `swift test --filter BackupRestoreDataSafetyTests/testBackupRestorePreservesWalOnlyCommittedRows` from `core` → passed.
- `git diff --check` → passed.
- `python3 scripts/guard-tracked-artifacts.py` → `No tracked Paperclip/Xcode runtime artifacts found.`
- `cd core && swift test --filter BackupRestoreDataSafetyTests` → 5 tests passed.
- `cd core && swift test` → 2175 tests passed.

## Notes
- Core-only data durability change; no UI files changed, so no iOS UI smoke was required for this PR.
