### PR TITLE
Fix break auto-fill default time validation

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBreakSettingsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBreakSettingsPage.swift
@@ -411,6 +411,9 @@ struct IOSBreakSettingsPage: View {
                 Spacer()
                 TextField("10:00", text: $defaultMorningBreak)
                     .multilineTextAlignment(.trailing)
+                    .keyboardType(.numbersAndPunctuation)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
                     .frame(width: 80)
                     .font(.system(.body, design: .monospaced))
             }
@@ -420,6 +423,9 @@ struct IOSBreakSettingsPage: View {
                 Spacer()
                 TextField("12:00", text: $defaultLunch)
                     .multilineTextAlignment(.trailing)
+                    .keyboardType(.numbersAndPunctuation)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
                     .frame(width: 80)
                     .font(.system(.body, design: .monospaced))
             }
@@ -429,6 +435,9 @@ struct IOSBreakSettingsPage: View {
                 Spacer()
                 TextField("14:30", text: $defaultAfternoonBreak)
                     .multilineTextAlignment(.trailing)
+                    .keyboardType(.numbersAndPunctuation)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
                     .frame(width: 80)
                     .font(.system(.body, design: .monospaced))
             }
@@ -532,6 +541,8 @@ struct IOSBreakSettingsPage: View {
             return
         }
 
