### PR TITLE
Fix unsupported staging movement option

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSMovementWizard.swift
@@ -240,7 +240,6 @@ struct IOSMovementWizard: View {
 
     private let locationTypes = [
         ("warehouse", "Warehouse", "building.2.fill"),
-        ("staging", "Staging", "tray.2.fill"),
         ("truck", "Truck", "truck.box.fill"),
         ("trailer", "Trailer", "box.truck.fill"),
         ("job", "Job Site", "hammer.fill"),

--- a/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
@@ -75,6 +75,23 @@ final class WarehouseWizardProgressAccessibilityTests: XCTestCase {
         )
     }
 
+    func testMovementWizardOnlyOffersCoreSupportedMovementLocations() throws {
+        let source = try Self.readWarehouseSource("IOSMovementWizard.swift")
+        let locationTypes = try Self.movementWizardLocationTypesSection(in: source)
+
+        XCTAssertTrue(
+            locationTypes.contains("\"warehouse\"") &&
+                locationTypes.contains("\"truck\"") &&
+                locationTypes.contains("\"trailer\"") &&
+                locationTypes.contains("\"job\""),
+            "Movement wizard should keep offering the core-supported warehouse/truck/trailer/job movement buckets."
+        )
+        XCTAssertFalse(
+            locationTypes.contains("\"staging\"") || locationTypes.contains("\"Staging\""),
+            "Movement wizard must not offer staging as a movement endpoint until WarehouseService accepts staging movement paths."
+        )
+    }
+
     func testMovementWizardPartSelectionDismissesKeyboardBeforeNextNavigation() throws {
         let source = try Self.readWarehouseSource("IOSMovementWizard.swift")
 
@@ -140,6 +157,16 @@ final class WarehouseWizardProgressAccessibilityTests: XCTestCase {
         }
         let afterStart = source[start.lowerBound...]
         let end = afterStart.range(of: "// MARK: - Step 1")?.lowerBound ?? afterStart.endIndex
+        return String(afterStart[..<end])
+    }
+
+    private static func movementWizardLocationTypesSection(in source: String) throws -> String {
+        guard let start = source.range(of: "private let locationTypes = [") else {
+            XCTFail("Missing movement wizard locationTypes list")
+            return source
+        }
+        let afterStart = source[start.lowerBound...]
+        let end = afterStart.range(of: "]")?.upperBound ?? afterStart.endIndex
         return String(afterStart[..<end])
     }
 


### PR DESCRIPTION
## Summary
- remove Staging from the iOS movement wizard endpoint picker because WarehouseService does not accept staging movement paths
- add a regression test that keeps the wizard endpoint list aligned to core-supported movement buckets

Closes #1106

## Verification
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5" -only-testing:"Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests/testMovementWizardOnlyOffersCoreSupportedMovementLocations"` — passed
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5" -only-testing:"Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests"` — passed
- `cd core && swift test --filter WarehouseServiceExtTests` — passed (133 tests)
- `git diff --check` — passed
- `python3 scripts/guard-tracked-artifacts.py` — passed

## Local runner path
This PR is ready for the repo local Mac Actions runner path (`self-hosted`, macOS/ARM64/Xcode/iOS/local-mac) for CI validation.