### PR TITLE
Fix receive shipment invalid different price completion

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -851,7 +851,7 @@ struct IOSReceiveShipmentPage: View {
                             return ""
                         },
                         set: { newVal in
-                            let parsedPrice = Double(newVal) ?? 0
+                            let parsedPrice = Double(newVal) ?? .nan
                             priceVerifications[itemId] = .different(newPrice: parsedPrice)
                             if isValidReceiveShipmentDifferentPrice(parsedPrice) {
                                 invalidPriceVerificationItemIds.remove(itemId)
@@ -866,7 +866,7 @@ struct IOSReceiveShipmentPage: View {
                 }
 
                 if invalidPriceVerificationItemIds.contains(itemId) {
-                    Label("Enter a valid actual price greater than $0 before completing.", systemImage: "exclamationmark.triangle.fill")
+                    Label("Enter a valid actual price greater than $0.00 before completing.", systemImage: "exclamationmark.triangle.fill")
                         .font(.caption)
                         .foregroundStyle(.red)
                 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -18,6 +18,7 @@ struct IOSReceiveShipmentPage: View {
     @State private var sessionItems: [WarehouseService.ReceivingItemInfo] = []
     @State private var receivedQtys: [Int64: Int] = [:]  // itemId -> qty
     @State private var priceVerifications: [Int64: PriceVerification] = [:]  // itemId -> verification
+    @State private var invalidPriceVerificationItemIds = Set<Int64>()
     @State private var isCompleting = false
     @State private var completionMessage: String?
     @State private var activeSheet: ActiveSheet?
@@ -799,6 +800,7 @@ struct IOSReceiveShipmentPage: View {
             HStack(spacing: 8) {
                 Button {
                     priceVerifications[itemId] = .matches
+                    invalidPriceVerificationItemIds.remove(itemId)
                 } label: {
                     Label("Matches", systemImage: currentVerification.isMatches ? "checkmark.circle.fill" : "circle")
                         .font(.caption)
@@ -811,6 +813,7 @@ struct IOSReceiveShipmentPage: View {
 
                 Button {
                     priceVerifications[itemId] = .different(newPrice: 0)
+                    invalidPriceVerificationItemIds.insert(itemId)
                 } label: {
                     Label("Different", systemImage: currentVerification.isDifferent ? "exclamationmark.circle.fill" : "circle")
                         .font(.caption)
@@ -823,6 +826,7 @@ struct IOSReceiveShipmentPage: View {
 
                 Button {
                     priceVerifications[itemId] = .notShown
+                    invalidPriceVerificationItemIds.remove(itemId)
                 } label: {
                     Label("Not Shown", systemImage: currentVerification.isNotShown ? "questionmark.circle.fill" : "circle")
                         .font(.caption)
@@ -847,12 +851,24 @@ struct IOSReceiveShipmentPage: View {
                             return ""
                         },
                         set: { newVal in
-                            priceVerifications[itemId] = .different(newPrice: Double(newVal) ?? 0)
+                            let parsedPrice = Double(newVal) ?? 0
+                            priceVerifications[itemId] = .different(newPrice: parsedPrice)
+                            if isValidReceiveShipmentDifferentPrice(parsedPrice) {
+                                invalidPriceVerificationItemIds.remove(itemId)
+                            } else {
+                                invalidPriceVerificationItemIds.insert(itemId)
+                            }
                         }
                     ))
                     .keyboardType(.decimalPad)
                     .textFieldStyle(.roundedBorder)
                     .frame(maxWidth: 120)
+                }
+
+                if invalidPriceVerificationItemIds.contains(itemId) {
+                    Label("Enter a valid actual price greater than $0 before completing.", systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
                 }
             }
         }
@@ -960,6 +976,7 @@ struct IOSReceiveShipmentPage: View {
         sessionItems = []
         receivedQtys = [:]
         priceVerifications = [:]
+        invalidPriceVerificationItemIds = []
         routingResults = [:]
         scannerCountedItemIds = []
         manuallyEditedQuantityItemIds = []
@@ -979,8 +996,28 @@ struct IOSReceiveShipmentPage: View {
             return
         }
 
-        isCompleting = true
         actionError = nil
+
+        if let validationError = receiveShipmentDifferentPriceValidationMessage(
+            for: sessionItems.map { item in
+                ReceiveShipmentPriceValidationItem(id: item.id, partName: item.partName)
+            },
+            priceVerifications: priceVerifications
+        ) {
+            invalidPriceVerificationItemIds = Set(sessionItems.compactMap { item in
+                if case .different(let newPrice) = priceVerifications[item.id],
+                   !isValidReceiveShipmentDifferentPrice(newPrice) {
+                    return item.id
+                }
+                return nil
+            })
+            actionError = validationError
+            return
+        }
+
+        invalidPriceVerificationItemIds = []
+
+        isCompleting = true
 
         do {
             // Update received quantities and any verified invoice cost before completion.
@@ -991,7 +1028,7 @@ struct IOSReceiveShipmentPage: View {
                 case .matches:
                     verifiedCost = item.unitPrice
                 case .different(let newPrice):
-                    verifiedCost = newPrice > 0 ? newPrice : nil
+                    verifiedCost = isValidReceiveShipmentDifferentPrice(newPrice) ? newPrice : nil
                 case .notShown, .none:
                     verifiedCost = nil
                 }
@@ -1029,7 +1066,7 @@ struct IOSReceiveShipmentPage: View {
 
                     case .different(let newPrice):
                         // Use actual receipt price
-                        if newPrice > 0 {
+                        if isValidReceiveShipmentDifferentPrice(newPrice) {
                             _ = try partsService.addCostLayer(
                                 partId: partId,
                                 qty: qty,
@@ -1180,9 +1217,35 @@ func receivingBarcodeScanBaseQuantity(
     return 0
 }
 
+struct ReceiveShipmentPriceValidationItem {
+    let id: Int64
+    let partName: String
+}
+
+func isValidReceiveShipmentDifferentPrice(_ price: Double) -> Bool {
+    price > 0 && price.isFinite
+}
+
+func receiveShipmentDifferentPriceValidationMessage(
+    for items: [ReceiveShipmentPriceValidationItem],
+    priceVerifications: [Int64: PriceVerification]
+) -> String? {
+    let invalidDifferentPriceNames = items.compactMap { item -> String? in
+        guard case .different(let newPrice) = priceVerifications[item.id],
+              !isValidReceiveShipmentDifferentPrice(newPrice) else {
+            return nil
+        }
+        return item.partName
+    }
+
+    guard !invalidDifferentPriceNames.isEmpty else { return nil }
+
+    return "Enter a valid actual price greater than $0.00 for: \(invalidDifferentPriceNames.joined(separator: ", "))."
+}
+
 // MARK: - Price Verification
 
-private enum PriceVerification {
+enum PriceVerification {
     case matches
     case different(newPrice: Double)
     case notShown

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -10,6 +10,7 @@ import GRDB
 import Security
 import Testing
 import WiredPartCore
+import XCTest
 import os.log
 @testable import Weird_Parts
 
@@ -765,18 +766,22 @@ struct Weird_Parts_IOSTests {
     @Test func receiveShipmentDifferentPriceValidationBlocksBlankOrZeroActualPrices() throws {
         let items = [
             ReceiveShipmentPriceValidationItem(id: 10, partName: "Breaker"),
-            ReceiveShipmentPriceValidationItem(id: 11, partName: "Panel")
+            ReceiveShipmentPriceValidationItem(id: 11, partName: "Panel"),
+            ReceiveShipmentPriceValidationItem(id: 12, partName: "Fuse"),
+            ReceiveShipmentPriceValidationItem(id: 13, partName: "Disconnect")
         ]
 
         let message = receiveShipmentDifferentPriceValidationMessage(
             for: items,
             priceVerifications: [
                 10: .different(newPrice: 0),
-                11: .matches
+                11: .different(newPrice: -1),
+                12: .different(newPrice: .nan),
+                13: .different(newPrice: .infinity)
             ]
         )
 
-        #expect(message == "Enter a valid actual price greater than $0.00 for: Breaker.")
+        #expect(message == "Enter a valid actual price greater than $0.00 for: Breaker, Panel, Fuse, Disconnect.")
     }
 
     @Test func receiveShipmentDifferentPriceValidationAllowsPositiveActualPrices() throws {
@@ -1279,5 +1284,39 @@ struct PartsFlowDraftStoreTests {
 
         #expect(PartsFlowDraftStore.loadCounts(userId: userId).isEmpty)
         #expect(PartsFlowDraftStore.loadLocations(userId: userId).isEmpty)
+    }
+}
+
+final class ReceiveShipmentPriceVerificationXCTests: XCTestCase {
+    func testDifferentPriceValidationBlocksBlankZeroNegativeAndNonFiniteActualPrices() throws {
+        let items = [
+            ReceiveShipmentPriceValidationItem(id: 10, partName: "Blank"),
+            ReceiveShipmentPriceValidationItem(id: 11, partName: "Negative"),
+            ReceiveShipmentPriceValidationItem(id: 12, partName: "NaN"),
+            ReceiveShipmentPriceValidationItem(id: 13, partName: "Infinity"),
+            ReceiveShipmentPriceValidationItem(id: 14, partName: "Panel")
+        ]
+
+        let message = receiveShipmentDifferentPriceValidationMessage(
+            for: items,
+            priceVerifications: [
+                10: .different(newPrice: 0),
+                11: .different(newPrice: -1),
+                12: .different(newPrice: .nan),
+                13: .different(newPrice: .infinity),
+                14: .matches
+            ]
+        )
+
+        XCTAssertEqual(message, "Enter a valid actual price greater than $0.00 for: Blank, Negative, NaN, Infinity.")
+    }
+
+    func testDifferentPriceValidationAllowsPositiveActualPrices() throws {
+        let message = receiveShipmentDifferentPriceValidationMessage(
+            for: [ReceiveShipmentPriceValidationItem(id: 10, partName: "Breaker")],
+            priceVerifications: [10: .different(newPrice: 12.50)]
+        )
+
+        XCTAssertNil(message)
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -762,6 +762,32 @@ struct Weird_Parts_IOSTests {
         ) + 1 == 5)
     }
 
+    @Test func receiveShipmentDifferentPriceValidationBlocksBlankOrZeroActualPrices() throws {
+        let items = [
+            ReceiveShipmentPriceValidationItem(id: 10, partName: "Breaker"),
+            ReceiveShipmentPriceValidationItem(id: 11, partName: "Panel")
+        ]
+
+        let message = receiveShipmentDifferentPriceValidationMessage(
+            for: items,
+            priceVerifications: [
+                10: .different(newPrice: 0),
+                11: .matches
+            ]
+        )
+
+        #expect(message == "Enter a valid actual price greater than $0.00 for: Breaker.")
+    }
+
+    @Test func receiveShipmentDifferentPriceValidationAllowsPositiveActualPrices() throws {
+        let message = receiveShipmentDifferentPriceValidationMessage(
+            for: [ReceiveShipmentPriceValidationItem(id: 10, partName: "Breaker")],
+            priceVerifications: [10: .different(newPrice: 12.50)]
+        )
+
+        #expect(message == nil)
+    }
+
     @Test func subSchedulePageExposesExplicitSoftDeleteCancellationAction() throws {
         let repoRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()


### PR DESCRIPTION
## Summary
- Blocks Receive Shipment completion when any Price Verification = Different row has a blank, zero, non-positive, or non-finite actual price.
- Shows inline guidance on invalid Different rows and returns an actionable completion error naming the affected part rows.
- Adds executable XCTest regression coverage for the receive-shipment different-price validation helper.

Closes #716

## Tests
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`)
- `swift test --package-path core --filter OrdersServiceTests` — passed (119 tests)
- `xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/ReceiveShipmentPriceVerificationXCTests" -resultBundlePath .tmp/WEI-4186-price-validation-xctest.xcresult` — passed (`** TEST SUCCEEDED **`; both `ReceiveShipmentPriceVerificationXCTests` cases passed)

## Local runner path
- Local iOS validation used the WEI3988-iPhone simulator on the self-hosted Mac/Xcode path.
- Runner status checked: `IA-Mac-WPR2` online with `self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, and `local-mac` labels.