+        guard validateDefaultBreakTimes() else { return }
+
         do {
             // Save company settings
             try breakSvc.updateCompanyBreakSettings(
@@ -610,5 +621,37 @@ struct IOSBreakSettingsPage: View {
     private func resetDirtyTracking() {
         baselineFormSignature = formSignature
         hasUnsavedChanges = false
+    }
+
+    private func validateDefaultBreakTimes() -> Bool {
+        let entries = [
+            (label: "Morning Break", value: defaultMorningBreak),
+            (label: "Lunch", value: defaultLunch),
+            (label: "Afternoon Break", value: defaultAfternoonBreak),
+        ]
+
+        for entry in entries where !isValidDefaultTime(entry.value) {
+            successMessage = nil
+            errorMessage = "\(entry.label) must be a valid 24-hour time in HH:mm format."
+            return false
+        }
+
+        return true
+    }
+
+    private func isValidDefaultTime(_ time: String) -> Bool {
+        let trimmed = time.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+        let parts = trimmed.split(separator: ":", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              parts[0].count == 2,
+              parts[1].count == 2,
+              parts[0].allSatisfy({ $0 >= "0" && $0 <= "9" }),
+              parts[1].allSatisfy({ $0 >= "0" && $0 <= "9" }),
+              let hour = Int(parts[0]),
+              let minute = Int(parts[1])
+        else { return false }
+
+        return (0...23).contains(hour) && (0...59).contains(minute)
     }
 }

--- a/core/Sources/WiredPartCore/Services/BreakService.swift
+++ b/core/Sources/WiredPartCore/Services/BreakService.swift
@@ -7,11 +7,14 @@ public final class BreakService: Sendable {
 
     public enum BreakError: Error, LocalizedError, Sendable, Equatable {
         case activeBreakAlreadyInProgress(userId: Int64, activeBreakId: Int64?)
+        case invalidDefaultBreakTime(field: String, value: String)
 
         public var errorDescription: String? {
             switch self {
             case .activeBreakAlreadyInProgress:
                 return "An active break is already in progress. End the current break before starting another."
+            case .invalidDefaultBreakTime(let field, _):
+                return "\(field) must be a valid 24-hour time in HH:mm format."
             }
         }
     }
@@ -304,11 +307,12 @@ public final class BreakService: Sendable {
                     $0.breakType == "break" && $0.startedAt.hasPrefix(scheduledMinutePrefix)
                 }
                 guard !alreadyExists else { return }
+                guard let endDateTime = Self.endDateTimeString(dateStr: dateStr, startTime: time, durationMinutes: 15) else { return }
 
                 var record = BreakRecord(
                     id: nil, userId: userId, laborEntryId: laborEntryId,
                     breakType: "break", startedAt: startStr,
-                    endedAt: "\(dateStr)T\(Self.addMinutes(time, 15)):00",
+                    endedAt: endDateTime,
                     durationMinutes: 15, isPaid: true,
                     autoFilled: true, timerDurationMinutes: 15,
                     createdAt: nil, deletedAt: nil
@@ -318,23 +322,24 @@ public final class BreakService: Sendable {
 
             // Auto-fill each scheduled break independently so one existing break
             // does not suppress the other configured default break.
-            if let morningTime = settings.defaultMorningBreak {
+            if let morningTime = Self.validatedDefaultTime(settings.defaultMorningBreak) {
                 try insertScheduledBreakIfMissing(at: morningTime)
             }
 
-            if let afternoonTime = settings.defaultAfternoonBreak {
+            if let afternoonTime = Self.validatedDefaultTime(settings.defaultAfternoonBreak) {
                 try insertScheduledBreakIfMissing(at: afternoonTime)
             }
 
             // Auto-fill lunch if missing
             let hasLunch = existing.contains { $0.breakType.hasPrefix("lunch") }
             if !hasLunch {
-                if let lunchTime = settings.defaultLunch {
+                if let lunchTime = Self.validatedDefaultTime(settings.defaultLunch),
+                   let lunchEndDateTime = Self.endDateTimeString(dateStr: dateStr, startTime: lunchTime, durationMinutes: 30) {
                     let startStr = "\(dateStr)T\(lunchTime):00"
                     var record = BreakRecord(
                         id: nil, userId: userId, laborEntryId: laborEntryId,
                         breakType: "lunch_paid", startedAt: startStr,
-                        endedAt: "\(dateStr)T\(Self.addMinutes(lunchTime, 30)):00",
+                        endedAt: lunchEndDateTime,
                         durationMinutes: 30, isPaid: true,
                         autoFilled: true, timerDurationMinutes: 30,
                         createdAt: nil, deletedAt: nil
@@ -390,6 +395,10 @@ public final class BreakService: Sendable {
         defaultLunch: String? = "12:00",
         defaultAfternoonBreak: String? = "14:30"
     ) throws {
+        let normalizedMorningBreak = try Self.normalizedDefaultTime(defaultMorningBreak, field: "Morning Break")
+        let normalizedLunch = try Self.normalizedDefaultTime(defaultLunch, field: "Lunch")
+        let normalizedAfternoonBreak = try Self.normalizedDefaultTime(defaultAfternoonBreak, field: "Afternoon Break")
+
         do {
             try db.writer.write { dbConn in
                 try dbConn.execute(sql: """
@@ -401,8 +410,8 @@ public final class BreakService: Sendable {
                     WHERE id = (SELECT id FROM company_break_settings LIMIT 1)
                     """, arguments: [
                         stateCode, roundingMinutes, roundingEnabled,
-                        autoFillBreaks, defaultMorningBreak,
-                        defaultLunch, defaultAfternoonBreak
+                        autoFillBreaks, normalizedMorningBreak,
+                        normalizedLunch, normalizedAfternoonBreak
                     ])
             }
         } catch {
@@ -492,12 +501,52 @@ public final class BreakService: Sendable {
             .fetchOne(dbConn)
     }
 
-    /// Add minutes to a time string like "10:00" → "10:15".
-    private static func addMinutes(_ timeStr: String, _ minutes: Int) -> String {
-        let parts = timeStr.split(separator: ":")
-        guard parts.count == 2, let hour = Int(parts[0]), let min = Int(parts[1]) else { return timeStr }
-        let total = hour * 60 + min + minutes
-        return String(format: "%02d:%02d", total / 60, total % 60)
+    private static func normalizedDefaultTime(_ timeStr: String?, field: String) throws -> String? {
+        guard let timeStr else { return nil }
+        let trimmed = timeStr.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard let validated = validatedDefaultTime(trimmed) else {
+            throw BreakError.invalidDefaultBreakTime(field: field, value: timeStr)
+        }
+        return validated
+    }
+
+    private static func validatedDefaultTime(_ timeStr: String?) -> String? {
+        guard let timeStr else { return nil }
+        let trimmed = timeStr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = trimmed.split(separator: ":", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              parts[0].count == 2,
+              parts[1].count == 2,
+              parts[0].allSatisfy({ $0 >= "0" && $0 <= "9" }),
+              parts[1].allSatisfy({ $0 >= "0" && $0 <= "9" }),
+              let hour = Int(parts[0]),
+              let min = Int(parts[1]),
+              (0...23).contains(hour),
+              (0...59).contains(min)
+        else { return nil }
+        return String(format: "%02d:%02d", hour, min)
+    }
+
+    private static func endDateTimeString(dateStr: String, startTime timeStr: String, durationMinutes: Int) -> String? {
+        guard let validTime = validatedDefaultTime(timeStr),
+              let startDate = CoreFormatters.yearMonthDay.date(from: dateStr)
+        else { return nil }
+
+        let parts = validTime.split(separator: ":")
+        guard parts.count == 2, let hour = Int(parts[0]), let min = Int(parts[1]) else { return nil }
+        let total = hour * 60 + min + durationMinutes
+        guard total >= 0 else { return nil }
+
+        let dayOffset = total / 1440
+        let minuteOfDay = total % 1440
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? TimeZone(secondsFromGMT: 0)!
+        guard let endDate = calendar.date(byAdding: .day, value: dayOffset, to: startDate) else { return nil }
+
+        let endDateStr = CoreFormatters.yearMonthDay.string(from: endDate)
+        let endTime = String(format: "%02d:%02d", minuteOfDay / 60, minuteOfDay % 60)
+        return "\(endDateStr)T\(endTime):00"
     }
 
     private func isTableNotFoundError(_ error: Error) -> Bool {

--- a/core/Tests/WiredPartCoreTests/BreakServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/BreakServiceTests.swift
@@ -242,6 +242,66 @@ struct BreakServiceTests {
         #expect(updated.roundingEnabled)
     }
 
+    @Test("Company break settings reject malformed default times")
+    func testCompanyBreakSettingsRejectMalformedDefaultTimes() throws {
+        let env = try freshEnv()
+        let breakService = BreakService(db: env.db)
+
+        #expect(throws: BreakService.BreakError.invalidDefaultBreakTime(field: "Morning Break", value: "bad")) {
+            try breakService.updateCompanyBreakSettings(
+                stateCode: "CA",
+                defaultMorningBreak: "bad",
+                defaultLunch: "12:00",
+                defaultAfternoonBreak: "14:30"
+            )
+        }
+
+        #expect(throws: BreakService.BreakError.invalidDefaultBreakTime(field: "Lunch", value: "24:00")) {
+            try breakService.updateCompanyBreakSettings(
+                stateCode: "CA",
+                defaultMorningBreak: "10:00",
+                defaultLunch: "24:00",
+                defaultAfternoonBreak: "14:30"
+            )
+        }
+
+        #expect(throws: BreakService.BreakError.invalidDefaultBreakTime(field: "Lunch", value: "+1:00")) {
+            try breakService.updateCompanyBreakSettings(
+                stateCode: "CA",
+                defaultMorningBreak: "10:00",
+                defaultLunch: "+1:00",
+                defaultAfternoonBreak: "14:30"
+            )
+        }
+
+        #expect(throws: BreakService.BreakError.invalidDefaultBreakTime(field: "Afternoon Break", value: "25:99")) {
+            try breakService.updateCompanyBreakSettings(
+                stateCode: "CA",
+                defaultMorningBreak: "10:00",
+                defaultLunch: "12:00",
+                defaultAfternoonBreak: "25:99"
+            )
+        }
+    }
+
+    @Test("Company break settings accept HH:mm boundary defaults")
+    func testCompanyBreakSettingsAcceptBoundaryDefaultTimes() throws {
+        let env = try freshEnv()
+        let breakService = BreakService(db: env.db)
+
+        try breakService.updateCompanyBreakSettings(
+            stateCode: "CA",
+            defaultMorningBreak: "00:00",
+            defaultLunch: "23:59",
+            defaultAfternoonBreak: nil
+        )
+
+        let settings = try breakService.getCompanyBreakSettings()
+        #expect(settings.defaultMorningBreak == "00:00")
+        #expect(settings.defaultLunch == "23:59")
+        #expect(settings.defaultAfternoonBreak == nil)
+    }
+
     // MARK: - Compliance
 
     @Test("Break compliance reflects completed lunch break duration")
@@ -304,6 +364,52 @@ struct BreakServiceTests {
         // morning break + afternoon break + lunch = 3 auto-filled records
         #expect(records.count == 3)
         #expect(records.allSatisfy { $0.autoFilled == true })
+    }
+
+    @Test("autoFillBreaksForDay ignores malformed persisted default times")
+    func testAutoFillSkipsMalformedPersistedDefaultTimes() throws {
+        let env = try freshEnv()
+        let breakService = BreakService(db: env.db)
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                UPDATE company_break_settings
+                SET auto_fill_breaks = 1,
+                    default_morning_break = 'bad',
+                    default_lunch = '12:00',
+                    default_afternoon_break = '25:99'
+                """)
+        }
+
+        try breakService.autoFillBreaksForDay(userId: env.adminUserId)
+
+        let records = try breakService.getBreakRecordsForDay(userId: env.adminUserId)
+        #expect(records.count == 1)
+        #expect(records.first?.breakType == "lunch_paid")
+        #expect(records.first?.startedAt.hasSuffix("T12:00:00") == true)
+        #expect(records.first?.endedAt?.hasSuffix("T12:30:00") == true)
+    }
+
+    @Test("autoFillBreaksForDay rolls end timestamps to next day when default crosses midnight")
+    func testAutoFillCrossMidnightDefaultEndsNextDay() throws {
+        let env = try freshEnv()
+        let breakService = BreakService(db: env.db)
+        let testDate = Date(timeIntervalSince1970: 0)
+
+        try breakService.updateCompanyBreakSettings(
+            stateCode: "CA",
+            autoFillBreaks: true,
+            defaultMorningBreak: nil,
+            defaultLunch: "23:59",
+            defaultAfternoonBreak: nil
+        )
+
+        try breakService.autoFillBreaksForDay(userId: env.adminUserId, date: testDate)
+
+        let records = try breakService.getBreakRecordsForDay(userId: env.adminUserId, date: testDate)
+        #expect(records.count == 1)
+        #expect(records.first?.startedAt == "1970-01-01T23:59:00")
+        #expect(records.first?.endedAt == "1970-01-02T00:29:00")
     }
 
     @Test("autoFillBreaksForDay skips if breaks already exist")


### PR DESCRIPTION
## Summary
- Validate BreakService default auto-fill times as strict ASCII 24-hour HH:mm values before saving settings.
- Skip malformed legacy/persisted default times during auto-fill so malformed break timestamps are never created.
- Roll auto-filled end timestamps to the next UTC date when a valid late-day default crosses midnight.
- Add Settings UI validation and time-friendly keyboard hints for Morning Break, Lunch, and Afternoon Break fields.
- Add regression coverage for malformed defaults, HH:mm boundary defaults, signed/non-numeric values, malformed persisted defaults, and midnight rollover.

Closes #1205

## Verification
- `git diff --check origin/main...HEAD` — passed.
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`).
- `cd core && swift test --filter BreakServiceTests` — passed, 26 tests in 1 suite.
- `cd core && swift test` — passed, 2216 tests in 67 suites.
- `xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build` — passed (`** BUILD SUCCEEDED **`; existing unrelated warnings only).

## Review follow-up
- Addressed Copilot review feedback by rolling end timestamps over midnight and adding regression coverage.
- Re-applied the review fix through the normal Hermes/Paperclip branch lane and squashed the PR branch to a single non-Copilot-authored commit.
