### PR TITLE
Fix supplier sent confirmation after Mail cancel

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
@@ -80,6 +80,7 @@ struct POSendToSupplierSheet: View {
     @State private var siblingPDFs: [Int64: Data] = [:]  // sibling id → pdf
     @State private var isGeneratingPDF = false
     @State private var pdfError: String?
+    @State private var mailError: String?
     @State private var showMailComposer = false
     @State private var showShareSheet   = false
     @State private var shareItems: [Any] = []
@@ -196,6 +197,9 @@ struct POSendToSupplierSheet: View {
             .alert("PDF Error", isPresented: Binding(
                 get: { pdfError != nil }, set: { if !$0 { pdfError = nil } }
             )) { Button("OK") {} } message: { Text(pdfError ?? "") }
+            .alert("Mail Error", isPresented: Binding(
+                get: { mailError != nil }, set: { if !$0 { mailError = nil } }
+            )) { Button("OK") {} } message: { Text(mailError ?? "") }
             .alert("Save Error", isPresented: Binding(
                 get: { saveError != nil }, set: { if !$0 { saveError = nil } }
             )) { Button("OK") {} } message: { Text(saveError ?? "") }
@@ -507,10 +511,24 @@ struct POSendToSupplierSheet: View {
                 subject: emailSubject,
                 body: emailBody,
                 attachments: attachments
-            ) { _ in
-                showMailComposer = false
-                withAnimation { showConfirmSent = true }
+            ) { result in
+                handleMailComposerFinished(result)
             }
+        }
+    }
+
+    private func handleMailComposerFinished(_ result: MFMailComposeResult) {
+        showMailComposer = false
+
+        switch result {
+        case .sent:
+            withAnimation { showConfirmSent = true }
+        case .cancelled, .saved:
+            break
+        case .failed:
+            mailError = "Mail did not send, so supplier confirmation was not opened automatically. Try sending again, use the share sheet fallback, or confirm manually only after verifying the supplier message was sent."
+        @unknown default:
+            mailError = "Mail finished with an unknown result, so supplier confirmation was not opened automatically. Verify the message was sent before confirming manually."
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
@@ -170,6 +170,28 @@ final class OrdersSessionUnavailableRegressionTests: XCTestCase {
         )
     }
 
+    func testMailComposerOnlyRevealsConfirmSentAfterSentResult() throws {
+        let sendSheetSource = try Self.readOrdersSource(named: "POSendToSupplierSheet.swift")
+
+        XCTAssertFalse(
+            sendSheetSource.contains(") { _ in\n                showMailComposer = false\n                withAnimation { showConfirmSent = true }"),
+            "Mail composer completion must not ignore MFMailComposeResult and reveal Confirm Sent for cancelled/saved/failed dismissals."
+        )
+        XCTAssertTrue(
+            sendSheetSource.contains(") { result in\n                handleMailComposerFinished(result)"),
+            "The mail composer callback should route the actual result into a focused handler."
+        )
+        XCTAssertTrue(
+            sendSheetSource.contains("private func handleMailComposerFinished(_ result: MFMailComposeResult)") &&
+            sendSheetSource.contains("case .sent:\n            withAnimation { showConfirmSent = true }") &&
+            sendSheetSource.contains("case .cancelled, .saved:\n            break") &&
+            sendSheetSource.contains("case .failed:\n            mailError =") &&
+            sendSheetSource.contains(".alert(\"Mail Error\"") &&
+            sendSheetSource.contains("get: { mailError != nil }, set: { if !$0 { mailError = nil } }"),
+            "Only .sent should reveal Confirm Sent; cancelled/saved should not, and failed sends should surface an error."
+        )
+    }
+
     private static func readOrdersSource(named filename: String, file: StaticString = #filePath) throws -> String {
         let testFileURL = URL(fileURLWithPath: "\(file)")
         let projectRoot = testFileURL


### PR DESCRIPTION
## Summary
- Routes `MFMailComposeResult` from `POSendToSupplierSheet` into a focused completion handler.
- Only reveals the supplier `Confirm Sent` card after `.sent`.
- Keeps `.cancelled` and `.saved` in the prep state, and surfaces a visible error for `.failed`/unknown results.
- Adds a regression guard covering the callback/result handling.

Closes #1125

## Tests
- `python3 - <<'PY' ... PY` source regression assertions for `POSendToSupplierSheet.swift` — passed
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`)
- `cd core && swift test --filter OrdersServiceTests` — passed (119 tests)
- Local Mac runner-equivalent iOS build path: `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build` — passed (`** BUILD SUCCEEDED **`; pre-existing warnings only)
- Focused iOS XCTest on local simulator: `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests/testMailComposerOnlyRevealsConfirmSentAfterSentResult" test` — passed (`** TEST SUCCEEDED **`; pre-existing warnings only)
