### PR TITLE
Fix paginated GitHub issue sync snapshots

### DIFF
--- a/scripts/github-issue-sync.sh
+++ b/scripts/github-issue-sync.sh
@@ -96,16 +96,39 @@ LATEST_JSON="$OUT_DIR/latest-sync.json"
 LATEST_MD="$OUT_DIR/latest-sync.md"
 TMP_JSON="$OUT_DIR/.issues-${STAMP_DIR}.json.tmp"
 
-# Pull up to 200 issues and exclude pull requests.
+# Pull all repository issues through the paginated REST API and exclude pull requests.
+# `gh issue list` defaults to a capped result set; use `gh api --paginate` so
+# canonical all-state snapshots cannot silently truncate above 200 issues.
 mkdir -p "$RUN_DIR"
 
-gh issue list \
-  --repo "$REPO" \
-  --state "$ISSUE_STATE" \
-  --limit 200 \
-  --json number,title,state,labels,assignees,author,createdAt,updatedAt,url > "$TMP_JSON"
+gh api \
+  --method GET \
+  --paginate \
+  --slurp \
+  -f state="$ISSUE_STATE" \
+  -f per_page=100 \
+  "repos/$REPO/issues" > "$TMP_JSON"
 
-jq 'map(select(.url | contains("/pull/") | not))' "$TMP_JSON" > "$JSON_PATH"
+jq '
+  def issue_pages:
+    if type == "array" and (length == 0 or (.[0] | type) == "array") then .[] else . end;
+
+  [
+    issue_pages[]
+    | select(has("pull_request") | not)
+    | {
+        number,
+        title,
+        state: (.state | ascii_upcase),
+        labels,
+        assignees,
+        author: .user,
+        createdAt: .created_at,
+        updatedAt: .updated_at,
+        url: .html_url
+      }
+  ]
+' "$TMP_JSON" > "$JSON_PATH"
 rm -f "$TMP_JSON"
 
 TOTAL="$(jq 'length' "$JSON_PATH")"

--- a/tests/test_github_issue_sync_source_issue.py
+++ b/tests/test_github_issue_sync_source_issue.py
@@ -29,10 +29,61 @@ class GitHubIssueSyncSourceIssueTests(unittest.TestCase):
                 """\
                 #!/usr/bin/env bash
                 set -euo pipefail
+
+                if [[ "${FAKE_GH_LARGE_PAGINATED:-}" == "1" ]]; then
+                  python3 - <<'PY'
+                import json
+                page1 = [
+                    {
+                        "number": number,
+                        "title": f"Issue {number}",
+                        "state": "open" if number % 2 else "closed",
+                        "labels": [],
+                        "assignees": [],
+                        "user": {"login": "tester"},
+                        "created_at": "2026-01-01T00:00:00Z",
+                        "updated_at": f"2026-01-02T00:00:{number % 60:02d}Z",
+                        "html_url": f"https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/{number}",
+                    }
+                    for number in range(1, 151)
+                ]
+                page2 = [
+                    {
+                        "number": number,
+                        "title": f"Issue {number}",
+                        "state": "open" if number % 2 else "closed",
+                        "labels": [],
+                        "assignees": [],
+                        "user": {"login": "tester"},
+                        "created_at": "2026-01-01T00:00:00Z",
+                        "updated_at": f"2026-01-03T00:00:{number % 60:02d}Z",
+                        "html_url": f"https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/{number}",
+                    }
+                    for number in range(151, 251)
+                ]
+                page2.append(
+                    {
+                        "number": 999,
+                        "title": "Pull request should be filtered",
+                        "state": "open",
+                        "labels": [],
+                        "assignees": [],
+                        "user": {"login": "tester"},
+                        "created_at": "2026-01-01T00:00:00Z",
+                        "updated_at": "2026-01-04T00:00:00Z",
+                        "html_url": "https://github.com/xXKillerNoobYT/Weird-Part-Run-2/pull/999",
+                        "pull_request": {"url": "https://api.github.com/repos/xXKillerNoobYT/Weird-Part-Run-2/pulls/999"},
+                    }
+                )
+                json.dump([page1, page2], __import__("sys").stdout)
+                PY
+                  exit 0
+                fi
+
                 cat <<'JSON'
                 [
-                  {"number":752,"title":"Sync metadata bug","state":"OPEN","labels":[],"assignees":[],"author":{"login":"tester"},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-02T00:00:00Z","url":"https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/752"},
-                  {"number":900,"title":"Pull request should be filtered","state":"OPEN","labels":[],"assignees":[],"author":{"login":"tester"},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-03T00:00:00Z","url":"https://github.com/xXKillerNoobYT/Weird-Part-Run-2/pull/900"}
+                  {"number":752,"title":"Sync metadata bug","state":"open","labels":[],"assignees":[],"user":{"login":"tester"},"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z","html_url":"https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/752"},
+                  {"number":900,"title":"Pull request should be filtered","state":"open","labels":[],"assignees":[],"user":{"login":"tester"},"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-03T00:00:00Z","html_url":"https://github.com/xXKillerNoobYT/Weird-Part-Run-2/pull/900","pull_request":{"url":"https://api.github.com/repos/xXKillerNoobYT/Weird-Part-Run-2/pulls/900"}}
                 ]
                 JSON
                 """
@@ -77,6 +128,16 @@ class GitHubIssueSyncSourceIssueTests(unittest.TestCase):
 
         self.assertIn("- Source issue: `WEI-44`", latest_md)
         self.assertEqual(latest_json["sourceIssue"], "WEI-44")
+
+    def test_paginated_api_sync_keeps_more_than_200_non_pr_issues(self):
+        out_dir = self.run_sync("--state", "all", env={"FAKE_GH_LARGE_PAGINATED": "1"})
+        latest_json = json.loads((out_dir / "latest-sync.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(latest_json["issueCount"], 250)
+        self.assertEqual(latest_json["openCount"], 125)
+        self.assertEqual(latest_json["closedCount"], 125)
+        self.assertNotIn(999, {issue["number"] for issue in latest_json["issues"]})
+        self.assertEqual(latest_json["issues"][0]["state"], "OPEN")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace the capped `gh issue list --limit 200` sync with paginated `gh api --paginate --slurp` retrieval.
- Normalize REST issue fields back to the existing snapshot schema and preserve PR exclusion.
- Add a regression covering more than 200 non-PR issues across paginated API pages.

Closes #842

## Verification
- `python3 tests/test_github_issue_sync_source_issue.py`
- `scripts/github-issue-sync.sh --repo xXKillerNoobYT/Weird-Part-Run-2 --state all --output-dir "$tmpdir" --source-issue WEI-4160` produced `issueCount=722`, `openCount=129`, `closedCount=593`, `oldest=4`, `newest=1214`.
- Control paginated GitHub API query matched exactly: `issueCount=722`, `openCount=129`, `closedCount=593`, `oldest=4`, `newest=1214`.
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`

## Scope notes
- Script/test-only change; no Swift/core/UI code changed, so `swift test` and iOS build/UI smoke were not applicable.
