### PR TITLE
fix: keep companion retry synchronous

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCompanionsPage.swift
@@ -104,7 +104,7 @@ struct PartsCompanionsPage: View {
                 ProgressView("Loading...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let error = loadError {
-                ErrorStateView(message: error, retryAction: retryLoadData)
+                ErrorStateView(message: error) { retryLoadData() }
             } else {
                 switch activeTab {
                 case .rules:
@@ -887,8 +887,9 @@ struct PartsCompanionsPage: View {
     }
 
     // MARK: - Data Loading
+    @MainActor
     private func retryLoadData() {
-        Task { @MainActor in reloadToken += 1 }
+        reloadToken += 1
     }
 
     private func loadDataAndMarkViewed() async {


### PR DESCRIPTION
## Summary\n- Follow-up to merged PR #1273 after Copilot's fresh review on the final head.\n- Keeps companion retry driven by the SwiftUI-managed reload token without spawning an unstructured Task.\n- Wraps the retry callback at the ErrorStateView call site so the retry helper can remain MainActor-isolated while matching ErrorStateView's non-actor-isolated closure type.\n\nRefs #1273\nRefs #730\nPaperclip: WEI-4139\n\n## Verification\n- PASS: git diff --check\n- PASS: python3 scripts/guard-tracked-artifacts.py\n- PASS: xcodebuild test -workspace "Wierd Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -derivedDataPath /tmp/wpr2-dd-wei4187-cto-heartbeat2 -only-testing:"Weird Parts IOSTests/PartsCompanionsPageSessionRegressionTests" -quiet\n\n## Local runner path\nUse the WPR2 self-hosted local Mac runner for PR checks: [self-hosted, macOS, ARM64, xcode, ios, local-mac].