### PR TITLE
fix: preserve partial receiving route resume state

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -60,9 +60,9 @@ struct IOSReceiveShipmentPage: View {
         private let source: Source
         private let routedQty: Int?
 
-        init(route: WarehouseService.ReceivingRoute) {
+        init(route: WarehouseService.ReceivingRoute, routedQty: Int) {
             self.source = .live(route)
-            self.routedQty = nil
+            self.routedQty = routedQty
         }
 
         init(disposition: WarehouseService.ReceivingRoutingDisposition, routedQty: Int) {
@@ -305,7 +305,8 @@ struct IOSReceiveShipmentPage: View {
                         poLineId: item.poLineId,
                         receivedQty: receivedQtys[item.id] ?? item.expectedQty,
                         onRouteComplete: { route in
-                            routingResults[item.id] = RoutingResult(route: route)
+                            let routedQty = receivedQtys[item.id] ?? item.expectedQty
+                            routingResults[item.id] = RoutingResult(route: route, routedQty: routedQty)
                         },
                         onDismiss: {
                             activeSheet = nil

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -206,16 +206,24 @@ struct IOSReceiveShipmentPage: View {
         }
     }
 
-    private func isFullyRouted(_ item: WarehouseService.ReceivingItemInfo) -> Bool {
-        let qty = receivedQtys[item.id] ?? 0
-        return qty > 0 && (routingResults[item.id]?.covers(receivedQty: qty) ?? false)
-    }
-
     /// Items that have been received (qty > 0) but not yet fully routed (62H).
     private var unroutedItems: [WarehouseService.ReceivingItemInfo] {
         sessionItems.filter { item in
             let qty = receivedQtys[item.id] ?? 0
             return qty > 0 && !(routingResults[item.id]?.covers(receivedQty: qty) ?? false)
+        }
+    }
+
+    private var receivedItems: [WarehouseService.ReceivingItemInfo] {
+        sessionItems.filter { item in
+            (receivedQtys[item.id] ?? 0) > 0
+        }
+    }
+
+    private var fullyRoutedReceivedItems: [WarehouseService.ReceivingItemInfo] {
+        receivedItems.filter { item in
+            let qty = receivedQtys[item.id] ?? 0
+            return routingResults[item.id]?.covers(receivedQty: qty) ?? false
         }
     }
 
@@ -656,20 +664,20 @@ struct IOSReceiveShipmentPage: View {
     // MARK: - Routing Progress Summary
 
     private var routingProgressSummary: some View {
-        let routedCount = sessionItems.filter(isFullyRouted).count
-        let totalCount = sessionItems.count
-        let allRouted = routedCount == totalCount
+        let routedCount = fullyRoutedReceivedItems.count
+        let totalCount = receivedItems.count
+        let allRouted = totalCount > 0 && routedCount == totalCount
 
         return VStack(alignment: .leading, spacing: 8) {
             HStack {
                 Image(systemName: allRouted ? "checkmark.circle.fill" : "arrow.triangle.branch")
                     .foregroundStyle(allRouted ? .green : .blue)
-                Text("\(routedCount)/\(totalCount) items fully routed")
+                Text("\(routedCount)/\(totalCount) received items fully routed")
                     .font(.subheadline)
                     .fontWeight(.medium)
                 Spacer()
                 if allRouted {
-                    Text("All routed")
+                    Text("All received quantities routed")
                         .font(.caption)
                         .foregroundStyle(.green)
                 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -58,7 +58,7 @@ struct IOSReceiveShipmentPage: View {
         }
 
         private let source: Source
-        private let routedQty: Int?
+        private let routedQty: Int
 
         init(route: WarehouseService.ReceivingRoute, routedQty: Int) {
             self.source = .live(route)
@@ -202,9 +202,13 @@ struct IOSReceiveShipmentPage: View {
         }
 
         func covers(receivedQty: Int) -> Bool {
-            guard let routedQty else { return true }
             return routedQty >= receivedQty
         }
+    }
+
+    private func isFullyRouted(_ item: WarehouseService.ReceivingItemInfo) -> Bool {
+        let qty = receivedQtys[item.id] ?? 0
+        return qty > 0 && (routingResults[item.id]?.covers(receivedQty: qty) ?? false)
     }
 
     /// Items that have been received (qty > 0) but not yet fully routed (62H).
@@ -645,14 +649,14 @@ struct IOSReceiveShipmentPage: View {
             }
             Button("Go Back and Route Items", role: .cancel) { }
         } message: {
-            Text("\(unroutedItems.count) item\(unroutedItems.count == 1 ? " has" : "s have") been received but not routed to a location. Continue anyway?")
+            Text("\(unroutedItems.count) item\(unroutedItems.count == 1 ? " has" : "s have") received quantities that are not fully routed. Continue anyway?")
         }
     }
 
     // MARK: - Routing Progress Summary
 
     private var routingProgressSummary: some View {
-        let routedCount = routingResults.count
+        let routedCount = sessionItems.filter(isFullyRouted).count
         let totalCount = sessionItems.count
         let allRouted = routedCount == totalCount
 
@@ -660,7 +664,7 @@ struct IOSReceiveShipmentPage: View {
             HStack {
                 Image(systemName: allRouted ? "checkmark.circle.fill" : "arrow.triangle.branch")
                     .foregroundStyle(allRouted ? .green : .blue)
-                Text("\(routedCount)/\(totalCount) items routed")
+                Text("\(routedCount)/\(totalCount) items fully routed")
                     .font(.subheadline)
                     .fontWeight(.medium)
                 Spacer()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -58,13 +58,16 @@ struct IOSReceiveShipmentPage: View {
         }
 
         private let source: Source
+        private let routedQty: Int?
 
         init(route: WarehouseService.ReceivingRoute) {
             self.source = .live(route)
+            self.routedQty = nil
         }
 
-        init(disposition: WarehouseService.ReceivingRoutingDisposition) {
+        init(disposition: WarehouseService.ReceivingRoutingDisposition, routedQty: Int) {
             self.source = .persisted(disposition)
+            self.routedQty = routedQty
         }
 
         var label: String {
@@ -197,13 +200,18 @@ struct IOSReceiveShipmentPage: View {
                 false
             }
         }
+
+        func covers(receivedQty: Int) -> Bool {
+            guard let routedQty else { return true }
+            return routedQty >= receivedQty
+        }
     }
 
-    /// Items that have been received (qty > 0) but not yet routed (62H).
+    /// Items that have been received (qty > 0) but not yet fully routed (62H).
     private var unroutedItems: [WarehouseService.ReceivingItemInfo] {
         sessionItems.filter { item in
             let qty = receivedQtys[item.id] ?? 0
-            return qty > 0 && routingResults[item.id] == nil
+            return qty > 0 && !(routingResults[item.id]?.covers(receivedQty: qty) ?? false)
         }
     }
 
@@ -1056,8 +1064,8 @@ struct IOSReceiveShipmentPage: View {
                 if routingResults[item.id] == nil,
                    let disposition = item.routingDisposition,
                    currentReceivedQty > 0,
-                   item.routedQty >= currentReceivedQty {
-                    routingResults[item.id] = RoutingResult(disposition: disposition)
+                   item.routedQty > 0 {
+                    routingResults[item.id] = RoutingResult(disposition: disposition, routedQty: item.routedQty)
                 }
             }
             postAIContext()
@@ -1200,8 +1208,8 @@ struct IOSReceiveShipmentPage: View {
                 if stagedCount > 0 { parts.append("\(stagedCount) routed to staging") }
                 if shelfCount > 0 { parts.append("\(shelfCount) shelved") }
                 if returnCount > 0 { parts.append("\(returnCount) returning") }
-                if otherCount > 0 { parts.append("\(otherCount) routed for review") }
-                summary = "Receiving complete. \(routedCount)/\(totalCount) items routed: \(parts.joined(separator: ", "))."
+                if otherCount > 0 { parts.append("\(otherCount) routed other ways") }
+                summary = "Receiving complete. \(routedCount)/\(totalCount) items with routes: \(parts.joined(separator: ", "))."
             } else {
                 summary = "Receiving complete. Stock has been updated."
             }


### PR DESCRIPTION
## Summary
- follow-up to PR #1282 Copilot review after GH #1136 was closed
- keep partial persisted routes visible after resume while still warning when routed quantity does not cover the current received quantity
- use neutral completion summary wording for routed dispositions outside staging/shelf/return

Refs #1136
Follow-up to #1282

## Tests
- git diff --check origin/main...HEAD
- python3 scripts/guard-tracked-artifacts.py
- cd core && swift test --filter WarehouseServiceExtTests/testSessionItemsIncludePersistedRoutingState
- xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build (succeeded; existing unrelated warnings only)
