### PR TITLE
fix: preserve zero receiving quantity on resume

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -1045,10 +1045,11 @@ struct IOSReceiveShipmentPage: View {
             let currentItemIds = Set(sessionItems.map(\.id))
             routingResults = routingResults.filter { currentItemIds.contains($0.key) }
             // Restore saved quantities from DB (PE-041: auto-save draft persistence).
-            // If the item has a saved receivedQty > 0, use it (resumed session).
-            // Otherwise fall back to expectedQty so fresh sessions are pre-filled (61L).
+            // `receivedQty == 0` is a valid saved draft value after Clear All or a
+            // manual zero count. Use scannedAt as the persisted-touch marker so
+            // untouched fresh-session rows still pre-fill from expectedQty.
             for item in sessionItems {
-                let restoredReceivedQty = item.receivedQty > 0 ? item.receivedQty : item.expectedQty
+                let restoredReceivedQty = item.scannedAt == nil ? item.expectedQty : item.receivedQty
                 let currentReceivedQty = receivedQtys[item.id] ?? restoredReceivedQty
                 if receivedQtys[item.id] == nil {
                     receivedQtys[item.id] = restoredReceivedQty

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -1426,6 +1426,35 @@ struct WarehouseServiceExtTests {
         #expect(resumedItem.routedAt != nil)
     }
 
+    @Test("getSessionItems marks an explicitly saved zero receiving quantity as touched")
+    func testSessionItemsPreserveTouchedZeroQuantityForResume() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        let supplierId = try E2ETestHelpers.seedSupplier(env)
+        let poId = try env.orders.createPurchaseOrder(
+            poNumber: "PO-ZERO-RESUME",
+            supplierId: supplierId
+        )
+        _ = try env.orders.addPOLineItem(poId: poId, partId: partId, quantity: 4, unitPrice: 2.50)
+
+        let sessionId = try env.warehouse.startReceivingSession(
+            poId: poId,
+            startedBy: env.adminUserId
+        )
+        let item = try #require(try env.warehouse.getSessionItems(sessionId: sessionId).first)
+        #expect(item.expectedQty == 4)
+        #expect(item.receivedQty == 0)
+        #expect(item.scannedAt == nil)
+
+        try env.warehouse.updateSessionItem(itemId: item.id, receivedQty: 0)
+
+        let resumedItem = try #require(try env.warehouse.getSessionItems(sessionId: sessionId).first)
+        #expect(resumedItem.expectedQty == 4)
+        #expect(resumedItem.receivedQty == 0)
+        #expect(resumedItem.scannedAt != nil)
+    }
+
     // MARK: - Audit Sessions
 
     @Test("createAuditSession returns a valid session ID")


### PR DESCRIPTION
## Summary
- Fix Receive Shipment resume state so an explicitly saved zero count stays zero instead of being replaced by the expected PO quantity.
- Use `scannedAt` as the persisted-touch marker: fresh untouched receiving-session rows still prefill expected quantity, while Clear All/manual zero rows restore `receivedQty`.
- Add a WarehouseService regression test proving a saved zero quantity is returned with a touch marker for resume flows.

Closes #1161

## Tests
- `swift test --filter WarehouseServiceExtTests/testSessionItemsPreserveTouchedZeroQuantityForResume`
- `swift test --filter WarehouseServiceExtTests`
- `swift test`
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build` (succeeded with existing warnings)

## Local runner / CI note
This PR is ready for the WPR2 local self-hosted Mac runner path (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`) for required iOS/Xcode validation.