### PR TITLE
Prune hidden panel schedule circuits after shrink

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
@@ -7,6 +7,7 @@ struct PanelScheduleBuilder: View {
     let onSave: (PanelSchedule) -> Void
 
     @State private var selectedCircuit: CircuitEntry?
+    @State private var showHiddenCircuitPruneConfirmation = false
 
     private enum ActiveSheet: Identifiable {
         case circuitEditor
@@ -41,6 +42,14 @@ struct PanelScheduleBuilder: View {
             case .panelSettings:
                 PanelSettingsSheet(schedule: $schedule)
             }
+        }
+        .alert("Remove Hidden Circuits?", isPresented: $showHiddenCircuitPruneConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Remove & Save", role: .destructive) {
+                saveNormalizedSchedule()
+            }
+        } message: {
+            Text("Saving will permanently remove \(schedule.circuitsOutsideTotalSpaces.count) hidden circuit\(schedule.circuitsOutsideTotalSpaces.count == 1 ? "" : "s") outside the visible 1–\(schedule.totalSpaces) panel range.")
         }
     }
 
@@ -231,7 +240,11 @@ struct PanelScheduleBuilder: View {
             Spacer()
 
             Button {
-                onSave(schedule)
+                if schedule.circuitsOutsideTotalSpaces.isEmpty {
+                    saveNormalizedSchedule()
+                } else {
+                    showHiddenCircuitPruneConfirmation = true
+                }
             } label: {
                 Label("Save", systemImage: "checkmark.circle")
                     .font(.caption)
@@ -257,6 +270,12 @@ struct PanelScheduleBuilder: View {
         } else {
             schedule.circuits.append(circuit)
         }
+    }
+
+    private func saveNormalizedSchedule() {
+        let normalized = schedule.pruningCircuitsOutsideTotalSpaces()
+        schedule = normalized
+        onSave(normalized)
     }
 }
 
@@ -349,6 +368,14 @@ private struct PanelSettingsSheet: View {
                         ForEach(spaceOptions, id: \.self) { size in
                             Text("\(size) spaces").tag(size)
                         }
+                    }
+                    if !schedule.circuitsOutsideTotalSpaces.isEmpty {
+                        Label(
+                            "Saving will remove \(schedule.circuitsOutsideTotalSpaces.count) hidden circuit\(schedule.circuitsOutsideTotalSpaces.count == 1 ? "" : "s") outside the visible 1–\(schedule.totalSpaces) panel range.",
+                            systemImage: "exclamationmark.triangle"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.orange)
                     }
                     Picker("Main Breaker", selection: $schedule.mainBreakerAmps) {
                         Text("None / MLO").tag(nil as Int?)

--- a/Weird Parts IOS/Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests.swift
@@ -52,6 +52,28 @@ final class PanelScheduleBuilderAccessibilityTests: XCTestCase {
         )
     }
 
