### PR TITLE
fix: require current user for companion poll votes

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
@@ -35,6 +35,10 @@ struct PartsCompanionsPage: View {
     @State private var showSkipConfirm = false
     @State private var pollToSkip: Int64?
 
+    private var currentUserId: Int64? {
+        appCore.currentUser?.id
+    }
+
     // Single active-sheet enum to avoid multiple .sheet conflicts
     enum ActiveSheet: Identifiable {
         case addRule
@@ -94,7 +98,7 @@ struct PartsCompanionsPage: View {
                 ProgressView("Loading...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let error = loadError {
-                ErrorStateView(message: error) { Task { await loadData() } }
+                ErrorStateView(message: error, retryAction: retryLoadData)
             } else {
                 switch activeTab {
                 case .rules:
@@ -205,8 +209,10 @@ struct PartsCompanionsPage: View {
         }
         .background(DS.Background.page)
         .task {
-            await loadData()
-            appCore.onboardingManager?.markCompleted("companions-view")
+            await loadDataAndMarkViewed()
+        }
+        .onChange(of: currentUserId) { _, _ in
+            reloadForCurrentUserChange()
         }
         .onAppear { postCompanionsContext() }
         .onDisappear {
@@ -879,6 +885,24 @@ struct PartsCompanionsPage: View {
 
     // MARK: - Data Loading
 
+    private func retryLoadData() {
+        Task { await loadDataAndMarkViewed() }
+    }
+
+    private func loadDataAndMarkViewed() async {
+        await loadData()
+        markCompanionsViewedIfReady()
+    }
+
+    private func markCompanionsViewedIfReady() {
+        guard currentUserId != nil, loadError == nil else { return }
+        appCore.onboardingManager?.markCompleted("companions-view")
+    }
+
+    private func reloadForCurrentUserChange() {
+        Task { await loadDataAndMarkViewed() }
+    }
+
     private func postCompanionsContext() {
         var context = "Page: Companion Rules\n"
         context += "Rules: \(companionRules.count), Alternatives: \(alternatives.count)\n"
@@ -911,7 +935,13 @@ struct PartsCompanionsPage: View {
             let alts = try service.listAllAlternatives()
 
             // Poll data
-            let userId = appCore.currentUser?.id ?? 0
+            guard let userId = currentUserId else {
+                await MainActor.run {
+                    loadError = "User session unavailable. Sign in again."
+                    isLoading = false
+                }
+                return
+            }
             let isAdmin = appCore.hasPermission("vote_veto")
             let polls = try service.getActivePolls(userId: userId, isAdmin: isAdmin)
             let results = try service.getLastWeekResults(userId: userId)

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsCompanionsPageSessionRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsCompanionsPageSessionRegressionTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+final class PartsCompanionsPageSessionRegressionTests: XCTestCase {
+    func testCompanionPollsDoNotFallBackToSyntheticUserZero() throws {
+        let source = try Self.readPartsCompanionsPageSource()
+
+        XCTAssertFalse(
+            source.contains("appCore.currentUser?.id ?? 0"),
+            "Companion polls must not substitute user id 0 for a missing session."
+        )
+        XCTAssertTrue(
+            source.contains("private var currentUserId: Int64?"),
+            "Companion polls should model the current user id as optional so missing-session state is explicit."
+        )
+        XCTAssertTrue(
+            source.contains("guard let userId = currentUserId else"),
+            "Companion poll loads should fail closed until a real current user id exists."
+        )
+        XCTAssertTrue(
+            source.contains("loadError = \"User session unavailable. Sign in again.\""),
+            "Companion polls should show a visible session error instead of loading vote state for user 0."
+        )
+        XCTAssertTrue(
+            source.contains("try service.getActivePolls(userId: userId, isAdmin: isAdmin)")
+                && source.contains("try service.getLastWeekResults(userId: userId)"),
+            "Companion poll service calls should use the unwrapped real user id."
+        )
+        XCTAssertTrue(
+            source.contains(".onChange(of: currentUserId)")
+                && source.contains("reloadForCurrentUserChange()")
+                && source.contains("await loadDataAndMarkViewed()"),
+            "Companion polls should reload when the current user becomes available after initial page load."
+        )
+        XCTAssertTrue(
+            source.contains("markCompanionsViewedIfReady()")
+                && source.contains("currentUserId != nil")
+                && source.contains("loadError == nil"),
+            "Companion polls should not mark onboarding completed when the missing-session load fails closed."
+        )
+    }
+
+    private static func readPartsCompanionsPageSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Parts")
+            .appendingPathComponent("PartsCompanionsPage.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Prevent Parts companion poll loading from falling back to synthetic `userId = 0` when `appCore.currentUser` is unavailable.
- Surface a visible session error instead of querying vote state for the wrong user.
- Reload companion poll data when the current user becomes available after initial hydration, and share the same successful post-load onboarding completion path for initial load, retry, and user-change reloads.
- Add an iOS regression test guarding the session/user-id behavior.

Closes #730

## Verification
- `xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -derivedDataPath /tmp/wpr2-dd-wei4187d -only-testing:"Weird Parts IOSTests/PartsCompanionsPageSessionRegressionTests" -quiet`
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`

Note: one earlier focused test retry without a custom DerivedData path hit Xcode's build database lock; reruns with isolated DerivedData paths passed.
