### PR TITLE
Fix malformed timesheet correction timestamp handling

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
@@ -443,9 +443,9 @@ private struct TimesheetCorrectionSheet: View {
         let parsedClockOut = segment.clockOut.flatMap(CoreFormatters.parseDateTime)
         let timestampError: String?
         if parsedClockIn == nil {
-            timestampError = "Original clock-in timestamp is malformed. Repair the stored time entry before saving a correction."
+            timestampError = ReportsError.invalidTimesheetOriginalTimestamp("clock-in").localizedDescription
         } else if segment.clockOut != nil && parsedClockOut == nil {
-            timestampError = "Original clock-out timestamp is malformed. Repair the stored time entry before saving a correction."
+            timestampError = ReportsError.invalidTimesheetOriginalTimestamp("clock-out").localizedDescription
         } else {
             timestampError = nil
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
@@ -452,7 +452,6 @@ private struct TimesheetCorrectionSheet: View {
         let fallbackClockIn = parsedClockIn ?? Date(timeIntervalSince1970: 0)
         let fallbackClockOut = parsedClockOut ?? fallbackClockIn.addingTimeInterval(3600)
         _originalTimestampError = State(initialValue: timestampError)
-        _validationMessage = State(initialValue: timestampError)
         _adjustedClockIn = State(initialValue: fallbackClockIn)
         _adjustedClockOut = State(initialValue: fallbackClockOut)
     }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
@@ -424,6 +424,7 @@ private struct TimesheetCorrectionSheet: View {
     @State private var adjustedClockOut: Date
     @State private var reason = ""
     @State private var validationMessage: String?
+    @State private var originalTimestampError: String?
     @State private var isSaving = false
 
     init(
@@ -438,10 +439,22 @@ private struct TimesheetCorrectionSheet: View {
         self.actorName = actorName
         self.reportsService = reportsService
         self.onSave = onSave
-        let clockIn = CoreFormatters.parseDateTime(segment.clockIn) ?? Date()
-        let clockOut = segment.clockOut.flatMap(CoreFormatters.parseDateTime) ?? clockIn.addingTimeInterval(3600)
-        _adjustedClockIn = State(initialValue: clockIn)
-        _adjustedClockOut = State(initialValue: clockOut)
+        let parsedClockIn = CoreFormatters.parseDateTime(segment.clockIn)
+        let parsedClockOut = segment.clockOut.flatMap(CoreFormatters.parseDateTime)
+        let timestampError: String?
+        if parsedClockIn == nil {
+            timestampError = "Original clock-in timestamp is malformed. Repair the stored time entry before saving a correction."
+        } else if segment.clockOut != nil && parsedClockOut == nil {
+            timestampError = "Original clock-out timestamp is malformed. Repair the stored time entry before saving a correction."
+        } else {
+            timestampError = nil
+        }
+        let fallbackClockIn = parsedClockIn ?? Date(timeIntervalSince1970: 0)
+        let fallbackClockOut = parsedClockOut ?? fallbackClockIn.addingTimeInterval(3600)
+        _originalTimestampError = State(initialValue: timestampError)
+        _validationMessage = State(initialValue: timestampError)
+        _adjustedClockIn = State(initialValue: fallbackClockIn)
+        _adjustedClockOut = State(initialValue: fallbackClockOut)
     }
 
     var body: some View {
@@ -458,7 +471,9 @@ private struct TimesheetCorrectionSheet: View {
 
                 Section("Adjusted Values") {
                     DatePicker("Clock In", selection: $adjustedClockIn)
+                        .disabled(originalTimestampError != nil)
                     DatePicker("Clock Out", selection: $adjustedClockOut)
+                        .disabled(originalTimestampError != nil)
                     labeledValue("Paid Time Preview", String(format: "%.1fh", adjustedTotalHours))
                         .accessibilityIdentifier("timesheetCorrectionPaidTimePreview")
                     Label("Regular and overtime hours are calculated from the current overtime policy when saved.", systemImage: "clock.badge.exclamationmark")
@@ -501,7 +516,7 @@ private struct TimesheetCorrectionSheet: View {
                         }
                     }
                     .accessibilityIdentifier("timesheetCorrectionSaveButton")
-                    .disabled(isSaving)
+                    .disabled(isSaving || originalTimestampError != nil)
                 }
             }
         }
@@ -526,6 +541,11 @@ private struct TimesheetCorrectionSheet: View {
     }
 
     private func save() {
+        if let originalTimestampError {
+            validationMessage = originalTimestampError
+            return
+        }
+
         let trimmedReason = reason.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedReason.isEmpty else {
             validationMessage = "Reason is required before save."

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
@@ -470,16 +470,21 @@ private struct TimesheetCorrectionSheet: View {
                 }
 
                 Section("Adjusted Values") {
-                    DatePicker("Clock In", selection: $adjustedClockIn)
-                        .disabled(originalTimestampError != nil)
-                    DatePicker("Clock Out", selection: $adjustedClockOut)
-                        .disabled(originalTimestampError != nil)
-                    labeledValue("Paid Time Preview", String(format: "%.1fh", adjustedTotalHours))
-                        .accessibilityIdentifier("timesheetCorrectionPaidTimePreview")
-                    Label("Regular and overtime hours are calculated from the current overtime policy when saved.", systemImage: "clock.badge.exclamationmark")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .accessibilityIdentifier("timesheetCorrectionPolicyAllocationCopy")
+                    if let originalTimestampError {
+                        Label(originalTimestampError, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                            .accessibilityElement(children: .combine)
+                            .accessibilityIdentifier("timesheetCorrectionOriginalTimestampError")
+                    } else {
+                        DatePicker("Clock In", selection: $adjustedClockIn)
+                        DatePicker("Clock Out", selection: $adjustedClockOut)
+                        labeledValue("Paid Time Preview", String(format: "%.1fh", adjustedTotalHours))
+                            .accessibilityIdentifier("timesheetCorrectionPaidTimePreview")
+                        Label("Regular and overtime hours are calculated from the current overtime policy when saved.", systemImage: "clock.badge.exclamationmark")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .accessibilityIdentifier("timesheetCorrectionPolicyAllocationCopy")
+                    }
                 }
 
                 Section {

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -760,6 +760,22 @@ struct Weird_Parts_IOSTests {
         #expect(scannerSource.contains("activeContinuation?.finish()"), "Startup failures should finish the scan stream instead of leaving a dead sheet")
     }
 
+    @Test func timesheetCorrectionRejectsMalformedOriginalTimestampsBeforeSave() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let timesheetsURL = repoRoot
+            .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift")
+        let source = try String(contentsOf: timesheetsURL, encoding: .utf8)
+
+        #expect(!source.contains("CoreFormatters.parseDateTime(segment.clockIn) ?? Date()"), "Malformed original clock-in must not default correction pickers to the current time")
+        #expect(source.contains("Original clock-in timestamp is malformed"), "Malformed clock-in needs user-facing data-integrity copy")
+        #expect(source.contains("Original clock-out timestamp is malformed"), "Malformed clock-out needs user-facing data-integrity copy")
+        #expect(source.contains(".disabled(isSaving || originalTimestampError != nil)"), "The correction save action must stay disabled while original timestamps are malformed")
+        #expect(source.contains("if let originalTimestampError"), "The save path needs a guard even if a disabled button is bypassed")
+    }
+
     @Test func dispatchAssignmentConflictCheckFailureShowsActionError() throws {
         let repoRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/core/Sources/WiredPartCore/Services/ReportsService.swift
+++ b/core/Sources/WiredPartCore/Services/ReportsService.swift
@@ -435,6 +435,14 @@ public final class ReportsService: Sendable {
                 let originalRegular: Double = original["regular_hours"] ?? 0
                 let originalOvertime: Double = original["overtime_hours"] ?? 0
                 let changedAt = CoreFormatters.nowISO()
+
+                guard CoreFormatters.parseDateTime(originalClockIn) != nil else {
+                    throw ReportsError.invalidTimesheetOriginalTimestamp("clock-in")
+                }
+                if let originalClockOut, CoreFormatters.parseDateTime(originalClockOut) == nil {
+                    throw ReportsError.invalidTimesheetOriginalTimestamp("clock-out")
+                }
+
                 let adjustedTotalHours = try Self.correctedBillableHours(
                     dbConn: dbConn,
                     laborEntryId: request.laborEntryId,
@@ -1782,6 +1790,7 @@ public enum ReportsError: Error, LocalizedError, Equatable {
     case timesheetSegmentNotFound(Int64)
     case invalidTimesheetCorrectionReason
     case invalidTimesheetCorrectionRange
+    case invalidTimesheetOriginalTimestamp(String)
     case timesheetCorrectionAuditUnavailable
 
     public var errorDescription: String? {
@@ -1794,6 +1803,8 @@ public enum ReportsError: Error, LocalizedError, Equatable {
             return "Correction reason is required."
         case .invalidTimesheetCorrectionRange:
             return "Adjusted clock out cannot be before adjusted clock in."
+        case .invalidTimesheetOriginalTimestamp(let field):
+            return "Original \(field) timestamp is malformed. Repair the stored time entry before saving a correction."
         case .timesheetCorrectionAuditUnavailable:
             return "Timesheet correction audit storage is not available."
         }

--- a/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
@@ -178,6 +178,62 @@ struct ReportsServiceTests {
         #expect(updated?["status"] as String? == "completed")
     }
 
+    @Test("Timesheet correction rejects malformed original clock-in")
+    func testTimesheetCorrectionRejectsMalformedOriginalClockIn() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-CORR-BAD-IN", name: "Malformed Clock-In Job")
+        let laborEntryId = try env.db.writer.write { db -> Int64 in
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, 'not-a-date', '2026-03-05T16:00:00Z', 8.0, 0.0, 'completed', datetime('now'))
+                """, arguments: [env.adminUserId, jobId])
+            return db.lastInsertedRowID
+        }
+
+        #expect(throws: ReportsError.invalidTimesheetOriginalTimestamp("clock-in")) {
+            _ = try env.reports.saveTimesheetCorrection(
+                ReportsService.TimesheetCorrectionRequest(
+                    laborEntryId: laborEntryId,
+                    adjustedClockIn: "2026-03-05T08:15:00Z",
+                    adjustedClockOut: "2026-03-05T17:45:00Z",
+                    clientPreviewRegularHours: 8.0,
+                    clientPreviewOvertimeHours: 1.5,
+                    reason: "Manager correction should not hide malformed original data.",
+                    actorUserId: env.adminUserId
+                )
+            )
+        }
+    }
+
+    @Test("Timesheet correction rejects malformed original clock-out")
+    func testTimesheetCorrectionRejectsMalformedOriginalClockOut() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-CORR-BAD-OUT", name: "Malformed Clock-Out Job")
+        let laborEntryId = try env.db.writer.write { db -> Int64 in
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, '2026-03-05T08:00:00Z', 'not-a-date', 8.0, 0.0, 'completed', datetime('now'))
+                """, arguments: [env.adminUserId, jobId])
+            return db.lastInsertedRowID
+        }
+
+        #expect(throws: ReportsError.invalidTimesheetOriginalTimestamp("clock-out")) {
+            _ = try env.reports.saveTimesheetCorrection(
+                ReportsService.TimesheetCorrectionRequest(
+                    laborEntryId: laborEntryId,
+                    adjustedClockIn: "2026-03-05T08:15:00Z",
+                    adjustedClockOut: "2026-03-05T17:45:00Z",
+                    clientPreviewRegularHours: 8.0,
+                    clientPreviewOvertimeHours: 1.5,
+                    reason: "Manager correction should not hide malformed original data.",
+                    actorUserId: env.adminUserId
+                )
+            )
+        }
+    }
+
     @Test("Timesheet correction allocates weekly overtime from current settings instead of request buckets")
     func testTimesheetCorrectionUsesOvertimeSettingsForAdjustedHours() throws {
         try withDenverTimeZone {


### PR DESCRIPTION
## Summary
- Stops the timesheet correction sheet from seeding malformed original clock-in values to the current time.
- Shows a data-integrity error and disables correction pickers/save when original clock-in or clock-out cannot be parsed.
- Adds a ReportsService guard so direct correction saves cannot overwrite malformed original timestamps.

Closes #1211

## Tests
- `swift test --filter ReportsServiceTests` — passed (50 tests)
- `xcodebuild test -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/timesheetCorrectionRejectsMalformedOriginalTimestampsBeforeSave"` — passed
- `cd core && swift test` — passed (2210 Swift Testing tests + 4 XCTest tests)
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed

## Local runner / CI note
Local iOS test/build verification ran on this Mac against the `WEI3988-iPhone` simulator. Per the repo CI runbook, PR CI should use the self-hosted local Mac runner path for trusted same-repo iOS work when GitHub-hosted runner capacity is unavailable.
