### PR TITLE
fix: enforce iOS manual backup retention

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import WiredPartCore
 
 enum IOSBackupFileCopier {
+    nonisolated static let retainedBackupLimit = 7
+
     struct CleanupFailure: LocalizedError {
         let copyError: Error
         let cleanupError: Error
@@ -40,6 +42,27 @@ enum IOSBackupFileCopier {
                 throw CleanupFailure(copyError: error, cleanupError: cleanupError)
             }
             throw error
+        }
+    }
+
+    nonisolated static func retainedBackupFiles(in directoryURL: URL) throws -> [URL] {
+        try FileManager.default.contentsOfDirectory(at: directoryURL, includingPropertiesForKeys: nil)
+            .filter { url in
+                url.lastPathComponent.hasPrefix("wiredpart-backup-") && url.pathExtension == "sqlite"
+            }
+            .sorted { $0.lastPathComponent > $1.lastPathComponent }
+    }
+
+    nonisolated static func pruneBackups(in directoryURL: URL, retaining maxCount: Int = retainedBackupLimit) throws {
+        guard maxCount >= 0 else { return }
+
+        let backupsToRemove = try retainedBackupFiles(in: directoryURL).dropFirst(maxCount)
+        for backupURL in backupsToRemove {
+            for url in [backupURL, URL(fileURLWithPath: backupURL.path + "-wal"), URL(fileURLWithPath: backupURL.path + "-shm")] {
+                if FileManager.default.fileExists(atPath: url.path) {
+                    try FileManager.default.removeItem(at: url)
+                }
+            }
         }
     }
 }
