### PR TITLE
Fix grouped supplier send atomicity

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
@@ -669,15 +669,13 @@ struct POSendToSupplierSheet: View {
 
         Task {
             do {
-                for poId in includedPOs {
-                    try svc.markPOSentToSupplier(
-                        id: poId,
-                        sentByUserId: userId,
-                        confirmationNumber: confNum,
-                        emailRequestType: reqType,
-                        sendGroupId: groupId
-                    )
-                }
+                try svc.markPOsSentToSupplier(
+                    ids: includedPOs,
+                    sentByUserId: userId,
+                    confirmationNumber: confNum,
+                    emailRequestType: reqType,
+                    sendGroupId: groupId
+                )
                 await MainActor.run {
                     isSaving = false
                     dismiss()

--- a/core/Sources/WiredPartCore/Services/OrdersService.swift
+++ b/core/Sources/WiredPartCore/Services/OrdersService.swift
@@ -3238,51 +3238,108 @@ public final class OrdersService: Sendable {
         emailRequestType: String = "order",
         sendGroupId: String? = nil
     ) throws {
+        try markPOsSentToSupplier(
+            ids: [id],
+            sentByUserId: sentByUserId,
+            confirmationNumber: confirmationNumber,
+            emailRequestType: emailRequestType,
+            sendGroupId: sendGroupId
+        )
+    }
+
+    /// Atomically mark a supplier-send group as sent.
+    ///
+    /// All selected POs are validated before any row is updated so grouped sends
+    /// cannot leave earlier POs ordered/sent when a later selected PO has become
+    /// invalid after mail/share preparation.
+    public func markPOsSentToSupplier(
+        ids: [Int64],
+        sentByUserId: Int64,
+        confirmationNumber: String? = nil,
+        emailRequestType: String = "order",
+        sendGroupId: String? = nil
+    ) throws {
         try db.writer.write { dbConn in
             guard emailRequestType == "order" || emailRequestType == "pricing" else {
                 throw OrdersError.invalidSupplierTransmission("Supplier transmission type must be 'order' or 'pricing'")
             }
 
-            guard let row = try Row.fetchOne(
-                dbConn,
-                sql: "SELECT status FROM purchase_orders WHERE id = ? AND deleted_at IS NULL",
-                arguments: [id]
-            ) else {
-                throw OrdersError.purchaseOrderNotFound(id)
+            var uniqueIds: [Int64] = []
+            var seenIds = Set<Int64>()
+            for id in ids {
+                if seenIds.insert(id).inserted {
+                    uniqueIds.append(id)
+                }
             }
 
-            let oldStatus: String = row["status"] ?? "draft"
-            guard oldStatus == "draft" || oldStatus == "submitted" else {
+            guard !uniqueIds.isEmpty else {
+                throw OrdersError.invalidSupplierTransmission("At least one purchase order is required for supplier transmission")
+            }
+
+            var validatedPOs: [(id: Int64, oldStatus: String)] = []
+            var invalidPODescriptions: [String] = []
+
+            for id in uniqueIds {
+                guard let row = try Row.fetchOne(
+                    dbConn,
+                    sql: "SELECT po_number, status FROM purchase_orders WHERE id = ? AND deleted_at IS NULL",
+                    arguments: [id]
+                ) else {
+                    if uniqueIds.count == 1 {
+                        throw OrdersError.purchaseOrderNotFound(id)
+                    }
+                    invalidPODescriptions.append("PO #\(id) not found")
+                    continue
+                }
+
+                let poNumber: String = row["po_number"] ?? "#\(id)"
+                let oldStatus: String = row["status"] ?? "draft"
+                guard oldStatus == "draft" || oldStatus == "submitted" else {
+                    if uniqueIds.count == 1 {
+                        throw OrdersError.invalidSupplierTransmission(
+                            "Cannot send supplier \(emailRequestType) for PO in \(oldStatus) status"
+                        )
+                    }
+                    invalidPODescriptions.append("\(poNumber) is in \(oldStatus) status")
+                    continue
+                }
+
+                validatedPOs.append((id: id, oldStatus: oldStatus))
+            }
+
+            guard invalidPODescriptions.isEmpty else {
                 throw OrdersError.invalidSupplierTransmission(
-                    "Cannot send supplier \(emailRequestType) for PO in \(oldStatus) status"
+                    "Cannot send supplier \(emailRequestType) for every selected PO: \(invalidPODescriptions.joined(separator: "; "))"
                 )
             }
-            let newStatus = emailRequestType == "order" ? "ordered" : oldStatus
 
             let now = ISO8601DateFormatter().string(from: Date())
-            try dbConn.execute(
-                sql: """
-                    UPDATE purchase_orders
-                    SET sent_to_supplier_at       = ?,
-                        sent_by_user_id           = ?,
-                        supplier_confirmation_num = ?,
-                        email_request_type        = ?,
-                        send_group_id             = COALESCE(?, send_group_id),
-                        status                    = ?,
-                        updated_at                = ?
-                    WHERE id = ? AND deleted_at IS NULL
-                    """,
-                arguments: [now, sentByUserId, confirmationNumber, emailRequestType, sendGroupId, newStatus, now, id]
-            )
-
-            if oldStatus != newStatus {
+            for po in validatedPOs {
+                let newStatus = emailRequestType == "order" ? "ordered" : po.oldStatus
                 try dbConn.execute(
                     sql: """
-                        INSERT INTO order_status_history (entity_type, entity_id, old_status, new_status, changed_by, created_at)
-                        VALUES ('purchase_order', ?, ?, ?, ?, datetime('now'))
+                        UPDATE purchase_orders
+                        SET sent_to_supplier_at       = ?,
+                            sent_by_user_id           = ?,
+                            supplier_confirmation_num = ?,
+                            email_request_type        = ?,
+                            send_group_id             = COALESCE(?, send_group_id),
+                            status                    = ?,
+                            updated_at                = ?
+                        WHERE id = ? AND deleted_at IS NULL
                         """,
-                    arguments: [id, oldStatus, newStatus, sentByUserId]
+                    arguments: [now, sentByUserId, confirmationNumber, emailRequestType, sendGroupId, newStatus, now, po.id]
                 )
+
+                if po.oldStatus != newStatus {
+                    try dbConn.execute(
+                        sql: """
+                            INSERT INTO order_status_history (entity_type, entity_id, old_status, new_status, changed_by, created_at)
+                            VALUES ('purchase_order', ?, ?, ?, ?, datetime('now'))
+                            """,
+                        arguments: [po.id, po.oldStatus, newStatus, sentByUserId]
+                    )
+                }
             }
         }
     }

--- a/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
@@ -301,6 +301,61 @@ struct OrdersServiceTests {
         }
     }
 
+    @Test("Grouped supplier send validates all selected POs before mutating any")
+    func testMarkPOsSentToSupplierIsAtomicWhenSelectedPOBecomesInvalid() throws {
+        let env = try E2ETestHelpers.setUp()
+        let supplierId = try E2ETestHelpers.seedSupplier(env)
+        let firstPOId = try env.orders.createPurchaseOrder(
+            poNumber: "PO-GROUP-VALID",
+            supplierId: supplierId,
+            notes: nil
+        )
+        let invalidPOId = try env.orders.createPurchaseOrder(
+            poNumber: "PO-GROUP-CANCELLED",
+            supplierId: supplierId,
+            notes: nil
+        )
+
+        try env.db.writer.write { db in
+            try db.execute(
+                sql: "UPDATE purchase_orders SET status = 'cancelled' WHERE id = ?",
+                arguments: [invalidPOId]
+            )
+        }
+
+        #expect(throws: OrdersService.OrdersError.invalidSupplierTransmission(
+            "Cannot send supplier order for every selected PO: PO-GROUP-CANCELLED is in cancelled status"
+        )) {
+            try env.orders.markPOsSentToSupplier(
+                ids: [firstPOId, invalidPOId],
+                sentByUserId: env.adminUserId,
+                confirmationNumber: "SHOULD-NOT-WRITE",
+                emailRequestType: "order",
+                sendGroupId: "group-atomic"
+            )
+        }
+
+        let firstDetail = try env.orders.getPODetail(id: firstPOId)
+        let invalidDetail = try env.orders.getPODetail(id: invalidPOId)
+        #expect(firstDetail.status == "draft")
+        #expect(firstDetail.sentToSupplierAt == nil)
+        #expect(firstDetail.sentByUserId == nil)
+        #expect(firstDetail.supplierConfirmationNum == nil)
+        #expect(firstDetail.sendGroupId == nil)
+        #expect(invalidDetail.status == "cancelled")
+        #expect(invalidDetail.sentToSupplierAt == nil)
+        #expect(invalidDetail.sendGroupId == nil)
+
+        let historyCount = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM order_status_history
+                WHERE entity_type = 'purchase_order'
+                  AND entity_id IN (?, ?)
+                """, arguments: [firstPOId, invalidPOId]) ?? 0
+        }
+        #expect(historyCount == 0)
+    }
+
     @Test("Update PO status supports cancellation from active states")
     func testUpdatePOStatusCancellation() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Add `OrdersService.markPOsSentToSupplier` to validate every selected PO inside one database write before any grouped supplier-send mutation.
- Keep existing single-PO API as a wrapper around the atomic grouped path.
- Update `POSendToSupplierSheet.confirmSent()` to make one grouped service call instead of looping PO-by-PO.
- Add a regression test proving a stale/invalid selected sibling PO leaves the earlier valid PO untouched.

Closes #1119

## Verification
- `gh issue view 1119 -R xXKillerNoobYT/Weird-Part-Run-2 --json number,title,state,body,labels,comments,url` confirmed #1119 is still OPEN.
- `gh pr list -R xXKillerNoobYT/Weird-Part-Run-2 --state open --search "1119" --json number,title,headRefName,url,state` returned `[]` before implementation.
- `cd core && swift test --filter OrdersServiceTests/testMarkPOsSentToSupplierIsAtomicWhenSelectedPOBecomesInvalid` passed.
- `cd core && swift test --filter OrdersServiceTests` passed: 119 tests.
- `cd core && swift test` passed: 2178 tests.
- `git diff --check` passed.
- `python3 scripts/guard-tracked-artifacts.py` passed.

## CI / local runner note
This repo's required PR validation should run on the trusted local Mac self-hosted runner path (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`) per `docs/runbooks/local-mac-actions-runner.md`. No `.xcodeproj`/`.xcworkspace` exists in this worktree, so local app-target `xcodebuild`/UI smoke was not runnable from repo files; core package tests and static source compile through SwiftPM passed as above.
