### PR TITLE
fix: restore receiving route state on resume

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -1049,13 +1049,14 @@ struct IOSReceiveShipmentPage: View {
             // Otherwise fall back to expectedQty so fresh sessions are pre-filled (61L).
             for item in sessionItems {
                 let restoredReceivedQty = item.receivedQty > 0 ? item.receivedQty : item.expectedQty
+                let currentReceivedQty = receivedQtys[item.id] ?? restoredReceivedQty
                 if receivedQtys[item.id] == nil {
                     receivedQtys[item.id] = restoredReceivedQty
                 }
                 if routingResults[item.id] == nil,
                    let disposition = item.routingDisposition,
-                   restoredReceivedQty > 0,
-                   item.routedQty >= restoredReceivedQty {
+                   currentReceivedQty > 0,
+                   item.routedQty >= currentReceivedQty {
                     routingResults[item.id] = RoutingResult(disposition: disposition)
                 }
             }
@@ -1194,10 +1195,12 @@ struct IOSReceiveShipmentPage: View {
                 let returnCount = routingResults.values.filter { result in
                     result.isReturn
                 }.count
+                let otherCount = routedCount - stagedCount - shelfCount - returnCount
                 var parts: [String] = []
                 if stagedCount > 0 { parts.append("\(stagedCount) routed to staging") }
                 if shelfCount > 0 { parts.append("\(shelfCount) shelved") }
                 if returnCount > 0 { parts.append("\(returnCount) returning") }
+                if otherCount > 0 { parts.append("\(otherCount) routed for review") }
                 summary = "Receiving complete. \(routedCount)/\(totalCount) items routed: \(parts.joined(separator: ", "))."
             } else {
                 summary = "Receiving complete. Stock has been updated."

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -52,65 +52,149 @@ struct IOSReceiveShipmentPage: View {
 
     /// Summary of a completed routing decision for display.
     private struct RoutingResult {
-        let route: WarehouseService.ReceivingRoute
+        private enum Source {
+            case live(WarehouseService.ReceivingRoute)
+            case persisted(WarehouseService.ReceivingRoutingDisposition)
+        }
+
+        private let source: Source
+
+        init(route: WarehouseService.ReceivingRoute) {
+            self.source = .live(route)
+        }
+
+        init(disposition: WarehouseService.ReceivingRoutingDisposition) {
+            self.source = .persisted(disposition)
+        }
+
         var label: String {
-            switch route {
-            case .stageForJob(_, let jobName, _):
-                "Staged for \(jobName)"
-            case .suggestStaging(let demands):
-                "Staged for \(demands.first?.jobName ?? "job")"
-            case .restockShelf:
-                "Put on shelf"
-            case .recommendReturn:
-                "Return recommended"
-            case .returnOverstock:
-                "Return (overstocked)"
-            case .usedToShelf:
-                "Used - shelved"
-            case .usedWriteOff:
-                "Used - written off"
-            case .damagedReturn:
-                "Damaged - returning"
-            case .wrongPart:
-                "Wrong part"
-            case .jobReturnHolding:
-                "Job return held"
-            case .jobReturnDamagedReview:
-                "Job return damaged review"
-            case .jobReturnSupplierReview:
-                "Job return supplier review"
-            case .jobReturnWrongPartReview:
-                "Job return wrong part review"
+            switch source {
+            case .live(let route):
+                switch route {
+                case .stageForJob(_, let jobName, _):
+                    "Staged for \(jobName)"
+                case .suggestStaging(let demands):
+                    "Staged for \(demands.first?.jobName ?? "job")"
+                case .restockShelf:
+                    "Put on shelf"
+                case .recommendReturn:
+                    "Return recommended"
+                case .returnOverstock:
+                    "Return (overstocked)"
+                case .usedToShelf:
+                    "Used - shelved"
+                case .usedWriteOff:
+                    "Used - written off"
+                case .damagedReturn:
+                    "Damaged - returning"
+                case .wrongPart:
+                    "Wrong part"
+                case .jobReturnHolding:
+                    "Job return held"
+                case .jobReturnDamagedReview:
+                    "Job return damaged review"
+                case .jobReturnSupplierReview:
+                    "Job return supplier review"
+                case .jobReturnWrongPartReview:
+                    "Job return wrong part review"
+                }
+            case .persisted(let disposition):
+                switch disposition {
+                case .staged:
+                    "Routed to staging"
+                case .supplierReturn:
+                    "Return recorded"
+                case .writeOff:
+                    "Written off"
+                case .wrongPart:
+                    "Wrong part"
+                case .review:
+                    "Needs review"
+                }
             }
         }
         var icon: String {
-            switch route {
-            case .stageForJob, .suggestStaging: "tray.and.arrow.down.fill"
-            case .restockShelf, .usedToShelf: "archivebox.fill"
-            case .recommendReturn, .returnOverstock: "arrow.uturn.backward.circle.fill"
-            case .usedWriteOff: "xmark.bin.fill"
-            case .damagedReturn: "exclamationmark.triangle.fill"
-            case .wrongPart: "questionmark.circle.fill"
-            case .jobReturnHolding: "tray.full.fill"
-            case .jobReturnDamagedReview: "exclamationmark.triangle.fill"
-            case .jobReturnSupplierReview: "arrow.uturn.backward.circle.fill"
-            case .jobReturnWrongPartReview: "questionmark.circle.fill"
+            switch source {
+            case .live(let route):
+                switch route {
+                case .stageForJob, .suggestStaging: "tray.and.arrow.down.fill"
+                case .restockShelf, .usedToShelf: "archivebox.fill"
+                case .recommendReturn, .returnOverstock: "arrow.uturn.backward.circle.fill"
+                case .usedWriteOff: "xmark.bin.fill"
+                case .damagedReturn: "exclamationmark.triangle.fill"
+                case .wrongPart: "questionmark.circle.fill"
+                case .jobReturnHolding: "tray.full.fill"
+                case .jobReturnDamagedReview: "exclamationmark.triangle.fill"
+                case .jobReturnSupplierReview: "arrow.uturn.backward.circle.fill"
+                case .jobReturnWrongPartReview: "questionmark.circle.fill"
+                }
+            case .persisted(let disposition):
+                switch disposition {
+                case .staged: "tray.and.arrow.down.fill"
+                case .supplierReturn: "arrow.uturn.backward.circle.fill"
+                case .writeOff: "xmark.bin.fill"
+                case .wrongPart: "questionmark.circle.fill"
+                case .review: "exclamationmark.triangle.fill"
+                }
             }
         }
         var color: Color {
-            switch route {
-            case .stageForJob, .suggestStaging: .purple
-            case .restockShelf: .green
-            case .recommendReturn: .orange
-            case .returnOverstock: .red
-            case .usedToShelf: .green
-            case .usedWriteOff: .orange
-            case .damagedReturn: .red
-            case .wrongPart: .red
-            case .jobReturnHolding: .blue
-            case .jobReturnDamagedReview: .red
-            case .jobReturnSupplierReview: .orange
-            case .jobReturnWrongPartReview: .red
+            switch source {
+            case .live(let route):
+                switch route {
+                case .stageForJob, .suggestStaging: .purple
+                case .restockShelf: .green
+                case .recommendReturn: .orange
+                case .returnOverstock: .red
+                case .usedToShelf: .green
+                case .usedWriteOff: .orange
+                case .damagedReturn: .red
+                case .wrongPart: .red
+                case .jobReturnHolding: .blue
+                case .jobReturnDamagedReview: .red
+                case .jobReturnSupplierReview: .orange
+                case .jobReturnWrongPartReview: .red
+                }
+            case .persisted(let disposition):
+                switch disposition {
+                case .staged: .purple
+                case .supplierReturn: .orange
+                case .writeOff: .orange
+                case .wrongPart: .red
+                case .review: .red
+                }
+            }
+        }
+
+        var isStaged: Bool {
+            switch source {
+            case .live(.stageForJob), .live(.suggestStaging):
+                true
+            case .persisted(.staged):
+                true
+            default:
+                false
+            }
+        }
+
+        var isShelf: Bool {
+            switch source {
+            case .live(.restockShelf), .live(.usedToShelf):
+                true
+            default:
+                false
+            }
+        }
+
+        var isReturn: Bool {
+            switch source {
+            case .live(.recommendReturn), .live(.returnOverstock), .live(.damagedReturn),
+                 .live(.jobReturnDamagedReview), .live(.jobReturnSupplierReview):
+                true
+            case .persisted(.supplierReturn):
+                true
+            default:
+                false
             }
         }
     }
@@ -958,12 +1042,21 @@ struct IOSReceiveShipmentPage: View {
         }
         do {
             sessionItems = try service.getSessionItems(sessionId: sessionId)
+            let currentItemIds = Set(sessionItems.map(\.id))
+            routingResults = routingResults.filter { currentItemIds.contains($0.key) }
             // Restore saved quantities from DB (PE-041: auto-save draft persistence).
             // If the item has a saved receivedQty > 0, use it (resumed session).
             // Otherwise fall back to expectedQty so fresh sessions are pre-filled (61L).
             for item in sessionItems {
+                let restoredReceivedQty = item.receivedQty > 0 ? item.receivedQty : item.expectedQty
                 if receivedQtys[item.id] == nil {
-                    receivedQtys[item.id] = item.receivedQty > 0 ? item.receivedQty : item.expectedQty
+                    receivedQtys[item.id] = restoredReceivedQty
+                }
+                if routingResults[item.id] == nil,
+                   let disposition = item.routingDisposition,
+                   restoredReceivedQty > 0,
+                   item.routedQty >= restoredReceivedQty {
+                    routingResults[item.id] = RoutingResult(disposition: disposition)
                 }
             }
             postAIContext()
@@ -1093,26 +1186,16 @@ struct IOSReceiveShipmentPage: View {
             let summary: String
             if routedCount > 0 {
                 let stagedCount = routingResults.values.filter { result in
-                    switch result.route {
-                    case .stageForJob, .suggestStaging: return true
-                    default: return false
-                    }
+                    result.isStaged
                 }.count
                 let shelfCount = routingResults.values.filter { result in
-                    switch result.route {
-                    case .restockShelf, .usedToShelf: return true
-                    default: return false
-                    }
+                    result.isShelf
                 }.count
                 let returnCount = routingResults.values.filter { result in
-                    switch result.route {
-                    case .recommendReturn, .returnOverstock, .damagedReturn: return true
-                    case .jobReturnDamagedReview, .jobReturnSupplierReview: return true
-                    default: return false
-                    }
+                    result.isReturn
                 }.count
                 var parts: [String] = []
-                if stagedCount > 0 { parts.append("\(stagedCount) staged for jobs") }
+                if stagedCount > 0 { parts.append("\(stagedCount) routed to staging") }
                 if shelfCount > 0 { parts.append("\(shelfCount) shelved") }
                 if returnCount > 0 { parts.append("\(returnCount) returning") }
                 summary = "Receiving complete. \(routedCount)/\(totalCount) items routed: \(parts.joined(separator: ", "))."

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -1565,6 +1565,10 @@ public final class WarehouseService: Sendable {
         public let unitPrice: Double?
         public let scannedAt: String?
         public let notes: String?
+        public let routingDisposition: ReceivingRoutingDisposition?
+        public let routedQty: Int
+        public let routedBy: Int64?
+        public let routedAt: String?
     }
 
     /// Explicit source for receiving/routing work. Job returns are intentionally
@@ -1783,7 +1787,8 @@ public final class WarehouseService: Sendable {
                     arguments: [sessionId]
                 )
                 return rows.map { row in
-                    ReceivingItemInfo(
+                    let routingDispositionRaw = row["routing_disposition"] as String?
+                    return ReceivingItemInfo(
                         id: row["id"] ?? 0,
                         sessionId: row["session_id"] ?? 0,
                         poLineId: row["po_line_id"] ?? 0,
@@ -1795,7 +1800,11 @@ public final class WarehouseService: Sendable {
                         actualCost: row["actual_cost"] as Double?,
                         unitPrice: row["unit_cost"] as Double?,
                         scannedAt: row["scanned_at"] as String?,
-                        notes: row["notes"] as String?
+                        notes: row["notes"] as String?,
+                        routingDisposition: routingDispositionRaw.flatMap(ReceivingRoutingDisposition.init(rawValue:)),
+                        routedQty: row["routed_qty"] ?? 0,
+                        routedBy: row["routed_by"] as Int64?,
+                        routedAt: row["routed_at"] as String?
                     )
                 }
             }

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -1393,6 +1393,39 @@ struct WarehouseServiceExtTests {
         }
     }
 
+    @Test("getSessionItems restores persisted routing state for resumed receiving sessions")
+    func testSessionItemsIncludePersistedRoutingState() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        let supplierId = try E2ETestHelpers.seedSupplier(env)
+        let poId = try env.orders.createPurchaseOrder(
+            poNumber: "PO-ROUTE-RESUME",
+            supplierId: supplierId
+        )
+        _ = try env.orders.addPOLineItem(poId: poId, partId: partId, quantity: 4, unitPrice: 2.50)
+
+        let sessionId = try env.warehouse.startReceivingSession(
+            poId: poId,
+            startedBy: env.adminUserId
+        )
+        let item = try #require(try env.warehouse.getSessionItems(sessionId: sessionId).first)
+        try env.warehouse.updateSessionItem(itemId: item.id, receivedQty: 3)
+        try env.warehouse.markReceivingSessionItemRouted(
+            itemId: item.id,
+            disposition: .staged,
+            routedQty: 3,
+            routedBy: env.adminUserId
+        )
+
+        let resumedItem = try #require(try env.warehouse.getSessionItems(sessionId: sessionId).first)
+        #expect(resumedItem.receivedQty == 3)
+        #expect(resumedItem.routingDisposition == .staged)
+        #expect(resumedItem.routedQty == 3)
+        #expect(resumedItem.routedBy == env.adminUserId)
+        #expect(resumedItem.routedAt != nil)
+    }
+
     // MARK: - Audit Sessions
 
     @Test("createAuditSession returns a valid session ID")


### PR DESCRIPTION
## Summary
- expose persisted receiving route metadata from `WarehouseService.getSessionItems`
- rebuild resumed receiving-page route badges/progress from persisted route dispositions
- add regression coverage that a routed receiving-session item reloads with disposition, routed quantity, routed actor, and route timestamp

Closes #1136

## Tests
- `swift test --filter WarehouseServiceExtTests/testSessionItemsIncludePersistedRoutingState`
- `swift test --filter WarehouseServiceExtTests/testReceivingSession --filter WarehouseServiceExtTests/testReceivingCompletionUpdatesOrderLifecycle --filter WarehouseServiceExtTests/testSessionItemsUnitCost --filter WarehouseServiceExtTests/testSessionItemsIncludePersistedRoutingState`
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `cd core && swift test`
- `xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build 2>&1 | grep -E "error:|warning:|BUILD SUCCEEDED|BUILD FAILED"` (succeeded; existing warnings only)