@@ -233,9 +256,7 @@ struct IOSBackupsPage: View {
 
         // Scan backups
         if let dir = backupDir,
-           let files = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: [.fileSizeKey, .creationDateKey]) {
-            let backups = files.filter { $0.pathExtension == "sqlite" }
-                .sorted { $0.lastPathComponent > $1.lastPathComponent }
+           let backups = try? IOSBackupFileCopier.retainedBackupFiles(in: dir) {
             backupCount = backups.count
             if let newest = backups.first {
                 lastBackupTime = newest.lastPathComponent
@@ -280,6 +301,7 @@ struct IOSBackupsPage: View {
         do {
             let sourceURL = URL(fileURLWithPath: sourcePath)
             try IOSBackupFileCopier.copySQLiteSnapshot(from: sourceURL, to: destURL)
+            try IOSBackupFileCopier.pruneBackups(in: dir)
 
             backupSuccess = true
             loadData()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
@@ -13,6 +13,14 @@ enum IOSBackupFileCopier {
         }
     }
 
+    struct InvalidRetentionLimit: LocalizedError {
+        let limit: Int
+
+        var errorDescription: String? {
+            "Backup retention limit must be zero or greater, got \(limit)."
+        }
+    }
+
     nonisolated static func copySQLiteSnapshot(from sourceURL: URL, to destURL: URL) throws {
         var createdURLs: [URL] = []
 
@@ -45,7 +53,7 @@ enum IOSBackupFileCopier {
         }
     }
 
-    nonisolated static func retainedBackupFiles(in directoryURL: URL) throws -> [URL] {
+    nonisolated static func manualBackupSnapshotFiles(in directoryURL: URL) throws -> [URL] {
         try FileManager.default.contentsOfDirectory(at: directoryURL, includingPropertiesForKeys: nil)
             .filter { url in
                 url.lastPathComponent.hasPrefix("wiredpart-backup-") && url.pathExtension == "sqlite"
@@ -54,9 +62,9 @@ enum IOSBackupFileCopier {
     }
 
     nonisolated static func pruneBackups(in directoryURL: URL, retaining maxCount: Int = retainedBackupLimit) throws {
-        guard maxCount >= 0 else { return }
+        guard maxCount >= 0 else { throw InvalidRetentionLimit(limit: maxCount) }
 
-        let backupsToRemove = try retainedBackupFiles(in: directoryURL).dropFirst(maxCount)
+        let backupsToRemove = try manualBackupSnapshotFiles(in: directoryURL).dropFirst(maxCount)
         for backupURL in backupsToRemove {
             for url in [backupURL, URL(fileURLWithPath: backupURL.path + "-wal"), URL(fileURLWithPath: backupURL.path + "-shm")] {
                 if FileManager.default.fileExists(atPath: url.path) {
@@ -256,7 +264,7 @@ struct IOSBackupsPage: View {
 
         // Scan backups
         if let dir = backupDir,
-           let backups = try? IOSBackupFileCopier.retainedBackupFiles(in: dir) {
+           let backups = try? IOSBackupFileCopier.manualBackupSnapshotFiles(in: dir) {
             backupCount = backups.count
             if let newest = backups.first {
                 lastBackupTime = newest.lastPathComponent

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
@@ -5,11 +5,11 @@ enum IOSBackupFileCopier {
     nonisolated static let retainedBackupLimit = 7
 
     struct CleanupFailure: LocalizedError {
-        let copyError: Error
+        let originalError: Error
         let cleanupError: Error
 
         var errorDescription: String? {
-            "Backup failed and the partial backup could not be cleaned up: \(cleanupError.localizedDescription). Original backup error: \(copyError.localizedDescription)"
+            "Backup failed and the partial backup could not be cleaned up: \(cleanupError.localizedDescription). Original backup error: \(originalError.localizedDescription)"
         }
     }
 
@@ -47,9 +47,17 @@ enum IOSBackupFileCopier {
             }
 
             if let cleanupError {
-                throw CleanupFailure(copyError: error, cleanupError: cleanupError)
+                throw CleanupFailure(originalError: error, cleanupError: cleanupError)
             }
             throw error
+        }
+    }
+
+    nonisolated static func removeSQLiteSnapshot(at snapshotURL: URL) throws {
+        for url in [snapshotURL, URL(fileURLWithPath: snapshotURL.path + "-wal"), URL(fileURLWithPath: snapshotURL.path + "-shm")] {
+            if FileManager.default.fileExists(atPath: url.path) {
+                try FileManager.default.removeItem(at: url)
+            }
         }
     }
 
@@ -309,7 +317,16 @@ struct IOSBackupsPage: View {
         do {
             let sourceURL = URL(fileURLWithPath: sourcePath)
             try IOSBackupFileCopier.copySQLiteSnapshot(from: sourceURL, to: destURL)
-            try IOSBackupFileCopier.pruneBackups(in: dir)
+            do {
+                try IOSBackupFileCopier.pruneBackups(in: dir)
+            } catch {
+                do {
+                    try IOSBackupFileCopier.removeSQLiteSnapshot(at: destURL)
+                } catch let cleanupError {
+                    throw IOSBackupFileCopier.CleanupFailure(originalError: error, cleanupError: cleanupError)
+                }
+                throw error
+            }
 
             backupSuccess = true
             loadData()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
@@ -74,11 +74,7 @@ enum IOSBackupFileCopier {
 
         let backupsToRemove = try manualBackupSnapshotFiles(in: directoryURL).dropFirst(maxCount)
         for backupURL in backupsToRemove {
-            for url in [backupURL, URL(fileURLWithPath: backupURL.path + "-wal"), URL(fileURLWithPath: backupURL.path + "-shm")] {
-                if FileManager.default.fileExists(atPath: url.path) {
-                    try FileManager.default.removeItem(at: url)
-                }
-            }
+            try removeSQLiteSnapshot(at: backupURL)
         }
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -1022,6 +1022,24 @@ struct Weird_Parts_IOSTests {
         }
     }
 
+    @Test func manualBackupSnapshotRemovalDeletesSidecars() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("IOSBackupSnapshotRemovalTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let backupURL = tempRoot.appendingPathComponent("wiredpart-backup-2026-06-10-120000.sqlite")
+        try Data("backup".utf8).write(to: backupURL)
+        try Data("wal".utf8).write(to: URL(fileURLWithPath: backupURL.path + "-wal"))
+        try Data("shm".utf8).write(to: URL(fileURLWithPath: backupURL.path + "-shm"))
+
+        try IOSBackupFileCopier.removeSQLiteSnapshot(at: backupURL)
+
+        #expect(!FileManager.default.fileExists(atPath: backupURL.path))
+        #expect(!FileManager.default.fileExists(atPath: backupURL.path + "-wal"))
+        #expect(!FileManager.default.fileExists(atPath: backupURL.path + "-shm"))
+    }
+
     @Test func manualBackupSidecarCopiesAreNotSwallowedBeforeSuccessState() throws {
         let repoRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -1036,6 +1054,7 @@ struct Weird_Parts_IOSTests {
         #expect(source.contains("try IOSBackupFileCopier.copySQLiteSnapshot"), "Manual backup creation should use the throwing SQLite snapshot copier")
         #expect(source.contains("try IOSBackupFileCopier.pruneBackups"), "Successful manual backup creation should enforce the rolling retention limit")
         #expect(source.contains("createdURLs.reversed()"), "Partial backup cleanup should remove sidecars before the main database")
+        #expect(source.contains("try IOSBackupFileCopier.removeSQLiteSnapshot(at: destURL)"), "A backup copied before retention failure should be rolled back instead of being left on disk")
         let snapshotCall = try #require(source.range(of: "try IOSBackupFileCopier.copySQLiteSnapshot"))
         let pruneCall = try #require(source.range(of: "try IOSBackupFileCopier.pruneBackups"))
         let successState = try #require(source.range(of: "backupSuccess = true"))

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -1000,7 +1000,7 @@ struct Weird_Parts_IOSTests {
 
         try IOSBackupFileCopier.pruneBackups(in: tempRoot)
 
-        let retained = try IOSBackupFileCopier.retainedBackupFiles(in: tempRoot)
+        let retained = try IOSBackupFileCopier.manualBackupSnapshotFiles(in: tempRoot)
         #expect(retained.map(\.lastPathComponent) == (3...9).reversed().map { String(format: "wiredpart-backup-2026-06-%02d-120000.sqlite", $0) })
         #expect(FileManager.default.fileExists(atPath: unrelatedSQLite.path), "Retention should only manage wiredpart manual backup snapshots")
         for day in 1...2 {
@@ -1008,6 +1008,17 @@ struct Weird_Parts_IOSTests {
             #expect(!FileManager.default.fileExists(atPath: removedBackupURL.path))
             #expect(!FileManager.default.fileExists(atPath: removedBackupURL.path + "-wal"))
             #expect(!FileManager.default.fileExists(atPath: removedBackupURL.path + "-shm"))
+        }
+    }
+
+    @Test func manualBackupRetentionRejectsInvalidLimits() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("IOSBackupRetentionLimitTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        #expect(throws: IOSBackupFileCopier.InvalidRetentionLimit.self) {
+            try IOSBackupFileCopier.pruneBackups(in: tempRoot, retaining: -1)
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -983,6 +983,34 @@ struct Weird_Parts_IOSTests {
         }
     }
 
+    @Test func manualBackupPrunesOldestBackupsAndSidecars() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("IOSBackupRetentionTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        for day in 1...9 {
+            let backupURL = tempRoot.appendingPathComponent(String(format: "wiredpart-backup-2026-06-%02d-120000.sqlite", day))
+            try Data("backup \(day)".utf8).write(to: backupURL)
+            try Data("wal \(day)".utf8).write(to: URL(fileURLWithPath: backupURL.path + "-wal"))
+            try Data("shm \(day)".utf8).write(to: URL(fileURLWithPath: backupURL.path + "-shm"))
+        }
+        let unrelatedSQLite = tempRoot.appendingPathComponent("operator-notes.sqlite")
+        try Data("not a wiredpart manual backup".utf8).write(to: unrelatedSQLite)
+
+        try IOSBackupFileCopier.pruneBackups(in: tempRoot)
+
+        let retained = try IOSBackupFileCopier.retainedBackupFiles(in: tempRoot)
+        #expect(retained.map(\.lastPathComponent) == (3...9).reversed().map { String(format: "wiredpart-backup-2026-06-%02d-120000.sqlite", $0) })
+        #expect(FileManager.default.fileExists(atPath: unrelatedSQLite.path), "Retention should only manage wiredpart manual backup snapshots")
+        for day in 1...2 {
+            let removedBackupURL = tempRoot.appendingPathComponent(String(format: "wiredpart-backup-2026-06-%02d-120000.sqlite", day))
+            #expect(!FileManager.default.fileExists(atPath: removedBackupURL.path))
+            #expect(!FileManager.default.fileExists(atPath: removedBackupURL.path + "-wal"))
+            #expect(!FileManager.default.fileExists(atPath: removedBackupURL.path + "-shm"))
+        }
+    }
+
     @Test func manualBackupSidecarCopiesAreNotSwallowedBeforeSuccessState() throws {
         let repoRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -995,10 +1023,13 @@ struct Weird_Parts_IOSTests {
         #expect(!source.contains("try? FileManager.default.copyItem"), "Manual backup WAL/SHM copy failures must not be swallowed")
         #expect(!source.contains("try? FileManager.default.removeItem"), "Failed manual backups must not swallow cleanup failures")
         #expect(source.contains("try IOSBackupFileCopier.copySQLiteSnapshot"), "Manual backup creation should use the throwing SQLite snapshot copier")
+        #expect(source.contains("try IOSBackupFileCopier.pruneBackups"), "Successful manual backup creation should enforce the rolling retention limit")
         #expect(source.contains("createdURLs.reversed()"), "Partial backup cleanup should remove sidecars before the main database")
         let snapshotCall = try #require(source.range(of: "try IOSBackupFileCopier.copySQLiteSnapshot"))
+        let pruneCall = try #require(source.range(of: "try IOSBackupFileCopier.pruneBackups"))
         let successState = try #require(source.range(of: "backupSuccess = true"))
-        #expect(snapshotCall.lowerBound < successState.lowerBound, "Success state must only be set after all database sidecars are copied")
+        #expect(snapshotCall.lowerBound < pruneCall.lowerBound, "Retention should run after the full SQLite snapshot is copied")
+        #expect(pruneCall.lowerBound < successState.lowerBound, "Success state must only be set after retention succeeds")
     }
 
     @Test func fullDatabaseExportCheckpointsAndIncludesWALChanges() throws {


### PR DESCRIPTION
## Summary
- Enforces the iOS manual backup 7-snapshot retention limit after successful SQLite snapshot copy.
- Prunes matching WAL/SHM sidecars with each removed backup.
- Counts only `wiredpart-backup-*.sqlite` snapshots in the backup status UI.
- Adds regression coverage for retaining newest 7 backups and removing old sidecars.

Closes #1100
Paperclip: WEI-4139

## Verification
- PASS: `xcodebuild test -project "Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/manualBackupPrunesOldestBackupsAndSidecars" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/manualBackupSidecarCopiesAreNotSwallowedBeforeSuccessState"`\n- WARN: full `-only-testing:"Weird Parts IOSTests"` run failed outside this change in `SettingsSaveButtonValidationTests.testDailyReportTemplatesPageHasIsDirtyGuard()` plus simulator app-launch fallout; targeted backup retention tests passed.\n\n## Local runner path\nUse the WPR2 self-hosted local Mac runner for PR checks: `[self-hosted, macOS, ARM64, xcode, ios, local-mac]`.