### PR TITLE
Fix supplier PO emails related job context

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/POPDFGenerator.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/POPDFGenerator.swift
@@ -12,21 +12,6 @@ struct POPDFGenerator {
     let supplierEmail: String?
     let companyName: String
 
-    private var relatedJobSummary: String? {
-        var seen = Set<String>()
-        let jobNames = po.lines.compactMap { line -> String? in
-            guard let name = line.jobName?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !name.isEmpty,
-                  !seen.contains(name)
-            else { return nil }
-            seen.insert(name)
-            return name
-        }
-
-        guard !jobNames.isEmpty else { return nil }
-        return jobNames.joined(separator: ", ")
-    }
-
     // Layout constants
     private let pageW: CGFloat = 612
     private let pageH: CGFloat = 792
@@ -123,7 +108,7 @@ struct POPDFGenerator {
 
             metaRow("Supplier:",      po.supplierName)
             if let email = supplierEmail { metaRow("Supplier Email:", email) }
-            if let relatedJobSummary { metaRow("Related Job(s):", relatedJobSummary) }
+            if let relatedJobSummary = po.supplierRelatedJobSummary { metaRow("Related Job(s):", relatedJobSummary) }
             metaRow("Order Date:",    po.orderDate ?? "—")
             metaRow("Expected By:",   po.expectedDelivery ?? "—")
             if let tracking = po.trackingNumber { metaRow("Tracking:", tracking) }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/POPDFGenerator.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/POPDFGenerator.swift
@@ -12,6 +12,21 @@ struct POPDFGenerator {
     let supplierEmail: String?
     let companyName: String
 
+    private var relatedJobSummary: String? {
+        var seen = Set<String>()
+        let jobNames = po.lines.compactMap { line -> String? in
+            guard let name = line.jobName?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !name.isEmpty,
+                  !seen.contains(name)
+            else { return nil }
+            seen.insert(name)
+            return name
+        }
+
+        guard !jobNames.isEmpty else { return nil }
+        return jobNames.joined(separator: ", ")
+    }
+
     // Layout constants
     private let pageW: CGFloat = 612
     private let pageH: CGFloat = 792
@@ -108,6 +123,7 @@ struct POPDFGenerator {
 
             metaRow("Supplier:",      po.supplierName)
             if let email = supplierEmail { metaRow("Supplier Email:", email) }
+            if let relatedJobSummary { metaRow("Related Job(s):", relatedJobSummary) }
             metaRow("Order Date:",    po.orderDate ?? "—")
             metaRow("Expected By:",   po.expectedDelivery ?? "—")
             if let tracking = po.trackingNumber { metaRow("Tracking:", tracking) }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
@@ -127,19 +127,21 @@ struct POSendToSupplierSheet: View {
 
     private var emailSubject: String {
         let type = selectedRequestType == .pricing ? "Pricing Request" : "Purchase Order"
-        let jobSuffix = relatedJobSummary.map { " — Job: \($0)" } ?? ""
-        if groupEnabled && !includedSiblingIds.isEmpty {
-            return "\(type) — \(po.supplierName) (\(includedPOs.count) orders)\(jobSuffix)"
+        let isGroupedSend = groupEnabled && !includedSiblingIds.isEmpty
+        let jobSuffix = isGroupedSend ? "" : (relatedJobSummary.map { " — Job: \($0)" } ?? "")
+        if isGroupedSend {
+            return "\(type) — \(po.supplierName) (\(includedPOs.count) orders)"
         }
         return "\(type) \(po.poNumber) — \(po.supplierName)\(jobSuffix)"
     }
 
     private var emailBody: String {
         var lines: [String] = []
+        let isGroupedSend = groupEnabled && !includedSiblingIds.isEmpty
         lines.append("Dear \(po.supplierName),")
         lines.append("")
 
-        if let relatedJobSummary {
+        if !isGroupedSend, let relatedJobSummary {
             lines.append("Re: \(relatedJobSummary)")
             lines.append("")
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
@@ -110,18 +110,39 @@ struct POSendToSupplierSheet: View {
         return siblingPOs.filter { includedSiblingIds.contains($0.id) }
     }
 
+    private var relatedJobSummary: String? {
+        var seen = Set<String>()
+        let jobNames = po.lines.compactMap { line -> String? in
+            guard let name = line.jobName?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !name.isEmpty,
+                  !seen.contains(name)
+            else { return nil }
+            seen.insert(name)
+            return name
+        }
+
+        guard !jobNames.isEmpty else { return nil }
+        return jobNames.joined(separator: ", ")
+    }
+
     private var emailSubject: String {
         let type = selectedRequestType == .pricing ? "Pricing Request" : "Purchase Order"
+        let jobSuffix = relatedJobSummary.map { " — Job: \($0)" } ?? ""
         if groupEnabled && !includedSiblingIds.isEmpty {
-            return "\(type) — \(po.supplierName) (\(includedPOs.count) orders)"
+            return "\(type) — \(po.supplierName) (\(includedPOs.count) orders)\(jobSuffix)"
         }
-        return "\(type) \(po.poNumber) — \(po.supplierName)"
+        return "\(type) \(po.poNumber) — \(po.supplierName)\(jobSuffix)"
     }
 
     private var emailBody: String {
         var lines: [String] = []
         lines.append("Dear \(po.supplierName),")
         lines.append("")
+
+        if let relatedJobSummary {
+            lines.append("Re: \(relatedJobSummary)")
+            lines.append("")
+        }
 
         if selectedRequestType == .pricing {
             lines.append("Please find attached our pricing request\(groupEnabled && !includedSiblingIds.isEmpty ? "s" : "") for the following items.")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
@@ -2,6 +2,23 @@ import SwiftUI
 import MessageUI
 import WiredPartCore
 
+extension OrdersService.PODetail {
+    var supplierRelatedJobSummary: String? {
+        var seen = Set<String>()
+        let jobNames = lines.compactMap { line -> String? in
+            guard let name = line.jobName?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !name.isEmpty,
+                  !seen.contains(name)
+            else { return nil }
+            seen.insert(name)
+            return name
+        }
+
+        guard !jobNames.isEmpty else { return nil }
+        return jobNames.joined(separator: ", ")
+    }
+}
+
 // MARK: - POSendToSupplierSheet
 //
 // Full "Send to Supplier" flow for one or more Purchase Orders.
@@ -110,25 +127,10 @@ struct POSendToSupplierSheet: View {
         return siblingPOs.filter { includedSiblingIds.contains($0.id) }
     }
 
-    private var relatedJobSummary: String? {
-        var seen = Set<String>()
-        let jobNames = po.lines.compactMap { line -> String? in
-            guard let name = line.jobName?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !name.isEmpty,
-                  !seen.contains(name)
-            else { return nil }
-            seen.insert(name)
-            return name
-        }
-
-        guard !jobNames.isEmpty else { return nil }
-        return jobNames.joined(separator: ", ")
-    }
-
     private var emailSubject: String {
         let type = selectedRequestType == .pricing ? "Pricing Request" : "Purchase Order"
         let isGroupedSend = groupEnabled && !includedSiblingIds.isEmpty
-        let jobSuffix = isGroupedSend ? "" : (relatedJobSummary.map { " — Job: \($0)" } ?? "")
+        let jobSuffix = isGroupedSend ? "" : (po.supplierRelatedJobSummary.map { " — Job: \($0)" } ?? "")
         if isGroupedSend {
             return "\(type) — \(po.supplierName) (\(includedPOs.count) orders)"
         }
@@ -141,16 +143,16 @@ struct POSendToSupplierSheet: View {
         lines.append("Dear \(po.supplierName),")
         lines.append("")
 
-        if !isGroupedSend, let relatedJobSummary {
+        if !isGroupedSend, let relatedJobSummary = po.supplierRelatedJobSummary {
             lines.append("Re: \(relatedJobSummary)")
             lines.append("")
         }
 
         if selectedRequestType == .pricing {
-            lines.append("Please find attached our pricing request\(groupEnabled && !includedSiblingIds.isEmpty ? "s" : "") for the following items.")
+            lines.append("Please find attached our pricing request\(isGroupedSend ? "s" : "") for the following items.")
             lines.append("We would appreciate your best pricing and availability at your earliest convenience.")
         } else {
-            lines.append("Please find attached our purchase order\(groupEnabled && !includedSiblingIds.isEmpty ? "s" : "") for your review and processing.")
+            lines.append("Please find attached our purchase order\(isGroupedSend ? "s" : "") for your review and processing.")
         }
 
         lines.append("")

--- a/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
@@ -197,21 +197,22 @@ final class OrdersSessionUnavailableRegressionTests: XCTestCase {
         let pdfGeneratorSource = try Self.readOrdersSource(named: "POPDFGenerator.swift")
 
         XCTAssertTrue(
-            sendSheetSource.contains("private var relatedJobSummary: String?") &&
+            sendSheetSource.contains("extension OrdersService.PODetail") &&
+            sendSheetSource.contains("var supplierRelatedJobSummary: String?") &&
             sendSheetSource.contains("line.jobName?.trimmingCharacters(in: .whitespacesAndNewlines)") &&
             sendSheetSource.contains("return jobNames.joined(separator: \", \")"),
             "Supplier email content should derive a stable, deduplicated related-job summary from PO line job names."
         )
         XCTAssertTrue(
             sendSheetSource.contains("let isGroupedSend = groupEnabled && !includedSiblingIds.isEmpty") &&
-            sendSheetSource.contains("let jobSuffix = isGroupedSend ? \"\" : (relatedJobSummary.map { \" — Job: \\($0)\" } ?? \"\")") &&
-            sendSheetSource.contains("if !isGroupedSend, let relatedJobSummary") &&
+            sendSheetSource.contains("let jobSuffix = isGroupedSend ? \"\" : (po.supplierRelatedJobSummary.map { \" — Job: \\($0)\" } ?? \"\")") &&
+            sendSheetSource.contains("if !isGroupedSend, let relatedJobSummary = po.supplierRelatedJobSummary") &&
             sendSheetSource.contains("lines.append(\"Re: \\(relatedJobSummary)\")"),
             "Supplier email subject and body should surface related job context for single-PO sends without implying primary-only jobs apply to grouped sibling POs."
         )
         XCTAssertTrue(
-            pdfGeneratorSource.contains("private var relatedJobSummary: String?") &&
-            pdfGeneratorSource.contains("if let relatedJobSummary { metaRow(\"Related Job(s):\", relatedJobSummary) }"),
+            pdfGeneratorSource.contains("po.supplierRelatedJobSummary") &&
+            pdfGeneratorSource.contains("if let relatedJobSummary = po.supplierRelatedJobSummary { metaRow(\"Related Job(s):\", relatedJobSummary) }"),
             "Supplier PDF meta block should include a Related Job(s) row when PO lines are job-linked."
         )
     }

--- a/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
@@ -192,6 +192,28 @@ final class OrdersSessionUnavailableRegressionTests: XCTestCase {
         )
     }
 
+    func testSupplierEmailElevatesRelatedJobContext() throws {
+        let sendSheetSource = try Self.readOrdersSource(named: "POSendToSupplierSheet.swift")
+        let pdfGeneratorSource = try Self.readOrdersSource(named: "POPDFGenerator.swift")
+
+        XCTAssertTrue(
+            sendSheetSource.contains("private var relatedJobSummary: String?") &&
+            sendSheetSource.contains("line.jobName?.trimmingCharacters(in: .whitespacesAndNewlines)") &&
+            sendSheetSource.contains("return jobNames.joined(separator: \", \")"),
+            "Supplier email content should derive a stable, deduplicated related-job summary from PO line job names."
+        )
+        XCTAssertTrue(
+            sendSheetSource.contains("let jobSuffix = relatedJobSummary.map { \" — Job: \\($0)\" } ?? \"\"") &&
+            sendSheetSource.contains("lines.append(\"Re: \\(relatedJobSummary)\")"),
+            "Supplier email subject and body should surface related job context before supplier triage."
+        )
+        XCTAssertTrue(
+            pdfGeneratorSource.contains("private var relatedJobSummary: String?") &&
+            pdfGeneratorSource.contains("if let relatedJobSummary { metaRow(\"Related Job(s):\", relatedJobSummary) }"),
+            "Supplier PDF meta block should include a Related Job(s) row when PO lines are job-linked."
+        )
+    }
+
     private static func readOrdersSource(named filename: String, file: StaticString = #filePath) throws -> String {
         let testFileURL = URL(fileURLWithPath: "\(file)")
         let projectRoot = testFileURL

--- a/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
@@ -203,9 +203,11 @@ final class OrdersSessionUnavailableRegressionTests: XCTestCase {
             "Supplier email content should derive a stable, deduplicated related-job summary from PO line job names."
         )
         XCTAssertTrue(
-            sendSheetSource.contains("let jobSuffix = relatedJobSummary.map { \" — Job: \\($0)\" } ?? \"\"") &&
+            sendSheetSource.contains("let isGroupedSend = groupEnabled && !includedSiblingIds.isEmpty") &&
+            sendSheetSource.contains("let jobSuffix = isGroupedSend ? \"\" : (relatedJobSummary.map { \" — Job: \\($0)\" } ?? \"\")") &&
+            sendSheetSource.contains("if !isGroupedSend, let relatedJobSummary") &&
             sendSheetSource.contains("lines.append(\"Re: \\(relatedJobSummary)\")"),
-            "Supplier email subject and body should surface related job context before supplier triage."
+            "Supplier email subject and body should surface related job context for single-PO sends without implying primary-only jobs apply to grouped sibling POs."
         )
         XCTAssertTrue(
             pdfGeneratorSource.contains("private var relatedJobSummary: String?") &&


### PR DESCRIPTION
## Summary
- add deduplicated related-job summaries for PO supplier emails
- append related job context to single-PO supplier email subjects and add a `Re:` line to the body
- suppress primary-only job context on grouped sends until sibling PO details are loaded so grouped emails do not imply incomplete job coverage
- add `Related Job(s):` to generated PO PDF metadata through a shared PODetail helper
- add an iOS source regression test for the email/PDF context contract

Closes #1110

## Verification
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `xcodebuild -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -only-testing:"Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests/testSupplierEmailElevatesRelatedJobContext" test` (`** TEST SUCCEEDED **`)
- Prior branch verification before the grouped-send review fix: `cd core && swift test --filter OrdersServiceTests`, iOS OrdersSessionUnavailableRegressionTests, and iOS simulator build per earlier PR body.

## CI / local runner path
This PR is intended to validate on the WPR2 local self-hosted Mac runner path for trusted iOS/Xcode work (`/Users/IA/actions-runner/Weird-Part-Run-2`, labels include macOS/xcode/ios/arm64/local-mac) rather than depending on GitHub-hosted Actions capacity.