### PR TITLE
fix: validate numeric job estimation answers

### DIFF
--- a/core/Sources/WiredPartCore/Services/JobEstimationService.swift
+++ b/core/Sources/WiredPartCore/Services/JobEstimationService.swift
@@ -169,6 +169,28 @@ public final class JobEstimationService: Sendable {
     ) throws -> EstimationResponse {
         do {
             return try db.writer.write { dbConn in
+                try ServicePermissionGate.requirePermission(dbConn, userId: answeredBy, permissionKey: "manage_jobs")
+
+                let submittedValue: String?
+                let submittedIsUnknown: Bool
+
+                if isUnknown {
+                    submittedValue = nil
+                    submittedIsUnknown = true
+                } else if let question = try EstimationQuestion
+                    .filter(Column("id") == questionId &&
+                            Column("is_active") == 1 &&
+                            Column("deleted_at") == nil)
+                    .fetchOne(dbConn),
+                          question.answerType == "number",
+                          Self.parseNumericScore(value) == nil {
+                    submittedValue = nil
+                    submittedIsUnknown = true
+                } else {
+                    submittedValue = value
+                    submittedIsUnknown = false
+                }
+
                 // Delete any existing response for this job+question+stage
                 try dbConn.execute(sql: """
                     DELETE FROM estimation_responses
@@ -177,8 +199,8 @@ public final class JobEstimationService: Sendable {
 
                 var response = EstimationResponse(
                     id: nil, jobId: jobId, questionId: questionId,
-                    stage: stage, responseValue: isUnknown ? nil : value,
-                    isUnknown: isUnknown ? 1 : 0,
+                    stage: stage, responseValue: submittedValue,
+                    isUnknown: submittedIsUnknown ? 1 : 0,
                     answeredBy: answeredBy, answeredAt: nil
                 )
                 try response.insert(dbConn)
@@ -247,8 +269,12 @@ public final class JobEstimationService: Sendable {
                 continue
             }
 
+            guard let score = scoreResponse(response: response, question: question) else {
+                unknownCount += 1
+                continue
+            }
+
             answeredCount += 1
-            let score = scoreResponse(response: response, question: question)
             totalWeightedScore += score * question.weight
             totalWeight += question.weight
         }
@@ -297,13 +323,13 @@ public final class JobEstimationService: Sendable {
     }
 
     /// Score a single response on a 0-10 scale based on answer type and value.
-    private func scoreResponse(response: EstimationResponse, question: EstimationQuestion) -> Double {
-        guard let value = response.responseValue else { return 0 }
+    private func scoreResponse(response: EstimationResponse, question: EstimationQuestion) -> Double? {
+        guard let value = response.responseValue else { return nil }
 
         switch question.answerType {
         case "number":
-            // Normalize: treat as a direct numeric factor
-            return min(Double(value) ?? 0, 10.0)
+            // Normalize numeric answers to the supported 0...10 scoring range.
+            return Self.parseNumericScore(value)
         case "boolean":
             return value.lowercased() == "yes" ? 1.0 : 0.0
         case "choice":
@@ -316,6 +342,17 @@ public final class JobEstimationService: Sendable {
         default:
             return 1.0 // text answers get a neutral score
         }
+    }
+
+    private static func parseNumericScore(_ value: String?) -> Double? {
+        guard let rawValue = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawValue.isEmpty,
+              let parsed = Double(rawValue),
+              parsed.isFinite else {
+            return nil
+        }
+
+        return min(max(parsed, 0.0), 10.0)
     }
 
     /// Get the most recent estimation result for a job and stage.

--- a/core/Tests/WiredPartCoreTests/JobEstimationServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobEstimationServiceTests.swift
@@ -112,6 +112,42 @@ struct JobEstimationServiceTests {
         #expect(response.isUnknown != 0)
     }
 
+    @Test("Malformed numeric responses are stored as unknown")
+    func testMalformedNumericResponseStoredAsUnknown() throws {
+        let (env, est) = try freshEnv()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let q = try est.createQuestion(text: "Rooms?", group: "scope", stage: "initial", answerType: "number")
+
+        let response = try est.submitResponse(
+            jobId: jobId,
+            questionId: q.id!,
+            stage: "initial",
+            value: "abc",
+            answeredBy: env.adminUserId
+        )
+
+        #expect(response.isUnknown == 1)
+        #expect(response.responseValue == nil)
+    }
+
+    @Test("Submit response requires manage_jobs permission")
+    func testSubmitResponseRequiresManageJobsPermission() throws {
+        let (env, est) = try freshEnv()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let q = try est.createQuestion(text: "Rooms?", group: "scope", stage: "initial", answerType: "number")
+        let unprivilegedUserId = try env.auth.createUser(displayName: "No Job Estimation Permission", pin: "2468")
+
+        #expect(throws: ServicePermissionGate.GateError.insufficientPermissions(required: "manage_jobs")) {
+            _ = try est.submitResponse(
+                jobId: jobId,
+                questionId: q.id!,
+                stage: "initial",
+                value: "5",
+                answeredBy: unprivilegedUserId
+            )
+        }
+    }
+
     @Test("Filter responses by stage")
     func testResponsesByStage() throws {
         let (env, est) = try freshEnv()
@@ -140,6 +176,33 @@ struct JobEstimationServiceTests {
         let result = try est.calculateEstimate(jobId: jobId, stage: "initial")
         #expect(result.stage == "initial")
         #expect((result.estimatedDays ?? 0) >= 0)
+    }
+
+    @Test("Invalid numeric answers do not produce negative estimates or inflated confidence")
+    func testInvalidNumericAnswersDoNotProduceNegativeEstimatesOrInflatedConfidence() throws {
+        let (env, est) = try freshEnv()
+        let negativeJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-NEG", name: "Negative Estimate Test")
+        let malformedJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-MAL", name: "Malformed Estimate Test")
+        let highJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-HIGH", name: "High Estimate Test")
+
+        let negativeQuestion = try est.createQuestion(text: "Negative rooms?", group: "scope", stage: "initial", answerType: "number")
+        _ = try est.submitResponse(jobId: negativeJobId, questionId: negativeQuestion.id!, stage: "initial", value: "-5", answeredBy: env.adminUserId)
+        let negativeResult = try est.calculateEstimate(jobId: negativeJobId, stage: "initial")
+        #expect((negativeResult.estimatedDays ?? -1) >= 0)
+        #expect((negativeResult.estimatedHours ?? -1) >= 0)
+
+        let malformedQuestion = try est.createQuestion(text: "Malformed rooms?", group: "scope", stage: "malformed", answerType: "number")
+        let validQuestion = try est.createQuestion(text: "Valid rooms?", group: "scope", stage: "malformed", answerType: "number")
+        _ = try est.submitResponse(jobId: malformedJobId, questionId: malformedQuestion.id!, stage: "malformed", value: "not-a-number", answeredBy: env.adminUserId)
+        _ = try est.submitResponse(jobId: malformedJobId, questionId: validQuestion.id!, stage: "malformed", value: "5", answeredBy: env.adminUserId)
+        let malformedResult = try est.calculateEstimate(jobId: malformedJobId, stage: "malformed")
+        #expect(malformedResult.confidencePercent == 50)
+
+        let highQuestion = try est.createQuestion(text: "Oversized scope?", group: "scope", stage: "high", answerType: "number")
+        _ = try est.submitResponse(jobId: highJobId, questionId: highQuestion.id!, stage: "high", value: "25", answeredBy: env.adminUserId)
+        let highResult = try est.calculateEstimate(jobId: highJobId, stage: "high")
+        #expect(highResult.estimatedDays == 50)
+        #expect(highResult.estimatedHours == 400)
     }
 
     @Test("Get latest result for job")


### PR DESCRIPTION
## Summary
- Validate submitted numeric estimation answers before persistence so malformed values are stored as unknown.
- Treat legacy malformed numeric responses as unknown during scoring so confidence is not inflated.
- Clamp numeric scores to the supported 0...10 range so negative answers cannot produce negative estimates and large answers cannot exceed the scoring cap.
- Add the missing service-layer `manage_jobs` permission gate on estimation response mutation to prevent spoofed `answeredBy` audit writes.

Closes #1197

## Verification
- `gh issue view 1197 --repo xXKillerNoobYT/Weird-Part-Run-2 --json number,state,title,body,labels,comments,url` confirmed GH #1197 is open.
- `gh pr list --repo xXKillerNoobYT/Weird-Part-Run-2 --search "1197" --json number,title,state,headRefName,url` returned `[]`, so no newer open PR already covers it.
- `swift test --filter JobEstimationServiceTests` passed: 27 tests in 1 suite.
- `git diff --check` passed.
- `python3 scripts/guard-tracked-artifacts.py` passed: No tracked Paperclip/Xcode runtime artifacts found.
- `cd core && swift test` passed: 2204 tests in 67 suites.

## Notes
- Core-only change; no iOS UI files changed, so no iOS UI smoke was required for this fix.
- Local runner path remains the expected CI path for WPR2 PR validation per repo runbook.