### PR TITLE
Fix movement wizard staging endpoint mismatch

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
@@ -239,11 +239,10 @@ struct IOSMovementWizard: View {
     // MARK: - Step 1: Locations
 
     private let locationTypes = [
-        ("warehouse", "Warehouse", "building.2.fill"),
-        ("staging", "Staging", "tray.2.fill"),
-        ("truck", "Truck", "truck.box.fill"),
-        ("trailer", "Trailer", "box.truck.fill"),
-        ("job", "Job Site", "hammer.fill"),
+        (WarehouseService.GuidedMovementLocationType.warehouse.rawValue, "Warehouse", "building.2.fill"),
+        (WarehouseService.GuidedMovementLocationType.truck.rawValue, "Truck", "truck.box.fill"),
+        (WarehouseService.GuidedMovementLocationType.trailer.rawValue, "Trailer", "box.truck.fill"),
+        (WarehouseService.GuidedMovementLocationType.job.rawValue, "Job Site", "hammer.fill"),
     ]
 
     @ViewBuilder

--- a/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
@@ -75,6 +75,26 @@ final class WarehouseWizardProgressAccessibilityTests: XCTestCase {
         )
     }
 
+    func testMovementWizardLocationTilesComeFromCoreSupportedMovementTypes() throws {
+        let source = try Self.readWarehouseSource("IOSMovementWizard.swift")
+        let locationTypes = try Self.movementWizardLocationTypesSection(in: source)
+
+        for coreLocationType in ["warehouse", "truck", "trailer", "job"] {
+            XCTAssertTrue(
+                locationTypes.contains("WarehouseService.GuidedMovementLocationType.\(coreLocationType).rawValue"),
+                "Movement wizard \(coreLocationType) choices should use the core movement location topology instead of ad hoc strings."
+            )
+            XCTAssertFalse(
+                locationTypes.contains("\"\(coreLocationType)\""),
+                "Movement wizard \(coreLocationType) choices should not fall back to ad hoc string literals."
+            )
+        }
+        XCTAssertNil(
+            locationTypes.range(of: #"\(\s*"staging"\s*,\s*"Staging""#, options: .regularExpression),
+            "Movement wizard must not offer Staging as a generic movement endpoint until WarehouseService accepts staging paths."
+        )
+    }
+
     func testMovementWizardPartSelectionDismissesKeyboardBeforeNextNavigation() throws {
         let source = try Self.readWarehouseSource("IOSMovementWizard.swift")
 
@@ -140,6 +160,16 @@ final class WarehouseWizardProgressAccessibilityTests: XCTestCase {
         }
         let afterStart = source[start.lowerBound...]
         let end = afterStart.range(of: "// MARK: - Step 1")?.lowerBound ?? afterStart.endIndex
+        return String(afterStart[..<end])
+    }
+
+    private static func movementWizardLocationTypesSection(in source: String) throws -> String {
+        guard let start = source.range(of: "private let locationTypes = [") else {
+            XCTFail("Missing movement wizard locationTypes list")
+            return source
+        }
+        let afterStart = source[start.lowerBound...]
+        let end = afterStart.range(of: "]")?.upperBound ?? afterStart.endIndex
         return String(afterStart[..<end])
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
@@ -75,22 +75,22 @@ final class WarehouseWizardProgressAccessibilityTests: XCTestCase {
         )
     }
 
-    func testMovementWizardLocationTilesComeFromCoreSupportedMovementTypes() throws {
+    func testMovementWizardSelectableLocationTilesUseEnumBackedSupportedEndpoints() throws {
         let source = try Self.readWarehouseSource("IOSMovementWizard.swift")
         let locationTypes = try Self.movementWizardLocationTypesSection(in: source)
 
-        for coreLocationType in ["warehouse", "truck", "trailer", "job"] {
+        for supportedEndpoint in ["warehouse", "truck", "trailer", "job"] {
             XCTAssertTrue(
-                locationTypes.contains("WarehouseService.GuidedMovementLocationType.\(coreLocationType).rawValue"),
-                "Movement wizard \(coreLocationType) choices should use the core movement location topology instead of ad hoc strings."
-            )
-            XCTAssertFalse(
-                locationTypes.contains("\"\(coreLocationType)\""),
-                "Movement wizard \(coreLocationType) choices should not fall back to ad hoc string literals."
+                locationTypes.contains("WarehouseService.GuidedMovementLocationType.\(supportedEndpoint).rawValue"),
+                "Movement wizard \(supportedEndpoint) tile should use the core movement location topology instead of ad hoc strings."
             )
         }
         XCTAssertNil(
-            locationTypes.range(of: #"\(\s*"staging"\s*,\s*"Staging""#, options: .regularExpression),
+            locationTypes.range(of: #"(?m)^\s*\(\s*""#, options: .regularExpression),
+            "Movement wizard location tiles should not use string literals as tuple endpoints."
+        )
+        XCTAssertNil(
+            locationTypes.range(of: #"\bstaging\b"#, options: [.regularExpression, .caseInsensitive]),
             "Movement wizard must not offer Staging as a generic movement endpoint until WarehouseService accepts staging paths."
         )
     }


### PR DESCRIPTION
## Summary
- Removes the unsupported generic `Staging` endpoint from the iOS movement wizard so users cannot build Warehouse/Truck/Trailer/Job movements that the core service rejects.
- Backs the remaining wizard location tile raw values with `WarehouseService.GuidedMovementLocationType` instead of ad hoc strings.
- Adds a source-level regression guard requiring every remaining wizard endpoint to use the core movement topology and preventing the stale staging tile from being reintroduced until core supports staging paths.

Closes #1106

## Tests
- `cd core && swift test --filter WarehouseServiceExtTests/testValidateMovement`
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `cd core && swift test` (2218 tests passed)
- `python3` source guard confirming `IOSMovementWizard.swift` no longer contains the raw `("staging", "Staging")` tile and does contain the core enum-backed warehouse location
- `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -only-testing:"Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests/testMovementWizardSelectableLocationTilesUseEnumBackedSupportedEndpoints" test`
