### PR TITLE
Fix migration rollback retry open

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -142,14 +142,27 @@ final class AppCore: ObservableObject {
                     }
                     #else
                     #if !DEBUG
-                    // Migration failed — try to restore from backup
-                    if let backup = backupPath {
-                        try? AppDatabase.restoreDatabase(from: backup, to: path)
-                        // Retry with restored DB (old schema, but data preserved)
-                        self.logger.error("[AppCore] Migration failed, restored from backup. Error: \(error.localizedDescription)")
+                    // Migration failed — restore the pre-migration backup and retry once.
+                    // A successful restore leaves the old schema/data on disk; reopening it
+                    // lets normal startup migrations run again instead of surfacing the
+                    // original, now-recovered failure to the user.
+                    do {
+                        database = try Self.retryOpeningRestoredDatabase(
+                            backupPath: backupPath,
+                            databasePath: path,
+                            keyHex: try Self.deviceBootstrapKeyHex(),
+                            restoreDatabase: AppDatabase.restoreDatabase(from:to:),
+                            migratePlaintextDatabaseIfNeeded: AppDatabase.migratePlaintextDBIfNeeded(atPath:keyHex:),
+                            openEncryptedDatabase: AppDatabase.openEncryptedDatabase(atPath:keyHex:)
+                        )
+                        self.logger.error("[AppCore] Migration failed, restored from backup, and retry open succeeded. Original error: \(error.localizedDescription)")
+                    } catch {
+                        self.logger.error("[AppCore] Migration failed; restore/retry also failed. Retry error: \(error.localizedDescription)")
+                        throw error
                     }
-                    #endif
+                    #else
                     throw error
+                    #endif
                     #endif
                 }
 
@@ -357,6 +370,23 @@ final class AppCore: ObservableObject {
         #else
         return false
         #endif
+    }
+
+    nonisolated static func retryOpeningRestoredDatabase<Database>(
+        backupPath: String?,
+        databasePath: String,
+        keyHex: String,
+        restoreDatabase: (String, String) throws -> Void,
+        migratePlaintextDatabaseIfNeeded: (String, String) throws -> Void,
+        openEncryptedDatabase: (String, String) throws -> Database
+    ) throws -> Database {
+        guard let backupPath else {
+            throw AppCoreError.missingMigrationRollbackBackup
+        }
+
+        try restoreDatabase(backupPath, databasePath)
+        try migratePlaintextDatabaseIfNeeded(databasePath, keyHex)
+        return try openEncryptedDatabase(databasePath, keyHex)
     }
 
     // MARK: - Auth Actions
@@ -756,8 +786,15 @@ final class AppCore: ObservableObject {
 
     enum AppCoreError: LocalizedError {
         case noDocumentsDirectory
+        case missingMigrationRollbackBackup
+
         var errorDescription: String? {
-            "Unable to locate app storage directory. Please restart the app."
+            switch self {
+            case .noDocumentsDirectory:
+                return "Unable to locate app storage directory. Please restart the app."
+            case .missingMigrationRollbackBackup:
+                return "Unable to restore the app database because no migration rollback backup is available."
+            }
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -19,6 +19,12 @@ private enum BootstrapAuditTestError: Error {
     case operation
 }
 
+private enum MigrationRollbackRetryTestError: Error {
+    case restore
+    case migrate
+    case open
+}
+
 private final class MockBootstrapTaskAuditor: AppCoreBackgroundTaskAuditing, @unchecked Sendable {
     var startedNames: [String] = []
     var completedIds: [Int64] = []
@@ -473,6 +479,48 @@ struct Weird_Parts_IOSTests {
         #else
         #expect(!AppCore.shouldResetLocalDatabaseAfterCipherOpenFailure(sqlCipherError))
         #endif
+    }
+
+    @Test func migrationRollbackRestoresThenRetriesMigrationAndOpen() throws {
+        var events: [String] = []
+
+        let database = try AppCore.retryOpeningRestoredDatabase(
+            backupPath: "/tmp/wired-part.sqlite.rollback",
+            databasePath: "/tmp/wired-part.sqlite",
+            keyHex: "device-key",
+            restoreDatabase: { backupPath, databasePath in
+                events.append("restore")
+                #expect(backupPath == "/tmp/wired-part.sqlite.rollback")
+                #expect(databasePath == "/tmp/wired-part.sqlite")
+            },
+            migratePlaintextDatabaseIfNeeded: { databasePath, keyHex in
+                events.append("migrate")
+                #expect(databasePath == "/tmp/wired-part.sqlite")
+                #expect(keyHex == "device-key")
+            },
+            openEncryptedDatabase: { databasePath, keyHex in
+                events.append("open")
+                #expect(databasePath == "/tmp/wired-part.sqlite")
+                #expect(keyHex == "device-key")
+                return "opened-restored-database"
+            }
+        )
+
+        #expect(events == ["restore", "migrate", "open"])
+        #expect(database == "opened-restored-database")
+    }
+
+    @Test func migrationRollbackRequiresBackupBeforeRetry() {
+        #expect(throws: AppCore.AppCoreError.self) {
+            _ = try AppCore.retryOpeningRestoredDatabase(
+                backupPath: nil,
+                databasePath: "/tmp/wired-part.sqlite",
+                keyHex: "device-key",
+                restoreDatabase: { _, _ in throw MigrationRollbackRetryTestError.restore },
+                migratePlaintextDatabaseIfNeeded: { _, _ in throw MigrationRollbackRetryTestError.migrate },
+                openEncryptedDatabase: { _, _ in throw MigrationRollbackRetryTestError.open }
+            ) as String
+        }
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- restore the pre-migration backup and retry the encrypted database migration/open path once before surfacing startup failure
- add a testable rollback retry helper so the recovery sequence is permanently guarded
- add iOS regression tests for restore -> migrate -> open ordering and missing-backup failure handling

Closes #748

## Verification

- `git diff --check` — PASS
- `python3 scripts/guard-tracked-artifacts.py` — PASS (`No tracked Paperclip/Xcode runtime artifacts found.`)
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/migrationRollbackRestoresThenRetriesMigrationAndOpen" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/migrationRollbackRequiresBackupBeforeRetry"` — PASS (`** TEST SUCCEEDED **`)
- `cd core && swift test` — PASS (`Test run with 2175 tests in 65 suites passed after 102.726 seconds.`)

## Notes

- The first attempted simulator target, `iPhone 16`, was unavailable on this Mac; reran against the installed `WEI3988-iPhone` iOS 26.5 simulator.
