### PR TITLE
fix: reject malformed LAN sync content length

### DIFF
--- a/core/Sources/WiredPartCore/Sync/LanSyncServer.swift
+++ b/core/Sources/WiredPartCore/Sync/LanSyncServer.swift
@@ -286,6 +286,14 @@ public actor SyncServerState {
 /// Binds to `0.0.0.0:0` so the OS assigns a random available port,
 /// which is then advertised via mDNS.
 public final class LanSyncServer: Sendable {
+    static let maxHTTPRequestBodyBytes = 1_048_576
+
+    enum ContentLengthParseResult: Equatable {
+        case missing
+        case valid(Int)
+        case invalid
+    }
+
     private let state: SyncServerState
     private let listenerLock = OSAllocatedUnfairLock<NWListener?>(initialState: nil)
     private let logger = Logger(subsystem: "com.wiredpart.core", category: "LanSyncServer")
@@ -415,11 +423,19 @@ public final class LanSyncServer: Sendable {
                 let currentBodyLength = buffer.count - bodyStart
 
                 if let headerString = String(data: headerData, encoding: .utf8) {
-                    let contentLength = Self.parseContentLength(from: headerString)
-                    if currentBodyLength >= contentLength {
+                    switch Self.parseContentLength(from: headerString) {
+                    case .missing:
+                        completion(buffer)
+                        return
+                    case .invalid:
+                        completion(buffer)
+                        return
+                    case .valid(let contentLength) where currentBodyLength >= contentLength:
                         // We have the full request
                         completion(buffer)
                         return
+                    case .valid:
+                        break
                     }
                 }
             }
@@ -435,21 +451,27 @@ public final class LanSyncServer: Sendable {
     }
 
     /// Extract Content-Length value from raw HTTP header string.
-    private static func parseContentLength(from headers: String) -> Int {
+    static func parseContentLength(from headers: String) -> ContentLengthParseResult {
         for line in headers.components(separatedBy: "\r\n") {
             let lower = line.lowercased()
             if lower.hasPrefix("content-length:") {
                 let value = line[line.index(line.startIndex, offsetBy: 15)...].trimmingCharacters(in: .whitespaces)
-                return Int(value) ?? 0
+                guard !value.isEmpty,
+                      value.allSatisfy(\.isNumber),
+                      let contentLength = Int(value),
+                      contentLength <= maxHTTPRequestBodyBytes else {
+                    return .invalid
+                }
+                return .valid(contentLength)
             }
         }
-        return 0
+        return .missing
     }
 
     // MARK: - HTTP Parsing & Routing
 
     /// Parse a raw HTTP/1.1 request and route it to the appropriate handler.
-    private static func routeHTTPRequest(
+    static func routeHTTPRequest(
         data: Data,
         state: SyncServerState,
         logger: Logger
@@ -492,6 +514,9 @@ public final class LanSyncServer: Sendable {
         let bodyData = data[separatorRange.upperBound...]
 
         guard let headerString = String(data: headerData, encoding: .utf8) else { return nil }
+
+        guard parseContentLength(from: headerString) != .invalid else { return nil }
+
         var lines = headerString.components(separatedBy: "\r\n")
         guard !lines.isEmpty else { return nil }
 
@@ -515,8 +540,7 @@ public final class LanSyncServer: Sendable {
 
         // Determine body length from Content-Length header
         var body = Data(bodyData)
-        if let contentLengthStr = headers["content-length"],
-           let contentLength = Int(contentLengthStr) {
+        if case .valid(let contentLength) = parseContentLength(from: headerString) {
             body = Data(bodyData.prefix(contentLength))
         }
 

--- a/core/Sources/WiredPartCore/Sync/LanSyncServer.swift
+++ b/core/Sources/WiredPartCore/Sync/LanSyncServer.swift
@@ -456,11 +456,12 @@ public final class LanSyncServer: Sendable {
         var parsedLength: Int?
 
         for line in headers.components(separatedBy: "\r\n") {
-            let lower = line.lowercased()
+            let normalizedLine = line.trimmingCharacters(in: .whitespaces)
+            let lower = normalizedLine.lowercased()
             if lower.hasPrefix(contentLengthHeaderPrefix) {
                 guard parsedLength == nil else { return .invalid }
 
-                let value = line
+                let value = normalizedLine
                     .dropFirst(contentLengthHeaderPrefix.count)
                     .trimmingCharacters(in: .whitespaces)
                 guard !value.isEmpty,

--- a/core/Sources/WiredPartCore/Sync/LanSyncServer.swift
+++ b/core/Sources/WiredPartCore/Sync/LanSyncServer.swift
@@ -287,6 +287,7 @@ public actor SyncServerState {
 /// which is then advertised via mDNS.
 public final class LanSyncServer: Sendable {
     static let maxHTTPRequestBodyBytes = 1_048_576
+    private static let contentLengthHeaderPrefix = "content-length:"
 
     enum ContentLengthParseResult: Equatable {
         case missing
@@ -456,10 +457,12 @@ public final class LanSyncServer: Sendable {
 
         for line in headers.components(separatedBy: "\r\n") {
             let lower = line.lowercased()
-            if lower.hasPrefix("content-length:") {
+            if lower.hasPrefix(contentLengthHeaderPrefix) {
                 guard parsedLength == nil else { return .invalid }
 
-                let value = line[line.index(line.startIndex, offsetBy: 15)...].trimmingCharacters(in: .whitespaces)
+                let value = line
+                    .dropFirst(contentLengthHeaderPrefix.count)
+                    .trimmingCharacters(in: .whitespaces)
                 guard !value.isEmpty,
                       value.allSatisfy(\.isNumber),
                       let contentLength = Int(value),
@@ -523,7 +526,8 @@ public final class LanSyncServer: Sendable {
 
         guard let headerString = String(data: headerData, encoding: .utf8) else { return nil }
 
-        guard parseContentLength(from: headerString) != .invalid else { return nil }
+        let contentLengthResult = parseContentLength(from: headerString)
+        guard contentLengthResult != .invalid else { return nil }
 
         var lines = headerString.components(separatedBy: "\r\n")
         guard !lines.isEmpty else { return nil }
@@ -548,7 +552,7 @@ public final class LanSyncServer: Sendable {
 
         // Determine body length from Content-Length header
         var body = Data(bodyData)
-        if case .valid(let contentLength) = parseContentLength(from: headerString) {
+        if case .valid(let contentLength) = contentLengthResult {
             guard bodyData.count >= contentLength else { return nil }
             body = Data(bodyData.prefix(contentLength))
         }

--- a/core/Sources/WiredPartCore/Sync/LanSyncServer.swift
+++ b/core/Sources/WiredPartCore/Sync/LanSyncServer.swift
@@ -452,9 +452,13 @@ public final class LanSyncServer: Sendable {
 
     /// Extract Content-Length value from raw HTTP header string.
     static func parseContentLength(from headers: String) -> ContentLengthParseResult {
+        var parsedLength: Int?
+
         for line in headers.components(separatedBy: "\r\n") {
             let lower = line.lowercased()
             if lower.hasPrefix("content-length:") {
+                guard parsedLength == nil else { return .invalid }
+
                 let value = line[line.index(line.startIndex, offsetBy: 15)...].trimmingCharacters(in: .whitespaces)
                 guard !value.isEmpty,
                       value.allSatisfy(\.isNumber),
@@ -462,8 +466,12 @@ public final class LanSyncServer: Sendable {
                       contentLength <= maxHTTPRequestBodyBytes else {
                     return .invalid
                 }
-                return .valid(contentLength)
+                parsedLength = contentLength
             }
+        }
+
+        if let parsedLength {
+            return .valid(parsedLength)
         }
         return .missing
     }
@@ -541,6 +549,7 @@ public final class LanSyncServer: Sendable {
         // Determine body length from Content-Length header
         var body = Data(bodyData)
         if case .valid(let contentLength) = parseContentLength(from: headerString) {
+            guard bodyData.count >= contentLength else { return nil }
             body = Data(bodyData.prefix(contentLength))
         }
 

--- a/core/Tests/WiredPartCoreTests/SyncServerTests.swift
+++ b/core/Tests/WiredPartCoreTests/SyncServerTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import os
 @testable import WiredPartCore
 
 @Suite("LAN Sync Server Tests")
@@ -15,6 +16,58 @@ struct SyncServerTests {
             deviceName: deviceName,
             companyId: companyId
         )
+    }
+
+    // MARK: - HTTP Framing
+
+    @Test("Content-Length parser distinguishes missing, valid, and invalid headers")
+    func testContentLengthParserStates() throws {
+        #expect(LanSyncServer.parseContentLength(from: "GET /sync/status HTTP/1.1\r\nHost: localhost") == .missing)
+        #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\nContent-Length: 42") == .valid(42))
+        #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\ncontent-length: 0") == .valid(0))
+        #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\nContent-Length: abc") == .invalid)
+        #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\nContent-Length: -1") == .invalid)
+        #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\nContent-Length: ") == .invalid)
+    }
+
+    @Test("Malformed Content-Length returns bad request before routing")
+    func testMalformedContentLengthReturnsBadRequest() async throws {
+        let state = makeState(companyId: "co-1")
+        let rawRequest = "POST /sync/push HTTP/1.1\r\n"
+            + "Host: 127.0.0.1\r\n"
+            + "Content-Type: application/json\r\n"
+            + "Content-Length: abc\r\n"
+            + "\r\n"
+            + "{\"device_id\":\"remote-dev\",\"company_id\":\"co-1\",\"changes\":[]}"
+
+        let (status, body) = await LanSyncServer.routeHTTPRequest(
+            data: Data(rawRequest.utf8),
+            state: state,
+            logger: Logger(subsystem: "com.wiredpart.core.tests", category: "SyncServerTests")
+        )
+
+        #expect(status == 400)
+        let json = try JSONSerialization.jsonObject(with: body) as? [String: String]
+        #expect(json?["error"] == "bad_request")
+    }
+
+    @Test("Negative Content-Length returns bad request before routing")
+    func testNegativeContentLengthReturnsBadRequest() async throws {
+        let state = makeState(companyId: "co-1")
+        let rawRequest = "POST /sync/push HTTP/1.1\r\n"
+            + "Host: 127.0.0.1\r\n"
+            + "Content-Type: application/json\r\n"
+            + "Content-Length: -1\r\n"
+            + "\r\n"
+            + "{\"device_id\":\"remote-dev\",\"company_id\":\"co-1\",\"changes\":[]}"
+
+        let (status, _) = await LanSyncServer.routeHTTPRequest(
+            data: Data(rawRequest.utf8),
+            state: state,
+            logger: Logger(subsystem: "com.wiredpart.core.tests", category: "SyncServerTests")
+        )
+
+        #expect(status == 400)
     }
 
     // MARK: - Server Lifecycle

--- a/core/Tests/WiredPartCoreTests/SyncServerTests.swift
+++ b/core/Tests/WiredPartCoreTests/SyncServerTests.swift
@@ -25,6 +25,7 @@ struct SyncServerTests {
         #expect(LanSyncServer.parseContentLength(from: "GET /sync/status HTTP/1.1\r\nHost: localhost") == .missing)
         #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\nContent-Length: 42") == .valid(42))
         #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\ncontent-length: 0") == .valid(0))
+        #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\n Content-Length: 7") == .valid(7))
         #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\nContent-Length: abc") == .invalid)
         #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\nContent-Length: -1") == .invalid)
         #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\nContent-Length: ") == .invalid)

--- a/core/Tests/WiredPartCoreTests/SyncServerTests.swift
+++ b/core/Tests/WiredPartCoreTests/SyncServerTests.swift
@@ -28,6 +28,7 @@ struct SyncServerTests {
         #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\nContent-Length: abc") == .invalid)
         #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\nContent-Length: -1") == .invalid)
         #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\nContent-Length: ") == .invalid)
+        #expect(LanSyncServer.parseContentLength(from: "POST /sync/push HTTP/1.1\r\nContent-Length: 1\r\nContent-Length: 2") == .invalid)
     }
 
     @Test("Malformed Content-Length returns bad request before routing")
@@ -60,6 +61,25 @@ struct SyncServerTests {
             + "Content-Length: -1\r\n"
             + "\r\n"
             + "{\"device_id\":\"remote-dev\",\"company_id\":\"co-1\",\"changes\":[]}"
+
+        let (status, _) = await LanSyncServer.routeHTTPRequest(
+            data: Data(rawRequest.utf8),
+            state: state,
+            logger: Logger(subsystem: "com.wiredpart.core.tests", category: "SyncServerTests")
+        )
+
+        #expect(status == 400)
+    }
+
+    @Test("Incomplete body returns bad request before routing")
+    func testIncompleteContentLengthBodyReturnsBadRequest() async throws {
+        let state = makeState(companyId: "co-1")
+        let rawRequest = "POST /sync/push HTTP/1.1\r\n"
+            + "Host: 127.0.0.1\r\n"
+            + "Content-Type: application/json\r\n"
+            + "Content-Length: 999\r\n"
+            + "\r\n"
+            + "{\"device_id\":\"remote-dev\"}"
 
         let (status, _) = await LanSyncServer.routeHTTPRequest(
             data: Data(rawRequest.utf8),


### PR DESCRIPTION
## Summary
- Replaces the LAN sync `Content-Length` parser's invalid-as-zero fallback with explicit missing/valid/invalid states.
- Rejects malformed, negative, empty, duplicate, over-cap, and incomplete-body `Content-Length` framing before routing sync requests.
- Adds regression coverage for missing/valid/malformed/negative/duplicate parsing plus 400 bad-request routing for malformed, negative, and incomplete-body requests.

Closes #1183

## Tests
- `swift test --filter SyncServerTests` — passed (20 tests)
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`)
- `cd core && swift test` — passed (2195 tests)

## Local runner / CI note
This is a core Swift package change. Local verification above was run on the Mac development machine; repo PR CI should use the local self-hosted Mac Actions runner path if GitHub-hosted capacity is unavailable.
