### PR TITLE
Fix SyncEngine ack failure reporting

### DIFF
--- a/core/Sources/WiredPartCore/Sync/SyncEngine.swift
+++ b/core/Sources/WiredPartCore/Sync/SyncEngine.swift
@@ -224,7 +224,21 @@ public actor SyncEngine {
                 "device_id": deviceId,
                 "sync_batch_id": syncBatchId,
             ]
-            let (_, ackResponse) = try await httpPost(url: ackURL, body: ackBody, authToken: authToken, timeout: 10)
+            let ackDataAndResponse: (Data, URLResponse)
+            do {
+                ackDataAndResponse = try await httpPost(url: ackURL, body: ackBody, authToken: authToken, timeout: 10)
+            } catch {
+                let pendingCount = (try? ChangeTracker.getPendingChangeCount(db: db)) ?? pendingChanges.count
+                updateState(
+                    status: .error,
+                    pendingCount: pendingCount,
+                    error: "Ack request failed: \(error.localizedDescription)",
+                    consecutiveFailures: state.consecutiveFailures + 1
+                )
+                scheduleRetry(deviceId: deviceId, shopUrl: shopUrl, authToken: authToken)
+                return false
+            }
+            let (_, ackResponse) = ackDataAndResponse
             guard let ackHTTPResponse = ackResponse as? HTTPURLResponse,
                   (200..<300).contains(ackHTTPResponse.statusCode) else {
                 let statusCode = (ackResponse as? HTTPURLResponse)?.statusCode ?? 0

--- a/core/Sources/WiredPartCore/Sync/SyncEngine.swift
+++ b/core/Sources/WiredPartCore/Sync/SyncEngine.swift
@@ -193,7 +193,16 @@ public actor SyncEngine {
                 return false
             }
 
-            let syncBatchId = resultData["sync_batch_id"] as? String ?? UUID().uuidString
+            guard let syncBatchId = resultData["sync_batch_id"] as? String,
+                  !syncBatchId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                updateState(
+                    status: .error,
+                    error: "Invalid push response: missing sync_batch_id",
+                    consecutiveFailures: state.consecutiveFailures + 1
+                )
+                scheduleRetry(deviceId: deviceId, shopUrl: shopUrl, authToken: authToken)
+                return false
+            }
 
             // 3. Apply shop changes to local DB
             if let shopChangesRaw = resultData["shop_changes"] as? [[String: Any]] {

--- a/core/Sources/WiredPartCore/Sync/SyncEngine.swift
+++ b/core/Sources/WiredPartCore/Sync/SyncEngine.swift
@@ -228,9 +228,10 @@ public actor SyncEngine {
             guard let ackHTTPResponse = ackResponse as? HTTPURLResponse,
                   (200..<300).contains(ackHTTPResponse.statusCode) else {
                 let statusCode = (ackResponse as? HTTPURLResponse)?.statusCode ?? 0
+                let pendingCount = (try? ChangeTracker.getPendingChangeCount(db: db)) ?? pendingChanges.count
                 updateState(
                     status: .error,
-                    pendingCount: pendingChanges.count,
+                    pendingCount: pendingCount,
                     error: "Ack failed: \(statusCode)",
                     consecutiveFailures: state.consecutiveFailures + 1
                 )

--- a/core/Sources/WiredPartCore/Sync/SyncEngine.swift
+++ b/core/Sources/WiredPartCore/Sync/SyncEngine.swift
@@ -239,9 +239,19 @@ public actor SyncEngine {
                 return false
             }
             let (_, ackResponse) = ackDataAndResponse
-            guard let ackHTTPResponse = ackResponse as? HTTPURLResponse,
-                  (200..<300).contains(ackHTTPResponse.statusCode) else {
-                let statusCode = (ackResponse as? HTTPURLResponse)?.statusCode ?? 0
+            guard let ackHTTPResponse = ackResponse as? HTTPURLResponse else {
+                let pendingCount = (try? ChangeTracker.getPendingChangeCount(db: db)) ?? pendingChanges.count
+                updateState(
+                    status: .error,
+                    pendingCount: pendingCount,
+                    error: "Ack failed: non-HTTP response",
+                    consecutiveFailures: state.consecutiveFailures + 1
+                )
+                scheduleRetry(deviceId: deviceId, shopUrl: shopUrl, authToken: authToken)
+                return false
+            }
+            guard (200..<300).contains(ackHTTPResponse.statusCode) else {
+                let statusCode = ackHTTPResponse.statusCode
                 let pendingCount = (try? ChangeTracker.getPendingChangeCount(db: db)) ?? pendingChanges.count
                 updateState(
                     status: .error,

--- a/core/Sources/WiredPartCore/Sync/SyncEngine.swift
+++ b/core/Sources/WiredPartCore/Sync/SyncEngine.swift
@@ -207,19 +207,33 @@ public actor SyncEngine {
                 }
             }
 
-            // 4. Mark local changes as synced
-            if !pendingChanges.isEmpty {
-                let syncedIds = pendingChanges.compactMap { $0.id }
-                try ChangeTracker.markSynced(db: db, ids: syncedIds, batchId: syncBatchId)
-            }
-
-            // 5. Acknowledge (non-critical)
+            // 4. Acknowledge the batch before declaring local rows fully synced.
+            // The shop/server side may use this ack to close out delivery state, so an
+            // ack failure must remain retryable instead of reporting a clean sync.
             let ackURL = baseURL.appendingPathComponent("api/sync/ack")
             let ackBody: [String: Any] = [
                 "device_id": deviceId,
                 "sync_batch_id": syncBatchId,
             ]
-            _ = try? await httpPost(url: ackURL, body: ackBody, authToken: authToken, timeout: 10)
+            let (_, ackResponse) = try await httpPost(url: ackURL, body: ackBody, authToken: authToken, timeout: 10)
+            guard let ackHTTPResponse = ackResponse as? HTTPURLResponse,
+                  (200..<300).contains(ackHTTPResponse.statusCode) else {
+                let statusCode = (ackResponse as? HTTPURLResponse)?.statusCode ?? 0
+                updateState(
+                    status: .error,
+                    pendingCount: pendingChanges.count,
+                    error: "Ack failed: \(statusCode)",
+                    consecutiveFailures: state.consecutiveFailures + 1
+                )
+                scheduleRetry(deviceId: deviceId, shopUrl: shopUrl, authToken: authToken)
+                return false
+            }
+
+            // 5. Mark local changes as synced only after push and ack both succeed.
+            if !pendingChanges.isEmpty {
+                let syncedIds = pendingChanges.compactMap { $0.id }
+                try ChangeTracker.markSynced(db: db, ids: syncedIds, batchId: syncBatchId)
+            }
 
             // Success
             let now = currentTimestamp()

--- a/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
@@ -1,6 +1,5 @@
 import Testing
 import Foundation
-import Network
 @testable import WiredPartCore
 
 @Suite("PeerManager Tests")
@@ -413,78 +412,5 @@ struct PeerManagerTests {
 extension PeerManager {
     func testEnrichChanges(_ entries: [ChangeLogEntry]) throws -> [IncomingChange] {
         try enrichChangesWithData(entries)
-    }
-}
-
-private final class HTTPStubServer: @unchecked Sendable {
-    private let listener: NWListener
-    private let statusCode: Int
-    private let body: String
-    private let queue = DispatchQueue(label: "com.wiredpart.tests.httpstub")
-
-    init(statusCode: Int, body: String) throws {
-        self.listener = try NWListener(using: .tcp, on: .any)
-        self.statusCode = statusCode
-        self.body = body
-    }
-
-    func start() async throws -> UInt16 {
-        try await withCheckedThrowingContinuation { continuation in
-            let continuationBox = OneShotContinuationBox(continuation)
-
-            listener.stateUpdateHandler = { [listener] state in
-                switch state {
-                case .ready:
-                    if let port = listener.port {
-                        continuationBox.resume(.success(port.rawValue))
-                    } else {
-                        continuationBox.resume(.failure(URLError(.badServerResponse)))
-                    }
-                case .failed(let error):
-                    continuationBox.resume(.failure(error))
-                default:
-                    break
-                }
-            }
-            listener.newConnectionHandler = { [body, statusCode, queue] connection in
-                connection.start(queue: queue)
-                connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { _, _, _, _ in
-                    let statusText = statusCode == 200 ? "OK" : "Error"
-                    let response = """
-                    HTTP/1.1 \(statusCode) \(statusText)\r
-                    Content-Type: application/json\r
-                    Content-Length: \(body.utf8.count)\r
-                    Connection: close\r
-                    \r
-                    \(body)
-                    """
-                    connection.send(content: Data(response.utf8), completion: .contentProcessed { _ in
-                        connection.cancel()
-                    })
-                }
-            }
-            listener.start(queue: queue)
-        }
-    }
-
-    func stop() {
-        listener.cancel()
-    }
-}
-
-private final class OneShotContinuationBox: @unchecked Sendable {
-    private var continuation: CheckedContinuation<UInt16, Error>?
-    private let lock = NSLock()
-
-    init(_ continuation: CheckedContinuation<UInt16, Error>) {
-        self.continuation = continuation
-    }
-
-    func resume(_ result: Result<UInt16, Error>) {
-        lock.lock()
-        let continuation = self.continuation
-        self.continuation = nil
-        lock.unlock()
-        continuation?.resume(with: result)
     }
 }

--- a/core/Tests/WiredPartCoreTests/SyncEngineTests.swift
+++ b/core/Tests/WiredPartCoreTests/SyncEngineTests.swift
@@ -188,6 +188,53 @@ struct SyncEngineTests {
         #expect(state.error == "Ack failed: 500")
         #expect(state.consecutiveFailures == 1)
     }
+
+    @Test("Sync rejects push responses without a batch ID before acking")
+    func testMissingBatchIdDoesNotAckOrReportSynced() async throws {
+        let db = try freshDB()
+        let engine = SyncEngine(db: db)
+        let ackCallCount = Mutex(0)
+
+        try ChangeTracker.trackChange(
+            db: db,
+            tableName: "users",
+            recordId: 1,
+            operation: .insert,
+            deviceId: "dev-001"
+        )
+
+        let server = try SyncEngineHTTPStubServer { request in
+            switch request.path {
+            case "/api/sync/push":
+                return SyncEngineHTTPStubResponse(
+                    statusCode: 200,
+                    body: #"{"data":{"shop_changes":[]}}"#
+                )
+            case "/api/sync/ack":
+                ackCallCount.withLock { $0 += 1 }
+                return SyncEngineHTTPStubResponse(statusCode: 200, body: #"{"ok":true}"#)
+            default:
+                return SyncEngineHTTPStubResponse(statusCode: 404, body: #"{"error":"not found"}"#)
+            }
+        }
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let result = await engine.runSync(
+            deviceId: "dev-001",
+            shopUrl: "http://127.0.0.1:\(port)",
+            authToken: nil
+        )
+
+        #expect(result == false)
+        #expect(ackCallCount.withLock { $0 } == 0)
+        #expect(try ChangeTracker.getPendingChangeCount(db: db) == 1)
+
+        let state = await engine.getState()
+        #expect(state.status == .error)
+        #expect(state.error == "Invalid push response: missing sync_batch_id")
+        #expect(state.consecutiveFailures == 1)
+    }
 }
 
 // Simple thread-safe wrapper for test assertions
@@ -241,8 +288,9 @@ private final class SyncEngineHTTPStubServer: @unchecked Sendable {
             }
             listener.newConnectionHandler = { [handler, queue] connection in
                 connection.start(queue: queue)
-                connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { data, _, _, _ in
-                    let rawRequest = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+
+                @Sendable func sendResponse(for requestData: Data) {
+                    let rawRequest = String(data: requestData, encoding: .utf8) ?? ""
                     let requestLine = rawRequest.components(separatedBy: "\r\n").first ?? ""
                     let path = requestLine.split(separator: " ").dropFirst().first.map(String.init) ?? "/"
                     let stubResponse = handler(SyncEngineHTTPStubRequest(path: path))
@@ -259,6 +307,24 @@ private final class SyncEngineHTTPStubServer: @unchecked Sendable {
                         connection.cancel()
                     })
                 }
+
+                @Sendable func receive(_ buffered: Data) {
+                    connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { data, _, isComplete, _ in
+                        var requestData = buffered
+                        if let data {
+                            requestData.append(data)
+                        }
+
+                        guard requestData.containsCRLF || isComplete else {
+                            receive(requestData)
+                            return
+                        }
+
+                        sendResponse(for: requestData)
+                    }
+                }
+
+                receive(Data())
             }
             listener.start(queue: queue)
         }
@@ -283,6 +349,13 @@ private final class SyncEngineOneShotContinuationBox: @unchecked Sendable {
         self.continuation = nil
         lock.unlock()
         continuation?.resume(with: result)
+    }
+}
+
+private extension Data {
+    var containsCRLF: Bool {
+        guard count >= 2 else { return false }
+        return zip(self, dropFirst()).contains { $0 == 13 && $1 == 10 }
     }
 }
 

--- a/core/Tests/WiredPartCoreTests/SyncEngineTests.swift
+++ b/core/Tests/WiredPartCoreTests/SyncEngineTests.swift
@@ -243,7 +243,7 @@ private final class SyncEngineHTTPStubServer: @unchecked Sendable {
                 connection.start(queue: queue)
                 connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { data, _, _, _ in
                     let rawRequest = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
-                    let requestLine = rawRequest.split(separator: "\r\n", maxSplits: 1, omittingEmptySubsequences: false).first ?? ""
+                    let requestLine = rawRequest.components(separatedBy: "\r\n").first ?? ""
                     let path = requestLine.split(separator: " ").dropFirst().first.map(String.init) ?? "/"
                     let stubResponse = handler(SyncEngineHTTPStubRequest(path: path))
                     let statusText = (200..<300).contains(stubResponse.statusCode) ? "OK" : "Error"

--- a/core/Tests/WiredPartCoreTests/SyncEngineTests.swift
+++ b/core/Tests/WiredPartCoreTests/SyncEngineTests.swift
@@ -1,6 +1,5 @@
 import Testing
 import Foundation
-import Network
 @testable import WiredPartCore
 
 @Suite("SyncEngine Tests")
@@ -154,20 +153,20 @@ struct SyncEngineTests {
         )
         #expect(try ChangeTracker.getPendingChangeCount(db: db) == 1)
 
-        let server = try SyncEngineHTTPStubServer { request in
+        let server = try HTTPStubServer { request in
             switch request.path {
             case "/api/sync/push":
-                return SyncEngineHTTPStubResponse(
+                return HTTPStubResponse(
                     statusCode: 200,
                     body: #"{"data":{"sync_batch_id":"batch-ack-fails","shop_changes":[]}}"#
                 )
             case "/api/sync/ack":
-                return SyncEngineHTTPStubResponse(
+                return HTTPStubResponse(
                     statusCode: 500,
                     body: #"{"error":"ack failed"}"#
                 )
             default:
-                return SyncEngineHTTPStubResponse(statusCode: 404, body: #"{"error":"not found"}"#)
+                return HTTPStubResponse(statusCode: 404, body: #"{"error":"not found"}"#)
             }
         }
         let port = try await server.start()
@@ -203,18 +202,18 @@ struct SyncEngineTests {
             deviceId: "dev-001"
         )
 
-        let server = try SyncEngineHTTPStubServer { request in
+        let server = try HTTPStubServer { request in
             switch request.path {
             case "/api/sync/push":
-                return SyncEngineHTTPStubResponse(
+                return HTTPStubResponse(
                     statusCode: 200,
                     body: #"{"data":{"shop_changes":[]}}"#
                 )
             case "/api/sync/ack":
                 ackCallCount.withLock { $0 += 1 }
-                return SyncEngineHTTPStubResponse(statusCode: 200, body: #"{"ok":true}"#)
+                return HTTPStubResponse(statusCode: 200, body: #"{"ok":true}"#)
             default:
-                return SyncEngineHTTPStubResponse(statusCode: 404, body: #"{"error":"not found"}"#)
+                return HTTPStubResponse(statusCode: 404, body: #"{"error":"not found"}"#)
             }
         }
         let port = try await server.start()
@@ -246,116 +245,6 @@ private final class Mutex<T>: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return body(&value)
-    }
-}
-
-private struct SyncEngineHTTPStubRequest: Sendable {
-    let path: String
-}
-
-private struct SyncEngineHTTPStubResponse: Sendable {
-    let statusCode: Int
-    let body: String
-}
-
-private final class SyncEngineHTTPStubServer: @unchecked Sendable {
-    private let listener: NWListener
-    private let handler: @Sendable (SyncEngineHTTPStubRequest) -> SyncEngineHTTPStubResponse
-    private let queue = DispatchQueue(label: "com.wiredpart.tests.syncengine.httpstub")
-
-    init(handler: @escaping @Sendable (SyncEngineHTTPStubRequest) -> SyncEngineHTTPStubResponse) throws {
-        self.listener = try NWListener(using: .tcp, on: .any)
-        self.handler = handler
-    }
-
-    func start() async throws -> UInt16 {
-        try await withCheckedThrowingContinuation { continuation in
-            let continuationBox = SyncEngineOneShotContinuationBox(continuation)
-
-            listener.stateUpdateHandler = { [listener] state in
-                switch state {
-                case .ready:
-                    if let port = listener.port {
-                        continuationBox.resume(.success(port.rawValue))
-                    } else {
-                        continuationBox.resume(.failure(URLError(.badServerResponse)))
-                    }
-                case .failed(let error):
-                    continuationBox.resume(.failure(error))
-                default:
-                    break
-                }
-            }
-            listener.newConnectionHandler = { [handler, queue] connection in
-                connection.start(queue: queue)
-
-                @Sendable func sendResponse(for requestData: Data) {
-                    let rawRequest = String(data: requestData, encoding: .utf8) ?? ""
-                    let requestLine = rawRequest.components(separatedBy: "\r\n").first ?? ""
-                    let path = requestLine.split(separator: " ").dropFirst().first.map(String.init) ?? "/"
-                    let stubResponse = handler(SyncEngineHTTPStubRequest(path: path))
-                    let statusText = (200..<300).contains(stubResponse.statusCode) ? "OK" : "Error"
-                    let response = """
-                    HTTP/1.1 \(stubResponse.statusCode) \(statusText)\r
-                    Content-Type: application/json\r
-                    Content-Length: \(stubResponse.body.utf8.count)\r
-                    Connection: close\r
-                    \r
-                    \(stubResponse.body)
-                    """
-                    connection.send(content: Data(response.utf8), completion: .contentProcessed { _ in
-                        connection.cancel()
-                    })
-                }
-
-                @Sendable func receive(_ buffered: Data) {
-                    connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { data, _, isComplete, _ in
-                        var requestData = buffered
-                        if let data {
-                            requestData.append(data)
-                        }
-
-                        guard requestData.containsCRLF || isComplete else {
-                            receive(requestData)
-                            return
-                        }
-
-                        sendResponse(for: requestData)
-                    }
-                }
-
-                receive(Data())
-            }
-            listener.start(queue: queue)
-        }
-    }
-
-    func stop() {
-        listener.cancel()
-    }
-}
-
-private final class SyncEngineOneShotContinuationBox: @unchecked Sendable {
-    private var continuation: CheckedContinuation<UInt16, Error>?
-    private let lock = NSLock()
-
-    init(_ continuation: CheckedContinuation<UInt16, Error>) {
-        self.continuation = continuation
-    }
-
-    func resume(_ result: Result<UInt16, Error>) {
-        lock.lock()
-        let continuation = self.continuation
-        self.continuation = nil
-        lock.unlock()
-        continuation?.resume(with: result)
-    }
-}
-
-private extension Data {
-    var containsCRLF: Bool {
-        guard count >= 2 else { return false }
-        return zip(self, dropFirst()).contains { $0 == 13 && $1 == 10 }
     }
 }
 

--- a/core/Tests/WiredPartCoreTests/SyncEngineTests.swift
+++ b/core/Tests/WiredPartCoreTests/SyncEngineTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import Network
 @testable import WiredPartCore
 
 @Suite("SyncEngine Tests")
@@ -138,6 +139,55 @@ struct SyncEngineTests {
         let fired = expectation.withLock { $0 }
         #expect(fired == true)
     }
+
+    @Test("Sync ack failure is retryable and does not mark changes synced")
+    func testAckFailureDoesNotReportSynced() async throws {
+        let db = try freshDB()
+        let engine = SyncEngine(db: db)
+
+        try ChangeTracker.trackChange(
+            db: db,
+            tableName: "users",
+            recordId: 1,
+            operation: .insert,
+            deviceId: "dev-001"
+        )
+        #expect(try ChangeTracker.getPendingChangeCount(db: db) == 1)
+
+        let server = try SyncEngineHTTPStubServer { request in
+            switch request.path {
+            case "/api/sync/push":
+                return SyncEngineHTTPStubResponse(
+                    statusCode: 200,
+                    body: #"{"data":{"sync_batch_id":"batch-ack-fails","shop_changes":[]}}"#
+                )
+            case "/api/sync/ack":
+                return SyncEngineHTTPStubResponse(
+                    statusCode: 500,
+                    body: #"{"error":"ack failed"}"#
+                )
+            default:
+                return SyncEngineHTTPStubResponse(statusCode: 404, body: #"{"error":"not found"}"#)
+            }
+        }
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let result = await engine.runSync(
+            deviceId: "dev-001",
+            shopUrl: "http://127.0.0.1:\(port)",
+            authToken: nil
+        )
+
+        #expect(result == false)
+        #expect(try ChangeTracker.getPendingChangeCount(db: db) == 1)
+
+        let state = await engine.getState()
+        #expect(state.status == .error)
+        #expect(state.pendingCount == 1)
+        #expect(state.error == "Ack failed: 500")
+        #expect(state.consecutiveFailures == 1)
+    }
 }
 
 // Simple thread-safe wrapper for test assertions
@@ -149,6 +199,90 @@ private final class Mutex<T>: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return body(&value)
+    }
+}
+
+private struct SyncEngineHTTPStubRequest: Sendable {
+    let path: String
+}
+
+private struct SyncEngineHTTPStubResponse: Sendable {
+    let statusCode: Int
+    let body: String
+}
+
+private final class SyncEngineHTTPStubServer: @unchecked Sendable {
+    private let listener: NWListener
+    private let handler: @Sendable (SyncEngineHTTPStubRequest) -> SyncEngineHTTPStubResponse
+    private let queue = DispatchQueue(label: "com.wiredpart.tests.syncengine.httpstub")
+
+    init(handler: @escaping @Sendable (SyncEngineHTTPStubRequest) -> SyncEngineHTTPStubResponse) throws {
+        self.listener = try NWListener(using: .tcp, on: .any)
+        self.handler = handler
+    }
+
+    func start() async throws -> UInt16 {
+        try await withCheckedThrowingContinuation { continuation in
+            let continuationBox = SyncEngineOneShotContinuationBox(continuation)
+
+            listener.stateUpdateHandler = { [listener] state in
+                switch state {
+                case .ready:
+                    if let port = listener.port {
+                        continuationBox.resume(.success(port.rawValue))
+                    } else {
+                        continuationBox.resume(.failure(URLError(.badServerResponse)))
+                    }
+                case .failed(let error):
+                    continuationBox.resume(.failure(error))
+                default:
+                    break
+                }
+            }
+            listener.newConnectionHandler = { [handler, queue] connection in
+                connection.start(queue: queue)
+                connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { data, _, _, _ in
+                    let rawRequest = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+                    let requestLine = rawRequest.split(separator: "\r\n", maxSplits: 1, omittingEmptySubsequences: false).first ?? ""
+                    let path = requestLine.split(separator: " ").dropFirst().first.map(String.init) ?? "/"
+                    let stubResponse = handler(SyncEngineHTTPStubRequest(path: path))
+                    let statusText = (200..<300).contains(stubResponse.statusCode) ? "OK" : "Error"
+                    let response = """
+                    HTTP/1.1 \(stubResponse.statusCode) \(statusText)\r
+                    Content-Type: application/json\r
+                    Content-Length: \(stubResponse.body.utf8.count)\r
+                    Connection: close\r
+                    \r
+                    \(stubResponse.body)
+                    """
+                    connection.send(content: Data(response.utf8), completion: .contentProcessed { _ in
+                        connection.cancel()
+                    })
+                }
+            }
+            listener.start(queue: queue)
+        }
+    }
+
+    func stop() {
+        listener.cancel()
+    }
+}
+
+private final class SyncEngineOneShotContinuationBox: @unchecked Sendable {
+    private var continuation: CheckedContinuation<UInt16, Error>?
+    private let lock = NSLock()
+
+    init(_ continuation: CheckedContinuation<UInt16, Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(_ result: Result<UInt16, Error>) {
+        lock.lock()
+        let continuation = self.continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume(with: result)
     }
 }
 

--- a/core/Tests/WiredPartCoreTests/TestHTTPStubServer.swift
+++ b/core/Tests/WiredPartCoreTests/TestHTTPStubServer.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Network
+
+struct HTTPStubRequest: Sendable {
+    let path: String
+}
+
+struct HTTPStubResponse: Sendable {
+    let statusCode: Int
+    let body: String
+}
+
+final class HTTPStubServer: @unchecked Sendable {
+    private let listener: NWListener
+    private let handler: @Sendable (HTTPStubRequest) -> HTTPStubResponse
+    private let queue = DispatchQueue(label: "com.wiredpart.tests.httpstub")
+
+    init(statusCode: Int, body: String) throws {
+        self.listener = try NWListener(using: .tcp, on: .any)
+        self.handler = { _ in HTTPStubResponse(statusCode: statusCode, body: body) }
+    }
+
+    init(handler: @escaping @Sendable (HTTPStubRequest) -> HTTPStubResponse) throws {
+        self.listener = try NWListener(using: .tcp, on: .any)
+        self.handler = handler
+    }
+
+    func start() async throws -> UInt16 {
+        try await withCheckedThrowingContinuation { continuation in
+            let continuationBox = HTTPStubOneShotContinuationBox(continuation)
+
+            listener.stateUpdateHandler = { [listener] state in
+                switch state {
+                case .ready:
+                    if let port = listener.port {
+                        continuationBox.resume(.success(port.rawValue))
+                    } else {
+                        continuationBox.resume(.failure(URLError(.badServerResponse)))
+                    }
+                case .failed(let error):
+                    continuationBox.resume(.failure(error))
+                default:
+                    break
+                }
+            }
+            listener.newConnectionHandler = { [handler, queue] connection in
+                connection.start(queue: queue)
+
+                @Sendable func sendResponse(for requestData: Data) {
+                    let rawRequest = String(data: requestData, encoding: .utf8) ?? ""
+                    let requestLine = rawRequest.components(separatedBy: "\r\n").first ?? ""
+                    let path = requestLine.split(separator: " ").dropFirst().first.map(String.init) ?? "/"
+                    let stubResponse = handler(HTTPStubRequest(path: path))
+                    let statusText = (200..<300).contains(stubResponse.statusCode) ? "OK" : "Error"
+                    let response = """
+                    HTTP/1.1 \(stubResponse.statusCode) \(statusText)\r
+                    Content-Type: application/json\r
+                    Content-Length: \(stubResponse.body.utf8.count)\r
+                    Connection: close\r
+                    \r
+                    \(stubResponse.body)
+                    """
+                    connection.send(content: Data(response.utf8), completion: .contentProcessed { _ in
+                        connection.cancel()
+                    })
+                }
+
+                @Sendable func receive(_ buffered: Data) {
+                    connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { data, _, isComplete, error in
+                        if error != nil {
+                            connection.cancel()
+                            return
+                        }
+
+                        var requestData = buffered
+                        if let data {
+                            requestData.append(data)
+                        }
+
+                        guard requestData.containsHTTPHeaderTerminator || isComplete else {
+                            receive(requestData)
+                            return
+                        }
+
+                        sendResponse(for: requestData)
+                    }
+                }
+
+                receive(Data())
+            }
+            listener.start(queue: queue)
+        }
+    }
+
+    func stop() {
+        listener.cancel()
+    }
+}
+
+private final class HTTPStubOneShotContinuationBox: @unchecked Sendable {
+    private var continuation: CheckedContinuation<UInt16, Error>?
+    private let lock = NSLock()
+
+    init(_ continuation: CheckedContinuation<UInt16, Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(_ result: Result<UInt16, Error>) {
+        lock.lock()
+        let continuation = self.continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume(with: result)
+    }
+}
+
+private extension Data {
+    var containsHTTPHeaderTerminator: Bool {
+        guard count >= 4 else { return false }
+        return zip(zip(zip(self, dropFirst()), dropFirst(2)), dropFirst(3)).contains { firstThree, fourth in
+            let ((first, second), third) = firstThree
+            return first == 13 && second == 10 && third == 13 && fourth == 10
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Makes `/api/sync/ack` part of the SyncEngine success gate instead of swallowing failures with `try?`.
- Leaves pending `_change_log` rows unsynced when ack fails, reports `.error`, increments the retry counter, and schedules retry with the real pending count.
- Rejects malformed push responses that omit `sync_batch_id` before sending any ack.
- Adds regression coverage with a shared local HTTP stub for SyncEngine and PeerManager tests.

Closes #1182

## Verification
- `swift test --filter SyncEngineTests` — passed (10 tests)
- `swift test --filter 'SyncEngineTests|PeerManagerTests'` — passed (25 tests)
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`)
- `cd core && swift test` — passed (2191 tests in 67 suites)

## Local runner / CI note
- Core-only Swift change; no UI files changed, so no iOS UI smoke was run locally.
- WPR2 local Mac Actions runner remains the intended trusted CI path for PR validation.