### PR TITLE
Clarify peer browser global sync action

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
@@ -129,15 +129,13 @@ struct IOSPeerBrowser: View {
 
                         Spacer()
 
-                        if peer.state == "found" || peer.state == "multipeer" || peer.state == "lan" {
-                            Button("Sync") {
-                                Task { await syncManager.syncNow() }
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                        } else if peer.state == "connecting" {
+                        if peer.state == "connecting" {
                             ProgressView()
                                 .scaleEffect(0.7)
+                        } else if peer.state == "found" || peer.state == "multipeer" || peer.state == "lan" {
+                            Text("Ready")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         } else {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(.green)
@@ -145,6 +143,13 @@ struct IOSPeerBrowser: View {
                     }
                     .frame(minHeight: 56)
                 }
+
+                Button {
+                    Task { await syncManager.syncNow() }
+                } label: {
+                    Label("Sync All Devices", systemImage: "arrow.triangle.2.circlepath")
+                }
+                .disabled(syncManager.syncStatus == .syncing)
             }
         }
         .listStyle(.insetGrouped)

--- a/Weird Parts IOS/Weird Parts IOSTests/IOSPeerBrowserRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/IOSPeerBrowserRegressionTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+final class IOSPeerBrowserRegressionTests: XCTestCase {
+    func testPeerRowsDoNotDispatchGlobalSyncAsRowLevelAction() throws {
+        let source = try Self.readSyncSource(named: "IOSPeerBrowser.swift")
+
+        XCTAssertFalse(
+            source.contains("Button(\"Sync\")"),
+            "A row-level Sync button must not dispatch the global syncNow() path; that can sync every peer/server while implying only the selected row is affected."
+        )
+        XCTAssertTrue(
+            source.contains("Label(\"Sync All Devices\", systemImage: \"arrow.triangle.2.circlepath\")"),
+            "The remaining global sync action should be labeled as Sync All Devices so users understand it can touch every peer/server."
+        )
+        XCTAssertTrue(
+            source.contains("Task { await syncManager.syncNow() }"),
+            "IOSPeerBrowser should still expose a manual global sync action, but not as a per-peer row control."
+        )
+        XCTAssertEqual(
+            source.components(separatedBy: "syncManager.syncNow()").count - 1,
+            1,
+            "IOSPeerBrowser should route syncNow() through one clearly labeled global action, not through any peer-row action."
+        )
+        XCTAssertTrue(
+            source.contains(".disabled(syncManager.syncStatus == .syncing)"),
+            "The global Sync All Devices action should be disabled while a sync is already running."
+        )
+    }
+
+    private static func readSyncSource(
+        named name: String,
+        file: StaticString = #filePath
+    ) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Sync")
+            .appendingPathComponent(name)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Removes the row-level `Sync` action from `IOSPeerBrowser` peer rows so a selected row no longer dispatches the global sync path.
- Shows discovered row-level peers as `Ready` instead of exposing a misleading targeted action.
- Adds an explicitly global `Sync All Devices` button outside the peer rows for the existing all-peer/server `syncNow()` behavior.
- Adds a regression guard that prevents the row-level global-sync wiring from returning.

Closes #1140

## Tests
- `python3 - <<'PY' ... PY` source regression assertions for `IOSPeerBrowser.swift` — passed
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`)
- Local Mac runner-equivalent focused iOS XCTest: `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/IOSPeerBrowserRegressionTests/testPeerRowsDoNotDispatchGlobalSyncAsRowLevelAction" test` — passed (`** TEST SUCCEEDED **`)
- Local Mac runner-equivalent iOS build path: `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build` — passed (`** BUILD SUCCEEDED **`; pre-existing warnings only)

## Notes
- No Swift core code changed; this is a focused iOS UI/wording fix around the existing global sync action.
