### PR TITLE
fix: validate edit job numeric inputs

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSEditJobSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSEditJobSheet.swift
@@ -186,12 +186,13 @@ struct IOSEditJobSheet: View {
             errorMessage = "Service not available"
             return
         }
+        guard validateNumericFields() else { return }
+        errorMessage = nil
         if selectedStageTemplateId != job.stageTemplateId && !applyTemplateChange {
             showingTemplateChangeConfirmation = true
             return
         }
         isSaving = true
-        errorMessage = nil
 
         do {
             try service.updateJob(
@@ -244,5 +245,26 @@ struct IOSEditJobSheet: View {
 
     private func shouldClearDouble(_ value: String, original: Double?) -> Bool {
         value.trimmingCharacters(in: .whitespaces).isEmpty && original != nil
+    }
+
+    private func validateNumericFields() -> Bool {
+        if let message = numericValidationMessage(for: estimatedHours, label: "Estimated Hours") {
+            errorMessage = message
+            return false
+        }
+        if let message = numericValidationMessage(for: budgetLimit, label: "Budget Limit") {
+            errorMessage = message
+            return false
+        }
+        return true
+    }
+
+    private func numericValidationMessage(for value: String, label: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+        guard Double(trimmed) != nil else {
+            return "\(label) must be a plain number, like 8 or 8.5. Clear the field to remove it."
+        }
+        return nil
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/IOSEditJobSheetRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/IOSEditJobSheetRegressionTests.swift
@@ -38,6 +38,24 @@ final class IOSEditJobSheetRegressionTests: XCTestCase {
         )
     }
 
+    func testMalformedEditableNumericFieldsShowValidationBeforeSaving() throws {
+        let source = try Self.readEditJobSheetSource()
+
+        XCTAssertTrue(
+            source.contains("guard validateNumericFields() else { return }")
+                && source.contains("private func validateNumericFields() -> Bool")
+                && source.contains("numericValidationMessage(for: estimatedHours, label: \"Estimated Hours\")")
+                && source.contains("numericValidationMessage(for: budgetLimit, label: \"Budget Limit\")"),
+            "Edit job sheet should validate estimated hours and budget limit before updateJob so malformed text cannot be silently ignored."
+        )
+        XCTAssertTrue(
+            source.contains("guard Double(trimmed) != nil else")
+                && source.contains("must be a plain number, like 8 or 8.5")
+                && source.contains("Clear the field to remove it."),
+            "Malformed numeric input should show a clear error while still allowing users to clear an optional value."
+        )
+    }
+
     private static func readEditJobSheetSource(file: StaticString = #filePath) throws -> String {
         let testFileURL = URL(fileURLWithPath: "\(file)")
         let projectRoot = testFileURL


### PR DESCRIPTION
## Summary
- Validate Estimated Hours and Budget Limit before saving the edit-job sheet.
- Keep the sheet open with a clear error when malformed numeric text is entered.
- Preserve existing optional numeric clear behavior for blank fields.
- Add regression coverage for malformed edit-job numeric inputs.

Closes #1108

## Tests
- `swift test --filter JobsServiceTests` (core package) — passed, 145 tests.
- `xcodebuild -scheme "WiredPart-iOS" -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:"Weird Parts IOSTests/IOSEditJobSheetRegressionTests" test` — passed, 2 tests.
- `git diff --check` — passed.
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`).
- `xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build` — passed (`** BUILD SUCCEEDED **`; existing warnings only).

## CI / local runner path
- This repo uses the local self-hosted Mac runner path for trusted iOS/macOS checks: `/Users/IA/actions-runner/Weird-Part-Run-2` with labels `macos,xcode,ios,arm64,local-mac`.
