### PR TITLE
fix: guard company default markup pricing

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
@@ -351,8 +351,7 @@ struct PricingBulkEditSheet: View {
     }
 
     static func isValidNonNegativePercent(_ text: String) -> Bool {
-        guard let value = Double(text.trimmingCharacters(in: .whitespacesAndNewlines)) else { return false }
-        return value.isFinite && value >= 0
+        nonNegativePercent(text) != nil
     }
 
     private func loadPreview() async {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
@@ -346,8 +346,13 @@ struct PricingBulkEditSheet: View {
     // MARK: - Logic
 
     private var hasValidInput: Bool {
-        if pricingMode == "markup" { return Double(markupText) != nil }
-        return Double(marginText) != nil
+        if pricingMode == "markup" { return Self.isValidNonNegativePercent(markupText) }
+        return Self.isValidNonNegativePercent(marginText)
+    }
+
+    static func isValidNonNegativePercent(_ text: String) -> Bool {
+        guard let value = Double(text.trimmingCharacters(in: .whitespacesAndNewlines)) else { return false }
+        return value.isFinite && value >= 0
     }
 
     private func loadPreview() async {
@@ -357,8 +362,8 @@ struct PricingBulkEditSheet: View {
         }
         saveError = nil
         do {
-            let markup = pricingMode == "markup" ? Double(markupText) : nil
-            let margin = pricingMode == "margin" ? Double(marginText) : nil
+            let markup = pricingMode == "markup" ? Self.nonNegativePercent(markupText) : nil
+            let margin = pricingMode == "margin" ? Self.nonNegativePercent(marginText) : nil
 
             previewParts = try service.getPreviewParts(
                 categoryId: scope == .category ? categoryId : nil,
@@ -381,8 +386,8 @@ struct PricingBulkEditSheet: View {
                 return
             }
 
-            let markup = pricingMode == "markup" ? Double(markupText) : nil
-            let margin = pricingMode == "margin" ? Double(marginText) : nil
+            let markup = pricingMode == "markup" ? Self.nonNegativePercent(markupText) : nil
+            let margin = pricingMode == "margin" ? Self.nonNegativePercent(marginText) : nil
 
             // Set tier at the appropriate level
             if scope == .category, let catId = categoryId {
@@ -404,5 +409,14 @@ struct PricingBulkEditSheet: View {
             saveError = userFriendlyError(error, context: "save data")
         }
         isSaving = false
+    }
+
+    private static func nonNegativePercent(_ text: String) -> Double? {
+        guard let value = Double(text.trimmingCharacters(in: .whitespacesAndNewlines)),
+              value.isFinite,
+              value >= 0 else {
+            return nil
+        }
+        return value
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
@@ -384,6 +384,11 @@ struct PricingBulkEditSheet: View {
                 isSaving = false
                 return
             }
+            guard let userId = appCore.currentUser?.id else {
+                saveError = "Please sign in before changing company pricing defaults."
+                isSaving = false
+                return
+            }
 
             let markup = pricingMode == "markup" ? Self.nonNegativePercent(markupText) : nil
             let margin = pricingMode == "margin" ? Self.nonNegativePercent(marginText) : nil
@@ -394,12 +399,12 @@ struct PricingBulkEditSheet: View {
             } else {
                 // "All" scope — update default markup in company settings
                 if let m = markup {
-                    try service.updateCompanyCostSetting(key: "default_markup_percent", value: String(format: "%.5f", m))
+                    try service.updateCompanyCostSetting(key: "default_markup_percent", value: String(format: "%.5f", m), updatedBy: userId)
                 }
                 if let m = margin {
                     // Convert margin to markup for default setting
                     let convertedMarkup = m < 100 ? (m / (100 - m)) * 100 : 100
-                    try service.updateCompanyCostSetting(key: "default_markup_percent", value: String(format: "%.5f", convertedMarkup))
+                    try service.updateCompanyCostSetting(key: "default_markup_percent", value: String(format: "%.5f", convertedMarkup), updatedBy: userId)
                 }
             }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
@@ -395,7 +395,7 @@ struct PricingBulkEditSheet: View {
 
             // Set tier at the appropriate level
             if scope == .category, let catId = categoryId {
-                _ = try service.setPricingTier(categoryId: catId, markupPercent: markup, marginPercent: margin)
+                _ = try service.setPricingTier(categoryId: catId, markupPercent: markup, marginPercent: margin, setBy: userId)
             } else {
                 // "All" scope — update default markup in company settings
                 if let m = markup {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
@@ -385,7 +385,7 @@ struct PricingBulkEditSheet: View {
                 return
             }
             guard let userId = appCore.currentUser?.id else {
-                saveError = "Please sign in before changing company pricing defaults."
+                saveError = "Please sign in before changing pricing."
                 isSaving = false
                 return
             }

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -1085,6 +1085,15 @@ struct Weird_Parts_IOSTests {
         #expect(detail.lines.count >= 2)
         #expect(detail.lines.allSatisfy { $0.partId != nil })
     }
+
+    @Test func pricingBulkEditRejectsNegativeOrNonFinitePercentInputs() {
+        #expect(PricingBulkEditSheet.isValidNonNegativePercent("0"))
+        #expect(PricingBulkEditSheet.isValidNonNegativePercent(" 12.5 "))
+        #expect(!PricingBulkEditSheet.isValidNonNegativePercent("-0.01"))
+        #expect(!PricingBulkEditSheet.isValidNonNegativePercent("nan"))
+        #expect(!PricingBulkEditSheet.isValidNonNegativePercent("inf"))
+        #expect(!PricingBulkEditSheet.isValidNonNegativePercent("not a number"))
+    }
 }
 
 struct PartsFlowDraftStoreTests {

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -3134,8 +3134,7 @@ public final class PartsService: Sendable {
     /// Update a company cost setting.
     public func updateCompanyCostSetting(key: String, value: String, updatedBy: Int64? = nil) throws {
         if key == "default_markup_percent" {
-            let markup = try ManualPricingInputValidator.parsePercent(value, fieldName: "Default markup percent")
-            try Validators.requireNonNegative(markup, field: "Default markup percent")
+            _ = try ManualPricingInputValidator.parsePercent(value, fieldName: "Default markup percent")
         }
 
         if let updatedBy {

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -2760,7 +2760,7 @@ public final class PartsService: Sendable {
 
             let weightedAvg: Double = part.weightedAvgCost ?? 0
             let pricingMode = try self.getCompanySetting(dbConn: dbConn, key: "pricing_mode") ?? "markup"
-            let defaultMarkup = Double(try self.getCompanySetting(dbConn: dbConn, key: "default_markup_percent") ?? "50") ?? 50
+            let defaultMarkup = try self.getDefaultMarkupPercent(dbConn: dbConn)
 
             // Check each level from most specific to least
             // 1. Part-level tier
@@ -2810,7 +2810,7 @@ public final class PartsService: Sendable {
             }
 
             // 6. Company default
-            let sell = weightedAvg * (1 + defaultMarkup / 100)
+            let sell = max(weightedAvg * (1 + defaultMarkup / 100), weightedAvg)
             let margin = sell > 0 ? ((sell - weightedAvg) / sell) * 100 : 0
             return ResolvedPricing(partId: partId, weightedAvgCost: weightedAvg, effectiveMarkup: defaultMarkup, effectiveMargin: margin, sellPrice: sell, tierLevel: "Default", tierId: nil, isInherited: true, isDirectOverride: false)
         }
@@ -2941,7 +2941,7 @@ public final class PartsService: Sendable {
     ) throws -> [OverrideConflict] {
         try db.writer.read { dbConn in
             let pricingMode = try self.getCompanySetting(dbConn: dbConn, key: "pricing_mode") ?? "markup"
-            let defaultMarkup = Double(try self.getCompanySetting(dbConn: dbConn, key: "default_markup_percent") ?? "50") ?? 50
+            let defaultMarkup = try self.getDefaultMarkupPercent(dbConn: dbConn)
 
             // Build a temporary tier for calculation
             let proposedTier = PricingTier(
@@ -3057,7 +3057,7 @@ public final class PartsService: Sendable {
     ) throws -> [PricingPreviewPart] {
         try db.writer.read { dbConn in
             let pricingMode = try self.getCompanySetting(dbConn: dbConn, key: "pricing_mode") ?? "markup"
-            let defaultMarkup = Double(try self.getCompanySetting(dbConn: dbConn, key: "default_markup_percent") ?? "50") ?? 50
+            let defaultMarkup = try self.getDefaultMarkupPercent(dbConn: dbConn)
 
             // Find parts in the target scope that have stock
             var conditions: [String] = ["p.deleted_at IS NULL"]
@@ -3122,8 +3122,23 @@ public final class PartsService: Sendable {
         return row?["setting_value"] as? String
     }
 
+    /// Company default markup is a pricing boundary: persisted corrupt/legacy
+    /// negative values must never allow below-cost default sell prices.
+    private func getDefaultMarkupPercent(dbConn: Database) throws -> Double {
+        let rawValue = try getCompanySetting(dbConn: dbConn, key: "default_markup_percent") ?? "50"
+        guard let parsed = Double(rawValue), parsed.isFinite else { return 50 }
+        return max(parsed, 0)
+    }
+
     /// Update a company cost setting.
     public func updateCompanyCostSetting(key: String, value: String, updatedBy: Int64? = nil) throws {
+        if key == "default_markup_percent" {
+            guard let markup = Double(value), markup.isFinite else {
+                throw ValidationError.emptyRequired(field: "Default markup percent")
+            }
+            try Validators.requireNonNegative(markup, field: "Default markup percent")
+        }
+
         if let updatedBy {
             try db.writer.read { dbConn in
                 try ServicePermissionGate.requirePermission(dbConn, userId: updatedBy, permissionKey: "parts.manage_company_costs")

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -3125,7 +3125,8 @@ public final class PartsService: Sendable {
     /// Company default markup is a pricing boundary: persisted corrupt/legacy
     /// negative values must never allow below-cost default sell prices.
     private func getDefaultMarkupPercent(dbConn: Database) throws -> Double {
-        let rawValue = try getCompanySetting(dbConn: dbConn, key: "default_markup_percent") ?? "50"
+        let rawValue = (try getCompanySetting(dbConn: dbConn, key: "default_markup_percent") ?? "50")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         guard let parsed = Double(rawValue), parsed.isFinite else { return 50 }
         return max(parsed, 0)
     }
@@ -3133,9 +3134,7 @@ public final class PartsService: Sendable {
     /// Update a company cost setting.
     public func updateCompanyCostSetting(key: String, value: String, updatedBy: Int64? = nil) throws {
         if key == "default_markup_percent" {
-            guard let markup = Double(value), markup.isFinite else {
-                throw ValidationError.emptyRequired(field: "Default markup percent")
-            }
+            let markup = try ManualPricingInputValidator.parsePercent(value, fieldName: "Default markup percent")
             try Validators.requireNonNegative(markup, field: "Default markup percent")
         }
 

--- a/core/Tests/WiredPartCoreTests/PartsServiceCoverageTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceCoverageTests.swift
@@ -300,6 +300,13 @@ struct PartsServiceCoverageTests {
         #expect(throws: (any Error).self) {
             try env.parts.updateCompanyCostSetting(key: "default_markup_percent", value: "-10", updatedBy: env.adminUserId)
         }
+
+        #expect(throws: (any Error).self) {
+            try env.parts.updateCompanyCostSetting(key: "default_markup_percent", value: "nan", updatedBy: env.adminUserId)
+        }
+
+        try env.parts.updateCompanyCostSetting(key: "default_markup_percent", value: " 35 ", updatedBy: env.adminUserId)
+        #expect(try env.parts.getCompanyCostSetting(key: "default_markup_percent") == " 35 ")
     }
 
     @Test("resolvePartPricing clamps corrupt negative company default markup")
@@ -312,7 +319,7 @@ struct PartsServiceCoverageTests {
             try db.execute(sql: "UPDATE parts SET weighted_avg_cost = 100 WHERE id = ?", arguments: [partId])
             try db.execute(sql: """
                 INSERT INTO company_cost_settings (setting_key, setting_value, updated_at)
-                VALUES ('default_markup_percent', '-25', datetime('now'))
+                VALUES ('default_markup_percent', ' -25 ', datetime('now'))
                 ON CONFLICT(setting_key) DO UPDATE SET
                     setting_value = excluded.setting_value,
                     updated_at = datetime('now')

--- a/core/Tests/WiredPartCoreTests/PartsServiceCoverageTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceCoverageTests.swift
@@ -293,6 +293,40 @@ struct PartsServiceCoverageTests {
         #expect(value == "55")
     }
 
+    @Test("updateCompanyCostSetting rejects negative default markup")
+    func testUpdateCompanyCostSettingRejectsNegativeDefaultMarkup() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        #expect(throws: (any Error).self) {
+            try env.parts.updateCompanyCostSetting(key: "default_markup_percent", value: "-10", updatedBy: env.adminUserId)
+        }
+    }
+
+    @Test("resolvePartPricing clamps corrupt negative company default markup")
+    func testResolvePartPricingClampsNegativeDefaultMarkup() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "DefaultMarkupClampCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Default Markup Clamp Part", categoryId: catId)
+
+        try env.db.writer.write { db in
+            try db.execute(sql: "UPDATE parts SET weighted_avg_cost = 100 WHERE id = ?", arguments: [partId])
+            try db.execute(sql: """
+                INSERT INTO company_cost_settings (setting_key, setting_value, updated_at)
+                VALUES ('default_markup_percent', '-25', datetime('now'))
+                ON CONFLICT(setting_key) DO UPDATE SET
+                    setting_value = excluded.setting_value,
+                    updated_at = datetime('now')
+                """)
+        }
+
+        let pricing = try env.parts.resolvePartPricing(partId: partId)
+
+        #expect(pricing.tierLevel == "Default")
+        #expect(pricing.effectiveMarkup == 0)
+        #expect(pricing.sellPrice == pricing.weightedAvgCost)
+        #expect(pricing.sellPrice >= 100)
+    }
+
     @Test("updateCompanyCostSetting is idempotent — upserts on repeated calls")
     func testUpdateCompanyCostSettingUpsert() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
@@ -382,6 +382,39 @@ struct PartsServiceExtTests {
         #expect(pricing.weightedAvgCost >= 0)
     }
 
+    @Test("Company default markup rejects negative writes and clamps corrupt saved values")
+    func testCompanyDefaultMarkupRejectsNegativeAndClampsCorruptSavedValues() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "Default Markup Guard")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Default Markup Guard Part", categoryId: catId)
+
+        try env.db.writer.write { db in
+            try db.execute(
+                sql: "UPDATE parts SET weighted_avg_cost = ?, updated_at = datetime('now') WHERE id = ?",
+                arguments: [100.0, partId]
+            )
+        }
+
+        #expect(throws: (any Error).self) {
+            try env.parts.updateCompanyCostSetting(key: "default_markup_percent", value: "-10")
+        }
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO company_cost_settings (setting_key, setting_value, updated_at)
+                VALUES ('default_markup_percent', '-75', datetime('now'))
+                ON CONFLICT(setting_key) DO UPDATE SET
+                    setting_value = excluded.setting_value,
+                    updated_at = excluded.updated_at
+                """)
+        }
+
+        let pricing = try env.parts.resolvePartPricing(partId: partId)
+        #expect(pricing.effectiveMarkup == 0)
+        #expect(pricing.sellPrice == 100)
+        #expect(pricing.sellPrice >= pricing.weightedAvgCost)
+    }
+
     @Test("Cost layer FIFO/LIFO")
     func testCostLayers() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Reject negative or non-finite all-company default markup writes at the PartsService boundary.
- Clamp corrupt/legacy saved company default markup values when resolving pricing so default sell prices cannot fall below cost.
- Tighten the bulk pricing sheet input parser so negative, NaN, infinity, and malformed markup/margin values do not enable preview/apply.
- Add regression coverage for service writes, corrupt saved settings, and the iOS bulk-pricing input guard.

Closes #1201

## Verification
- `gh issue view 1201 -R xXKillerNoobYT/Weird-Part-Run-2 --json number,title,state,body,labels,comments,url,closed,closedAt,closedByPullRequestsReferences,stateReason` confirmed GH #1201 is open and has no closing PR.
- `gh pr list -R xXKillerNoobYT/Weird-Part-Run-2 --search "1201" --json number,title,state,headRefName,url,body` returned `[]`.
- `cd core && swift test --filter PartsServiceExtTests/testCompanyDefaultMarkupRejectsNegativeAndClampsCorruptSavedValues` passed.
- `cd core && swift test --filter PartsServiceExtTests && swift test --filter PartsServiceCoverageTests` passed (81 + 57 tests).
- `xcodebuild -scheme "WiredPart-iOS" -destination 'id=F29F2637-4865-4685-92B3-98D2F45EF30C' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/pricingBulkEditRejectsNegativeOrNonFinitePercentInputs" test` passed (`** TEST SUCCEEDED **`).
- `git diff --check` passed.
- `python3 scripts/guard-tracked-artifacts.py` passed.
- `cd core && swift test` passed (2207 tests / 67 suites).

## CI note
- WPR2 PR validation should use the local self-hosted Mac runner path per repo runbook (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`) for trusted iOS/macOS gates.


### Follow-up verification after Copilot review fixes
- Resolved Copilot review threads for whitespace parsing, single-source input validation, user attribution/permission context, and redundant validation.
- `cd core && swift test --filter PartsServiceCoverageTests/testUpdateCompanyCostSettingRejectsNegativeDefaultMarkup` passed.
- `git diff --check` passed.
- `python3 scripts/guard-tracked-artifacts.py` passed.
- `xcodebuild -scheme "WiredPart-iOS" -destination 'id=F29F2637-4865-4685-92B3-98D2F45EF30C' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/pricingBulkEditRejectsNegativeOrNonFinitePercentInputs" test` passed (`** TEST SUCCEEDED **`).
- Latest GitHub checks on head `3a0a3afa918da5a75ba16cc2715ad744aaac8819` passed: Tracked artifact guard, CodeQL, Analyze (swift).
- Latest Copilot review/comment received on head `3a0a3afa918da5a75ba16cc2715ad744aaac8819`; no unresolved review threads remain.
