### PR TITLE
fix: record geofence supply run responses

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/GeofenceAlertView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/GeofenceAlertView.swift
@@ -244,11 +244,30 @@ struct GeofenceAlertView: View {
         let exitLat = geofenceManager.exitLocation?.latitude
         let exitLng = geofenceManager.exitLocation?.longitude
 
+        if reason.requiresActiveClockEntry && activeEntryId == nil {
+            await showMissingActiveClockEntryError()
+            return
+        }
+
         do {
             switch reason {
             case .supplyRun:
-                // Stay clocked in, acknowledge and continue
-                break
+                guard let entryId = activeEntryId else {
+                    await showMissingActiveClockEntryError()
+                    return
+                }
+                let notes = try service.getLaborEntryNotes(laborEntryId: entryId)
+                if !JobsService.isOnSupplyRun(notes: notes) {
+                    let newStatus = try service.toggleSupplyRun(laborEntryId: entryId)
+                    guard newStatus == "supply_run" else {
+                        await MainActor.run {
+                            errorMessage = "Supply run could not be started. Please refresh the Clock page and try again."
+                            showError = true
+                            isProcessing = false
+                        }
+                        return
+                    }
+                }
 
             case .anotherJob:
                 if let newJobId = targetJobId {
@@ -284,6 +303,14 @@ struct GeofenceAlertView: View {
                 showError = true
                 isProcessing = false
             }
+        }
+    }
+
+    private func showMissingActiveClockEntryError() async {
+        await MainActor.run {
+            errorMessage = "No active clock entry was found. Please refresh the Clock page and try again."
+            showError = true
+            isProcessing = false
         }
     }
 
@@ -337,6 +364,17 @@ struct GeofenceAlertView: View {
         case .breakTime: return "Taking a break. Clock pauses."
         case .doneForDay: return "Clock out and done."
         case .other: return "Something else — explain below."
+        }
+    }
+}
+
+private extension GeofenceAlertView.ExitReason {
+    var requiresActiveClockEntry: Bool {
+        switch self {
+        case .supplyRun, .lunch, .breakTime, .doneForDay:
+            return true
+        case .anotherJob, .other:
+            return false
         }
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/GeofenceAlertViewRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/GeofenceAlertViewRegressionTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+final class GeofenceAlertViewRegressionTests: XCTestCase {
+    func testSupplyRunExitReasonStartsSupplyRunBeforeAcknowledgingAlert() throws {
+        let source = try Self.readGeofenceAlertSource()
+        XCTAssertTrue(source.contains("case .supplyRun:"))
+        XCTAssertTrue(source.contains("guard let entryId = activeEntryId else"))
+        XCTAssertTrue(source.contains("await showMissingActiveClockEntryError()"))
+        XCTAssertTrue(source.contains("let notes = try service.getLaborEntryNotes(laborEntryId: entryId)"))
+        XCTAssertTrue(source.contains("if !JobsService.isOnSupplyRun(notes: notes)"))
+        XCTAssertTrue(source.contains("let newStatus = try service.toggleSupplyRun(laborEntryId: entryId)"))
+        XCTAssertTrue(source.contains("guard newStatus == \"supply_run\" else"))
+        XCTAssertTrue(
+            source.contains("Supply run could not be started. Please refresh the Clock page and try again."),
+            "Geofence Supply Run must surface an error if the active labor entry fails to enter supply-run state."
+        )
+
+        XCTAssertFalse(
+            source.contains("// Stay clocked in, acknowledge and continue"),
+            "The Supply Run branch must not remain a no-op."
+        )
+
+        let supplyRunCase = try XCTUnwrap(source.range(of: "case .supplyRun:"))
+        let supplyRunToggle = try XCTUnwrap(source.range(
+            of: "let newStatus = try service.toggleSupplyRun(laborEntryId: entryId)",
+            range: supplyRunCase.upperBound..<source.endIndex
+        ))
+        let acknowledgeExit = try XCTUnwrap(source.range(of: "geofenceManager.acknowledgeExit()"))
+        XCTAssertTrue(
+            supplyRunToggle.lowerBound < acknowledgeExit.lowerBound,
+            "Geofence Supply Run must start supply-run state before acknowledging and resolving the alert."
+        )
+    }
+
+    func testClockEntryRequiredGeofenceReasonsDoNotResolveWithoutActiveEntry() throws {
+        let source = try Self.readGeofenceAlertSource()
+
+        XCTAssertTrue(source.contains("if reason.requiresActiveClockEntry && activeEntryId == nil"))
+        XCTAssertTrue(source.contains("await showMissingActiveClockEntryError()"))
+        XCTAssertTrue(source.contains("No active clock entry was found. Please refresh the Clock page and try again."))
+        XCTAssertTrue(source.contains("showError = true"))
+        XCTAssertTrue(
+            source.contains("case .supplyRun, .lunch, .breakTime, .doneForDay:"),
+            "Clock-mutating geofence responses should require an active clock entry."
+        )
+        XCTAssertTrue(
+            source.contains("case .anotherJob, .other:"),
+            "Non-clock-entry responses should not require an active clock entry."
+        )
+    }
+
+    private static func readGeofenceAlertSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("App")
+            .appendingPathComponent("GeofenceAlertView.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/core/Sources/WiredPartCore/Services/JobsService.swift
+++ b/core/Sources/WiredPartCore/Services/JobsService.swift
@@ -3694,22 +3694,6 @@ public final class JobsService: Sendable {
         return true
     }
 
-    /// Returns the timestamp for the latest unmatched supply run start marker.
-    public static func activeSupplyRunStart(notes: String?) -> Date? {
-        guard let notes, notes.contains("[supply_run_start:") else { return nil }
-        let lastStart = notes.range(of: "[supply_run_start:", options: .backwards)
-        let lastEnd = notes.range(of: "[supply_run_end:", options: .backwards)
-        guard let start = lastStart else { return nil }
-        if let end = lastEnd, end.lowerBound > start.lowerBound {
-            return nil
-        }
-
-        let timestampStart = start.upperBound
-        guard let closeBracket = notes[timestampStart...].firstIndex(of: "]") else { return nil }
-        let timestamp = String(notes[timestampStart..<closeBracket])
-        return CoreFormatters.parseDateTime(timestamp)
-    }
-
     /// Returns the start timestamp for the latest active supply run, if the
     /// newest `supply_run_start` marker has not been matched by a later end marker.
     public static func activeSupplyRunStart(notes: String?) -> Date? {


### PR DESCRIPTION
## Summary
- Record the geofence alert `Supply Run` response by starting supply-run state on the active labor entry and validating the service actually entered `supply_run`.
- Keep clock-mutating geofence responses from silently resolving when no active clock entry can be found, including the defensive nil path inside the Supply Run branch.
- Avoid toggling an already-active supply run back to working when the geofence alert is acknowledged again.
- Add focused regression coverage for the geofence supply-run branch, no-op guard, status validation, ordering before alert acknowledgement, and missing active-entry guard.
- Resolved the post-main-merge duplicate `activeSupplyRunStart(notes:)` definition while preserving the newer ISO parser implementation.

Closes #1137

## Verification
- `gh issue view 1137 --repo xXKillerNoobYT/Weird-Part-Run-2 --json number,state,title,url,body,labels,comments,closedAt` confirmed GH #1137 is open and describes the no-op geofence `Supply Run` branch.
- `gh pr list --repo xXKillerNoobYT/Weird-Part-Run-2 --state open --search "1137 in:body" --json number,title,headRefName,state,isDraft,url` returned `[]`, so no open PR already covers it.
- `xcodebuild -scheme "Weird Parts" -destination 'id=F29F2637-4865-4685-92B3-98D2F45EF30C' -only-testing:"Weird Parts IOSTests/GeofenceAlertViewRegressionTests" test` passed (`** TEST SUCCEEDED **`, 2 tests after review fixes).
- `swift test --filter JobsServiceTests` passed in `core` (147 tests).
- `git diff --check` passed.
- `python3 scripts/guard-tracked-artifacts.py` passed (`No tracked Paperclip/Xcode runtime artifacts found.`).
- `xcodebuild -scheme "Weird Parts" -destination 'generic/platform=iOS Simulator' build` passed (`** BUILD SUCCEEDED **`).

## Review follow-up
- Addressed Copilot review by using inline/shared missing-entry UI error handling, making source regression checks indentation-insensitive and focused, applying the missing active-entry guard to lunch/break/done-for-day geofence responses, validating `toggleSupplyRun` returns `supply_run`, and asserting supply-run state starts before alert acknowledgement.

## CI / local runner path
- This repo uses the local self-hosted Mac runner path for trusted iOS/macOS checks: `/Users/IA/actions-runner/Weird-Part-Run-2` with labels `macos,xcode,ios,arm64,local-mac`.
- Note: this worktree's available app scheme is `Weird Parts`; `WiredPart-iOS` is not present in `xcodebuild -list` for this checkout.
