### PR TITLE
fix: validate warehouse floor feature grid placement

### DIFF
--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -4295,6 +4295,14 @@ public final class WarehouseService: Sendable {
             throw WarehouseError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in
+            let floorPlan = try WarehouseFloorPlan.fetchOne(dbConn, key: floorPlanId)
+            try validateFloorPlanGridPlacement(
+                floorPlan: floorPlan,
+                gridX: gridX,
+                gridY: gridY,
+                gridWidth: gridWidth,
+                gridHeight: gridHeight
+            )
             var feature = WarehouseFloorFeature(
                 floorPlanId: floorPlanId,
                 featureType: featureType,
@@ -4432,13 +4440,13 @@ public final class WarehouseService: Sendable {
         gridHeight: Int,
         dbConn: Database
     ) throws {
-        guard gridX >= 0, gridY >= 0, gridWidth > 0, gridHeight > 0 else {
-            throw WarehouseError.invalidDimension
-        }
-        if let cols = floorPlan?.gridCols, let rows = floorPlan?.gridRows,
-           gridX + gridWidth > cols || gridY + gridHeight > rows {
-            throw WarehouseError.invalidDimension
-        }
+        try validateFloorPlanGridPlacement(
+            floorPlan: floorPlan,
+            gridX: gridX,
+            gridY: gridY,
+            gridWidth: gridWidth,
+            gridHeight: gridHeight
+        )
 
         let existingZones = try WarehouseZone
             .filter(Column("floor_plan_id") == floorPlanId && Column("deleted_at") == nil)
@@ -4457,6 +4465,22 @@ public final class WarehouseService: Sendable {
             )
         }
         if collides {
+            throw WarehouseError.invalidDimension
+        }
+    }
+
+    private func validateFloorPlanGridPlacement(
+        floorPlan: WarehouseFloorPlan?,
+        gridX: Int,
+        gridY: Int,
+        gridWidth: Int,
+        gridHeight: Int
+    ) throws {
+        guard gridX >= 0, gridY >= 0, gridWidth > 0, gridHeight > 0 else {
+            throw WarehouseError.invalidDimension
+        }
+        if let cols = floorPlan?.gridCols, let rows = floorPlan?.gridRows,
+           gridX + gridWidth > cols || gridY + gridHeight > rows {
             throw WarehouseError.invalidDimension
         }
     }

--- a/core/Tests/WiredPartCoreTests/WarehouseFloorPlanTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseFloorPlanTests.swift
@@ -81,6 +81,93 @@ struct WarehouseFloorPlanTests {
         #expect(features.isEmpty)
     }
 
+    @Test("Floor features reject negative grid coordinates")
+    func testAddFloorFeatureRejectsNegativeGridCoordinates() throws {
+        let env = try freshEnv()
+        let plan = try env.warehouse.createFloorPlan(name: "Feature Bounds", widthInches: 200, lengthInches: 200)
+
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            _ = try env.warehouse.addFloorFeature(
+                floorPlanId: plan.id!,
+                featureType: "door",
+                label: "Bad X",
+                gridX: -1,
+                gridY: 0
+            )
+        }
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            _ = try env.warehouse.addFloorFeature(
+                floorPlanId: plan.id!,
+                featureType: "door",
+                label: "Bad Y",
+                gridX: 0,
+                gridY: -1
+            )
+        }
+    }
+
+    @Test("Floor features reject zero or negative grid dimensions")
+    func testAddFloorFeatureRejectsNonPositiveGridDimensions() throws {
+        let env = try freshEnv()
+        let plan = try env.warehouse.createFloorPlan(name: "Feature Dimensions", widthInches: 200, lengthInches: 200)
+
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            _ = try env.warehouse.addFloorFeature(
+                floorPlanId: plan.id!,
+                featureType: "walkway",
+                label: "Zero Width",
+                gridX: 0,
+                gridY: 0,
+                gridWidth: 0,
+                gridHeight: 1
+            )
+        }
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            _ = try env.warehouse.addFloorFeature(
+                floorPlanId: plan.id!,
+                featureType: "walkway",
+                label: "Negative Height",
+                gridX: 0,
+                gridY: 0,
+                gridWidth: 1,
+                gridHeight: -1
+            )
+        }
+    }
+
+    @Test("Floor features reject placements beyond configured floor plan grid")
+    func testAddFloorFeatureRejectsOutOfBoundsGridPlacement() throws {
+        let env = try freshEnv()
+        let plan = try env.warehouse.createFloorPlan(name: "Feature Grid", widthInches: 200, lengthInches: 200)
+        try env.warehouse.updateFloorPlanGrid(floorPlanId: plan.id!, rows: 3, cols: 4)
+
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            _ = try env.warehouse.addFloorFeature(
+                floorPlanId: plan.id!,
+                featureType: "office",
+                label: "Too Wide",
+                gridX: 3,
+                gridY: 0,
+                gridWidth: 2,
+                gridHeight: 1
+            )
+        }
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            _ = try env.warehouse.addFloorFeature(
+                floorPlanId: plan.id!,
+                featureType: "office",
+                label: "Too Tall",
+                gridX: 0,
+                gridY: 2,
+                gridWidth: 1,
+                gridHeight: 2
+            )
+        }
+
+        let features = try env.warehouse.listFloorFeatures(floorPlanId: plan.id!)
+        #expect(features.isEmpty)
+    }
+
     // MARK: - Storage Unit Hierarchy
 
     @Test("Full storage hierarchy: unit → level → area → bin")


### PR DESCRIPTION
## Summary
- Adds service-level grid placement validation to `WarehouseService.addFloorFeature` before inserting floor plan features.
- Reuses the shared floor-plan grid dimension/bounds guard from zone validation so negative coordinates, non-positive dimensions, and placements beyond configured `grid_cols`/`grid_rows` throw `WarehouseError.invalidDimension`.
- Adds regression coverage for invalid floor-feature coordinates, dimensions, and out-of-bounds placements.

Closes #1151

## Tests
- `cd core && swift test --filter WarehouseFloorPlanTests` (44 tests passed)
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `cd core && swift test` (2182 tests passed)

## Local runner / CI note
Local verification was run on the self-hosted Mac development path for this core-only change. No iOS UI files changed, so an Xcode UI smoke/build was not required for the focused fix.
