### PR TITLE
fix: cancel stale companion poll session loads

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
@@ -929,15 +929,14 @@ struct PartsCompanionsPage: View {
             isLoading = true
             loadError = nil
         }
+        let loadContext = await MainActor.run {
+            (
+                service: appCore.partsService,
+                userId: currentUserId,
+                isAdmin: appCore.hasPermission("vote_veto")
+            )
+        }
         do {
-            let loadContext = await MainActor.run {
-                (
-                    service: appCore.partsService,
-                    userId: currentUserId,
-                    isAdmin: appCore.hasPermission("vote_veto")
-                )
-            }
-
             guard let service = loadContext.service else {
                 guard !Task.isCancelled else { return }
                 await MainActor.run {
@@ -949,6 +948,7 @@ struct PartsCompanionsPage: View {
             guard let userId = loadContext.userId else {
                 guard !Task.isCancelled else { return }
                 await MainActor.run {
+                    guard currentUserId == nil else { return }
                     loadError = "User session unavailable. Sign in again."
                     isLoading = false
                 }
@@ -972,6 +972,7 @@ struct PartsCompanionsPage: View {
 
             guard !Task.isCancelled else { return }
             await MainActor.run {
+                guard currentUserId == userId else { return }
                 companionRules = rules
                 alternatives = alts
                 activePolls = polls
@@ -983,6 +984,7 @@ struct PartsCompanionsPage: View {
         } catch {
             guard !Task.isCancelled else { return }
             await MainActor.run {
+                guard currentUserId == loadContext.userId else { return }
                 loadError = userFriendlyError(error, context: "load companion parts")
                 isLoading = false
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
@@ -208,11 +208,8 @@ struct PartsCompanionsPage: View {
             Text("This poll will be closed and a -50 point penalty applied. A replacement poll will be created from the next-best suggestion.")
         }
         .background(DS.Background.page)
-        .task {
+        .task(id: currentUserId) {
             await loadDataAndMarkViewed()
-        }
-        .onChange(of: currentUserId) { _, _ in
-            reloadForCurrentUserChange()
         }
         .onAppear { postCompanionsContext() }
         .onDisappear {
@@ -885,22 +882,22 @@ struct PartsCompanionsPage: View {
 
     // MARK: - Data Loading
 
+    @MainActor
     private func retryLoadData() {
         Task { await loadDataAndMarkViewed() }
     }
 
+    @MainActor
     private func loadDataAndMarkViewed() async {
         await loadData()
+        guard !Task.isCancelled else { return }
         markCompanionsViewedIfReady()
     }
 
+    @MainActor
     private func markCompanionsViewedIfReady() {
-        guard currentUserId != nil, loadError == nil else { return }
+        guard !Task.isCancelled, currentUserId != nil, loadError == nil else { return }
         appCore.onboardingManager?.markCompleted("companions-view")
-    }
-
-    private func reloadForCurrentUserChange() {
-        Task { await loadDataAndMarkViewed() }
     }
 
     private func postCompanionsContext() {
@@ -922,26 +919,30 @@ struct PartsCompanionsPage: View {
         )
     }
 
+    @MainActor
     private func loadData() async {
         isLoading = true
         loadError = nil
         do {
             guard let service = appCore.partsService else {
+                guard !Task.isCancelled else { return }
                 loadError = "Parts service not available"
                 isLoading = false
                 return
             }
-            let rules = try service.listCompanionRulesHierarchy()
-            let alts = try service.listAllAlternatives()
-
-            // Poll data
             guard let userId = currentUserId else {
+                guard !Task.isCancelled else { return }
                 await MainActor.run {
                     loadError = "User session unavailable. Sign in again."
                     isLoading = false
                 }
                 return
             }
+
+            let rules = try service.listCompanionRulesHierarchy()
+            let alts = try service.listAllAlternatives()
+
+            // Poll data
             let isAdmin = appCore.hasPermission("vote_veto")
             let polls = try service.getActivePolls(userId: userId, isAdmin: isAdmin)
             let results = try service.getLastWeekResults(userId: userId)
@@ -949,9 +950,12 @@ struct PartsCompanionsPage: View {
             let preview = isAdmin ? try service.getNextPollPreview() : nil
 
             // Housekeeping
+            guard !Task.isCancelled else { return }
             try service.closeExpiredPolls()
+            guard !Task.isCancelled else { return }
             try service.purgeExpiredRules()
 
+            guard !Task.isCancelled else { return }
             await MainActor.run {
                 companionRules = rules
                 alternatives = alts
@@ -962,6 +966,7 @@ struct PartsCompanionsPage: View {
                 isLoading = false
             }
         } catch {
+            guard !Task.isCancelled else { return }
             await MainActor.run {
                 loadError = userFriendlyError(error, context: "load companion parts")
                 isLoading = false

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
@@ -887,9 +887,8 @@ struct PartsCompanionsPage: View {
     }
 
     // MARK: - Data Loading
-
     private func retryLoadData() {
-        reloadToken += 1
+        Task { @MainActor in reloadToken += 1 }
     }
 
     private func loadDataAndMarkViewed() async {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
@@ -34,9 +34,15 @@ struct PartsCompanionsPage: View {
     @State private var pollToLock: Int64?
     @State private var showSkipConfirm = false
     @State private var pollToSkip: Int64?
+    @State private var reloadToken = 0
 
     private var currentUserId: Int64? {
         appCore.currentUser?.id
+    }
+
+    private struct LoadDataTaskID: Equatable {
+        let userId: Int64?
+        let reloadToken: Int
     }
 
     // Single active-sheet enum to avoid multiple .sheet conflicts
@@ -208,7 +214,7 @@ struct PartsCompanionsPage: View {
             Text("This poll will be closed and a -50 point penalty applied. A replacement poll will be created from the next-best suggestion.")
         }
         .background(DS.Background.page)
-        .task(id: currentUserId) {
+        .task(id: LoadDataTaskID(userId: currentUserId, reloadToken: reloadToken)) {
             await loadDataAndMarkViewed()
         }
         .onAppear { postCompanionsContext() }
@@ -884,14 +890,13 @@ struct PartsCompanionsPage: View {
 
     @MainActor
     private func retryLoadData() {
-        Task { await loadDataAndMarkViewed() }
+        reloadToken += 1
     }
 
-    @MainActor
     private func loadDataAndMarkViewed() async {
         await loadData()
         guard !Task.isCancelled else { return }
-        markCompanionsViewedIfReady()
+        await MainActor.run { markCompanionsViewedIfReady() }
     }
 
     @MainActor
@@ -919,18 +924,29 @@ struct PartsCompanionsPage: View {
         )
     }
 
-    @MainActor
     private func loadData() async {
-        isLoading = true
-        loadError = nil
+        await MainActor.run {
+            isLoading = true
+            loadError = nil
+        }
         do {
-            guard let service = appCore.partsService else {
+            let loadContext = await MainActor.run {
+                (
+                    service: appCore.partsService,
+                    userId: currentUserId,
+                    isAdmin: appCore.hasPermission("vote_veto")
+                )
+            }
+
+            guard let service = loadContext.service else {
                 guard !Task.isCancelled else { return }
-                loadError = "Parts service not available"
-                isLoading = false
+                await MainActor.run {
+                    loadError = "Parts service not available"
+                    isLoading = false
+                }
                 return
             }
-            guard let userId = currentUserId else {
+            guard let userId = loadContext.userId else {
                 guard !Task.isCancelled else { return }
                 await MainActor.run {
                     loadError = "User session unavailable. Sign in again."
@@ -943,11 +959,10 @@ struct PartsCompanionsPage: View {
             let alts = try service.listAllAlternatives()
 
             // Poll data
-            let isAdmin = appCore.hasPermission("vote_veto")
-            let polls = try service.getActivePolls(userId: userId, isAdmin: isAdmin)
+            let polls = try service.getActivePolls(userId: userId, isAdmin: loadContext.isAdmin)
             let results = try service.getLastWeekResults(userId: userId)
             let training = try service.getTrainingQuestion()
-            let preview = isAdmin ? try service.getNextPollPreview() : nil
+            let preview = loadContext.isAdmin ? try service.getNextPollPreview() : nil
 
             // Housekeeping
             guard !Task.isCancelled else { return }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
@@ -888,7 +888,6 @@ struct PartsCompanionsPage: View {
 
     // MARK: - Data Loading
 
-    @MainActor
     private func retryLoadData() {
         reloadToken += 1
     }

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsCompanionsPageSessionRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsCompanionsPageSessionRegressionTests.swift
@@ -13,7 +13,7 @@ final class PartsCompanionsPageSessionRegressionTests: XCTestCase {
             "Companion polls should model the current user id as optional so missing-session state is explicit."
         )
         XCTAssertTrue(
-            source.contains("guard let userId = currentUserId else"),
+            source.contains("guard let userId = loadContext.userId else"),
             "Companion poll loads should fail closed until a real current user id exists."
         )
         XCTAssertTrue(
@@ -21,14 +21,23 @@ final class PartsCompanionsPageSessionRegressionTests: XCTestCase {
             "Companion polls should show a visible session error instead of loading vote state for user 0."
         )
         XCTAssertTrue(
-            source.contains("try service.getActivePolls(userId: userId, isAdmin: isAdmin)")
+            source.contains("try service.getActivePolls(userId: userId, isAdmin: loadContext.isAdmin)")
                 && source.contains("try service.getLastWeekResults(userId: userId)"),
             "Companion poll service calls should use the unwrapped real user id."
         )
         XCTAssertTrue(
-            source.contains(".task(id: currentUserId)")
+            source.contains(".task(id: LoadDataTaskID(userId: currentUserId, reloadToken: reloadToken))")
                 && source.contains("await loadDataAndMarkViewed()"),
             "Companion polls should reload with SwiftUI task cancellation when the current user becomes available after initial page load."
+        )
+        XCTAssertTrue(
+            source.contains("private func retryLoadData()")
+                && source.contains("reloadToken += 1"),
+            "Manual retry should route through the SwiftUI-managed task id instead of launching an uncancelled unstructured task."
+        )
+        XCTAssertFalse(
+            source.contains("@MainActor\n    private func loadData() async"),
+            "Companion poll service reads should not be forced onto the MainActor; only state access should hop to MainActor."
         )
         XCTAssertTrue(
             source.contains("markCompanionsViewedIfReady()")
@@ -60,7 +69,7 @@ final class PartsCompanionsPageSessionRegressionTests: XCTestCase {
             "Companion poll housekeeping should check cancellation between closeExpiredPolls and purgeExpiredRules writes."
         )
         XCTAssertTrue(
-            source.range(of: "guard let userId = currentUserId else")?.lowerBound ?? source.endIndex
+            source.range(of: "guard let userId = loadContext.userId else")?.lowerBound ?? source.endIndex
                 < source.range(of: "let rules = try service.listCompanionRulesHierarchy()")?.lowerBound ?? source.startIndex,
             "Companion loads should fail closed before doing unused service work when the user session is missing."
         )

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsCompanionsPageSessionRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsCompanionsPageSessionRegressionTests.swift
@@ -26,16 +26,43 @@ final class PartsCompanionsPageSessionRegressionTests: XCTestCase {
             "Companion poll service calls should use the unwrapped real user id."
         )
         XCTAssertTrue(
-            source.contains(".onChange(of: currentUserId)")
-                && source.contains("reloadForCurrentUserChange()")
+            source.contains(".task(id: currentUserId)")
                 && source.contains("await loadDataAndMarkViewed()"),
-            "Companion polls should reload when the current user becomes available after initial page load."
+            "Companion polls should reload with SwiftUI task cancellation when the current user becomes available after initial page load."
         )
         XCTAssertTrue(
             source.contains("markCompanionsViewedIfReady()")
                 && source.contains("currentUserId != nil")
                 && source.contains("loadError == nil"),
             "Companion polls should not mark onboarding completed when the missing-session load fails closed."
+        )
+        XCTAssertTrue(
+            source.contains("guard !Task.isCancelled, currentUserId != nil, loadError == nil else { return }"),
+            "Companion polls should not mark onboarding completed if cancellation happens immediately before the mark."
+        )
+        XCTAssertTrue(
+            source.contains("guard !Task.isCancelled else { return }"),
+            "Companion poll loads should not publish stale state or mark onboarding after SwiftUI cancels an old user-id task."
+        )
+        let closeExpiredRange = try XCTUnwrap(source.range(of: "try service.closeExpiredPolls()"))
+        let purgeExpiredRange = try XCTUnwrap(source.range(of: "try service.purgeExpiredRules()"))
+        XCTAssertNotNil(
+            source[..<closeExpiredRange.lowerBound].range(
+                of: "guard !Task.isCancelled else { return }",
+                options: .backwards
+            ),
+            "Companion poll housekeeping should check cancellation before closeExpiredPolls writes."
+        )
+        XCTAssertNotNil(
+            source[closeExpiredRange.upperBound..<purgeExpiredRange.lowerBound].range(
+                of: "guard !Task.isCancelled else { return }"
+            ),
+            "Companion poll housekeeping should check cancellation between closeExpiredPolls and purgeExpiredRules writes."
+        )
+        XCTAssertTrue(
+            source.range(of: "guard let userId = currentUserId else")?.lowerBound ?? source.endIndex
+                < source.range(of: "let rules = try service.listCompanionRulesHierarchy()")?.lowerBound ?? source.startIndex,
+            "Companion loads should fail closed before doing unused service work when the user session is missing."
         )
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsCompanionsPageSessionRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsCompanionsPageSessionRegressionTests.swift
@@ -53,6 +53,11 @@ final class PartsCompanionsPageSessionRegressionTests: XCTestCase {
             source.contains("guard !Task.isCancelled else { return }"),
             "Companion poll loads should not publish stale state or mark onboarding after SwiftUI cancels an old user-id task."
         )
+        XCTAssertTrue(
+            source.contains("guard currentUserId == userId else { return }")
+                && source.contains("guard currentUserId == loadContext.userId else { return }"),
+            "Companion poll loads should only publish results or errors for the still-current user session."
+        )
         let closeExpiredRange = try XCTUnwrap(source.range(of: "try service.closeExpiredPolls()"))
         let purgeExpiredRange = try XCTUnwrap(source.range(of: "try service.purgeExpiredRules()"))
         XCTAssertNotNil(


### PR DESCRIPTION
## Summary
- Follow-up to #1272 / #730 to address Copilot review findings before they become stale behavior.
- Replace separate `.task` + `.onChange` reloads with `.task(id:)` keyed by current user plus retry token so SwiftUI cancels stale in-flight companion poll loads when the session hydrates/changes or the user retries.
- Keep service reads/writes off the MainActor while hopping to MainActor only for `@State`/AppCore access.
- Add cancellation/session guards before marking onboarding viewed, before publishing load results/errors, and before housekeeping DB writes.
- Fail closed on missing `currentUserId` before running companion rule/alternative queries that would be discarded.
- Strengthen the regression test for cancellation/reload, session-change stale publish prevention, guarded housekeeping, and fail-before-unused-work behavior.

Refs #730
Refs #1272

## Verification
- `xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -derivedDataPath /tmp/wpr2-dd-wei4187-hermes6 -only-testing:"Weird Parts IOSTests/PartsCompanionsPageSessionRegressionTests" -quiet`
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
