### PR TITLE
fix: return configured storage units

### DIFF
--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -4944,7 +4944,7 @@ public final class WarehouseService: Sendable {
         let rowNumber = String(format: "R%02d", 1)
         let unitNumber = String(format: "U%02d", unitIndex)
 
-        let unit = try addStorageUnit(
+        var unit = try addStorageUnit(
             floorPlanId: floorPlanId,
             name: name,
             unitType: unitType,
@@ -4972,6 +4972,7 @@ public final class WarehouseService: Sendable {
         }
 
         try updateStorageUnit(id: unitId, isConfigured: true)
+        unit.isConfigured = true
 
         return unit
     }

--- a/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseServiceExtTests.swift
@@ -1770,10 +1770,14 @@ struct WarehouseServiceExtTests {
             areasPerLevel: 4
         )
         #expect(unit.id != nil)
+        #expect(unit.isConfigured)
 
         // Verify levels were created
         let levels = try env.warehouse.listLevelsForUnit(unitId: unit.id!)
         #expect(levels.count == 3)
+
+        let persistedUnit = try #require(try env.warehouse.listStorageUnits(floorPlanId: plan.id!).first { $0.id == unit.id })
+        #expect(persistedUnit.isConfigured)
 
         // Verify areas under the first level
         let areas = try env.warehouse.listAreasForLevel(levelId: levels[0].id!)


### PR DESCRIPTION
## Summary
- Return the updated configured storage unit from `WarehouseService.createStorageUnit` after hierarchy creation marks it configured.
- Extend the storage hierarchy regression test to assert both the returned value and persisted row are configured.

Closes #1164

## Tests
- `swift test --filter WarehouseServiceExtTests/testCreateStorageUnit`
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `cd core && swift test`

## CI / runner note
- Verified the local self-hosted Mac runner path is available: `IA-Mac-WPR2` online with labels `self-hosted, macOS, ARM64, xcode, ios, local-mac`.
- This is a Swift core service/test-only change; no UI smoke was required.
