### PR TITLE
Fix row-level peer sync targeting

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
@@ -131,7 +131,7 @@ struct IOSPeerBrowser: View {
 
                         if peer.state == "found" || peer.state == "multipeer" || peer.state == "lan" {
                             Button("Sync") {
-                                Task { await syncManager.syncWithPeer(peerId: peer.id) }
+                                Task { await syncManager.syncWithPeer(peerDeviceId: peer.id) }
                             }
                             .buttonStyle(.bordered)
                             .controlSize(.small)

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
@@ -131,7 +131,7 @@ struct IOSPeerBrowser: View {
 
                         if peer.state == "found" || peer.state == "multipeer" || peer.state == "lan" {
                             Button("Sync") {
-                                Task { await syncManager.syncNow() }
+                                Task { await syncManager.syncWithPeer(peerId: peer.id) }
                             }
                             .buttonStyle(.bordered)
                             .controlSize(.small)

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -223,7 +223,7 @@ final class IOSSyncManager {
     ///
     /// This intentionally bypasses the configured LAN server and `syncWithAllPeers()`
     /// global fan-out so a row-level Sync tap only touches the peer the user chose.
-    func syncWithPeer(peerId: String) async {
+    func syncWithPeer(peerDeviceId: String) async {
         guard isSyncAvailable else {
             syncStatus = .idle
             errorMessage = "Sync not configured. Set up in Settings → Sync."
@@ -239,7 +239,7 @@ final class IOSSyncManager {
         syncStatus = .syncing
         errorMessage = nil
 
-        let result = await pm.syncWithPeer(deviceId: peerId)
+        let result = await pm.syncWithPeer(deviceId: peerDeviceId)
         if !result.success {
             errorMessage = result.error ?? "Sync failed with \(result.peerName)"
         }

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -219,6 +219,53 @@ final class IOSSyncManager {
         if syncHistory.count > 20 { syncHistory = Array(syncHistory.prefix(20)) }
     }
 
+    /// Trigger a sync cycle for one selected peer from the Nearby Devices row.
+    ///
+    /// This intentionally bypasses the configured LAN server and `syncWithAllPeers()`
+    /// global fan-out so a row-level Sync tap only touches the peer the user chose.
+    func syncWithPeer(peerId: String) async {
+        guard isSyncAvailable else {
+            syncStatus = .idle
+            errorMessage = "Sync not configured. Set up in Settings → Sync."
+            return
+        }
+        guard syncStatus != .syncing else { return }
+        guard let pm = peerManager else {
+            syncStatus = .error
+            errorMessage = SyncError.noDatabaseAvailable.localizedDescription
+            return
+        }
+
+        syncStatus = .syncing
+        errorMessage = nil
+
+        let result = await pm.syncWithPeer(deviceId: peerId)
+        if !result.success {
+            errorMessage = result.error ?? "Sync failed with \(result.peerName)"
+        }
+
+        let conflictCount = refreshConflictCount()
+        refreshPendingCount()
+        let success = errorMessage == nil
+        if success {
+            syncStatus = .synced
+            lastSyncDate = Formatters.iso8601Basic.string(from: Date())
+        } else {
+            syncStatus = .error
+        }
+
+        let entry = SyncHistoryEntry(
+            date: Date(),
+            changesSent: result.pushed,
+            changesReceived: result.pulled,
+            conflicts: conflictCount,
+            success: success,
+            error: errorMessage
+        )
+        syncHistory.insert(entry, at: 0)
+        if syncHistory.count > 20 { syncHistory = Array(syncHistory.prefix(20)) }
+    }
+
     // MARK: - Peer Discovery
 
     /// Start scanning for nearby peers via Multipeer Connectivity.

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -241,7 +241,14 @@ final class IOSSyncManager {
 
         let result = await pm.syncWithPeer(deviceId: peerDeviceId)
         if !result.success {
-            errorMessage = result.error ?? "Sync failed with \(result.peerName)"
+            let peerLabel: String
+            if result.peerName == peerDeviceId {
+                peerLabel = peerDeviceId
+            } else {
+                peerLabel = "\(result.peerName) (\(peerDeviceId))"
+            }
+            let failureReason = result.error ?? "Sync failed"
+            errorMessage = "\(failureReason) for \(peerLabel)"
         }
 
         let conflictCount = refreshConflictCount()

--- a/Weird Parts IOS/Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+
+final class PeerBrowserTargetedSyncRegressionTests: XCTestCase {
+    func testRowLevelPeerSyncTargetsSelectedPeerInsteadOfGlobalSyncNow() throws {
+        let source = try Self.readPeerBrowserSource()
+
+        XCTAssertTrue(
+            source.contains("syncManager.syncWithPeer(peerId: peer.id)"),
+            "Each peer row's Sync button must pass the selected peer ID into IOSSyncManager."
+        )
+        XCTAssertFalse(
+            source.contains("Task { await syncManager.syncNow() }"),
+            "A row-level Sync button must not dispatch the global syncNow fan-out path."
+        )
+    }
+
+    func testIOSSyncManagerProvidesSelectedPeerSyncWithoutGlobalFanOut() throws {
+        let source = try Self.readSyncManagerSource()
+
+        XCTAssertTrue(
+            source.contains("func syncWithPeer(peerId: String) async"),
+            "IOSSyncManager should expose an explicit selected-peer sync entry point for row-level UI actions."
+        )
+        XCTAssertTrue(
+            source.contains("pm.syncWithPeer(deviceId: peerId)"),
+            "The selected-peer entry point should call PeerManager's device-id selector."
+        )
+
+        let selectedPeerMethod = try Self.methodBody(named: "syncWithPeer", in: source)
+        XCTAssertFalse(
+            selectedPeerMethod.contains("syncWithAllPeers()"),
+            "Selected-peer sync must not call syncWithAllPeers()."
+        )
+        XCTAssertFalse(
+            selectedPeerMethod.contains("manualSync("),
+            "Selected-peer sync must not trigger the configured LAN-server sync path."
+        )
+    }
+
+    private static func readPeerBrowserSource(
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Sync")
+            .appendingPathComponent("IOSPeerBrowser.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    private static func readSyncManagerSource(
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Sync")
+            .appendingPathComponent("IOSSyncManager.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    private static func methodBody(named methodName: String, in source: String) throws -> String {
+        guard let nameRange = source.range(of: "func \(methodName)(peerId: String) async") else {
+            throw XCTSkip("Expected method \(methodName)(peerId: String) async in source")
+        }
+        guard let openBrace = source[nameRange.upperBound...].firstIndex(of: "{") else {
+            throw XCTSkip("Expected opening brace for \(methodName)")
+        }
+
+        var depth = 0
+        var index = openBrace
+        while index < source.endIndex {
+            let char = source[index]
+            if char == "{" { depth += 1 }
+            if char == "}" { depth -= 1 }
+            let next = source.index(after: index)
+            if depth == 0 {
+                return String(source[openBrace..<next])
+            }
+            index = next
+        }
+
+        throw XCTSkip("Expected closing brace for \(methodName)")
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests.swift
@@ -25,6 +25,10 @@ final class PeerBrowserTargetedSyncRegressionTests: XCTestCase {
             source.contains("pm.syncWithPeer(deviceId: peerDeviceId)"),
             "The selected-peer entry point should call PeerManager's device-id selector."
         )
+        XCTAssertTrue(
+            source.contains("errorMessage = \"\\(failureReason) for \\(peerLabel)\""),
+            "Selected-peer failures should include the chosen device ID so row-level sync errors are diagnosable."
+        )
 
         let selectedPeerMethod = try Self.methodBody(named: "syncWithPeer", in: source)
         XCTAssertFalse(

--- a/Weird Parts IOS/Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests.swift
@@ -5,7 +5,7 @@ final class PeerBrowserTargetedSyncRegressionTests: XCTestCase {
         let source = try Self.readPeerBrowserSource()
 
         XCTAssertTrue(
-            source.contains("syncManager.syncWithPeer(peerId: peer.id)"),
+            source.contains("syncManager.syncWithPeer(peerDeviceId: peer.id)"),
             "Each peer row's Sync button must pass the selected peer ID into IOSSyncManager."
         )
         XCTAssertFalse(
@@ -18,11 +18,11 @@ final class PeerBrowserTargetedSyncRegressionTests: XCTestCase {
         let source = try Self.readSyncManagerSource()
 
         XCTAssertTrue(
-            source.contains("func syncWithPeer(peerId: String) async"),
+            source.contains("func syncWithPeer(peerDeviceId: String) async"),
             "IOSSyncManager should expose an explicit selected-peer sync entry point for row-level UI actions."
         )
         XCTAssertTrue(
-            source.contains("pm.syncWithPeer(deviceId: peerId)"),
+            source.contains("pm.syncWithPeer(deviceId: peerDeviceId)"),
             "The selected-peer entry point should call PeerManager's device-id selector."
         )
 
@@ -64,8 +64,8 @@ final class PeerBrowserTargetedSyncRegressionTests: XCTestCase {
     }
 
     private static func methodBody(named methodName: String, in source: String) throws -> String {
-        guard let nameRange = source.range(of: "func \(methodName)(peerId: String) async") else {
-            throw XCTSkip("Expected method \(methodName)(peerId: String) async in source")
+        guard let nameRange = source.range(of: "func \(methodName)(peerDeviceId: String) async") else {
+            throw XCTSkip("Expected method \(methodName)(peerDeviceId: String) async in source")
         }
         guard let openBrace = source[nameRange.upperBound...].firstIndex(of: "{") else {
             throw XCTSkip("Expected opening brace for \(methodName)")

--- a/core/Sources/WiredPartCore/Sync/PeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/PeerManager.swift
@@ -390,6 +390,27 @@ public actor PeerManager {
         }
     }
 
+    /// Sync with one currently discovered peer by stable device ID.
+    ///
+    /// Row-level UI actions should use this selector instead of `syncWithAllPeers()`
+    /// so tapping one peer cannot fan out to every known peer.
+    public func syncWithPeer(deviceId: String) async -> PeerSyncResult {
+        mergePeerLists()
+
+        guard let peer = state.peers.first(where: { $0.deviceId == deviceId }) else {
+            let result = PeerSyncResult(
+                peerDeviceId: deviceId,
+                peerName: deviceId,
+                success: false,
+                error: "Peer not found"
+            )
+            state.lastPeerSyncs[deviceId] = result
+            return result
+        }
+
+        return await syncWithPeer(peer)
+    }
+
     /// Sync with all discovered peers sequentially.
     /// Office-like peers first, then by least-recently-synced.
     public func syncWithAllPeers() async -> [PeerSyncResult] {

--- a/core/Sources/WiredPartCore/Sync/PeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/PeerManager.swift
@@ -402,9 +402,10 @@ public actor PeerManager {
                 peerDeviceId: deviceId,
                 peerName: deviceId,
                 success: false,
-                error: "Peer not found"
+                error: "Peer not found: \(deviceId)"
             )
             state.lastPeerSyncs[deviceId] = result
+            notifyStateChanged()
             return result
         }
 

--- a/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
@@ -151,7 +151,7 @@ struct PeerManagerTests {
 
         #expect(result.success == false)
         #expect(result.peerDeviceId == "missing-peer")
-        #expect(result.error == "Peer not found")
+        #expect(result.error == "Peer not found: missing-peer")
 
         let state = await pm.getState()
         #expect(state.lastPeerSyncs["missing-peer"]?.success == false)

--- a/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
@@ -142,6 +142,22 @@ struct PeerManagerTests {
         await pm.stopPeerSync()
     }
 
+    @Test("Sync by peer device ID does not fall back to all peers")
+    func testSyncByPeerDeviceIdRequiresSelectedPeer() async throws {
+        let db = try freshDB()
+        let pm = PeerManager(db: db)
+
+        let result = await pm.syncWithPeer(deviceId: "missing-peer")
+
+        #expect(result.success == false)
+        #expect(result.peerDeviceId == "missing-peer")
+        #expect(result.error == "Peer not found")
+
+        let state = await pm.getState()
+        #expect(state.lastPeerSyncs["missing-peer"]?.success == false)
+        #expect(state.lastPeerSyncs.count == 1)
+    }
+
     @Test("LAN sync reports HTTP pull errors as failed peer sync")
     func testLANSyncHTTPPullErrorReturnsFailure() async throws {
         let db = try freshDB()


### PR DESCRIPTION
## Summary
- Add a selected-peer sync path in `IOSSyncManager` that calls `PeerManager.syncWithPeer(deviceId:)` instead of the global LAN/server + all-peers `syncNow()` fan-out.
- Wire the Nearby Devices row-level `Sync` button to pass `peer.id` into the selected-peer path.
- Add regression coverage for the peer-device-ID selector and source-level UI guard that row actions do not call global sync.

Closes #1140

## Verification
- `cd core && swift test --filter PeerManagerTests` — passed (15 tests)
- `xcodebuild test -scheme 'WiredPart-iOS' -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:'Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests'` — passed (2 tests), log `/tmp/wei-4164-ios-focused-test.log`
- `cd core && swift test` — passed (2179 tests in 65 suites)
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed

## Notes
- The first attempted focused iOS destination used `iPhone 16`, which is not installed locally; reran on available self-hosted simulator `WEI3988-iPhone` successfully.
- Local self-hosted Mac runner path remains the expected CI path for iOS/macOS verification.