+    func testSaveNormalizesHiddenCircuitsAfterPanelShrink() throws {
+        let source = try Self.readNotebookSource("PanelScheduleBuilder.swift")
+
+        XCTAssertTrue(
+            source.contains("let normalized = schedule.pruningCircuitsOutsideTotalSpaces()") &&
+                source.contains("schedule = normalized") &&
+                source.contains("onSave(normalized)"),
+            "Saving a shrunk panel schedule should persist a normalized copy so hidden circuits above totalSpaces are not left in notebook JSON."
+        )
+        XCTAssertTrue(
+            source.contains("schedule.circuitsOutsideTotalSpaces") &&
+                source.contains("Saving will remove"),
+            "Panel settings should warn when a shrink will prune hidden circuits above the new total space count."
+        )
+        XCTAssertTrue(
+            source.contains("showHiddenCircuitPruneConfirmation") &&
+                source.contains("Remove Hidden Circuits?") &&
+                source.contains("Remove & Save"),
+            "Saving a shrunk panel with hidden circuits should require explicit confirmation before pruning persisted data."
+        )
+    }
+
     private static func readNotebookSource(_ filename: String, file: StaticString = #filePath) throws -> String {
         let testFileURL = URL(fileURLWithPath: "\(file)")
         let projectRoot = testFileURL

--- a/core/Sources/WiredPartCore/Models/Notebooks/PanelScheduleModels.swift
+++ b/core/Sources/WiredPartCore/Models/Notebooks/PanelScheduleModels.swift
@@ -33,6 +33,27 @@ public struct PanelSchedule: Codable, Identifiable, Sendable {
         self.location = location
         self.circuits = circuits
     }
+
+    /// Returns a copy safe to persist for the current panel size.
+    ///
+    /// Users can shrink `totalSpaces` from the builder settings while stale circuit
+    /// entries remain in memory. Persisting the schedule unchanged would hide those
+    /// circuits in the UI while keeping them in the saved JSON payload. Normalizing
+    /// before save makes the persisted circuit list match the visible panel range.
+    public func pruningCircuitsOutsideTotalSpaces() -> PanelSchedule {
+        var normalized = self
+        normalized.circuits = circuits.filter { circuit in
+            circuit.spaceNumber >= 1 && circuit.spaceNumber <= totalSpaces
+        }
+        return normalized
+    }
+
+    /// Circuits that would be removed by `pruningCircuitsOutsideTotalSpaces()`.
+    public var circuitsOutsideTotalSpaces: [CircuitEntry] {
+        circuits.filter { circuit in
+            circuit.spaceNumber < 1 || circuit.spaceNumber > totalSpaces
+        }
+    }
 }
 
 /// Panel types in electrical installations.

--- a/core/Tests/WiredPartCoreTests/PanelScheduleTests.swift
+++ b/core/Tests/WiredPartCoreTests/PanelScheduleTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import WiredPartCore
+
+@Suite("Panel schedule tests")
+struct PanelScheduleTests {
+    @Test("Pruning removes circuits outside total spaces before persistence")
+    func pruningCircuitsOutsideTotalSpacesDropsHiddenCircuits() {
+        let schedule = PanelSchedule(
+            totalSpaces: 20,
+            circuits: [
+                CircuitEntry(spaceNumber: 1, breakerAmps: 20, breakerType: .single, circuitDescription: "Office", isSpare: false),
+                CircuitEntry(spaceNumber: 20, breakerAmps: 20, breakerType: .single, circuitDescription: "Shop", isSpare: false),
+                CircuitEntry(spaceNumber: 21, breakerAmps: 15, breakerType: .single, circuitDescription: "Hidden old circuit", isSpare: false),
+                CircuitEntry(spaceNumber: 42, breakerAmps: 30, breakerType: .double, circuitDescription: "Hidden range", isSpare: false)
+            ]
+        )
+
+        let normalized = schedule.pruningCircuitsOutsideTotalSpaces()
+
+        #expect(normalized.totalSpaces == 20)
+        #expect(normalized.circuits.map(\.spaceNumber) == [1, 20])
+        #expect(normalized.circuits.allSatisfy { $0.spaceNumber <= normalized.totalSpaces })
+        #expect(schedule.circuitsOutsideTotalSpaces.map(\.spaceNumber) == [21, 42])
+    }
+}


### PR DESCRIPTION
## Summary
- Normalize panel schedules before save so shrinking `totalSpaces` prunes hidden circuit entries above the visible panel range.
- Surface a Panel Settings warning and require an explicit destructive confirmation before pruning hidden circuits.
- Add regression coverage in core model tests and the iOS builder source guard.

Closes #1152

## Tests
- `cd core && swift test --filter PanelScheduleTests` — passed (1 test)
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'id=F29F2637-4865-4685-92B3-98D2F45EF30C' -only-testing:"Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests"` — passed (`** TEST SUCCEEDED **`; 2 tests)
- `cd core && swift test` — passed (2183 tests in 66 suites)
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`)

## Local runner path
- iOS/macOS verification used the local self-hosted Mac simulator path (`WEI3988-iPhone`, id `F29F2637-4865-4685-92B3-98D2F45EF30C`), matching the repo's local Mac runner expectation while cloud capacity is constrained.
