### PR TITLE
fix: dismiss compact part edit before refresh

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
@@ -1402,8 +1402,8 @@ private struct QuickEditSheet: View {
                 companyCostPrice: cost,
                 companyMarkupPercent: markup
             )
-            await onSave()
             await MainActor.run { dismiss() }
+            await onSave()
         } catch {
             await MainActor.run {
                 saveError = userFriendlyError(error, context: "save data")

--- a/Weird Parts IOS/Weird Parts IOSTests/PartsCatalogPageRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartsCatalogPageRegressionTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+
+final class PartsCatalogPageRegressionTests: XCTestCase {
+    func testCompactPartEditDismissesBeforeParentRefresh() throws {
+        let source = try Self.readPartsCatalogPageSource()
+        guard let sheetStart = source.range(of: "private struct QuickEditSheet") else {
+            XCTFail("QuickEditSheet should exist.")
+            return
+        }
+        guard let sheetEnd = source[sheetStart.upperBound...].range(of: "// MARK: - Part Form Sheet") else {
+            XCTFail("QuickEditSheet should end before the full part form sheet.")
+            return
+        }
+
+        let sheetSource = source[sheetStart.lowerBound..<sheetEnd.lowerBound]
+        guard let saveStart = sheetSource.range(
+            of: #"private\s+func\s+save\s*\(\)\s+async\s*\{"#,
+            options: .regularExpression
+        ) else {
+            XCTFail("Quick edit save function should exist inside QuickEditSheet.")
+            return
+        }
+
+        let saveSource = sheetSource[saveStart.lowerBound...]
+        guard let dismissRange = saveSource.range(of: "dismiss()") else {
+            XCTFail("Successful compact part edit should dismiss the sheet.")
+            return
+        }
+        guard let onSaveRange = saveSource.range(of: "await onSave()") else {
+            XCTFail("Successful compact part edit should still refresh the parent catalog.")
+            return
+        }
+
+        XCTAssertLessThan(
+            dismissRange.lowerBound,
+            onSaveRange.lowerBound,
+            "Successful compact part edit should dismiss the sheet before awaiting the parent catalog refresh."
+        )
+    }
+
+    private static func readPartsCatalogPageSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Parts")
+            .appendingPathComponent("PartsCatalogPage.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Dismiss the compact part quick-edit sheet immediately after a successful `updatePart` save, before awaiting the parent catalog refresh.
- Add a regression test that guards against reintroducing the refresh-before-dismiss ordering that can leave the sheet stuck open after presenter rebuilds.

Closes #1068

## Tests
- `xcodebuild test -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/PartsCatalogPageRegressionTests"` — passed
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed (`No tracked Paperclip/Xcode runtime artifacts found.`)
- `xcodebuild -scheme "WiredPart-iOS" -destination 'generic/platform=iOS Simulator' build` — passed with existing warnings only

## CI / local runner path
- This PR is ready for the WPR2 local self-hosted Mac Actions runner path (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`) for iOS build/test validation.
- No core Swift package files changed, so full `cd core && swift test` was not run for this UI-only lifecycle fix.
