### PR TITLE
fix: dismiss SKU editor before parent refresh

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/TypeBrandColorSection.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/TypeBrandColorSection.swift
@@ -100,7 +100,8 @@ struct TypeBrandColorSection: View {
                         typeId: typeId,
                         brand: selectedBrand,
                         colors: allColors,
-                        onSave: handleSKUSave
+                        onSave: handleSKUSave,
+                        onRefreshAfterSave: refreshAfterSKUSave
                     )
                 }
             case .edit(let row):
@@ -110,7 +111,8 @@ struct TypeBrandColorSection: View {
                         typeId: typeId,
                         brand: brand,
                         colors: allColors,
-                        onSave: handleSKUSave
+                        onSave: handleSKUSave,
+                        onRefreshAfterSave: refreshAfterSKUSave
                     )
                 }
             }
@@ -417,6 +419,9 @@ struct TypeBrandColorSection: View {
             )
         }
 
+    }
+
+    private func refreshAfterSKUSave() async {
         await loadSKUData()
         await onRefresh()
     }
@@ -522,6 +527,7 @@ private struct ColorBrandSKUEditorSheet: View {
     let brand: Brand
     let colors: [PartColor]
     let onSave: (Draft) async throws -> Void
+    let onRefreshAfterSave: () async -> Void
 
     @State private var selectedColorId: Int64
     @State private var partNumber: String
@@ -529,12 +535,20 @@ private struct ColorBrandSKUEditorSheet: View {
     @State private var saveError: String?
     @State private var isSaving = false
 
-    init(mode: Mode, typeId: Int64, brand: Brand, colors: [PartColor], onSave: @escaping (Draft) async throws -> Void) {
+    init(
+        mode: Mode,
+        typeId: Int64,
+        brand: Brand,
+        colors: [PartColor],
+        onSave: @escaping (Draft) async throws -> Void,
+        onRefreshAfterSave: @escaping () async -> Void
+    ) {
         self.mode = mode
         self.typeId = typeId
         self.brand = brand
         self.colors = colors
         self.onSave = onSave
+        self.onRefreshAfterSave = onRefreshAfterSave
 
         switch mode {
         case .create:
@@ -673,10 +687,12 @@ private struct ColorBrandSKUEditorSheet: View {
                 unitCostText: unitCostText
             ))
             dismiss()
+            await onRefreshAfterSave()
+            isSaving = false
         } catch {
             saveError = userFriendlyError(error, context: "save SKU row")
+            isSaving = false
         }
-        isSaving = false
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/TypeBrandColorSectionRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/TypeBrandColorSectionRegressionTests.swift
@@ -52,6 +52,47 @@ final class TypeBrandColorSectionRegressionTests: XCTestCase {
         )
     }
 
+    func testSkuEditorDismissesBeforeRefreshingParentAfterSuccessfulSave() throws {
+        let source = try Self.readTypeBrandColorSectionSource()
+        guard let sheetStart = source.range(of: "private struct ColorBrandSKUEditorSheet") else {
+            XCTFail("ColorBrandSKUEditorSheet should exist.")
+            return
+        }
+        guard let sheetEnd = source[sheetStart.upperBound...].range(of: "private func parseLocalizedDecimal") else {
+            XCTFail("ColorBrandSKUEditorSheet should end before decimal helpers.")
+            return
+        }
+
+        let sheetSource = source[sheetStart.lowerBound..<sheetEnd.lowerBound]
+        guard let saveStart = sheetSource.range(
+            of: #"private\s+func\s+save\s*\(\)\s+async\s*\{"#,
+            options: .regularExpression
+        ) else {
+            XCTFail("SKU editor save function should exist inside ColorBrandSKUEditorSheet.")
+            return
+        }
+
+        let saveSource = sheetSource[saveStart.lowerBound...]
+        guard let dismissRange = saveSource.range(of: "dismiss()") else {
+            XCTFail("Successful SKU editor save should dismiss the sheet.")
+            return
+        }
+        guard let refreshRange = saveSource.range(of: "await onRefreshAfterSave()") else {
+            XCTFail("Successful SKU editor save should still refresh parent SKU data after dismissing.")
+            return
+        }
+
+        XCTAssertLessThan(
+            dismissRange.lowerBound,
+            refreshRange.lowerBound,
+            "Successful SKU editor save should dismiss before awaiting the parent refresh to avoid stale sheet dismissal."
+        )
+        XCTAssertTrue(
+            source.contains("private func refreshAfterSKUSave() async"),
+            "Parent refresh should be split from the save callback so it can run after the editor dismisses."
+        )
+    }
+
     private static func readTypeBrandColorSectionSource(
         file: StaticString = #filePath
     ) throws -> String {


### PR DESCRIPTION
## Summary
- Split SKU row persistence from the parent hierarchy refresh in TypeBrandColorSection
- Dismiss the SKU editor immediately after a successful save, then refresh parent SKU/hierarchy data
- Added a regression guard ensuring dismiss happens before the async parent refresh

Closes #1069

## Verification
- `xcodebuild test -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -only-testing:"Weird Parts IOSTests/TypeBrandColorSectionRegressionTests"` — passed
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed
- `xcodebuild build -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPad,OS=26.5'` — passed

## Notes
- No core Swift package files changed, so full `cd core && swift test` was not required for this UI-only fix.
- Initial iPhone 16 simulator test destination was unavailable; reran successfully on available WEI3988-iPhone simulator.
- Local runner path considered for CI per WPR2 runbook; PR uses same-repo branch suitable for the self-hosted Mac runner.