### PR TITLE
fix: reject negative audit unit costs

### DIFF
--- a/core/Sources/WiredPartCore/Services/ReportsService.swift
+++ b/core/Sources/WiredPartCore/Services/ReportsService.swift
@@ -1098,7 +1098,7 @@ public final class ReportsService: Sendable {
                            COUNT(ac.id) AS count_count,
                            SUM(CASE WHEN ac.variance != 0 THEN 1 ELSE 0 END) AS discrepancy_count,
                            COALESCE(SUM(ac.variance), 0) AS total_variance,
-                           COALESCE(SUM(ac.variance_dollars), 0) AS total_variance_dollars,
+                           COALESCE(SUM(ABS(ac.variance_dollars)), 0) AS total_variance_dollars,
                            MAX(ac.counted_at) AS last_counted_at
                     FROM audit_counts ac
                     JOIN audit_sessions_v2 aus ON aus.id = ac.session_id AND aus.deleted_at IS NULL

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -5790,13 +5790,14 @@ public final class WarehouseService: Sendable {
     ) throws -> AuditCount {
         guard userCount >= 0 else { throw WarehouseError.invalidQuantity }
         guard systemCount >= 0 else { throw WarehouseError.invalidQuantity }
+        guard unitCostDollars.isFinite && unitCostDollars >= 0 else { throw WarehouseError.invalidQuantity }
         return try db.writer.write { dbConn in
             let userExists = (try Int.fetchOne(dbConn, sql: """
                 SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [countedBy]) ?? 0) > 0
             guard userExists else { throw WarehouseError.userNotFound(countedBy) }
             let variance = userCount - systemCount
-            let varianceDollars = Double(abs(variance)) * unitCostDollars
+            let varianceDollars = max(0, Double(abs(variance)) * unitCostDollars)
             let variancePercent: Double = systemCount > 0 ? (Double(abs(variance)) / Double(systemCount)) * 100.0 : (variance == 0 ? 0 : 100)
             let result: String
             if variance == 0 { result = "exact" }

--- a/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
@@ -1186,7 +1186,7 @@ struct ReportsServiceTests {
         #expect(rows.first?.countCount == 2)
         #expect(rows.first?.discrepancyCount == 1)
         #expect(rows.first?.totalVariance == -2)
-        #expect(abs((rows.first?.totalVarianceDollars ?? 0) - -24.0) < 0.01)
+        #expect(abs((rows.first?.totalVarianceDollars ?? 0) - 24.0) < 0.01)
         #expect(rows.first?.sourceSummary == "2 audit counts, 1 discrepancy")
     }
 

--- a/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
@@ -137,6 +137,33 @@ struct WarehouseAuditTests {
         #expect(confidence.totalVarianceDollars == 20)
     }
 
+    @Test("Audit counts reject malformed unit costs before variance persistence")
+    func testRecordAuditCountRejectsMalformedUnitCosts() throws {
+        let env = try freshEnv()
+        #expect(throws: WarehouseService.WarehouseError.invalidQuantity) {
+            _ = try env.warehouse.recordAuditCount(
+                sessionId: 999,
+                partId: 999,
+                areaId: 999,
+                systemCount: 10,
+                userCount: 7,
+                countedBy: env.adminUserId,
+                unitCostDollars: -25
+            )
+        }
+        #expect(throws: WarehouseService.WarehouseError.invalidQuantity) {
+            _ = try env.warehouse.recordAuditCount(
+                sessionId: 999,
+                partId: 999,
+                areaId: 999,
+                systemCount: 10,
+                userCount: 7,
+                countedBy: env.adminUserId,
+                unitCostDollars: .infinity
+            )
+        }
+    }
+
     @Test("Audit variance within 5 percent dollar value neutral zone preserves confidence")
     func testAuditVarianceNeutralDollarThreshold() throws {
         let env = try freshEnv()


### PR DESCRIPTION
## Summary
- Reject negative, NaN, and infinite audit `unitCostDollars` before audit count persistence.
- Keep computed audit `varianceDollars` non-negative at the service boundary.
- Normalize audit summary variance-dollar reporting with `ABS(...)` so legacy malformed rows cannot display inverted negative cost impact.
- Add regression coverage for malformed audit unit cost rejection and update report summary expectations.

Closes #1209

## Tests
- `swift test --filter WarehouseAuditTests/testRecordAuditCountRejectsMalformedUnitCosts`
- `swift test --filter ReportsServiceTests/testAuditSummariesAggregateVarianceProvenance`
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `swift test --filter WarehouseAuditTests`
- `cd core && swift test`

## CI / local runner note
Core-only Swift package change. Full local core suite passed on this Mac; PR CI should use the repo local self-hosted Mac runner path when applicable (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`).
