### PR TITLE
fix: reject blank shop sync addresses

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Auth/DevicePairingView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/DevicePairingView.swift
@@ -28,6 +28,10 @@ struct DevicePairingView: View {
         SyncCrypto.normalizedPairingCode(pairingCode) != nil
     }
 
+    private var normalizedManualAddress: String? {
+        IOSSyncManager.normalizedShopServerAddress(manualAddress)
+    }
+
     var body: some View {
         VStack(spacing: 24) {
             Spacer()
@@ -113,7 +117,7 @@ struct DevicePairingView: View {
             // Show discovered peers as potential shops
             ForEach(syncManager.discoveredPeers) { peer in
                 Button {
-                    guard let address = peer.address else {
+                    guard let address = IOSSyncManager.normalizedShopServerAddress(peer.address) else {
                         errorMessage = "This device was found over Bluetooth only. Keep both devices on the same Wi-Fi network or enter the shop address manually."
                         return
                     }
@@ -161,16 +165,16 @@ struct DevicePairingView: View {
                     .autocorrectionDisabled()
 
                 Button("Connect") {
-                    guard !manualAddress.isEmpty else { return }
+                    guard let address = normalizedManualAddress else { return }
                     discoveredShop = DiscoveredShop(
-                        id: manualAddress,
-                        name: manualAddress,
-                        address: manualAddress
+                        id: address,
+                        name: address,
+                        address: address
                     )
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
-                .disabled(manualAddress.isEmpty)
+                .disabled(normalizedManualAddress == nil)
             }
             .padding(.horizontal, 32)
         }

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -82,7 +82,13 @@ final class IOSSyncManager {
     private var serverAddress: String? {
         guard let service = settingsService else { return nil }
         let addr = (try? service.getSettingsByCategory("sync"))?["shop_server_address"]
-        return addr?.isEmpty == true ? nil : addr
+        return Self.normalizedShopServerAddress(addr)
+    }
+
+    /// Trims a user-entered or persisted shop server address and rejects blank values.
+    static func normalizedShopServerAddress(_ address: String?) -> String? {
+        let trimmed = address?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     init() {}
@@ -634,6 +640,13 @@ final class IOSSyncManager {
         syncProgressMessage = "Connecting to shop..."
         syncProgressPercent = 0.1
 
+        guard let normalizedShopAddress = Self.normalizedShopServerAddress(shopAddress) else {
+            syncStatus = .error
+            syncProgressMessage = nil
+            errorMessage = SyncError.invalidShopAddress.localizedDescription
+            throw SyncError.invalidShopAddress
+        }
+
         guard let normalizedPairingCode = SyncCrypto.normalizedPairingCode(pairingCode) else {
             syncStatus = .error
             syncProgressMessage = nil
@@ -652,7 +665,7 @@ final class IOSSyncManager {
         }
 
         let pairResponse = try await verifyPairingCodeWithShop(
-            shopAddress: shopAddress,
+            shopAddress: normalizedShopAddress,
             pairingCode: normalizedPairingCode,
             deviceId: deviceId,
             deviceName: deviceName
@@ -672,7 +685,7 @@ final class IOSSyncManager {
         // local trusted-device registration succeeds.
         if let service = settingsService {
             try service.upsertSettingsMap([
-                "shop_server_address": shopAddress,
+                "shop_server_address": normalizedShopAddress,
                 "paired_shop_device_id": pairResponse.serverDeviceId,
                 "paired_company_id": pairResponse.companyId,
                 "device_pairing_verified_at": pairResponse.pairedAt,
@@ -729,7 +742,9 @@ final class IOSSyncManager {
     }
 
     private func normalizedShopBaseURL(_ shopAddress: String) throws -> URL {
-        let trimmed = shopAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmed = Self.normalizedShopServerAddress(shopAddress) else {
+            throw SyncError.invalidShopAddress
+        }
         let addressWithScheme = trimmed.contains("://") ? trimmed : "http://\(trimmed)"
         guard let url = URL(string: addressWithScheme),
               let scheme = url.scheme?.lowercased(),

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -265,6 +265,50 @@ struct Weird_Parts_IOSTests {
     }
 
     @MainActor
+    @Test func shopServerAddressNormalizationTrimsValidValuesAndRejectsBlankValues() async throws {
+        #expect(IOSSyncManager.normalizedShopServerAddress(nil) == nil)
+        #expect(IOSSyncManager.normalizedShopServerAddress("") == nil)
+        #expect(IOSSyncManager.normalizedShopServerAddress(" \n\t ") == nil)
+        #expect(IOSSyncManager.normalizedShopServerAddress("  http://127.0.0.1:8080\n") == "http://127.0.0.1:8080")
+        #expect(IOSSyncManager.normalizedShopServerAddress("  192.168.1.10:8080  ") == "192.168.1.10:8080")
+    }
+
+    @MainActor
+    @Test func whitespaceOnlyShopServerAddressDoesNotEnableSync() async throws {
+        let previousBluetooth = UserDefaults.standard.bool(forKey: "bluetooth_sync_enabled")
+        UserDefaults.standard.set(false, forKey: "bluetooth_sync_enabled")
+        defer { UserDefaults.standard.set(previousBluetooth, forKey: "bluetooth_sync_enabled") }
+
+        let db = try AppDatabase.openInMemoryDatabase()
+        let settings = SettingsService(db: db)
+        try settings.upsertSetting(key: "shop_server_address", value: " \n\t ", category: "sync")
+        let manager = IOSSyncManager()
+        manager.configure(db: db, settingsService: settings)
+
+        #expect(!manager.isSyncAvailable)
+
+        await manager.syncNow()
+
+        #expect(manager.syncStatus == .idle)
+        #expect(manager.errorMessage == "Sync not configured. Set up in Settings → Sync.")
+    }
+
+    @MainActor
+    @Test func trimmedShopServerAddressStillEnablesSync() async throws {
+        let previousBluetooth = UserDefaults.standard.bool(forKey: "bluetooth_sync_enabled")
+        UserDefaults.standard.set(false, forKey: "bluetooth_sync_enabled")
+        defer { UserDefaults.standard.set(previousBluetooth, forKey: "bluetooth_sync_enabled") }
+
+        let db = try AppDatabase.openInMemoryDatabase()
+        let settings = SettingsService(db: db)
+        try settings.upsertSetting(key: "shop_server_address", value: "  http://127.0.0.1:9\n", category: "sync")
+        let manager = IOSSyncManager()
+        manager.configure(db: db, settingsService: settings)
+
+        #expect(manager.isSyncAvailable)
+    }
+
+    @MainActor
     @Test func partsFlowDraftsAreScopedPerAuthenticatedUser() throws {
         let userA: Int64 = 101
         let userB: Int64 = 202


### PR DESCRIPTION
## Summary
- Normalize persisted and user-entered shop server addresses with `.whitespacesAndNewlines` trimming.
- Treat whitespace-only `shop_server_address` values as not configured so Sync Now / peer discovery hit the existing setup guard instead of attempting invalid sync.
- Normalize first-run Join Existing Business manual and discovered LAN addresses before enabling Connect or pairing.
- Store the normalized address after successful pairing and reject blank pairing addresses before network work.

Closes #1210

## Verification
- `gh issue view 1210 --repo xXKillerNoobYT/Weird-Part-Run-2 --json number,state,title,body,labels,url,comments,closed,closedAt,stateReason` confirmed GH #1210 is open and includes the DevicePairingView follow-up path.
- `gh pr list --repo xXKillerNoobYT/Weird-Part-Run-2 --state open --search '1210 in:body' --json number,title,headRefName,state,isDraft,url` returned `[]`, so no newer open PR already covers it.
- `xcodebuild -scheme "WiredPart-iOS" -destination 'id=F29F2637-4865-4685-92B3-98D2F45EF30C' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/shopServerAddressNormalizationTrimsValidValuesAndRejectsBlankValues" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/whitespaceOnlyShopServerAddressDoesNotEnableSync" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/trimmedShopServerAddressStillEnablesSync" test` passed (`** TEST SUCCEEDED **`).
- `xcodebuild -scheme "WiredPart-iOS" -destination 'generic/platform=iOS Simulator' build` passed (`** BUILD SUCCEEDED **`).
- `git diff --check` passed.
- `python3 scripts/guard-tracked-artifacts.py` passed: No tracked Paperclip/Xcode runtime artifacts found.
- `cd core && swift test` passed: 2208 tests in 67 suites.

## Notes
- UI-adjacent change is limited to manual join-address validation; build/test coverage ran through the local Mac/Xcode path expected for WPR2 PR validation.
