### PR TITLE
Fix forecasting stock target input validation

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsForecastingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsForecastingPage.swift
@@ -1203,9 +1203,9 @@ private struct ForecastDetailSheet: View {
             return
         }
 
-        let min = Int(editMinStock) ?? 0
-        let target = Int(editTargetStock) ?? 0
-        let max = Int(editMaxStock) ?? 0
+        guard let min = parseStockTarget(editMinStock, fieldName: "Min") else { return }
+        guard let target = parseStockTarget(editTargetStock, fieldName: "Target") else { return }
+        guard let max = parseStockTarget(editMaxStock, fieldName: "Max") else { return }
         guard min < target else {
             editError = "Min stock must be less than target stock"
             isSaving = false
@@ -1238,5 +1238,15 @@ private struct ForecastDetailSheet: View {
                 isSaving = false
             }
         }
+    }
+
+    private func parseStockTarget(_ text: String, fieldName: String) -> Int? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let value = Int(trimmed), value >= 0 else {
+            editError = "\(fieldName) stock must be a whole number"
+            isSaving = false
+            return nil
+        }
+        return value
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsForecastingPageRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsForecastingPageRegressionTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+final class PartsForecastingPageRegressionTests: XCTestCase {
+    func testForecastStockTargetsRejectMalformedTextInsteadOfDefaultingToZero() throws {
+        let source = try Self.readPartsForecastingPageSource()
+
+        XCTAssertTrue(
+            source.contains("guard let min = parseStockTarget(editMinStock, fieldName: \"Min\") else { return }"),
+            "Saving forecast settings should parse min stock through the required whole-number validator."
+        )
+        XCTAssertTrue(
+            source.contains("guard let target = parseStockTarget(editTargetStock, fieldName: \"Target\") else { return }"),
+            "Saving forecast settings should parse target stock through the required whole-number validator."
+        )
+        XCTAssertTrue(
+            source.contains("guard let max = parseStockTarget(editMaxStock, fieldName: \"Max\") else { return }"),
+            "Saving forecast settings should parse max stock through the required whole-number validator."
+        )
+        XCTAssertTrue(
+            source.contains("editError = \"\\(fieldName) stock must be a whole number\""),
+            "Malformed stock target input should leave a field-specific visible validation error."
+        )
+        XCTAssertTrue(
+            source.contains("trimmingCharacters(in: .whitespacesAndNewlines)"),
+            "Stock target parsing should accept padded whole-number text without treating whitespace as malformed."
+        )
+        XCTAssertTrue(
+            source.contains("value >= 0"),
+            "Stock targets should remain non-negative whole numbers."
+        )
+        XCTAssertFalse(
+            source.contains("Int(editMinStock) ?? 0") ||
+                source.contains("Int(editTargetStock) ?? 0") ||
+                source.contains("Int(editMaxStock) ?? 0"),
+            "Malformed stock target input must never be coerced to zero on save."
+        )
+    }
+
+    private static func readPartsForecastingPageSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Parts")
+            .appendingPathComponent("PartsForecastingPage.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Reject malformed/non-numeric forecasting stock target text instead of coercing it to zero.
- Trim padded whole-number text, require non-negative integers, and show field-specific validation errors for Min/Target/Max stock fields.
- Add a focused iOS regression test that guards against reintroducing `Int(...) ?? 0` saves for forecasting stock targets.

Closes #1173

## Verification
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/PartsForecastingPageRegressionTests"` — passed
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`)
- `xcodebuild build -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone'` — passed

CI note: local Mac runner path remains the expected CI route for trusted WPR2 iOS/macOS/Xcode PR gates per repo runbook.
