### PR TITLE
Fix dashboard attention timestamp aging

### DIFF
--- a/core/Sources/WiredPartCore/Services/DashboardService.swift
+++ b/core/Sources/WiredPartCore/Services/DashboardService.swift
@@ -1744,7 +1744,7 @@ public final class DashboardService: Sendable {
             }
             for row in jpos {
                 let dateStr: String = row["created_at"] ?? ""
-                let created = CoreFormatters.parseISO(dateStr) ?? Date()
+                guard let created = dashboardAttentionCreatedAt(from: dateStr) else { continue }
                 let age = Date().timeIntervalSince(created)
                 items.append(AttentionItem(
                     id: row["id"] ?? 0,
@@ -1870,7 +1870,7 @@ public final class DashboardService: Sendable {
                 """)
             }
             for row in questions {
-                let created = CoreFormatters.parseISO(row["created_at"] as String? ?? "") ?? Date()
+                guard let created = dashboardAttentionCreatedAt(from: row["created_at"] as String? ?? "") else { continue }
                 items.append(AttentionItem(
                     id: row["id"] ?? 0,
                     title: "Open Q&A: \(row["subject"] as String? ?? "Question")",
@@ -2126,6 +2126,16 @@ public final class DashboardService: Sendable {
     }
 
     // MARK: - Internal Helpers
+
+    /// Parse persisted attention timestamps without making malformed rows look brand-new.
+    ///
+    /// Dashboard attention priority depends on row age, so falling back to `Date()` hides
+    /// old SQLite `datetime('now')` strings and malformed persisted values. Use the shared
+    /// core parser for both ISO 8601 and SQLite `yyyy-MM-dd HH:mm:ss` text; callers skip
+    /// rows that cannot be parsed rather than under-prioritizing them as current time.
+    private func dashboardAttentionCreatedAt(from rawValue: String) -> Date? {
+        CoreFormatters.parseDateTime(rawValue)
+    }
 
     /// Execute a `SELECT COUNT(*)` query and return the integer result.
     /// If the table does not exist (e.g., migration hasn't run), returns 0.

--- a/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
@@ -700,6 +700,73 @@ struct DashboardServiceTests {
         #expect(itemTypes.contains("warranty_expiring"))
     }
 
+    @Test("Attention items parse SQLite timestamp text without resetting age")
+    func testAttentionItemsParseSQLiteCreatedAtTimestamps() throws {
+        let (env, dash) = try freshEnv()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-ATTENTION-DATES", name: "Attention Date Job")
+        let oldDate = Date().addingTimeInterval(-5 * 86400)
+        let sqliteFormatter = DateFormatter()
+        sqliteFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        let sqliteCreatedAt = sqliteFormatter.string(from: oldDate)
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO job_parts_orders (job_id, order_number, status, order_type, requested_by, created_at)
+                VALUES (?, 'JPO-ATTENTION-SQLITE', 'submitted', 'job', ?, ?)
+                """, arguments: [jobId, env.adminUserId, sqliteCreatedAt])
+            try db.execute(sql: """
+                INSERT INTO qa_threads (job_id, asked_by, subject, status, priority, created_at)
+                VALUES (?, ?, 'SQLite timestamp question', 'open', 'normal', ?)
+                """, arguments: [jobId, env.adminUserId, sqliteCreatedAt])
+        }
+
+        let items = try dash.getAttentionItems()
+        let jpo = try #require(items.first { $0.itemType == "jpo_approval" && $0.title.contains("Attention Date Job") })
+        let qa = try #require(items.first { $0.itemType == "open_qa" && $0.title.contains("SQLite timestamp question") })
+
+        #expect(jpo.priority == .overdue)
+        #expect(qa.priority == .overdue)
+        #expect(abs(jpo.createdAt.timeIntervalSince(oldDate)) < 1)
+        #expect(abs(qa.createdAt.timeIntervalSince(oldDate)) < 1)
+    }
+
+    @Test("Attention items parse ISO timestamps and skip malformed persisted timestamps")
+    func testAttentionItemsParseISOAndSkipMalformedCreatedAt() throws {
+        let (env, dash) = try freshEnv()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-ATTENTION-ISO", name: "Attention ISO Job")
+        let malformedJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-ATTENTION-BAD-DATE", name: "Malformed Date Job")
+        let oldDate = Date().addingTimeInterval(-5 * 86400)
+        let isoCreatedAt = CoreFormatters.iso8601.string(from: oldDate)
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO job_parts_orders (job_id, order_number, status, order_type, requested_by, created_at)
+                VALUES (?, 'JPO-ATTENTION-ISO', 'submitted', 'job', ?, ?)
+                """, arguments: [jobId, env.adminUserId, isoCreatedAt])
+            try db.execute(sql: """
+                INSERT INTO job_parts_orders (job_id, order_number, status, order_type, requested_by, created_at)
+                VALUES (?, 'JPO-ATTENTION-BAD-DATE', 'submitted', 'job', ?, 'not-a-date')
+                """, arguments: [malformedJobId, env.adminUserId])
+            try db.execute(sql: """
+                INSERT INTO qa_threads (job_id, asked_by, subject, status, priority, created_at)
+                VALUES (?, ?, 'ISO timestamp question', 'open', 'normal', ?)
+                """, arguments: [jobId, env.adminUserId, isoCreatedAt])
+            try db.execute(sql: """
+                INSERT INTO qa_threads (job_id, asked_by, subject, status, priority, created_at)
+                VALUES (?, ?, 'Malformed timestamp question', 'open', 'normal', 'not-a-date')
+                """, arguments: [jobId, env.adminUserId])
+        }
+
+        let items = try dash.getAttentionItems()
+        let jpo = try #require(items.first { $0.itemType == "jpo_approval" && $0.title.contains("Attention ISO Job") })
+        let qa = try #require(items.first { $0.itemType == "open_qa" && $0.title.contains("ISO timestamp question") })
+
+        #expect(jpo.priority == .overdue)
+        #expect(qa.priority == .overdue)
+        #expect(items.contains { $0.title.contains("Malformed timestamp question") } == false)
+        #expect(items.contains { $0.title.contains("Malformed Date Job") } == false)
+    }
+
     // MARK: - Financial Snapshot
 
     @Test("getFinancialSnapshot returns zeroes on fresh DB")


### PR DESCRIPTION
## Summary
- Parse dashboard attention `created_at` values with `CoreFormatters.parseDateTime(...)` so ISO8601 and SQLite `yyyy-MM-dd HH:mm:ss` timestamps preserve their real age.
- Stop falling back to `Date()` for persisted JPO/Q&A timestamps; malformed rows are skipped instead of being shown as brand-new/low-priority.
- Add DashboardService regression coverage for SQLite timestamps, ISO timestamps, and malformed persisted timestamp rows.

Closes #1186

## Verification
- `swift test --filter DashboardServiceTests/testAttentionItems` — passed (4 tests in DashboardService Tests).
- `git diff --check` — passed.
- `python3 scripts/guard-tracked-artifacts.py` — passed: No tracked Paperclip/Xcode runtime artifacts found.
- `cd core && swift test` — passed: 2200 tests in 67 suites.

## CI / local runner note
Core-only change; no iOS UI/build smoke required. Repository PR CI should use the local self-hosted Mac runner path for required checks when GitHub Actions runs.