### PR TITLE
Fix cart bin moves to deleted warehouse areas

### DIFF
--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -33,6 +33,7 @@ public final class WarehouseService: Sendable {
         case jobNotFound(Int64)
         case userNotFound(Int64)
         case areaNotFound(Int64)
+        case binNotFound(Int64)
         case unitNotFound(Int64)
         case levelNotFound(Int64)
         case sessionItemNotFound(Int64)
@@ -5206,12 +5207,25 @@ public final class WarehouseService: Sendable {
 
     /// Move multiple bins to a target area in a single transaction (Cart Mode multi-bin transfer).
     ///
-    /// Updates `area_id` for each bin in `binIds`. Bins not found in the database are silently
-    /// skipped so partial-cart moves don't abort on a stale ID.
+    /// Validates the target area and every selected bin before moving so stale
+    /// cart-mode selections cannot partially move bins or point active bins at
+    /// soft-deleted storage areas.
     public func moveBinsToArea(binIds: [Int64], targetAreaId: Int64) throws {
         guard !binIds.isEmpty else { return }
         try db.writer.write { dbConn in
+            let areaExists = (try Int.fetchOne(dbConn, sql: """
+                SELECT COUNT(*) FROM warehouse_storage_areas WHERE id = ? AND deleted_at IS NULL
+                """, arguments: [targetAreaId]) ?? 0) > 0
+            guard areaExists else { throw WarehouseError.areaNotFound(targetAreaId) }
+
             for binId in binIds {
+                let binExists = (try Int.fetchOne(dbConn, sql: """
+                    SELECT COUNT(*) FROM warehouse_bins WHERE id = ? AND deleted_at IS NULL
+                    """, arguments: [binId]) ?? 0) > 0
+                guard binExists else { throw WarehouseError.binNotFound(binId) }
+            }
+
+            for binId in Set(binIds) {
                 try dbConn.execute(
                     sql: "UPDATE warehouse_bins SET area_id = ? WHERE id = ? AND deleted_at IS NULL",
                     arguments: [targetAreaId, binId]

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -1767,6 +1767,56 @@ struct WarehouseServiceExtTests {
         try env.warehouse.moveBinsToArea(binIds: [], targetAreaId: 999)
     }
 
+    @Test("moveBinsToArea rejects soft-deleted target areas without moving bins")
+    func testMoveBinsToArea_rejectsSoftDeletedTargetArea() throws {
+        let env = try E2ETestHelpers.setUp()
+        let plan = try env.warehouse.createFloorPlan(name: "WH", widthInches: 300, lengthInches: 300)
+        let unit = try env.warehouse.addStorageUnit(floorPlanId: plan.id!, name: "Cart", unitType: "cart")
+        let level = try env.warehouse.addStorageLevel(unitId: unit.id!, levelCode: "L1")
+        let sourceArea = try env.warehouse.addStorageArea(levelId: level.id!, areaNumber: 1)
+        let targetArea = try env.warehouse.addStorageArea(levelId: level.id!, areaNumber: 2)
+        let bin = try env.warehouse.addBin(areaId: sourceArea.id!, binNumber: 1)
+
+        try env.warehouse.deleteStorageArea(id: targetArea.id!)
+
+        #expect(throws: WarehouseService.WarehouseError.areaNotFound(targetArea.id!)) {
+            try env.warehouse.moveBinsToArea(binIds: [bin.id!], targetAreaId: targetArea.id!)
+        }
+
+        let sourceBins = try env.warehouse.listBinsForArea(areaId: sourceArea.id!)
+        #expect(sourceBins.compactMap { $0.id }.contains(bin.id!))
+        let deletedTargetBins = try env.warehouse.listBinsForArea(areaId: targetArea.id!)
+        #expect(deletedTargetBins.isEmpty)
+    }
+
+    @Test("moveBinsToArea rejects stale bin IDs atomically")
+    func testMoveBinsToArea_rejectsStaleBinIdsAtomically() throws {
+        let env = try E2ETestHelpers.setUp()
+        let plan = try env.warehouse.createFloorPlan(name: "WH", widthInches: 300, lengthInches: 300)
+        let unit = try env.warehouse.addStorageUnit(floorPlanId: plan.id!, name: "Cart", unitType: "cart")
+        let level = try env.warehouse.addStorageLevel(unitId: unit.id!, levelCode: "L1")
+        let sourceArea = try env.warehouse.addStorageArea(levelId: level.id!, areaNumber: 1)
+        let targetArea = try env.warehouse.addStorageArea(levelId: level.id!, areaNumber: 2)
+        let activeBin = try env.warehouse.addBin(areaId: sourceArea.id!, binNumber: 1)
+        let staleBin = try env.warehouse.addBin(areaId: sourceArea.id!, binNumber: 2)
+
+        try env.db.writer.write { db in
+            try db.execute(
+                sql: "UPDATE warehouse_bins SET deleted_at = datetime('now') WHERE id = ?",
+                arguments: [staleBin.id!]
+            )
+        }
+
+        #expect(throws: WarehouseService.WarehouseError.binNotFound(staleBin.id!)) {
+            try env.warehouse.moveBinsToArea(binIds: [activeBin.id!, staleBin.id!], targetAreaId: targetArea.id!)
+        }
+
+        let sourceBins = try env.warehouse.listBinsForArea(areaId: sourceArea.id!)
+        #expect(sourceBins.compactMap { $0.id }.contains(activeBin.id!))
+        let targetBins = try env.warehouse.listBinsForArea(areaId: targetArea.id!)
+        #expect(targetBins.isEmpty)
+    }
+
     @Test("saveUnitPlacement updates grid position and zone for a storage unit")
     func testSaveUnitPlacement_updatesGridAndZone() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Validate cart-mode bin move target areas are active before writing `warehouse_bins.area_id`.
- Validate every selected bin is still active before moving any bin so stale cart selections fail atomically.
- Add regression coverage for soft-deleted destination areas and mixed active/stale bin IDs.

Closes #849

## Verification
- `swift test --filter WarehouseServiceExtTests/testMoveBinsToArea` (4 tests passed)
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `cd core && swift test` (2177 tests passed)

## UI / iOS smoke
- Not run: focused core service/data-integrity change only; no iOS UI files changed.