### PR TITLE
fix: start receive shipment barcode counts from zero

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -30,6 +30,8 @@ struct IOSReceiveShipmentPage: View {
     @State private var showBarcodeScanner = false
     @State private var highlightedItemId: Int64?
     @State private var scanError: String?
+    @State private var scannerCountedItemIds = Set<Int64>()
+    @State private var manuallyEditedQuantityItemIds = Set<Int64>()
 
     // Unrouted items warning (62H)
     @State private var showUnroutedWarning = false
@@ -640,6 +642,7 @@ struct IOSReceiveShipmentPage: View {
                         if current > 0 {
                             let newQty = current - 1
                             receivedQtys[item.id] = newQty
+                            manuallyEditedQuantityItemIds.insert(item.id)
                             let svc = appCore.warehouseService
                             let iid = item.id
                             Task {
@@ -668,6 +671,7 @@ struct IOSReceiveShipmentPage: View {
                         let current = receivedQtys[item.id] ?? item.expectedQty
                         let newQty = current + 1
                         receivedQtys[item.id] = newQty
+                        manuallyEditedQuantityItemIds.insert(item.id)
                         let svc = appCore.warehouseService
                         let iid = item.id
                         Task {
@@ -686,6 +690,7 @@ struct IOSReceiveShipmentPage: View {
                         Button {
                             let newQty = item.expectedQty
                             receivedQtys[item.id] = newQty
+                            manuallyEditedQuantityItemIds.insert(item.id)
                             let svc = appCore.warehouseService
                             let iid = item.id
                             Task {
@@ -888,10 +893,19 @@ struct IOSReceiveShipmentPage: View {
             return
         }
 
-        // Auto-increment received quantity and auto-save (PE-041)
-        let currentQty = receivedQtys[item.id] ?? item.expectedQty
+        // Auto-increment received quantity and auto-save (PE-041).
+        // Fresh sessions may display expected quantities, but barcode scans are
+        // physical counted units. The first scan starts from zero unless the
+        // worker has already saved/edited a quantity for this line.
+        let currentQty = receivingBarcodeScanBaseQuantity(
+            displayedQty: receivedQtys[item.id],
+            persistedReceivedQty: item.receivedQty,
+            hasScannerCount: scannerCountedItemIds.contains(item.id),
+            hasManualQuantityEdit: manuallyEditedQuantityItemIds.contains(item.id)
+        )
         let newQty = currentQty + 1
         receivedQtys[item.id] = newQty
+        scannerCountedItemIds.insert(item.id)
         let svc = appCore.warehouseService
         let iid = item.id
         Task {
@@ -919,6 +933,7 @@ struct IOSReceiveShipmentPage: View {
         do {
             let sessionId = try service.startReceivingSession(poId: poId, startedBy: userId)
             activeSessionId = sessionId
+            resetReceivingSessionState()
             loadSessionItems()
         } catch {
             actionError = userFriendlyError(error, context: "receive shipment")
@@ -946,6 +961,17 @@ struct IOSReceiveShipmentPage: View {
         } catch {
             actionError = userFriendlyError(error, context: "receive shipment")
         }
+    }
+
+    private func resetReceivingSessionState() {
+        sessionItems = []
+        receivedQtys = [:]
+        priceVerifications = [:]
+        routingResults = [:]
+        scannerCountedItemIds = []
+        manuallyEditedQuantityItemIds = []
+        highlightedItemId = nil
+        scanError = nil
     }
 
     private func completeReceiving() async {
@@ -1146,6 +1172,19 @@ struct IOSReceiveShipmentPage: View {
             userInfo: ["context": context]
         )
     }
+}
+
+func receivingBarcodeScanBaseQuantity(
+    displayedQty: Int?,
+    persistedReceivedQty: Int,
+    hasScannerCount: Bool,
+    hasManualQuantityEdit: Bool
+) -> Int {
+    if hasScannerCount || hasManualQuantityEdit || persistedReceivedQty > 0 {
+        return displayedQty ?? persistedReceivedQty
+    }
+
+    return 0
 }
 
 // MARK: - Price Verification

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -167,10 +167,7 @@ struct IOSReceiveShipmentPage: View {
             Button("OK") {
                 completionMessage = nil
                 activeSessionId = nil
-                sessionItems = []
-                priceVerifications = [:]
-                receivedQtys = [:]
-                routingResults = [:]
+                resetReceivingSessionState()
                 loadData()
             }
         } message: {
@@ -334,6 +331,7 @@ struct IOSReceiveShipmentPage: View {
                             let svc = appCore.warehouseService
                             let items = sessionItems
                             for item in items { receivedQtys[item.id] = item.expectedQty }
+                            manuallyEditedQuantityItemIds.formUnion(items.map(\.id))
                             Task {
                                 guard let svc else { return }
                                 var failed = 0
@@ -353,6 +351,7 @@ struct IOSReceiveShipmentPage: View {
                             let svc = appCore.warehouseService
                             let items = sessionItems
                             for item in items { receivedQtys[item.id] = 0 }
+                            manuallyEditedQuantityItemIds.formUnion(items.map(\.id))
                             Task {
                                 guard let svc else { return }
                                 var failed = 0
@@ -479,10 +478,7 @@ struct IOSReceiveShipmentPage: View {
                 Section {
                     Button(role: .destructive) {
                         activeSessionId = nil
-                        sessionItems = []
-                        priceVerifications = [:]
-                        receivedQtys = [:]
-                        routingResults = [:]
+                        resetReceivingSessionState()
                         loadData()
                     } label: {
                         HStack {
@@ -517,10 +513,7 @@ struct IOSReceiveShipmentPage: View {
                 // Quantities are auto-saved — no discard dialog needed (PE-041)
                 Button {
                     activeSessionId = nil
-                    sessionItems = []
-                    priceVerifications = [:]
-                    receivedQtys = [:]
-                    routingResults = [:]
+                    resetReceivingSessionState()
                     loadData()
                 } label: {
                     HStack(spacing: 4) {

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -728,6 +728,40 @@ struct Weird_Parts_IOSTests {
         #expect(ReceivingRoutingValidation.missingLinkedPartError(partId: 6) == nil)
     }
 
+    @Test func receiveShipmentBarcodeCountStartsFromZeroForFreshExpectedQuantity() throws {
+        let base = receivingBarcodeScanBaseQuantity(
+            displayedQty: 10,
+            persistedReceivedQty: 0,
+            hasScannerCount: false,
+            hasManualQuantityEdit: false
+        )
+
+        #expect(base + 1 == 1)
+    }
+
+    @Test func receiveShipmentBarcodeCountContinuesAfterScannerOrManualQuantity() throws {
+        #expect(receivingBarcodeScanBaseQuantity(
+            displayedQty: 1,
+            persistedReceivedQty: 0,
+            hasScannerCount: true,
+            hasManualQuantityEdit: false
+        ) + 1 == 2)
+
+        #expect(receivingBarcodeScanBaseQuantity(
+            displayedQty: 10,
+            persistedReceivedQty: 0,
+            hasScannerCount: false,
+            hasManualQuantityEdit: true
+        ) + 1 == 11)
+
+        #expect(receivingBarcodeScanBaseQuantity(
+            displayedQty: 4,
+            persistedReceivedQty: 4,
+            hasScannerCount: false,
+            hasManualQuantityEdit: false
+        ) + 1 == 5)
+    }
+
     @Test func subSchedulePageExposesExplicitSoftDeleteCancellationAction() throws {
         let repoRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()


### PR DESCRIPTION
## Summary
- Fixes the Receive Shipment barcode path so a fresh line that only displays the expected quantity starts scanner counting from 0, making the first scan save 1 instead of expected + 1.
- Tracks scanner-counted and manually edited lines separately so follow-up scans continue from the counted/manual quantity.
- Adds regression coverage for the fresh expected-quantity first-scan path and continued scanner/manual quantity paths.

Closes #715

## Tests
- `swift test --package-path core --filter OrdersServiceTests` — passed (119 tests).
- `git diff --check` — passed.
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`).
- `xcodebuild -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' build` — passed (`** BUILD SUCCEEDED **`).
- `xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests"` — new regression tests passed:
  - `Weird_Parts_IOSTests/receiveShipmentBarcodeCountContinuesAfterScannerOrManualQuantity()`
  - `Weird_Parts_IOSTests/receiveShipmentBarcodeCountStartsFromZeroForFreshExpectedQuantity()`
  Overall target currently fails on pre-existing unrelated tests: `timesheetCorrectionRejectsMalformedOriginalTimestampsBeforeSave`, `onboardingPeerDiscoveryKeepsLanAddressForPairing`, `WarehouseAuditFixtureRegressionTests.testFixtureVerificationItemFallsBackToPendingAssignmentWhenQueueItemMissing`, and `SettingsSaveButtonValidationTests.testDailyReportTemplatesPageHasIsDirtyGuard`.

## Local runner path
- Verified locally on the self-hosted Mac simulator path using `WEI3988-iPhone`; GitHub Actions/local runner review still required before merge.
