### PR TITLE
Preserve encrypted full database export snapshot

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
@@ -3,22 +3,38 @@ import WiredPartCore
 import GRDB
 
 enum IOSDatabaseExportSnapshotter {
-    nonisolated static func exportSQLiteSnapshot(from source: any DatabaseWriter, to destURL: URL) throws {
+    nonisolated static func exportSQLiteSnapshot(from source: any DatabaseWriter, sourceURL: URL, to destURL: URL) throws {
         for url in [destURL, URL(fileURLWithPath: destURL.path + "-wal"), URL(fileURLWithPath: destURL.path + "-shm")] {
             if FileManager.default.fileExists(atPath: url.path) {
                 try FileManager.default.removeItem(at: url)
             }
         }
 
-        let destination = try DatabaseQueue(path: destURL.path)
-        try source.backup(to: destination)
+        // Keep the exported artifact encrypted by preserving the live database file bytes.
+        // First force committed WAL pages into the main database so a single-file copy is
+        // complete, then copy only the checkpointed SQLite file into the share-sheet temp path.
+        try source.write { db in
+            guard let checkpoint = try Row.fetchOne(db, sql: "PRAGMA wal_checkpoint(TRUNCATE)") else {
+                throw NSError(domain: "IOSDatabaseExportSnapshotter", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "Database checkpoint did not return a result."
+                ])
+            }
+            let busy: Int = checkpoint[0]
+            guard busy == 0 else {
+                throw NSError(domain: "IOSDatabaseExportSnapshotter", code: 2, userInfo: [
+                    NSLocalizedDescriptionKey: "Database is busy. Try again in a moment."
+                ])
+            }
+            try FileManager.default.copyItem(at: sourceURL, to: destURL)
+        }
     }
 
     nonisolated static func userFriendlyExportError(raw: String) -> String {
-        if raw.contains("database is locked") {
+        let normalized = raw.lowercased()
+        if normalized.contains("database is locked") || normalized.contains("database is busy") {
             return "The database is busy. Please try again in a moment."
         }
-        if raw.contains("disk I/O error") || raw.contains("disk full") {
+        if normalized.contains("disk i/o error") || normalized.contains("disk full") {
             return "Storage problem. Check your device has enough space."
         }
         return "Couldn't export data. Pull down to retry."
@@ -309,7 +325,14 @@ struct IOSDataExportPage: View {
             isExporting = false
             return
         }
+        let uiTestingMode = ProcessInfo.processInfo.arguments.contains("-UITesting")
+        guard let dbPath = try? AppCore.databasePath(isUITesting: uiTestingMode) else {
+            errorMessage = "Cannot locate database."
+            isExporting = false
+            return
+        }
 
+        let sourceURL = URL(fileURLWithPath: dbPath)
         let tmpDir = FileManager.default.temporaryDirectory
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
@@ -318,7 +341,11 @@ struct IOSDataExportPage: View {
 
         Task.detached(priority: .userInitiated) {
             do {
-                try IOSDatabaseExportSnapshotter.exportSQLiteSnapshot(from: database.writer, to: destURL)
+                try IOSDatabaseExportSnapshotter.exportSQLiteSnapshot(
+                    from: database.writer,
+                    sourceURL: sourceURL,
+                    to: destURL
+                )
                 await MainActor.run {
                     exportURLs = [destURL]
                     exportSuccess = true

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
@@ -20,12 +20,24 @@ enum IOSDatabaseExportSnapshotter {
                 ])
             }
             let busy: Int = checkpoint[0]
+            let log: Int = checkpoint[1]
+            let checkpointed: Int = checkpoint[2]
             guard busy == 0 else {
                 throw NSError(domain: "IOSDatabaseExportSnapshotter", code: 2, userInfo: [
                     NSLocalizedDescriptionKey: "Database is busy. Try again in a moment."
                 ])
             }
-            try FileManager.default.copyItem(at: sourceURL, to: destURL)
+            guard checkpointed == log else {
+                throw NSError(domain: "IOSDatabaseExportSnapshotter", code: 3, userInfo: [
+                    NSLocalizedDescriptionKey: "Database is busy. Try again in a moment."
+                ])
+            }
+            do {
+                try FileManager.default.copyItem(at: sourceURL, to: destURL)
+            } catch {
+                try? FileManager.default.removeItem(at: destURL)
+                throw error
+            }
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -772,7 +772,7 @@ struct Weird_Parts_IOSTests {
         #expect(snapshotCall.lowerBound < successState.lowerBound, "Success state must only be set after all database sidecars are copied")
     }
 
-    @Test func fullDatabaseExportUsesGRDBSnapshotAndIncludesWALChanges() throws {
+    @Test func fullDatabaseExportCheckpointsAndIncludesWALChanges() throws {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("IOSDatabaseExportSnapshotterTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
@@ -790,7 +790,7 @@ struct Weird_Parts_IOSTests {
 
         #expect(FileManager.default.fileExists(atPath: sourceURL.path + "-wal"), "Test fixture should keep committed data in a WAL sidecar")
 
-        try IOSDatabaseExportSnapshotter.exportSQLiteSnapshot(from: source, to: destinationURL)
+        try IOSDatabaseExportSnapshotter.exportSQLiteSnapshot(from: source, sourceURL: sourceURL, to: destinationURL)
 
         let exported = try DatabaseQueue(path: destinationURL.path)
         let exportedValue = try exported.read { db in
@@ -809,7 +809,11 @@ struct Weird_Parts_IOSTests {
         let source = try String(contentsOf: exportPageURL, encoding: .utf8)
 
         #expect(!source.contains("copyItem(at: URL(fileURLWithPath: dbPath), to: destURL)"), "Full database export must not copy only the main SQLite file")
-        #expect(source.contains("try IOSDatabaseExportSnapshotter.exportSQLiteSnapshot"), "Full database export should use the GRDB snapshot helper")
+        #expect(source.contains("try IOSDatabaseExportSnapshotter.exportSQLiteSnapshot"), "Full database export should use the WAL-checkpoint snapshot helper")
+        #expect(source.contains("PRAGMA wal_checkpoint(TRUNCATE)"), "Full database export should checkpoint WAL pages before copying the encrypted SQLite file")
+        #expect(source.contains("let busy: Int = checkpoint[0]"), "Full database export should inspect checkpoint busy status before copying")
+        #expect(source.contains("try FileManager.default.copyItem(at: sourceURL, to: destURL)\n        }"), "Full database export should preserve encrypted database bytes while still under the writer lock")
+        #expect(source.contains("AppCore.databasePath(isUITesting: uiTestingMode)"), "Full database export should resolve the same UI-testing database path that bootstrap used")
         #expect(source.contains("Task.detached(priority: .userInitiated)"), "Full database export should run the snapshot off the main actor so large exports do not freeze Settings")
         #expect(source.contains("await MainActor.run"), "Full database export should return success and error state updates to the main actor")
         let snapshotCall = try #require(source.range(of: "try IOSDatabaseExportSnapshotter.exportSQLiteSnapshot"))

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -812,7 +812,9 @@ struct Weird_Parts_IOSTests {
         #expect(source.contains("try IOSDatabaseExportSnapshotter.exportSQLiteSnapshot"), "Full database export should use the WAL-checkpoint snapshot helper")
         #expect(source.contains("PRAGMA wal_checkpoint(TRUNCATE)"), "Full database export should checkpoint WAL pages before copying the encrypted SQLite file")
         #expect(source.contains("let busy: Int = checkpoint[0]"), "Full database export should inspect checkpoint busy status before copying")
-        #expect(source.contains("try FileManager.default.copyItem(at: sourceURL, to: destURL)\n        }"), "Full database export should preserve encrypted database bytes while still under the writer lock")
+        let writeBlockStart = try #require(source.range(of: "source.write"))
+        #expect(source.range(of: "FileManager.default.copyItem(at: sourceURL, to: destURL)", range: writeBlockStart.lowerBound..<source.endIndex) != nil,
+                "Full database export should preserve encrypted database bytes while still under the writer lock")
         #expect(source.contains("AppCore.databasePath(isUITesting: uiTestingMode)"), "Full database export should resolve the same UI-testing database path that bootstrap used")
         #expect(source.contains("Task.detached(priority: .userInitiated)"), "Full database export should run the snapshot off the main actor so large exports do not freeze Settings")
         #expect(source.contains("await MainActor.run"), "Full database export should return success and error state updates to the main actor")


### PR DESCRIPTION
## Summary
- follow up #1224 by preserving the encrypted SQLite database bytes during full database export
- checkpoint committed WAL pages with `PRAGMA wal_checkpoint(TRUNCATE)` before copying the main database file so the single exported artifact is current and still encrypted
- keep the export work in `Task.detached(priority: .userInitiated)` and marshal UI state changes through `MainActor.run`
- update iOS regression coverage to prove WAL-resident committed rows are present after export and to guard against plaintext GRDB backup exports returning

Refs #746

## Tests
- `xcodebuild -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/fullDatabaseExportCheckpointsAndIncludesWALChanges" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/fullDatabaseExportDoesNotCopyMainDatabaseFileDirectly" test` — passed
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed
- `xcodebuild -scheme "WiredPart-iOS" -destination 'generic/platform=iOS Simulator' build | grep -E "error:|warning:|BUILD SUCCEEDED|BUILD FAILED"` — passed (`** BUILD SUCCEEDED **`; pre-existing warnings remain)