### PR TITLE
Normalize spare panel circuit metadata

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
@@ -265,15 +265,16 @@ struct PanelScheduleBuilder: View {
     // MARK: - Circuit Management
 
     private func updateCircuit(_ circuit: CircuitEntry) {
-        if let index = schedule.circuits.firstIndex(where: { $0.spaceNumber == circuit.spaceNumber }) {
-            schedule.circuits[index] = circuit
+        let normalized = circuit.normalizedForPersistence()
+        if let index = schedule.circuits.firstIndex(where: { $0.spaceNumber == normalized.spaceNumber }) {
+            schedule.circuits[index] = normalized
         } else {
-            schedule.circuits.append(circuit)
+            schedule.circuits.append(normalized)
         }
     }
 
     private func saveNormalizedSchedule() {
-        let normalized = schedule.pruningCircuitsOutsideTotalSpaces()
+        let normalized = schedule.normalizedForPersistence()
         schedule = normalized
         onSave(normalized)
     }
@@ -329,7 +330,7 @@ struct CircuitEditorSheet: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
-                        onSave(circuit)
+                        onSave(circuit.normalizedForPersistence())
                         dismiss()
                     }
                     .fontWeight(.semibold)

--- a/Weird Parts IOS/Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests.swift
@@ -56,10 +56,10 @@ final class PanelScheduleBuilderAccessibilityTests: XCTestCase {
         let source = try Self.readNotebookSource("PanelScheduleBuilder.swift")
 
         XCTAssertTrue(
-            source.contains("let normalized = schedule.pruningCircuitsOutsideTotalSpaces()") &&
+            source.contains("let normalized = schedule.normalizedForPersistence()") &&
                 source.contains("schedule = normalized") &&
                 source.contains("onSave(normalized)"),
-            "Saving a shrunk panel schedule should persist a normalized copy so hidden circuits above totalSpaces are not left in notebook JSON."
+            "Saving a panel schedule should persist a normalized copy so hidden circuits and spare-circuit metadata are not left in notebook JSON."
         )
         XCTAssertTrue(
             source.contains("schedule.circuitsOutsideTotalSpaces") &&
@@ -71,6 +71,21 @@ final class PanelScheduleBuilderAccessibilityTests: XCTestCase {
                 source.contains("Remove Hidden Circuits?") &&
                 source.contains("Remove & Save"),
             "Saving a shrunk panel with hidden circuits should require explicit confirmation before pruning persisted data."
+        )
+    }
+
+    func testSpareCircuitSavesNormalizeHiddenActiveMetadata() throws {
+        let source = try Self.readNotebookSource("PanelScheduleBuilder.swift")
+
+        XCTAssertTrue(
+            source.contains("let normalized = circuit.normalizedForPersistence()") &&
+                source.contains("schedule.circuits[index] = normalized") &&
+                source.contains("schedule.circuits.append(normalized)"),
+            "Updating a circuit should normalize spare entries before they are kept in builder state."
+        )
+        XCTAssertTrue(
+            source.contains("onSave(circuit.normalizedForPersistence())"),
+            "The circuit editor should not hand contradictory spare/active metadata back to the builder."
         )
     }
 

--- a/core/Sources/WiredPartCore/Models/Notebooks/PanelScheduleModels.swift
+++ b/core/Sources/WiredPartCore/Models/Notebooks/PanelScheduleModels.swift
@@ -48,6 +48,17 @@ public struct PanelSchedule: Codable, Identifiable, Sendable {
         return normalized
     }
 
+    /// Returns a copy safe to persist after panel builder edits.
+    ///
+    /// A circuit marked spare should not retain active breaker/load metadata that
+    /// will be hidden by the grid and exports. Normalize both the visible panel
+    /// range and the per-circuit spare payload before writing notebook JSON.
+    public func normalizedForPersistence() -> PanelSchedule {
+        var normalized = pruningCircuitsOutsideTotalSpaces()
+        normalized.circuits = normalized.circuits.map { $0.normalizedForPersistence() }
+        return normalized
+    }
+
     /// Circuits that would be removed by `pruningCircuitsOutsideTotalSpaces()`.
     public var circuitsOutsideTotalSpaces: [CircuitEntry] {
         circuits.filter { circuit in
@@ -96,6 +107,21 @@ public struct CircuitEntry: Codable, Identifiable, Sendable {
         self.conduit = conduit
         self.isSpare = isSpare
         self.isFedFrom = isFedFrom
+    }
+
+    /// Returns a persistable copy where spare circuits cannot keep hidden
+    /// active-circuit metadata.
+    public func normalizedForPersistence() -> CircuitEntry {
+        guard isSpare else { return self }
+
+        var normalized = self
+        normalized.breakerAmps = nil
+        normalized.breakerType = .spare
+        normalized.circuitDescription = ""
+        normalized.wire = nil
+        normalized.conduit = nil
+        normalized.isFedFrom = nil
+        return normalized
     }
 }
 

--- a/core/Tests/WiredPartCoreTests/PanelScheduleTests.swift
+++ b/core/Tests/WiredPartCoreTests/PanelScheduleTests.swift
@@ -22,4 +22,62 @@ struct PanelScheduleTests {
         #expect(normalized.circuits.allSatisfy { $0.spaceNumber <= normalized.totalSpaces })
         #expect(schedule.circuitsOutsideTotalSpaces.map(\.spaceNumber) == [21, 42])
     }
+
+    @Test("Spare circuits drop hidden active metadata before persistence")
+    func spareCircuitsDropActiveMetadataBeforePersistence() {
+        let activeSpare = CircuitEntry(
+            spaceNumber: 7,
+            breakerAmps: 20,
+            breakerType: .single,
+            circuitDescription: "Old office outlets",
+            wire: "#12 THHN",
+            conduit: "3/4 EMT",
+            isSpare: true,
+            isFedFrom: "MDP"
+        )
+
+        let normalizedCircuit = activeSpare.normalizedForPersistence()
+
+        #expect(normalizedCircuit.spaceNumber == 7)
+        #expect(normalizedCircuit.isSpare)
+        #expect(normalizedCircuit.breakerAmps == nil)
+        #expect(normalizedCircuit.breakerType == .spare)
+        #expect(normalizedCircuit.circuitDescription.isEmpty)
+        #expect(normalizedCircuit.wire == nil)
+        #expect(normalizedCircuit.conduit == nil)
+        #expect(normalizedCircuit.isFedFrom == nil)
+    }
+
+    @Test("Panel persistence normalizes spare circuits and hidden range together")
+    func panelPersistenceNormalizesSpareCircuitsAndHiddenRange() {
+        let schedule = PanelSchedule(
+            totalSpaces: 20,
+            circuits: [
+                CircuitEntry(
+                    spaceNumber: 1,
+                    breakerAmps: 20,
+                    breakerType: .single,
+                    circuitDescription: "Hidden active data",
+                    wire: "#12 THHN",
+                    conduit: "1/2 EMT",
+                    isSpare: true,
+                    isFedFrom: "Panel B"
+                ),
+                CircuitEntry(spaceNumber: 21, breakerAmps: 15, breakerType: .single, circuitDescription: "Hidden old circuit", isSpare: false)
+            ]
+        )
+
+        let normalized = schedule.normalizedForPersistence()
+
+        #expect(normalized.circuits.count == 1)
+        let circuit = normalized.circuits[0]
+        #expect(circuit.spaceNumber == 1)
+        #expect(circuit.isSpare)
+        #expect(circuit.breakerAmps == nil)
+        #expect(circuit.breakerType == .spare)
+        #expect(circuit.circuitDescription.isEmpty)
+        #expect(circuit.wire == nil)
+        #expect(circuit.conduit == nil)
+        #expect(circuit.isFedFrom == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- Add shared PanelSchedule/CircuitEntry persistence normalization so spare circuits cannot retain hidden active breaker metadata.
- Use the normalizer from the panel builder when saving a circuit and when persisting the full schedule.
- Add core regression coverage plus an iOS builder source guard for the spare-circuit save path.

Closes #1153

## Tests
- `cd core && swift test --filter PanelScheduleTests` — passed (3 tests)
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests"` — passed (`** TEST SUCCEEDED **`; 3 tests)
- `cd core && swift test` — passed (2185 tests in 66 suites)
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`)

## Local runner path
- iOS/macOS verification used the local self-hosted Mac simulator path (`WEI3988-iPhone`), matching the repo's local Mac runner expectation while cloud capacity is constrained.
