### PR TITLE
fix: isolate companion poll retry callback

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
@@ -104,7 +104,7 @@ struct PartsCompanionsPage: View {
                 ProgressView("Loading...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let error = loadError {
-                ErrorStateView(message: error, retryAction: retryLoadData)
+                ErrorStateView(message: error) { retryLoadData() }
             } else {
                 switch activeTab {
                 case .rules:
@@ -887,8 +887,10 @@ struct PartsCompanionsPage: View {
     }
 
     // MARK: - Data Loading
+
+    @MainActor
     private func retryLoadData() {
-        Task { @MainActor in reloadToken += 1 }
+        reloadToken += 1
     }
 
     private func loadDataAndMarkViewed() async {


### PR DESCRIPTION
## Summary
- Follow up on the late Copilot review comment from #1273 after it merged.
- Keep the companion-poll retry action synchronous and MainActor-isolated instead of spawning an unstructured task just to mutate the reload token.
- Wrap the ErrorStateView callback so the MainActor-isolated retry method is invoked from the UI action closure.

Refs #730
Refs #1273

## Verification
- `xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -derivedDataPath /tmp/wpr2-dd-wei4187-hermes8 -only-testing:"Weird Parts IOSTests/PartsCompanionsPageSessionRegressionTests" -quiet`
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`