### PR TITLE
fix: validate different receive prices

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -854,6 +854,12 @@ struct IOSReceiveShipmentPage: View {
                     .textFieldStyle(.roundedBorder)
                     .frame(maxWidth: 120)
                 }
+
+                if case .different(let newPrice) = currentVerification, newPrice <= 0 {
+                    Label("Enter a valid price greater than $0 before completing receiving.", systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.red)
+                }
             }
         }
     }
@@ -976,6 +982,24 @@ struct IOSReceiveShipmentPage: View {
         }
         guard let userId = appCore.currentUser?.id else {
             actionError = "Not logged in. Please log in and try again."
+            return
+        }
+
+        let itemNamesById = Dictionary(uniqueKeysWithValues: sessionItems.map { ($0.id, $0.partName) })
+        let invalidDifferentPriceItemNames = ReceiveShipmentPriceVerificationValidation.invalidDifferentPriceItemNames(
+            itemNamesById: itemNamesById,
+            verifications: priceVerifications
+        )
+        if let message = ReceiveShipmentPriceVerificationValidation.completionErrorMessage(
+            invalidItemNames: invalidDifferentPriceItemNames
+        ) {
+            highlightedItemId = sessionItems.first { item in
+                if case .different(let newPrice) = priceVerifications[item.id] {
+                    return newPrice <= 0
+                }
+                return false
+            }?.id
+            actionError = message
             return
         }
 
@@ -1182,10 +1206,34 @@ func receivingBarcodeScanBaseQuantity(
 
 // MARK: - Price Verification
 
-private enum PriceVerification {
+enum PriceVerification {
     case matches
     case different(newPrice: Double)
     case notShown
+}
+
+enum ReceiveShipmentPriceVerificationValidation {
+    nonisolated static func invalidDifferentPriceItemNames(
+        itemNamesById: [Int64: String],
+        verifications: [Int64: PriceVerification]
+    ) -> [String] {
+        itemNamesById
+            .compactMap { itemId, partName -> String? in
+                if case .different(let newPrice) = verifications[itemId], newPrice <= 0 {
+                    return partName
+                }
+                return nil
+            }
+            .sorted()
+    }
+
+    nonisolated static func completionErrorMessage(invalidItemNames: [String]) -> String? {
+        guard !invalidItemNames.isEmpty else { return nil }
+
+        let listedNames = invalidItemNames.prefix(3).joined(separator: ", ")
+        let suffix = invalidItemNames.count > 3 ? " and \(invalidItemNames.count - 3) more" : ""
+        return "Enter a valid actual price greater than $0 for: \(listedNames)\(suffix)."
+    }
 }
 
 extension Optional where Wrapped == PriceVerification {

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -762,6 +762,42 @@ struct Weird_Parts_IOSTests {
         ) + 1 == 5)
     }
 
+    @Test func receiveShipmentDifferentPriceValidationBlocksMissingOrZeroActualPrices() throws {
+        let invalidNames = ReceiveShipmentPriceVerificationValidation.invalidDifferentPriceItemNames(
+            itemNamesById: [
+                10: "Breaker",
+                11: "Conduit",
+                12: "Outlet"
+            ],
+            verifications: [
+                10: .different(newPrice: 0),
+                11: .different(newPrice: -1),
+                12: .different(newPrice: 4.25)
+            ]
+        )
+
+        #expect(invalidNames == ["Breaker", "Conduit"])
+        #expect(ReceiveShipmentPriceVerificationValidation.completionErrorMessage(invalidItemNames: invalidNames) == "Enter a valid actual price greater than $0 for: Breaker, Conduit.")
+    }
+
+    @Test func receiveShipmentDifferentPriceValidationAllowsPositiveActualPrices() throws {
+        let invalidNames = ReceiveShipmentPriceVerificationValidation.invalidDifferentPriceItemNames(
+            itemNamesById: [
+                10: "Breaker",
+                11: "Conduit",
+                12: "Outlet"
+            ],
+            verifications: [
+                10: .different(newPrice: 1.25),
+                11: .matches,
+                12: .notShown
+            ]
+        )
+
+        #expect(invalidNames.isEmpty)
+        #expect(ReceiveShipmentPriceVerificationValidation.completionErrorMessage(invalidItemNames: invalidNames) == nil)
+    }
+
     @Test func subSchedulePageExposesExplicitSoftDeleteCancellationAction() throws {
         let repoRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()


### PR DESCRIPTION
## Summary
- Blocks Receive Shipment completion when any Price Verification → Different line has a missing, zero, or negative actual price.
- Shows an inline row warning and names/highlights the first invalid line so the operator can fix it before finalization.
- Adds regression coverage for the different-price validation helper.

Closes #716

## Tests
- `xcodebuild -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/receiveShipmentDifferentPriceValidationBlocksMissingOrZeroActualPrices" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/receiveShipmentDifferentPriceValidationAllowsPositiveActualPrices" test` — passed
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed
- `xcodebuild -scheme "WiredPart-iOS" -destination 'generic/platform=iOS Simulator' build` — passed with pre-existing warnings in unrelated files

## Local runner path
CI should use the trusted local self-hosted Mac runner path for WPR2 iOS validation when GitHub Actions gates run.