### PR TITLE
Fix issue sync source metadata

### DIFF
--- a/docs/github-issue-sync/README.md
+++ b/docs/github-issue-sync/README.md
@@ -14,6 +14,14 @@ scripts/github-issue-sync.sh --state all
 
 The default state is `all`, so the snapshot validates both open and closed GitHub issue paths. Use `--state open` or `--state closed` only for targeted diagnostics.
 
+Pass `--source-issue WEI-N` when a Paperclip/GitHub maintenance issue owns the sync run:
+
+```bash
+scripts/github-issue-sync.sh --state all --source-issue WEI-4159
+```
+
+If `--source-issue` is omitted, the script uses `PAPERCLIP_TASK_ID` when present, then `GITHUB_ISSUE_SYNC_SOURCE_ISSUE`, and finally the legacy `WEI-44` fallback for backward compatibility.
+
 ## Output Location
 Generated snapshots are local, ignored run artifacts under `.tmp/github-issue-sync/` by default. They should not be committed.
 

--- a/docs/runbooks/github-issue-sync-workflow.md
+++ b/docs/runbooks/github-issue-sync-workflow.md
@@ -70,11 +70,14 @@ scripts/paperclip-github-tracker-sync.sh --dry-run
 ## Manual Fallback (Do Not Remove Yet)
 If automated sync fails, use the existing snapshot path:
 ```bash
-scripts/github-issue-sync.sh --repo xXKillerNoobYT/Weird-Part-Run-2 --state all
+scripts/github-issue-sync.sh --repo xXKillerNoobYT/Weird-Part-Run-2 --state all --source-issue WEI-N
 ```
+When the sync is launched from a Paperclip heartbeat, `PAPERCLIP_TASK_ID` is also accepted as the default source issue. If neither `--source-issue` nor `PAPERCLIP_TASK_ID` is set, the script uses `GITHUB_ISSUE_SYNC_SOURCE_ISSUE` and then keeps the historical `WEI-44` fallback for older callers.
+
 Artifacts (local only, ignored by git):
 - `.tmp/github-issue-sync/<UTC timestamp>/issues.json`
 - `.tmp/github-issue-sync/latest-sync.md`
+- `.tmp/github-issue-sync/latest-sync.json`
 
 Do not commit generated snapshot artifacts; they are regenerated operational evidence, not project source.
 

--- a/scripts/github-issue-sync.sh
+++ b/scripts/github-issue-sync.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/github-issue-sync.sh [--repo owner/repo] [--output-dir path] [--state open|closed|all]
+  scripts/github-issue-sync.sh [--repo owner/repo] [--output-dir path] [--state open|closed|all] [--source-issue WEI-123]
   scripts/github-issue-sync.sh [owner/repo] [output-dir]
 
 Examples:
   scripts/github-issue-sync.sh
-  scripts/github-issue-sync.sh --repo xXKillerNoobYT/Weird-Part-Run-2 --state all
+  scripts/github-issue-sync.sh --repo xXKillerNoobYT/Weird-Part-Run-2 --state all --source-issue WEI-4159
   scripts/github-issue-sync.sh xXKillerNoobYT/Weird-Part-Run-2 .tmp/github-issue-sync
 EOF
 }
@@ -32,6 +32,7 @@ fi
 REPO_ARG=""
 OUT_DIR_ARG=""
 STATE_ARG=""
+SOURCE_ISSUE_ARG=""
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -45,6 +46,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --state)
       STATE_ARG="${2:?error: --state requires open, closed, or all}"
+      shift 2
+      ;;
+    --source-issue)
+      SOURCE_ISSUE_ARG="${2:?error: --source-issue requires an issue identifier}"
       shift 2
       ;;
     --)
@@ -69,6 +74,7 @@ done
 REPO="${REPO_ARG:-${POSITIONAL[0]:-${GITHUB_REPO:-xXKillerNoobYT/Weird-Part-Run-2}}}"
 OUT_DIR="${OUT_DIR_ARG:-${POSITIONAL[1]:-.tmp/github-issue-sync}}"
 ISSUE_STATE="${STATE_ARG:-${GITHUB_ISSUE_SYNC_STATE:-all}}"
+SOURCE_ISSUE="${SOURCE_ISSUE_ARG:-${PAPERCLIP_TASK_ID:-${GITHUB_ISSUE_SYNC_SOURCE_ISSUE:-WEI-44}}}"
 STAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 STAMP_DIR="${STAMP//:/-}"
 mkdir -p "$OUT_DIR"
@@ -83,7 +89,6 @@ if [[ ! "$ISSUE_STATE" =~ ^(open|closed|all)$ ]]; then
   usage >&2
   exit 1
 fi
-
 RUN_DIR="$OUT_DIR/$STAMP_DIR"
 JSON_PATH="$RUN_DIR/issues.json"
 MD_PATH="$RUN_DIR/summary.md"
@@ -112,7 +117,7 @@ CLOSED_TOTAL="$(jq 'map(select(.state == "CLOSED")) | length' "$JSON_PATH")"
   echo
   printf -- "- Repository: \`%s\`\n" "$REPO"
   printf -- "- Run timestamp (UTC): \`%s\`\n" "$STAMP"
