### PR TITLE
fix: centralize required text validation

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
+++ b/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
@@ -521,7 +521,7 @@ struct IOSAIAssistantPanel: View {
                     .foregroundStyle(Color.accentColor)
             }
             .accessibilityLabel("Send message")
-            .disabled(query.trimmingCharacters(in: .whitespaces).isEmpty || isProcessing || isClearingConversation)
+            .disabled(query.isBlankRequiredText || isProcessing || isClearingConversation)
         }
         .padding(.horizontal)
         .padding(.vertical, 8)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Chat/CreateChannelSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Chat/CreateChannelSheet.swift
@@ -82,7 +82,7 @@ struct CreateChannelSheet: View {
 
     private var isCreateDisabled: Bool {
         if isSupplier { return selectedSupplierId == 0 }
-        return channelName.isEmpty
+        return channelName.isBlankRequiredText
     }
 
     private func saveChannel() {
@@ -97,7 +97,7 @@ struct CreateChannelSheet: View {
             if isSupplier {
                 let supplier = suppliers.first(where: { ($0.supplier.id ?? 0) == selectedSupplierId })
                 let displayName = supplier?.supplier.contactName ?? supplier?.supplier.name ?? "Supplier"
-                let name = channelName.isEmpty ? "Channel: \(supplier?.supplier.name ?? "Supplier")" : channelName
+                let name = channelName.normalizedRequiredText ?? "Channel: \(supplier?.supplier.name ?? "Supplier")"
                 _ = try service.createSupplierChannel(
                     name: name,
                     supplierId: selectedSupplierId,
@@ -107,8 +107,13 @@ struct CreateChannelSheet: View {
                     createdBy: userId
                 )
             } else {
+                guard let name = channelName.normalizedRequiredText else {
+                    saveError = "Channel name is required"
+                    isSaving = false
+                    return
+                }
                 _ = try service.createChannel(
-                    name: channelName,
+                    name: name,
                     channelType: channelType,
                     createdBy: userId
                 )

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/ReportBuilderView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/ReportBuilderView.swift
@@ -440,7 +440,7 @@ struct ReportBuilderView: View {
                         Label("Save Configuration", systemImage: "square.and.arrow.down")
                     }
                     .buttonStyle(.bordered)
-                    .disabled(reportName.isEmpty)
+                    .disabled(reportName.isBlankRequiredText)
 
                     Spacer()
 
@@ -506,9 +506,13 @@ struct ReportBuilderView: View {
             saveError = "Not logged in"
             return
         }
+        guard let normalizedName = reportName.normalizedRequiredText else {
+            saveError = "Report name is required"
+            return
+        }
         do {
             try service.saveReportConfig(
-                name: reportName,
+                name: normalizedName,
                 type: selectedType.rawValue,
                 columns: selectedColumnKeys,
                 filters: [:],

--- a/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
@@ -156,7 +156,7 @@ struct QRScanSheet: View {
 
                 Button("Look Up") { processManualEntry() }
                     .buttonStyle(.bordered)
-                    .disabled(manualCode.trimmingCharacters(in: .whitespaces).isEmpty || isProcessing)
+                    .disabled(manualCode.isBlankRequiredText || isProcessing)
             }
             .padding(.horizontal)
             .padding(.bottom, 12)
@@ -187,7 +187,7 @@ struct QRScanSheet: View {
 
                 Button("Look Up") { processManualEntry() }
                     .buttonStyle(.borderedProminent)
-                    .disabled(manualCode.isEmpty || isProcessing)
+                    .disabled(manualCode.isBlankRequiredText || isProcessing)
             }
             .padding(.horizontal, 24)
 
@@ -249,10 +249,8 @@ struct QRScanSheet: View {
     }
 
     // MARK: - Processing
-
     private func processManualEntry() {
-        let code = manualCode.trimmingCharacters(in: .whitespaces)
-        guard !code.isEmpty else { return }
+        guard let code = manualCode.normalizedRequiredText else { return }
         Task {
             await processPayload(code)
             await MainActor.run { manualCode = "" }

--- a/core/Sources/WiredPartCore/AI/FoundationModelsService.swift
+++ b/core/Sources/WiredPartCore/AI/FoundationModelsService.swift
@@ -305,8 +305,8 @@ public actor FoundationModelsService {
         remoteText: String,
         context: String? = nil
     ) async -> AIResult {
-        guard !localText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
-              !remoteText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !localText.isBlankRequiredText ||
+              !remoteText.isBlankRequiredText else {
             return .fail("No text to merge")
         }
 
@@ -369,7 +369,7 @@ public actor FoundationModelsService {
     /// - Parameter query: The user's question.
     /// - Returns: An `AIResult` containing the assistant's response.
     public func chat(query: String) async -> AIResult {
-        guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !query.isBlankRequiredText else {
             return .fail("Empty query")
         }
 
@@ -410,7 +410,7 @@ public actor FoundationModelsService {
         navigationContext: String,
         conversationId: String = "default"
     ) async -> AIResult {
-        guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !query.isBlankRequiredText else {
             return .fail("Empty query")
         }
 

--- a/core/Sources/WiredPartCore/RequiredTextValidation.swift
+++ b/core/Sources/WiredPartCore/RequiredTextValidation.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Shared normalization rules for durable user-entered text.
+///
+/// Service boundaries use these helpers so SwiftUI forms, tests, sync/import paths,
+/// and future non-UI callers all reject visually blank required values the same way.
+public extension String {
+    /// Returns this value trimmed with `.whitespacesAndNewlines`.
+    var trimmedRequiredText: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// True when a required durable value is empty after whitespace/newline trimming.
+    var isBlankRequiredText: Bool {
+        trimmedRequiredText.isEmpty
+    }
+
+    /// Trims a required durable value, returning `nil` when the input is visually blank.
+    var normalizedRequiredText: String? {
+        let trimmed = trimmedRequiredText
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+public extension Optional where Wrapped == String {
+    /// Trims optional durable text and normalizes whitespace/newline-only input to `nil`.
+    var normalizedOptionalText: String? {
+        guard let value = self else { return nil }
+        return value.normalizedRequiredText
+    }
+}

--- a/core/Sources/WiredPartCore/Services/AuthService.swift
+++ b/core/Sources/WiredPartCore/Services/AuthService.swift
@@ -472,7 +472,7 @@ public final class AuthService: Sendable {
 
     /// Add a permission key to a hat.
     public func addHatPermission(hatId: Int64, permissionKey: String) throws {
-        guard !permissionKey.isBlankRequiredText else {
+        guard !permissionKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw AuthError.requiredFieldEmpty("permissionKey")
         }
         try db.writer.write { dbConnection in
@@ -790,7 +790,7 @@ public final class AuthService: Sendable {
         // Validate inputs: display name must be non-blank; PIN must be 4–8 digits.
         // Previously a blank displayName would create a login-screen entry the user
         // couldn't select, and a too-short PIN bypassed lockout timing.
-        guard !displayName.isBlankRequiredText else {
+        guard !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw AuthError.requiredFieldEmpty("displayName")
         }
         let trimmedPin = pin.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/core/Sources/WiredPartCore/Services/AuthService.swift
+++ b/core/Sources/WiredPartCore/Services/AuthService.swift
@@ -472,7 +472,7 @@ public final class AuthService: Sendable {
 
     /// Add a permission key to a hat.
     public func addHatPermission(hatId: Int64, permissionKey: String) throws {
-        guard !permissionKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !permissionKey.isBlankRequiredText else {
             throw AuthError.requiredFieldEmpty("permissionKey")
         }
         try db.writer.write { dbConnection in
@@ -790,7 +790,7 @@ public final class AuthService: Sendable {
         // Validate inputs: display name must be non-blank; PIN must be 4–8 digits.
         // Previously a blank displayName would create a login-screen entry the user
         // couldn't select, and a too-short PIN bypassed lockout timing.
-        guard !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !displayName.isBlankRequiredText else {
             throw AuthError.requiredFieldEmpty("displayName")
         }
         let trimmedPin = pin.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/core/Sources/WiredPartCore/Services/ChatService.swift
+++ b/core/Sources/WiredPartCore/Services/ChatService.swift
@@ -324,7 +324,7 @@ public final class ChatService: Sendable {
     /// Send a message to a channel. Returns the inserted message row ID.
     @discardableResult
     public func sendMessage(channelId: Int64, senderId: Int64, content: String) throws -> Int64 {
-        guard !content.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !content.isBlankRequiredText else {
             throw ChatError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in
@@ -368,7 +368,7 @@ public final class ChatService: Sendable {
             try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_chat")
         }
 
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw ChatError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in
@@ -502,7 +502,7 @@ public final class ChatService: Sendable {
         subject: String,
         priority: String = "normal"
     ) throws -> Int64 {
-        guard !subject.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !subject.isBlankRequiredText else {
             throw ChatError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in

--- a/core/Sources/WiredPartCore/Services/FleetService.swift
+++ b/core/Sources/WiredPartCore/Services/FleetService.swift
@@ -1054,10 +1054,10 @@ public final class FleetService: Sendable {
         guard try auth.hasPermission(actorId, permissionKey: "manage_fleet") else {
             throw FleetError.insufficientPermissions(required: "manage_fleet")
         }
-        guard !vehicleNumber.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !vehicleNumber.isBlankRequiredText else {
             throw FleetError.requiredFieldEmpty("vehicleNumber")
         }
-        guard !vehicleName.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !vehicleName.isBlankRequiredText else {
             throw FleetError.requiredFieldEmpty("vehicleName")
         }
         return try db.writer.write { dbConn in
@@ -1090,10 +1090,10 @@ public final class FleetService: Sendable {
         guard try auth.hasPermission(actorId, permissionKey: "manage_fleet") else {
             throw FleetError.insufficientPermissions(required: "manage_fleet")
         }
-        guard !trailerNumber.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !trailerNumber.isBlankRequiredText else {
             throw FleetError.requiredFieldEmpty("trailerNumber")
         }
-        guard !trailerType.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !trailerType.isBlankRequiredText else {
             throw FleetError.requiredFieldEmpty("trailerType")
         }
         return try db.writer.write { dbConn in
@@ -1616,7 +1616,7 @@ public final class FleetService: Sendable {
         guard try auth.hasPermission(actorId, permissionKey: "log_fleet") else {
             throw FleetError.insufficientPermissions(required: "log_fleet")
         }
-        guard !partName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !partName.isBlankRequiredText else {
             throw FleetError.requiredFieldEmpty("partName")
         }
         guard quantity > 0 else { throw FleetError.invalidQuantity(quantity) }

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -835,8 +835,8 @@ public final class JobsService: Sendable {
         createdBy: Int64? = nil,
         jobClassification: String = "standard"
     ) throws -> Int64 {
-        guard !jobName.trimmingCharacters(in: .whitespaces).isEmpty else { throw JobsError.requiredFieldEmpty }
-        guard !jobNumber.trimmingCharacters(in: .whitespaces).isEmpty else { throw JobsError.requiredFieldEmpty }
+        guard !jobName.isBlankRequiredText else { throw JobsError.requiredFieldEmpty }
+        guard !jobNumber.isBlankRequiredText else { throw JobsError.requiredFieldEmpty }
         let notebooks = NotebooksService(db: db)
         return try db.writer.write { dbConn in
             try dbConn.execute(
@@ -941,10 +941,10 @@ public final class JobsService: Sendable {
         clearEstimatedHours: Bool = false,
         clearBudgetLimit: Bool = false
     ) throws {
-        if let jobName, jobName.trimmingCharacters(in: .whitespaces).isEmpty {
+        if let jobName, jobName.isBlankRequiredText {
             throw JobsError.requiredFieldEmpty
         }
-        if let status, status.trimmingCharacters(in: .whitespaces).isEmpty {
+        if let status, status.isBlankRequiredText {
             throw JobsError.requiredFieldEmpty
         }
         try db.writer.write { dbConn in
@@ -1863,7 +1863,7 @@ public final class JobsService: Sendable {
 
     /// Set work type for a clock entry ("new_work" or "warranty").
     public func setClockEntryWorkType(clockEntryId: Int64, workType: String) throws {
-        guard !workType.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !workType.isBlankRequiredText else {
             throw JobsError.requiredFieldEmpty
         }
         try db.writer.write { dbConn in
@@ -2048,7 +2048,7 @@ public final class JobsService: Sendable {
             ).map { (row: Row) -> Int64 in row["id"] as Int64 }
             let answeredSet = Set(
                 responses
-                    .filter { !$0.answer.trimmingCharacters(in: .whitespaces).isEmpty }
+                    .filter { !$0.answer.isBlankRequiredText }
                     .map { $0.questionId }
             )
             for reqId in requiredIds {
@@ -2155,7 +2155,7 @@ public final class JobsService: Sendable {
         createdBy: Int64,
         targetUserId: Int64? = nil
     ) throws -> Int64 {
-        guard !text.trimmingCharacters(in: .whitespaces).isEmpty else { throw JobsError.requiredFieldEmpty }
+        guard !text.isBlankRequiredText else { throw JobsError.requiredFieldEmpty }
         return try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
@@ -2175,7 +2175,7 @@ public final class JobsService: Sendable {
         answerText: String,
         answeredBy: Int64
     ) throws {
-        guard !answerText.trimmingCharacters(in: .whitespaces).isEmpty else { throw JobsError.requiredFieldEmpty }
+        guard !answerText.isBlankRequiredText else { throw JobsError.requiredFieldEmpty }
         try db.writer.write { dbConn in
             let count = try Int.fetchOne(
                 dbConn,

--- a/core/Sources/WiredPartCore/Services/NotebooksService.swift
+++ b/core/Sources/WiredPartCore/Services/NotebooksService.swift
@@ -370,7 +370,7 @@ public final class NotebooksService: Sendable {
             try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_notebooks")
         }
 
-        guard !title.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !title.isBlankRequiredText else {
             throw NotebooksError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in
@@ -424,7 +424,7 @@ public final class NotebooksService: Sendable {
             try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_notebooks")
         }
 
-        guard !title.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !title.isBlankRequiredText else {
             throw NotebooksError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in
@@ -803,7 +803,7 @@ public final class NotebooksService: Sendable {
     /// Create a new section group in a notebook.
     @discardableResult
     public func createSectionGroup(notebookId: Int64, name: String) throws -> Int64 {
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw NotebooksError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in
@@ -822,7 +822,7 @@ public final class NotebooksService: Sendable {
 
     /// Update a section group's name.
     public func updateSectionGroup(groupId: Int64, name: String) throws {
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw NotebooksError.requiredFieldEmpty
         }
         try db.writer.write { dbConn in
@@ -867,7 +867,7 @@ public final class NotebooksService: Sendable {
     /// Create a new section in a notebook, optionally within a group.
     @discardableResult
     public func createSection(notebookId: Int64, groupId: Int64?, name: String) throws -> Int64 {
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw NotebooksError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in
@@ -886,7 +886,7 @@ public final class NotebooksService: Sendable {
 
     /// Update a section's name.
     public func updateSection(sectionId: Int64, name: String) throws {
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw NotebooksError.requiredFieldEmpty
         }
         try db.writer.write { dbConn in
@@ -1485,7 +1485,7 @@ public final class NotebooksService: Sendable {
             try ServicePermissionGate.requirePermission(dbConn, userId: createdBy, permissionKey: "manage_templates")
         }
 
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw NotebooksError.requiredFieldEmpty
         }
         let jsonData = try JSONEncoder().encode(templateData)
@@ -1903,7 +1903,7 @@ public final class NotebooksService: Sendable {
 
         guard let pending else { return false }
         guard let merged = await mergeText(pending.local, pending.remote, pending.context),
-              !merged.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+              !merged.isBlankRequiredText else {
             return false
         }
 

--- a/core/Sources/WiredPartCore/Services/OrdersService.swift
+++ b/core/Sources/WiredPartCore/Services/OrdersService.swift
@@ -966,7 +966,7 @@ public final class OrdersService: Sendable {
         partName: String,
         jpoId: Int64
     ) throws -> Int64 {
-        guard !holdReason.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !holdReason.isBlankRequiredText else {
             throw OrdersError.requiredFieldEmpty("holdReason")
         }
 
@@ -3351,7 +3351,7 @@ public final class OrdersService: Sendable {
         supplierId: Int64,
         notes: String? = nil
     ) throws -> Int64 {
-        guard !poNumber.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !poNumber.isBlankRequiredText else {
             throw OrdersError.requiredFieldEmpty("poNumber")
         }
 
@@ -3447,10 +3447,10 @@ public final class OrdersService: Sendable {
 
     /// Append a timestamped note to a purchase order's notes field.
     public func addPONote(poId: Int64, note: String, author: String) throws {
-        guard !note.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !note.isBlankRequiredText else {
             throw OrdersError.requiredFieldEmpty("note")
         }
-        guard !author.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !author.isBlankRequiredText else {
             throw OrdersError.requiredFieldEmpty("author")
         }
         try db.writer.write { dbConn in
@@ -3886,10 +3886,10 @@ public final class OrdersService: Sendable {
         jobId: Int64? = nil,
         initiatedBy: Int64
     ) throws -> Int64 {
-        guard !returnType.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !returnType.isBlankRequiredText else {
             throw OrdersError.requiredFieldEmpty("returnType")
         }
-        guard !reason.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !reason.isBlankRequiredText else {
             throw OrdersError.requiredFieldEmpty("reason")
         }
 
@@ -3930,7 +3930,7 @@ public final class OrdersService: Sendable {
 
     /// Update the status of a return.
     public func updateReturnStatus(returnId: Int64, status: String) throws {
-        guard !status.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !status.isBlankRequiredText else {
             throw OrdersError.requiredFieldEmpty("status")
         }
 

--- a/core/Sources/WiredPartCore/Services/PartsService+OCRImportPreview.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService+OCRImportPreview.swift
@@ -115,7 +115,7 @@ extension PartsService {
         chunkLineLimit: Int = 8
     ) throws -> PartsOCRImportPreview {
         let cleanedPages = pages
-            .filter { !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .filter { !$0.text.isBlankRequiredText }
             .sorted { $0.pageNumber < $1.pageNumber }
         guard !cleanedPages.isEmpty else {
             throw PartsError.invalidInput("OCR import preview requires at least one page of extracted text.")

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -4358,7 +4358,7 @@ public final class PartsService: Sendable {
         guard try auth.hasPermission(byUserId, permissionKey: "forecasting.dismiss_recommendation") else {
             throw PartsError.insufficientPermissions(required: "forecasting.dismiss_recommendation")
         }
-        guard !reason.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !reason.isBlankRequiredText else {
             throw PartsError.invalidInput("Dismiss reason is required")
         }
         try db.writer.write { dbConn in
@@ -7214,7 +7214,7 @@ public final class PartsService: Sendable {
             let hash = service.importSourceHash(Data(csv.utf8))
             let records = service.parseImportCSVRecords(csv)
             let rows = records.compactMap { record -> PartsImportDraftRow? in
-                guard record.fields.contains(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) else {
+                guard record.fields.contains(where: { !$0.isBlankRequiredText }) else {
                     return nil
                 }
                 return PartsImportDraftRow(

--- a/core/Sources/WiredPartCore/Services/PeopleService.swift
+++ b/core/Sources/WiredPartCore/Services/PeopleService.swift
@@ -582,10 +582,10 @@ public final class PeopleService: Sendable {
         expiryDate: String? = nil,
         notes: String? = nil
     ) throws -> Certification {
-        guard !certType.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !certType.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("certType")
         }
-        guard !certName.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !certName.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("certName")
         }
         try db.writer.read { dbConn in
@@ -641,10 +641,10 @@ public final class PeopleService: Sendable {
         yearsExperience: Double? = nil,
         verifiedBy: Int64? = nil
     ) throws -> UserSkill {
-        guard !skillName.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !skillName.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("skillName")
         }
-        guard !proficiency.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !proficiency.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("proficiency")
         }
         try db.writer.read { dbConn in
@@ -987,7 +987,7 @@ public final class PeopleService: Sendable {
         zip: String? = nil,
         notes: String? = nil
     ) throws -> Int64 {
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("name")
         }
         return try db.writer.write { dbConn in
@@ -1016,10 +1016,10 @@ public final class PeopleService: Sendable {
         isPrimary: Bool = false,
         notes: String? = nil
     ) throws -> Int64 {
-        guard !entityType.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !entityType.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("entityType")
         }
-        guard !firstName.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !firstName.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("firstName")
         }
         return try db.writer.write { dbConn in
@@ -1043,7 +1043,7 @@ public final class PeopleService: Sendable {
         email: String? = nil,
         role: String? = nil
     ) throws {
-        guard !firstName.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !firstName.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("firstName")
         }
         let encryptedEmail = try encryptSensitiveField(email)
@@ -1070,7 +1070,7 @@ public final class PeopleService: Sendable {
         trade: String? = nil,
         notes: String? = nil
     ) throws -> Int64 {
-        guard !companyName.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !companyName.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("companyName")
         }
         return try db.writer.write { dbConn in
@@ -1088,7 +1088,7 @@ public final class PeopleService: Sendable {
     /// Create a new team. Returns the new team's ID.
     @discardableResult
     public func createTeam(name: String, description: String? = nil) throws -> Int64 {
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("name")
         }
         return try db.writer.write { dbConn in
@@ -1261,7 +1261,7 @@ public final class PeopleService: Sendable {
 
     /// Update team name and description.
     public func updateTeam(teamId: Int64, name: String, description: String?) throws {
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("name")
         }
         try db.writer.write { dbConn in
@@ -1326,7 +1326,7 @@ public final class PeopleService: Sendable {
     /// Create a new hat (role). Returns the new hat's ID.
     @discardableResult
     public func createHat(name: String, description: String? = nil, level: Int = 0) throws -> Int64 {
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("name")
         }
         return try db.writer.write { dbConn in
@@ -1821,10 +1821,10 @@ public final class PeopleService: Sendable {
     /// Add a communication entry for a customer.
     @discardableResult
     public func addCommunicationEntry(customerId: Int64, commType: String, content: String, createdBy: Int64) throws -> Int64 {
-        guard !commType.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !commType.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("commType")
         }
-        guard !content.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !content.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("content")
         }
         return try db.writer.write { dbConn in
@@ -1952,7 +1952,7 @@ public final class PeopleService: Sendable {
     /// Add a note to a contractor.
     @discardableResult
     public func addContractorNote(contractorId: Int64, content: String, createdBy: Int64) throws -> Int64 {
-        guard !content.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !content.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("content")
         }
         return try db.writer.write { dbConn in
@@ -2282,7 +2282,7 @@ public final class PeopleService: Sendable {
         }
 
         guard amount > 0 else { throw PeopleError.invalidAmount(amount) }
-        guard !dueDate.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !dueDate.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("dueDate")
         }
         return try db.writer.write { dbConn in
@@ -2313,7 +2313,7 @@ public final class PeopleService: Sendable {
     /// Record a payment against an existing invoice.
     public func recordPayment(recordId: Int64, amount: Double, paidDate: String) throws {
         guard amount > 0 else { throw PeopleError.invalidAmount(amount) }
-        guard !paidDate.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !paidDate.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("paidDate")
         }
         try db.writer.write { dbConn in

--- a/core/Sources/WiredPartCore/Services/ReportsService.swift
+++ b/core/Sources/WiredPartCore/Services/ReportsService.swift
@@ -1268,6 +1268,11 @@ public final class ReportsService: Sendable {
         name: String, type: String, columns: [String],
         filters: [String: String], userId: Int64, isShared: Bool
     ) throws -> Int64 {
+        guard let normalizedName = name.normalizedRequiredText,
+              let normalizedType = type.normalizedRequiredText else {
+            throw ReportsError.requiredFieldEmpty
+        }
+
         try db.writer.read { dbConn in
             try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "view_reports")
         }
@@ -1280,7 +1285,7 @@ public final class ReportsService: Sendable {
             try dbConn.execute(sql: """
                 INSERT INTO saved_reports (name, report_type, columns_json, filters_json, created_by, is_shared)
                 VALUES (?, ?, ?, ?, ?, ?)
-                """, arguments: [name, type, columnsJson, filtersJson, userId, isShared])
+                """, arguments: [normalizedName, normalizedType, columnsJson, filtersJson, userId, isShared])
             return dbConn.lastInsertedRowID
         }
     }
@@ -1773,6 +1778,7 @@ public final class ReportsService: Sendable {
 }
 
 public enum ReportsError: Error, LocalizedError, Equatable {
+    case requiredFieldEmpty
     case timesheetSegmentNotFound(Int64)
     case invalidTimesheetCorrectionReason
     case invalidTimesheetCorrectionRange
@@ -1780,6 +1786,8 @@ public enum ReportsError: Error, LocalizedError, Equatable {
 
     public var errorDescription: String? {
         switch self {
+        case .requiredFieldEmpty:
+            return "Required report text is missing."
         case .timesheetSegmentNotFound:
             return "Timesheet entry was not found."
         case .invalidTimesheetCorrectionReason:

--- a/core/Sources/WiredPartCore/Services/ReportsService.swift
+++ b/core/Sources/WiredPartCore/Services/ReportsService.swift
@@ -1787,7 +1787,7 @@ public enum ReportsError: Error, LocalizedError, Equatable {
     public var errorDescription: String? {
         switch self {
         case .requiredFieldEmpty:
-            return "Required report text is missing."
+            return "Report name and type are required."
         case .timesheetSegmentNotFound:
             return "Timesheet entry was not found."
         case .invalidTimesheetCorrectionReason:

--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -605,10 +605,10 @@ public final class SchedulingService: Sendable {
         endDate: String,
         reason: String? = nil
     ) throws -> Int64 {
-        guard !startDate.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !startDate.isBlankRequiredText else {
             throw SchedulingError.requiredFieldEmpty
         }
-        guard !endDate.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !endDate.isBlankRequiredText else {
             throw SchedulingError.requiredFieldEmpty
         }
         // Guard: user must exist and not be tombstoned — otherwise the INSERT INTO
@@ -1120,7 +1120,7 @@ public final class SchedulingService: Sendable {
         notes: String? = nil,
         forceCreateDespiteTimeOff: Bool = false
     ) throws -> Int64 {
-        guard !date.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !date.isBlankRequiredText else {
             throw SchedulingError.requiredFieldEmpty
         }
         // Service-layer time-off conflict enforcement (fixes #355).
@@ -1389,7 +1389,7 @@ public final class SchedulingService: Sendable {
         timeSlot: String = "full",
         forceCreateDespiteTimeOff: Bool = false
     ) throws -> Int64 {
-        guard !date.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !date.isBlankRequiredText else {
             throw SchedulingError.requiredFieldEmpty
         }
         // Service-layer time-off conflict enforcement (consistent with createDispatch).
@@ -1781,7 +1781,7 @@ public final class SchedulingService: Sendable {
 
     /// Snooze a callback to a future date (updates the job's due_date).
     public func snoozeCallback(jobId: Int64, until: String) throws {
-        guard !until.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !until.isBlankRequiredText else {
             throw SchedulingError.requiredFieldEmpty
         }
         try db.writer.write { dbConn in
@@ -2255,16 +2255,16 @@ public final class SchedulingService: Sendable {
         breakMinutes: Int = 30, breakPaid: Bool = false,
         overtimeRule: String = "company_default"
     ) throws -> Int64 {
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw SchedulingError.requiredFieldEmpty
         }
-        guard !workDays.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !workDays.isBlankRequiredText else {
             throw SchedulingError.requiredFieldEmpty
         }
-        guard !startTime.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !startTime.isBlankRequiredText else {
             throw SchedulingError.requiredFieldEmpty
         }
-        guard !endTime.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !endTime.isBlankRequiredText else {
             throw SchedulingError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in
@@ -2350,10 +2350,10 @@ public final class SchedulingService: Sendable {
         id: Int64? = nil, name: String, date: String,
         isPaid: Bool = true, isRecurring: Bool = false
     ) throws -> Int64 {
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw SchedulingError.requiredFieldEmpty
         }
-        guard !date.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !date.isBlankRequiredText else {
             throw SchedulingError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in

--- a/core/Sources/WiredPartCore/Services/SettingsService.swift
+++ b/core/Sources/WiredPartCore/Services/SettingsService.swift
@@ -779,10 +779,10 @@ public final class SettingsService: Sendable {
     /// Add a new clock-out question. Returns the inserted row ID.
     @discardableResult
     public func addClockOutQuestion(text: String, type: String, isRequired: Bool, sortOrder: Int) throws -> Int64 {
-        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !text.isBlankRequiredText else {
             throw SettingsError.requiredFieldEmpty("text")
         }
-        guard !type.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !type.isBlankRequiredText else {
             throw SettingsError.requiredFieldEmpty("type")
         }
         return try db.writer.write { dbConnection -> Int64 in
@@ -796,10 +796,10 @@ public final class SettingsService: Sendable {
 
     /// Update an existing clock-out question.
     public func updateClockOutQuestion(id: String, text: String, type: String, isRequired: Bool) throws {
-        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !text.isBlankRequiredText else {
             throw SettingsError.requiredFieldEmpty("text")
         }
-        guard !type.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !type.isBlankRequiredText else {
             throw SettingsError.requiredFieldEmpty("type")
         }
         try db.writer.write { dbConnection in

--- a/core/Sources/WiredPartCore/Services/ToolsService.swift
+++ b/core/Sources/WiredPartCore/Services/ToolsService.swift
@@ -781,7 +781,7 @@ public final class ToolsService: Sendable {
     public func checkoutToolWithCondition(
         toolId: Int64, userId: Int64, condition: String, notes: String? = nil
     ) throws {
-        guard !condition.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !condition.isBlankRequiredText else {
             throw ToolsError.requiredFieldEmpty("condition")
         }
         try db.writer.write { dbConn in
@@ -827,7 +827,7 @@ public final class ToolsService: Sendable {
     public func returnToolWithCondition(
         toolId: Int64, userId: Int64, condition: String, notes: String? = nil
     ) throws {
-        guard !condition.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !condition.isBlankRequiredText else {
             throw ToolsError.requiredFieldEmpty("condition")
         }
         try db.writer.write { dbConn in
@@ -1098,7 +1098,7 @@ public final class ToolsService: Sendable {
     ) throws -> Int64 {
         // tool_trades.condition_at_send is NOT NULL — a blank string passes the constraint
         // but poisons every downstream UI that shows the "condition at send" column.
-        guard !condition.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !condition.isBlankRequiredText else {
             throw ToolsError.requiredFieldEmpty("condition")
         }
         // A self-trade is nonsensical (tool already assigned to fromUser) and the tool
@@ -1325,7 +1325,7 @@ public final class ToolsService: Sendable {
     ) throws {
         // A blank reportType would silently overwrite tools.status with "" and file
         // a useless audit entry; a blank description makes the audit trail meaningless.
-        guard !reportType.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !reportType.isBlankRequiredText else {
             throw ToolsError.requiredFieldEmpty("reportType")
         }
         // Enforce the valid reportType set — the value is written straight into
@@ -1334,7 +1334,7 @@ public final class ToolsService: Sendable {
         guard validReportTypes.contains(reportType) else {
             throw ToolsError.requiredFieldEmpty("reportType")
         }
-        guard !description.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !description.isBlankRequiredText else {
             throw ToolsError.requiredFieldEmpty("description")
         }
         try db.writer.write { dbConn in
@@ -1415,7 +1415,7 @@ public final class ToolsService: Sendable {
         decayFloor: Double? = nil, conditionTriggers: [String]? = nil,
         description: String? = nil
     ) throws -> Int64 {
-        guard !type.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !type.isBlankRequiredText else {
             throw ToolsError.requiredFieldEmpty("type")
         }
         let triggersJSON = conditionTriggers.map { triggers -> String in

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -863,7 +863,7 @@ public final class WarehouseService: Sendable {
         // which of fromLocationType/toLocationType is non-nil, not by sign. A
         // negative qty inverts the stock delta: `qty = qty - (-3)` = qty + 3.
         guard qty > 0 else { throw WarehouseError.invalidQuantity }
-        guard !movementType.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !movementType.isBlankRequiredText else {
             throw WarehouseError.requiredFieldEmpty
         }
         try Self.validateLocationEndpointCompleteness(locationType: fromLocationType, locationId: fromLocationId)
@@ -1135,7 +1135,7 @@ public final class WarehouseService: Sendable {
         guard !movements.isEmpty else { return [] }
         for m in movements {
             guard m.qty > 0 else { throw WarehouseError.invalidQuantity }
-            guard !m.movementType.trimmingCharacters(in: .whitespaces).isEmpty else {
+            guard !m.movementType.isBlankRequiredText else {
                 throw WarehouseError.requiredFieldEmpty
             }
             try Self.validateLocationEndpointCompleteness(locationType: m.fromLocationType, locationId: m.fromLocationId)
@@ -2655,7 +2655,7 @@ public final class WarehouseService: Sendable {
             try ServicePermissionGate.requirePermission(dbConn, userId: userId, permissionKey: "perform_audit")
         }
 
-        guard !scope.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !scope.isBlankRequiredText else {
             throw WarehouseError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in
@@ -2865,8 +2865,8 @@ public final class WarehouseService: Sendable {
         status: String = "active",
         notes: String? = nil
     ) throws -> Int64 {
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty,
-              !trailerCode.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText,
+              !trailerCode.isBlankRequiredText else {
             throw WarehouseError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in
@@ -4222,7 +4222,7 @@ public final class WarehouseService: Sendable {
 
     /// Create a new warehouse floor plan.
     public func createFloorPlan(name: String, widthInches: Int, lengthInches: Int) throws -> WarehouseFloorPlan {
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw WarehouseError.requiredFieldEmpty
         }
         guard widthInches > 0, lengthInches > 0 else {
@@ -4291,7 +4291,7 @@ public final class WarehouseService: Sendable {
         floorPlanId: Int64, featureType: String, label: String?,
         gridX: Int, gridY: Int, gridWidth: Int = 1, gridHeight: Int = 1, rotation: Int = 0
     ) throws -> WarehouseFloorFeature {
-        guard !featureType.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !featureType.isBlankRequiredText else {
             throw WarehouseError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in
@@ -4345,7 +4345,7 @@ public final class WarehouseService: Sendable {
         gridX: Int = 0, gridY: Int = 0, gridWidth: Int = 4, gridHeight: Int = 4,
         rotation: Int = 0, zoneOrder: Int = 0
     ) throws -> WarehouseZone {
-        guard !zoneType.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !zoneType.isBlankRequiredText else {
             throw WarehouseError.requiredFieldEmpty
         }
         guard gridX >= 0, gridY >= 0, gridWidth > 0, gridHeight > 0 else {
@@ -4844,7 +4844,7 @@ public final class WarehouseService: Sendable {
         rotation: Int = 0, frontFace: String? = "south",
         isMovable: Bool = false, isJobReady: Bool = false
     ) throws -> WarehouseStorageUnit {
-        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !name.isBlankRequiredText else {
             throw WarehouseError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in
@@ -4891,7 +4891,7 @@ public final class WarehouseService: Sendable {
         rotation: Int? = nil, frontFace: String? = nil,
         isConfigured: Bool? = nil, zoneId: Int64? = nil
     ) throws {
-        if let name, name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if let name, name.isBlankRequiredText {
             throw WarehouseError.requiredFieldEmpty
         }
 
@@ -4986,7 +4986,7 @@ public final class WarehouseService: Sendable {
         unitId: Int64, levelCode: String, levelName: String? = nil,
         order: Int = 0, heightInches: Int? = nil, areaCount: Int = 1
     ) throws -> WarehouseStorageLevel {
-        guard !levelCode.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !levelCode.isBlankRequiredText else {
             throw WarehouseError.requiredFieldEmpty
         }
         return try db.writer.write { dbConn in
@@ -6513,7 +6513,7 @@ public final class WarehouseService: Sendable {
 
     /// Resolve a misplaced part entry.
     public func resolveMisplacedPart(logId: Int64, resolution: String, resolvedBy: Int64) throws {
-        guard !resolution.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard !resolution.isBlankRequiredText else {
             throw WarehouseError.requiredFieldEmpty
         }
         try db.writer.write { dbConn in

--- a/core/Sources/WiredPartCore/Services/WishlistService.swift
+++ b/core/Sources/WiredPartCore/Services/WishlistService.swift
@@ -579,7 +579,7 @@ public final class WishlistService: Sendable {
     /// Internal dismiss — called by system paths that bypass the permission gate.
     @discardableResult
     private func _performDismiss(id: Int64, dismissedByName: String, reason: String) throws -> WishlistItem {
-        guard !reason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !reason.isBlankRequiredText else {
             throw WishlistError.dismissReasonRequired
         }
         return try db.writer.write { dbConn in

--- a/core/Tests/WiredPartCoreTests/RequiredTextValidationTests.swift
+++ b/core/Tests/WiredPartCoreTests/RequiredTextValidationTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import WiredPartCore
+
+@Suite("Required text validation")
+struct RequiredTextValidationTests {
+    @Test("central helper rejects whitespace and newline-only required text")
+    func centralHelperRejectsNewlineOnlyText() {
+        #expect("   ".isBlankRequiredText)
+        #expect("\n\t\r".isBlankRequiredText)
+        #expect("  Durable Name\n".normalizedRequiredText == "Durable Name")
+
+        let optionalWhitespace: String? = "\n\t"
+        #expect(optionalWhitespace.normalizedOptionalText == nil)
+    }
+
+    @Test("chat service rejects newline-only required text at service boundary")
+    func chatRejectsNewlineOnlyRequiredText() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        #expect(throws: ChatService.ChatError.self) {
+            _ = try env.chat.createChannel(
+                name: "\n\t",
+                channelType: "group",
+                jobId: nil,
+                createdBy: env.adminUserId
+            )
+        }
+
+        let channelId = try env.chat.createChannel(
+            name: "Crew chat",
+            channelType: "group",
+            jobId: nil,
+            createdBy: env.adminUserId
+        )
+        #expect(throws: ChatService.ChatError.self) {
+            _ = try env.chat.sendMessage(
+                channelId: channelId,
+                senderId: env.adminUserId,
+                content: "\n\t"
+            )
+        }
+    }
+
+    @Test("warehouse floor plan required text rejects newline-only values")
+    func warehouseRejectsNewlineOnlyRequiredText() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        #expect(throws: WarehouseService.WarehouseError.requiredFieldEmpty) {
+            _ = try env.warehouse.createFloorPlan(name: "\n\t", widthInches: 120, lengthInches: 120)
+        }
+
+        let plan = try env.warehouse.createFloorPlan(name: "Main floor", widthInches: 120, lengthInches: 120)
+        #expect(throws: WarehouseService.WarehouseError.requiredFieldEmpty) {
+            _ = try env.warehouse.addFloorFeature(
+                floorPlanId: plan.id!,
+                featureType: "\n\t",
+                label: nil,
+                gridX: 0,
+                gridY: 0
+            )
+        }
+    }
+
+    @Test("reports service trims saved report names and rejects newline-only report metadata")
+    func reportsNormalizeAndRejectRequiredText() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        #expect(throws: ReportsError.requiredFieldEmpty) {
+            _ = try env.reports.saveReportConfig(
+                name: "\n\t",
+                type: "labor",
+                columns: ["employee"],
+                filters: [:],
+                userId: env.adminUserId,
+                isShared: false
+            )
+        }
+
+        let reportId = try env.reports.saveReportConfig(
+            name: "  Weekly Labor\n",
+            type: "  labor\n",
+            columns: ["employee"],
+            filters: [:],
+            userId: env.adminUserId,
+            isShared: false
+        )
+        let saved = try env.reports.getSavedReports(userId: env.adminUserId)
+        let report = try #require(saved.first { $0.id == reportId })
+        #expect(report.name == "Weekly Labor")
+        #expect(report.reportType == "labor")
+    }
+}


### PR DESCRIPTION
## Summary
- Add shared WiredPartCore required-text normalization helpers that trim `.whitespacesAndNewlines` and expose optional normalization for durable text.
- Route required service-boundary checks through the shared helper across chat, warehouse, jobs, orders, people, fleet, tools, scheduling, notebooks, settings, wishlist, AI, and related core services.
- Harden saved report config persistence plus cited SwiftUI affordances for chat channel names, saved report names, manual QR lookup, and assistant send buttons.
- Add regression coverage for newline-only values through helper, chat, warehouse, and reports service paths.

Closes #1166

## Verification
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `swift test --package-path core --filter RequiredTextValidationTests`
- `cd core && swift test` (2189 tests passed)
- `xcodebuild -scheme WiredPart-iOS -destination 'generic/platform=iOS Simulator' build`\n\n## Review follow-up\n- Addressed Copilot review by clarifying the saved-report required-field error copy.\n- Left `AuthService` unchanged after Copilot flagged it as security-sensitive; this PR now avoids auth-surface changes.\n\n## Local runner path\nValidated locally on the WPR2 self-hosted Mac/Xcode path before opening this PR.