### PR TITLE
fix: keep malformed movement dates out of active queue

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseMovementsPage.swift
@@ -244,12 +244,12 @@ struct WarehouseMovementsPage: View {
 
     private var activeMovements: [WarehouseService.MovementRow] {
         let cutoff = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
-        return filteredMovements.filter { movementDate($0) ?? Date.distantFuture >= cutoff }
+        return WarehouseMovementDatePartitioning.activeMovements(filteredMovements, cutoff: cutoff)
     }
 
     private var completedHistoryMovements: [WarehouseService.MovementRow] {
         let cutoff = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
-        return filteredMovements.filter { movementDate($0) ?? Date.distantFuture < cutoff }
+        return WarehouseMovementDatePartitioning.completedHistoryMovements(filteredMovements, cutoff: cutoff)
     }
 
     @ViewBuilder
@@ -344,7 +344,7 @@ struct WarehouseMovementsPage: View {
                 Text(quantityLabel(for: movement))
                     .font(.subheadline)
                     .fontWeight(.semibold)
-                Text(formatDate(movement.createdAt))
+                Text(WarehouseMovementDatePartitioning.displayDate(movement.createdAt))
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
             }
@@ -460,15 +460,38 @@ struct WarehouseMovementsPage: View {
         return movement.qty >= 0 ? "+\(movement.qty)" : "\(movement.qty)"
     }
 
-    private func formatDate(_ dateStr: String?) -> String {
-        guard let dateStr else { return "" }
-        return dateStr.count >= 10 ? String(dateStr.prefix(10)) : dateStr
+}
+
+enum WarehouseMovementDatePartitioning {
+    static func activeMovements(_ movements: [WarehouseService.MovementRow], cutoff: Date) -> [WarehouseService.MovementRow] {
+        movements.filter { movement in
+            guard let movementDate = parsedDate(for: movement) else { return false }
+            return movementDate >= cutoff
+        }
     }
 
-    private func movementDate(_ movement: WarehouseService.MovementRow) -> Date? {
+    static func completedHistoryMovements(_ movements: [WarehouseService.MovementRow], cutoff: Date) -> [WarehouseService.MovementRow] {
+        movements.filter { movement in
+            guard let movementDate = parsedDate(for: movement) else { return true }
+            return movementDate < cutoff
+        }
+    }
+
+    static func displayDate(_ rawDate: String?) -> String {
+        guard let rawDate, !rawDate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return "Unknown date"
+        }
+        guard parsedDate(from: rawDate) != nil else { return "Unknown date" }
+        return rawDate.count >= 10 ? String(rawDate.prefix(10)) : rawDate
+    }
+
+    static func parsedDate(for movement: WarehouseService.MovementRow) -> Date? {
         guard let raw = movement.createdAt else { return nil }
-        return Self.sqliteDateFormatter.date(from: raw)
-            ?? ISO8601DateFormatter().date(from: raw)
+        return parsedDate(from: raw)
+    }
+
+    private static func parsedDate(from raw: String) -> Date? {
+        sqliteDateFormatter.date(from: raw) ?? iso8601DateFormatter.date(from: raw)
     }
 
     private static let sqliteDateFormatter: DateFormatter = {
@@ -477,6 +500,8 @@ struct WarehouseMovementsPage: View {
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         return formatter
     }()
+
+    private static let iso8601DateFormatter = ISO8601DateFormatter()
 }
 
 // MARK: - Quick Log Sheet

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -1086,6 +1086,24 @@ struct Weird_Parts_IOSTests {
         #expect(detail.lines.allSatisfy { $0.partId != nil })
     }
 
+    @MainActor
+    @Test func warehouseMovementDatePartitionKeepsMalformedRowsOutOfActiveQueue() throws {
+        let cutoff = try #require(Calendar(identifier: .gregorian).date(from: DateComponents(year: 2026, month: 6, day: 8)))
+        let recent = Self.warehouseMovement(id: 1, reason: "Recent", createdAt: "2026-06-10 08:30:00")
+        let old = Self.warehouseMovement(id: 2, reason: "Old", createdAt: "2026-06-01 08:30:00")
+        let malformed = Self.warehouseMovement(id: 3, reason: "Malformed", createdAt: "not-a-date")
+        let missing = Self.warehouseMovement(id: 4, reason: "Missing", createdAt: nil)
+
+        let movements = [recent, old, malformed, missing]
+        let active = WarehouseMovementDatePartitioning.activeMovements(movements, cutoff: cutoff)
+        let history = WarehouseMovementDatePartitioning.completedHistoryMovements(movements, cutoff: cutoff)
+
+        #expect(active.map(\.id) == [recent.id])
+        #expect(history.map(\.id) == [old.id, malformed.id, missing.id])
+        #expect(WarehouseMovementDatePartitioning.displayDate(malformed.createdAt) == "Unknown date")
+        #expect(WarehouseMovementDatePartitioning.displayDate(missing.createdAt) == "Unknown date")
+    }
+
     @Test func pricingBulkEditRejectsNegativeOrNonFinitePercentInputs() {
         #expect(PricingBulkEditSheet.isValidNonNegativePercent("0"))
         #expect(PricingBulkEditSheet.isValidNonNegativePercent(" 12.5 "))
@@ -1093,6 +1111,25 @@ struct Weird_Parts_IOSTests {
         #expect(!PricingBulkEditSheet.isValidNonNegativePercent("nan"))
         #expect(!PricingBulkEditSheet.isValidNonNegativePercent("inf"))
         #expect(!PricingBulkEditSheet.isValidNonNegativePercent("not a number"))
+    }
+
+    static func warehouseMovement(id: Int64, reason: String, createdAt: String?) -> WarehouseService.MovementRow {
+        WarehouseService.MovementRow(
+            id: id,
+            partId: 10,
+            partName: "QA Part",
+            qty: 1,
+            fromLocationType: nil,
+            fromLocationId: nil,
+            toLocationType: "warehouse",
+            toLocationId: 1,
+            movementType: "received",
+            reason: reason,
+            notes: nil,
+            performedBy: 1,
+            performedByName: "Tester",
+            createdAt: createdAt
+        )
     }
 }
 


### PR DESCRIPTION
Closes #1202

## Summary
- Replaces the warehouse movements page's `Date.distantFuture` fallback with explicit date partitioning logic.
- Keeps malformed or missing movement timestamps out of the Active queue and places them in Completed History for review instead.
- Displays malformed/missing movement timestamps as `Unknown date`.
- Adds an iOS regression test covering recent, old, malformed, and missing movement timestamps.

## Verification
- `git diff --check` ✅
- `python3 scripts/guard-tracked-artifacts.py` ✅ (`No tracked Paperclip/Xcode runtime artifacts found.`)
- `swift test --filter WarehouseServiceExtTests/testMovementQueryFilters` ✅ (1 selected core warehouse test passed)
- `xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme WiredPart-iOS -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -derivedDataPath /tmp/wei4176-dd -only-testing:'Weird Parts IOSTests/Weird_Parts_IOSTests/warehouseMovementDatePartitionKeepsMalformedRowsOutOfActiveQueue'` ✅ (`** TEST SUCCEEDED **`)

## CI / review notes
- GitHub checks passed: `Tracked artifact guard`, `CodeQL`, `Analyze (swift)`.
- Local self-hosted Mac runner path is available for PR checks: `IA-Mac-WPR2` online with `self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac` labels.
- Copilot review was requested with `gh pr edit 1260 --add-reviewer @copilot`; merge remains blocked until Copilot review/comment evidence is present or the owner explicitly accepts Copilot as unavailable for this PR.
