### PR TITLE
Fix malformed clock summary timestamps

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Shared/UserFriendlyError.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/UserFriendlyError.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WiredPartCore
 
 /// Wraps a raw error into a user-friendly message for display in loadError states.
 ///
@@ -17,6 +18,11 @@ import Foundation
 ///   "load truck tools", "load vehicle details", "load vehicles",
 ///   "load inspection data", "save inspection"
 func userFriendlyError(_ error: Error, context: String = "load data") -> String {
+    if let jobsError = error as? JobsService.JobsError,
+       case .invalidClockTimestamp = jobsError {
+        return "A saved clock entry has an invalid timestamp. Ask an admin to review the timesheet before using today's hours."
+    }
+
     let raw = error.localizedDescription
     if raw.contains("no such table") {
         return "This feature isn't set up yet. Contact your admin."

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -52,6 +52,12 @@ public final class JobsService: Sendable {
         case stageInUse(Int64)
         case invalidStageTemplate(Int64)
         case invalidClockOutTime(laborEntryId: Int64)
+        case invalidClockTimestamp(laborEntryId: Int64, field: ClockTimestampField)
+    }
+
+    public enum ClockTimestampField: String, Sendable, Equatable {
+        case clockIn = "clock_in"
+        case clockOut = "clock_out"
     }
 
     // =========================================================================
@@ -1935,8 +1941,18 @@ public final class JobsService: Sendable {
                 let todoName: String? = row["todo_name"] as String?
                 let wType: String = row["work_type"] ?? "new_work"
 
-                let startDate = Self.parseSQLiteUTCDateTime(clockInStr) ?? Date()
-                let endDate: Date? = clockOutStr.flatMap { Self.parseSQLiteUTCDateTime($0) }
+                guard let startDate = Self.parseSQLiteUTCDateTime(clockInStr) else {
+                    throw JobsError.invalidClockTimestamp(laborEntryId: entryId, field: .clockIn)
+                }
+                let endDate: Date?
+                if let clockOutStr {
+                    guard let parsedEndDate = Self.parseSQLiteUTCDateTime(clockOutStr) else {
+                        throw JobsError.invalidClockTimestamp(laborEntryId: entryId, field: .clockOut)
+                    }
+                    endDate = parsedEndDate
+                } else {
+                    endDate = nil
+                }
 
                 let summary = ClockEntrySummary(
                     id: entryId,

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -995,6 +995,30 @@ struct JobsServiceTests {
         }
     }
 
+    @Test("Today's clock entries reject malformed clock-in timestamps")
+    func testGetTodaysClockEntriesRejectsMalformedClockInTimestamp() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-CLOCK-BAD", name: "Bad Clock Job")
+        let malformedClockIn = try env.db.writer.read { db in
+            let today = try String.fetchOne(db, sql: "SELECT date('now', 'localtime')")
+            return try #require(today)
+        }
+
+        let laborEntryId = try env.db.writer.write { db -> Int64 in
+            try db.execute(sql: "DELETE FROM labor_entries")
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, ?, NULL, 0.0, 0.0, 'clocked_in', datetime('now'))
+                """, arguments: [env.adminUserId, jobId, malformedClockIn])
+            return db.lastInsertedRowID
+        }
+
+        #expect(throws: JobsService.JobsError.invalidClockTimestamp(laborEntryId: laborEntryId, field: .clockIn)) {
+            _ = try env.jobs.getTodaysClockEntries(userId: env.adminUserId)
+        }
+    }
+
     // MARK: - Report Detail & Review
 
     @Test("Get report detail and mark reviewed")


### PR DESCRIPTION
## Summary
- Replace the `getTodaysClockEntries` `?? Date()` fallback with a deterministic `JobsError.invalidClockTimestamp` for malformed `clock_in` / `clock_out` values.
- Add regression coverage for date-only `clock_in` text that still matches the SQL local-day filter but cannot be rendered as a clock summary start time.
- Map the new timestamp-integrity error to a clear iOS clock-page banner instead of a generic/raw failure.

Closes #1193

## Tests
- `swift test --filter JobsServiceTests/testGetTodaysClockEntriesRejectsMalformedClockInTimestamp`
- `swift test --filter JobsServiceTests`
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `cd core && swift test` (2201 tests passed)
- `xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build` (BUILD SUCCEEDED; existing warnings only)

## CI / local runner path
- This PR is ready for the repo's local self-hosted Mac Actions runner path (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`) if/when CI is queued.