-  printf -- "- Source issue: \`WEI-44\`\n"
+  printf -- "- Source issue: \`%s\`\n" "$SOURCE_ISSUE"
   printf -- "- Requested state: \`%s\`\n" "$ISSUE_STATE"
   printf -- "- Issues (non-PR): \`%s\`\n" "$TOTAL"
   printf -- "- Open issues: \`%s\`\n" "$OPEN_TOTAL"
@@ -129,7 +134,7 @@ CLOSED_TOTAL="$(jq 'map(select(.state == "CLOSED")) | length' "$JSON_PATH")"
 jq -n \
   --arg repository "$REPO" \
   --arg runTimestampUtc "$STAMP" \
-  --arg sourceIssue "WEI-44" \
+  --arg sourceIssue "$SOURCE_ISSUE" \
   --arg requestedState "$ISSUE_STATE" \
   --argjson issueCount "$TOTAL" \
   --argjson openCount "$OPEN_TOTAL" \

--- a/tests/test_github_issue_sync_source_issue.py
+++ b/tests/test_github_issue_sync_source_issue.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Regression tests for scripts/github-issue-sync.sh source metadata."""
+
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SYNC_SCRIPT = REPO_ROOT / "scripts" / "github-issue-sync.sh"
+
+
+class GitHubIssueSyncSourceIssueTests(unittest.TestCase):
+    def run_sync(self, *args: str, env: dict[str, str] | None = None) -> Path:
+        tmpdir_handle = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir_handle.cleanup)
+        tmpdir = Path(tmpdir_handle.name)
+        bin_dir = tmpdir / "bin"
+        out_dir = tmpdir / "out"
+        bin_dir.mkdir()
+        fake_gh = bin_dir / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                cat <<'JSON'
+                [
+                  {"number":752,"title":"Sync metadata bug","state":"OPEN","labels":[],"assignees":[],"author":{"login":"tester"},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-02T00:00:00Z","url":"https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/752"},
+                  {"number":900,"title":"Pull request should be filtered","state":"OPEN","labels":[],"assignees":[],"author":{"login":"tester"},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-03T00:00:00Z","url":"https://github.com/xXKillerNoobYT/Weird-Part-Run-2/pull/900"}
+                ]
+                JSON
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(0o755)
+
+        run_env = os.environ.copy()
+        run_env.update(env or {})
+        run_env["PATH"] = f"{bin_dir}:{run_env['PATH']}"
+
+        result = subprocess.run(
+            [str(SYNC_SCRIPT), "--repo", "xXKillerNoobYT/Weird-Part-Run-2", "--output-dir", str(out_dir), *args],
+            cwd=REPO_ROOT,
+            env=run_env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        return out_dir
+
+    def test_source_issue_option_updates_markdown_and_json(self):
+        out_dir = self.run_sync("--state", "all", "--source-issue", "WEI-4159")
+
+        latest_md = (out_dir / "latest-sync.md").read_text(encoding="utf-8")
+        latest_json = json.loads((out_dir / "latest-sync.json").read_text(encoding="utf-8"))
+
+        self.assertIn("- Source issue: `WEI-4159`", latest_md)
+        self.assertEqual(latest_json["sourceIssue"], "WEI-4159")
+        self.assertEqual(latest_json["issueCount"], 1)
+
+    def test_paperclip_task_id_defaults_source_issue(self):
+        out_dir = self.run_sync("--state", "open", env={"PAPERCLIP_TASK_ID": "WEI-4160"})
+        latest_json = json.loads((out_dir / "latest-sync.json").read_text(encoding="utf-8"))
+        self.assertEqual(latest_json["sourceIssue"], "WEI-4160")
+
+    def test_legacy_default_preserves_existing_callers(self):
+        out_dir = self.run_sync("--state", "closed", env={"PAPERCLIP_TASK_ID": ""})
+        latest_md = (out_dir / "latest-sync.md").read_text(encoding="utf-8")
+        latest_json = json.loads((out_dir / "latest-sync.json").read_text(encoding="utf-8"))
+
+        self.assertIn("- Source issue: `WEI-44`", latest_md)
+        self.assertEqual(latest_json["sourceIssue"], "WEI-44")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `--source-issue` support to `scripts/github-issue-sync.sh` so generated markdown/JSON snapshots no longer hardcode `WEI-44`.
- Default source metadata from `PAPERCLIP_TASK_ID`, then `GITHUB_ISSUE_SYNC_SOURCE_ISSUE`, with legacy `WEI-44` fallback for existing callers.
- Document the new source metadata behavior and add Python regression coverage with a fake `gh` CLI.

Closes #752

## Verification
- `python3 -m unittest tests.test_github_issue_sync_source_issue`
- `scripts/github-issue-sync.sh --repo xXKillerNoobYT/Weird-Part-Run-2 --state open --source-issue WEI-4159 --output-dir .tmp/github-issue-sync-wei4159` (verified `latest-sync.md` and `latest-sync.json` report `WEI-4159`)
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`

## Local runner path
This PR is docs/script/test-only and does not require an iOS/Xcode simulator build, but it still uses the repo's trusted local Mac runner path for CI if GitHub Actions runs are triggered.
