### PR TITLE
fix: surface clock todo picker failures

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
@@ -1890,11 +1890,13 @@ struct IOSClockPage: View {
             errorMessage = "Jobs service not available"
             return
         }
-        currentTodo = todo
         do {
             try service.linkClockEntryToTodo(clockEntryId: entry.id, todoId: todo.id)
+            currentTodo = todo
+            errorMessage = nil
         } catch {
             logger.warning("linkClockEntryToTodo failed (select): \(error.localizedDescription, privacy: .public)")
+            errorMessage = "Could not link this to-do to your clock entry. Your previous to-do selection is still active. Try again."
         }
     }
 
@@ -1907,17 +1909,21 @@ struct IOSClockPage: View {
             try notebooksService.completeEntry(entryId: todo.id)
             let remaining = try jobsService.getActiveJobTodos(jobId: entry.jobId)
 
+            var didUnlinkTodo = false
             await MainActor.run {
                 activeTodos = remaining
-                currentTodo = nil
                 do {
                     try jobsService.linkClockEntryToTodo(clockEntryId: entry.id, todoId: nil)
+                    currentTodo = nil
+                    errorMessage = nil
+                    didUnlinkTodo = true
                 } catch {
                     self.logger.warning("linkClockEntryToTodo failed (unlink): \(error.localizedDescription, privacy: .public)")
+                    errorMessage = "The to-do was completed, but the clock entry could not be unlinked from it. Refresh or try again before picking the next to-do."
                 }
             }
 
-            if !remaining.isEmpty {
+            if !remaining.isEmpty, didUnlinkTodo {
                 await MainActor.run {
                     activeSheet = .todoPicker
                 }
@@ -1936,8 +1942,10 @@ struct IOSClockPage: View {
         }
         do {
             activeTodos = try service.getActiveJobTodos(jobId: jobId)
+            errorMessage = nil
         } catch {
-            activeTodos = []
+            logger.warning("getActiveJobTodos failed: \(error.localizedDescription, privacy: .public)")
+            errorMessage = "Could not load this job's to-dos. Keeping the previous list so an app error is not mistaken for no to-dos."
         }
     }
 
@@ -2056,9 +2064,15 @@ struct IOSClockPage: View {
             // Load to-dos for the active job
             var todos: [JobsService.ClockTodoItem] = []
             var linkedTodo: JobsService.ClockTodoItem?
+            var todoLoadError: String?
             var currentWorkType = "new_work"
             if let entry {
-                todos = try service.getActiveJobTodos(jobId: entry.jobId)
+                do {
+                    todos = try service.getActiveJobTodos(jobId: entry.jobId)
+                } catch {
+                    logger.warning("getActiveJobTodos failed while loading clock data: \(error.localizedDescription, privacy: .public)")
+                    todoLoadError = "Could not load this job's to-dos. Keeping the previous list so an app error is not mistaken for no to-dos."
+                }
                 currentWorkType = entry.workType ?? "new_work"
                 if let todoId = entry.linkedTodoId {
                     linkedTodo = todos.first(where: { $0.id == todoId })
@@ -2072,15 +2086,27 @@ struct IOSClockPage: View {
             }
 
             await MainActor.run {
+                let previousActiveJobId = activeEntry?.jobId
                 activeEntry = entry
                 todayHours = todayH
                 todayJobGroups = groups
                 sortedJobs = jobsWithDist
-                activeTodos = todos
-                currentTodo = linkedTodo
+                if entry != nil, todoLoadError == nil {
+                    activeTodos = todos
+                    currentTodo = linkedTodo
+                } else if let entry, previousActiveJobId != entry.jobId {
+                    activeTodos = []
+                    currentTodo = nil
+                } else if entry == nil {
+                    activeTodos = []
+                    currentTodo = nil
+                } else if previousActiveJobId != entry?.jobId {
+                    activeTodos = []
+                    currentTodo = nil
+                }
                 workType = currentWorkType
                 isLoading = false
-                errorMessage = nil  // Clear errors on successful load
+                errorMessage = todoLoadError  // Clear errors on successful load unless to-dos failed separately.
 
                 // Apply break state
                 activeBreakRecord = currentBreak

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
@@ -1212,6 +1212,7 @@ struct IOSClockPage: View {
                             .controlSize(.small)
 
                             Button {
+                                loadTodosForJob(jobId: entry.jobId)
                                 activeSheet = .todoPicker
                             } label: {
                                 Label("Switch", systemImage: "arrow.triangle.swap")
@@ -1223,6 +1224,7 @@ struct IOSClockPage: View {
                 } else {
                     // No to-do selected
                     Button {
+                        loadTodosForJob(jobId: entry.jobId)
                         activeSheet = .todoPicker
                     } label: {
                         Label("Pick a To-Do", systemImage: "checklist")
@@ -1885,9 +1887,12 @@ struct IOSClockPage: View {
     // MARK: - To-Do Actions
 
     private func selectTodo(_ todo: JobsService.ClockTodoItem) {
-        guard let service = appCore.jobsService,
-              let entry = activeEntry else {
+        guard let service = appCore.jobsService else {
             errorMessage = "Jobs service not available"
+            return
+        }
+        guard let entry = activeEntry else {
+            errorMessage = "No active clock entry available"
             return
         }
         do {
@@ -1909,17 +1914,17 @@ struct IOSClockPage: View {
             try notebooksService.completeEntry(entryId: todo.id)
             let remaining = try jobsService.getActiveJobTodos(jobId: entry.jobId)
 
-            var didUnlinkTodo = false
-            await MainActor.run {
+            let didUnlinkTodo = await MainActor.run {
                 activeTodos = remaining
                 do {
                     try jobsService.linkClockEntryToTodo(clockEntryId: entry.id, todoId: nil)
                     currentTodo = nil
                     errorMessage = nil
-                    didUnlinkTodo = true
+                    return true
                 } catch {
                     self.logger.warning("linkClockEntryToTodo failed (unlink): \(error.localizedDescription, privacy: .public)")
                     errorMessage = "The to-do was completed, but the clock entry could not be unlinked from it. Refresh or try again before picking the next to-do."
+                    return false
                 }
             }
 
@@ -2098,9 +2103,6 @@ struct IOSClockPage: View {
                     activeTodos = []
                     currentTodo = nil
                 } else if entry == nil {
-                    activeTodos = []
-                    currentTodo = nil
-                } else if previousActiveJobId != entry?.jobId {
                     activeTodos = []
                     currentTodo = nil
                 }

--- a/Weird Parts IOS/Weird Parts IOSTests/ClockTodoFailureRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/ClockTodoFailureRegressionTests.swift
@@ -19,6 +19,7 @@ final class ClockTodoFailureRegressionTests: XCTestCase {
         let assignmentRange = try XCTUnwrap(section.range(of: "currentTodo = todo"))
         XCTAssertLessThan(linkRange.lowerBound, assignmentRange.lowerBound, "The picker must not show the selected to-do until the database link succeeds.")
         XCTAssertTrue(section.contains("errorMessage = \"Could not link this to-do to your clock entry"), "Link failures need a visible field-user error, not only a log line.")
+        XCTAssertTrue(section.contains("errorMessage = \"No active clock entry available\""), "Missing active-entry failures should be distinct from missing service failures.")
     }
 
     func testCompletedTodoUnlinkFailureKeepsCurrentTodoAndSurfacesError() throws {
@@ -33,6 +34,7 @@ final class ClockTodoFailureRegressionTests: XCTestCase {
         let clearRange = try XCTUnwrap(section.range(of: "currentTodo = nil"))
         XCTAssertLessThan(unlinkRange.lowerBound, clearRange.lowerBound, "The UI must not clear the current to-do until the clock-entry unlink succeeds.")
         XCTAssertTrue(section.contains("The to-do was completed, but the clock entry could not be unlinked"), "Unlink failures need a visible error before another to-do can be picked.")
+        XCTAssertTrue(section.contains("let didUnlinkTodo = await MainActor.run"), "The unlink result should be returned from MainActor.run instead of mutating captured state across an await.")
         XCTAssertTrue(section.contains("if !remaining.isEmpty, didUnlinkTodo"), "The next picker should only open after the unlink succeeded.")
     }
 
@@ -45,10 +47,24 @@ final class ClockTodoFailureRegressionTests: XCTestCase {
         )
 
         XCTAssertTrue(loadDataSection.contains("var todoLoadError: String?"), "Full clock refresh should isolate to-do load failures from the rest of the clock data.")
-        XCTAssertTrue(loadDataSection.contains("if entry != nil, todoLoadError == nil {\n                    activeTodos = todos"), "Full clock refresh should preserve the previous to-do list when only to-do loading fails.")
+        let normalizedLoadData = Self.normalizedWhitespace(loadDataSection)
+        XCTAssertTrue(normalizedLoadData.contains("if entry != nil, todoLoadError == nil { activeTodos = todos"), "Full clock refresh should preserve the previous to-do list when only to-do loading fails.")
         XCTAssertTrue(loadDataSection.contains("let previousActiveJobId = activeEntry?.jobId"), "Full clock refresh should remember which job the preserved to-do list belongs to.")
-        XCTAssertTrue(loadDataSection.contains("} else if let entry, previousActiveJobId != entry.jobId {\n                    activeTodos = []\n                    currentTodo = nil"), "A to-do load failure for a changed active job must clear stale to-dos from the previous job.")
+        XCTAssertTrue(normalizedLoadData.contains("} else if let entry, previousActiveJobId != entry.jobId { activeTodos = [] currentTodo = nil"), "A to-do load failure for a changed active job must clear stale to-dos from the previous job.")
         XCTAssertTrue(loadDataSection.contains("errorMessage = todoLoadError"), "To-do load failures should remain visible after the rest of the clock data loads.")
+    }
+
+    func testPickerButtonsReloadTodosBeforeOpeningSheet() throws {
+        let source = try Self.readClockSource()
+        let section = try Self.section(
+            named: "private func currentTaskSection",
+            in: source,
+            endingBefore: "// MARK: - Flex Pool Actions"
+        )
+        let normalized = Self.normalizedWhitespace(section)
+        let reloadBeforePickerCount = normalized.components(separatedBy: "loadTodosForJob(jobId: entry.jobId) activeSheet = .todoPicker").count - 1
+
+        XCTAssertEqual(reloadBeforePickerCount, 2, "Both picker buttons should reload the active job's list before showing the picker.")
     }
 
     private static func section(named startMarker: String, in source: String, endingBefore endMarker: String) throws -> String {
@@ -62,6 +78,12 @@ final class ClockTodoFailureRegressionTests: XCTestCase {
             return ""
         }
         return String(afterStart[..<end.lowerBound])
+    }
+
+    private static func normalizedWhitespace(_ source: String) -> String {
+        source
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
     }
 
     private static func readClockSource(file: StaticString = #filePath) throws -> String {

--- a/Weird Parts IOS/Weird Parts IOSTests/ClockTodoFailureRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/ClockTodoFailureRegressionTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+
+/// Regression coverage for GitHub #1207 / Paperclip WEI-4183.
+///
+/// Clock to-do selection must not show optimistic state when persistence fails,
+/// and to-do load failures must remain visible instead of looking like an empty
+/// picker. These source guards protect the SwiftUI state transitions until the
+/// clock page is split into a directly injectable view model.
+final class ClockTodoFailureRegressionTests: XCTestCase {
+    func testSelectingTodoOnlyUpdatesCurrentTodoAfterLinkSucceeds() throws {
+        let source = try Self.readClockSource()
+        let section = try Self.section(
+            named: "private func selectTodo",
+            in: source,
+            endingBefore: "private func markTodoDoneAndPickNext"
+        )
+
+        let linkRange = try XCTUnwrap(section.range(of: "try service.linkClockEntryToTodo(clockEntryId: entry.id, todoId: todo.id)"))
+        let assignmentRange = try XCTUnwrap(section.range(of: "currentTodo = todo"))
+        XCTAssertLessThan(linkRange.lowerBound, assignmentRange.lowerBound, "The picker must not show the selected to-do until the database link succeeds.")
+        XCTAssertTrue(section.contains("errorMessage = \"Could not link this to-do to your clock entry"), "Link failures need a visible field-user error, not only a log line.")
+    }
+
+    func testCompletedTodoUnlinkFailureKeepsCurrentTodoAndSurfacesError() throws {
+        let source = try Self.readClockSource()
+        let section = try Self.section(
+            named: "private func markTodoDoneAndPickNext",
+            in: source,
+            endingBefore: "// MARK: - Helpers"
+        )
+
+        let unlinkRange = try XCTUnwrap(section.range(of: "try jobsService.linkClockEntryToTodo(clockEntryId: entry.id, todoId: nil)"))
+        let clearRange = try XCTUnwrap(section.range(of: "currentTodo = nil"))
+        XCTAssertLessThan(unlinkRange.lowerBound, clearRange.lowerBound, "The UI must not clear the current to-do until the clock-entry unlink succeeds.")
+        XCTAssertTrue(section.contains("The to-do was completed, but the clock entry could not be unlinked"), "Unlink failures need a visible error before another to-do can be picked.")
+        XCTAssertTrue(section.contains("if !remaining.isEmpty, didUnlinkTodo"), "The next picker should only open after the unlink succeeded.")
+    }
+
+    func testTodoLoadFailuresPreserveSameJobListClearChangedJobAndShowSpecificError() throws {
+        let source = try Self.readClockSource()
+        let loadDataSection = try Self.section(
+            named: "private func loadJobsAndClockStatus",
+            in: source,
+            endingBefore: "// MARK: - Switch Job Picker Sheet"
+        )
+
+        XCTAssertTrue(loadDataSection.contains("var todoLoadError: String?"), "Full clock refresh should isolate to-do load failures from the rest of the clock data.")
+        XCTAssertTrue(loadDataSection.contains("if entry != nil, todoLoadError == nil {\n                    activeTodos = todos"), "Full clock refresh should preserve the previous to-do list when only to-do loading fails.")
+        XCTAssertTrue(loadDataSection.contains("let previousActiveJobId = activeEntry?.jobId"), "Full clock refresh should remember which job the preserved to-do list belongs to.")
+        XCTAssertTrue(loadDataSection.contains("} else if let entry, previousActiveJobId != entry.jobId {\n                    activeTodos = []\n                    currentTodo = nil"), "A to-do load failure for a changed active job must clear stale to-dos from the previous job.")
+        XCTAssertTrue(loadDataSection.contains("errorMessage = todoLoadError"), "To-do load failures should remain visible after the rest of the clock data loads.")
+    }
+
+    private static func section(named startMarker: String, in source: String, endingBefore endMarker: String) throws -> String {
+        guard let start = source.range(of: startMarker) else {
+            XCTFail("Missing section starting with \(startMarker)")
+            return ""
+        }
+        let afterStart = source[start.lowerBound...]
+        guard let end = afterStart.range(of: endMarker) else {
+            XCTFail("Missing section ending before \(endMarker)")
+            return ""
+        }
+        return String(afterStart[..<end.lowerBound])
+    }
+
+    private static func readClockSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Jobs")
+            .appendingPathComponent("IOSClockPage.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Stop the clock to-do picker from updating `currentTodo` until `linkClockEntryToTodo` succeeds.
- Surface link/unlink failures through the existing clock-page error banner instead of log-only handling.
- Preserve the previous active to-do list only when the same active job's to-dos fail to reload; clear stale to-dos when the active job changes and the new list cannot load.
- Reload the active job's to-do list before opening the picker from the Clock page buttons.
- Add source-level regression coverage for the Clock page state transitions until this large SwiftUI page is split into an injectable view model.

Closes #1207

## Verification
- `git diff --check` — PASS
- `python3 scripts/guard-tracked-artifacts.py` — PASS
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,id=F29F2637-4865-4685-92B3-98D2F45EF30C' -derivedDataPath /tmp/wei-4183-derived -only-testing:"Weird Parts IOSTests/ClockTodoFailureRegressionTests"` — PASS (4 tests)
- `cd core && swift test` — PASS (2216 tests / 67 suites)
- `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/wei-4183-build-derived build` — PASS

## CI / runner note
Repo-owned PR validation should use the local self-hosted Mac runner path documented for WPR2 (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`) rather than GitHub-hosted macOS capacity.
