### PR TITLE
fix: surface representative service failures

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Auth/CompanySetupWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/CompanySetupWizard.swift
@@ -707,7 +707,21 @@ struct CompanySetupWizard: View {
     // MARK: - Persistence (SQLite draft — no PII in UserDefaults)
 
     private func loadProgress() {
-        guard let draft = try? appCore.settingsService?.loadSetupDraft() else { return }
+        guard let settingsService = appCore.settingsService else {
+            saveError = "Settings are still loading. Please try again in a moment."
+            return
+        }
+
+        let draft: SettingsService.CompanySetupDraft?
+        do {
+            draft = try settingsService.loadSetupDraft()
+        } catch {
+            saveError = userFriendlyError(error, context: "load saved setup progress")
+            logger.error("loadSetupDraft failed; keeping setup wizard in a visible retryable state: \(error.localizedDescription)")
+            return
+        }
+
+        guard let draft else { return }
         completedSteps = draft.completedSteps
         skippedSteps = draft.skippedSteps
         companyName = draft.name

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
@@ -592,13 +592,17 @@ struct JobsListPage: View {
     // MARK: - Status Change
 
     private func updateJobStatus(job: JobsService.JobListItem, newStatus: String) {
-        guard let service = appCore.jobsService else { return }
+        guard let service = appCore.jobsService else {
+            loadError = "Jobs service is not available. Please try again in a moment."
+            quickStatusTarget = nil
+            return
+        }
         do {
             try service.updateJob(id: job.id, status: newStatus)
             quickStatusTarget = nil
             loadJobs()
         } catch {
-            loadError = "Could not update status: \(error.localizedDescription)"
+            loadError = userFriendlyError(error, context: "update job status")
             quickStatusTarget = nil
         }
     }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleCalendarPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleCalendarPage.swift
@@ -29,6 +29,7 @@ struct IOSScheduleCalendarPage: View {
     @State private var selectedDate = Date()
     @State private var searchText = ""
     @State private var loadError: String?
+    @State private var dayDetailError: String?
     private enum ActiveSheet: String, Identifiable {
         case createEntry
         case help
@@ -231,6 +232,9 @@ struct IOSScheduleCalendarPage: View {
         if isLoading {
             ProgressView("Loading...")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let dayDetailError {
+            ErrorStateView(message: dayDetailError) { loadDayDetail() }
+                .padding(.horizontal)
         } else if dayEntries.isEmpty && timeOffEntries.isEmpty {
             VStack(spacing: 8) {
                 Text(selectedDate, format: .dateTime.weekday(.wide).month().day())
@@ -580,12 +584,12 @@ struct IOSScheduleCalendarPage: View {
             return
         }
         let dateStr = selectedDateString
+        dayDetailError = nil
         do {
             dayEntries = try service.getScheduleEntriesForDate(date: dateStr)
             timeOffEntries = try service.getTimeOffForDate(date: dateStr)
         } catch {
-            dayEntries = []
-            timeOffEntries = []
+            dayDetailError = userFriendlyError(error, context: "load selected day schedule")
         }
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleCalendarPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleCalendarPage.swift
@@ -579,7 +579,7 @@ struct IOSScheduleCalendarPage: View {
 
     private func loadDayDetail() {
         guard let service = appCore.schedulingService else {
-            loadError = "Scheduling service not available"
+            dayDetailError = "Scheduling service not available"
             isLoading = false
             return
         }

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -58,6 +58,7 @@ final class IOSSyncManager {
     private var peerManager: PeerManager?
     private var multipeerManager: MultipeerManager?
     private var multipeerDiscoveryMode: PeerDiscoveryMode?
+    private var lastSurfacedSyncReadFailure: String?
 
     struct PeerInfo: Identifiable, Sendable {
         let id: String
@@ -105,6 +106,9 @@ final class IOSSyncManager {
 
     private func syncSettingsReadFailed(_ error: Error, context: String) {
         let message = userFriendlyError(error, context: context)
+        let failureKey = "\(context): \(message)"
+        guard lastSurfacedSyncReadFailure != failureKey else { return }
+        lastSurfacedSyncReadFailure = failureKey
         errorMessage = message
         logger.error("[IOSSyncManager] \(context) failed: \(error.localizedDescription)")
     }

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -23,7 +23,14 @@ final class IOSSyncManager {
     var syncProgressMessage: String?
     var syncProgressPercent: Double = 0
     var isPaired: Bool {
-        guard let map = try? settingsService?.getSettingsByCategory("sync") else {
+        guard let service = settingsService else {
+            return false
+        }
+        let map: [String: String]
+        do {
+            map = try service.getSettingsByCategory("sync")
+        } catch {
+            syncSettingsReadFailed(error, context: "load pairing status")
             return false
         }
         return !(map["device_pairing_verified_at"] ?? "").isEmpty
@@ -75,14 +82,31 @@ final class IOSSyncManager {
 
     /// Whether automatic launch/foreground sync is enabled by settings.
     var isAutoSyncEnabled: Bool {
-        (try? settingsService?.isAutoSyncEnabled()) ?? true
+        guard let service = settingsService else { return false }
+        do {
+            return try service.isAutoSyncEnabled()
+        } catch {
+            syncSettingsReadFailed(error, context: "load auto-sync setting")
+            return false
+        }
     }
 
     /// The configured shop server address from settings, or nil.
     private var serverAddress: String? {
         guard let service = settingsService else { return nil }
-        let addr = (try? service.getSettingsByCategory("sync"))?["shop_server_address"]
-        return Self.normalizedShopServerAddress(addr)
+        do {
+            let addr = try service.getSettingsByCategory("sync")["shop_server_address"]
+            return Self.normalizedShopServerAddress(addr)
+        } catch {
+            syncSettingsReadFailed(error, context: "load sync server address")
+            return nil
+        }
+    }
+
+    private func syncSettingsReadFailed(_ error: Error, context: String) {
+        let message = userFriendlyError(error, context: context)
+        errorMessage = message
+        logger.error("[IOSSyncManager] \(context) failed: \(error.localizedDescription)")
     }
 
     /// Trims a user-entered or persisted shop server address and rejects blank values.
@@ -584,22 +608,39 @@ final class IOSSyncManager {
 
     private func refreshPendingCount() {
         guard let db else { return }
-        pendingChanges = (try? ChangeTracker.getPendingChangeCount(db: db)) ?? 0
+        do {
+            pendingChanges = try ChangeTracker.getPendingChangeCount(db: db)
+        } catch {
+            errorMessage = userFriendlyError(error, context: "load pending sync changes")
+            logger.error("[IOSSyncManager] pending change count refresh failed: \(error.localizedDescription)")
+        }
     }
 
     /// Refresh and return the current unreviewed conflict count.
     @discardableResult
     func refreshConflictCount() -> Int {
         guard let db else { return 0 }
-        let stats = try? ConflictResolver.getConflictStats(db: db)
-        unreviewedConflictCount = stats?.unreviewed ?? 0
-        return stats?.last24h ?? 0
+        do {
+            let stats = try ConflictResolver.getConflictStats(db: db)
+            unreviewedConflictCount = stats.unreviewed
+            return stats.last24h
+        } catch {
+            errorMessage = userFriendlyError(error, context: "load sync conflict count")
+            logger.error("[IOSSyncManager] conflict count refresh failed: \(error.localizedDescription)")
+            return 0
+        }
     }
 
     /// Get unreviewed conflicts for the review page.
     func getUnreviewedConflicts() -> [ConflictLogEntry] {
         guard let db else { return [] }
-        return (try? ConflictResolver.getUnreviewedConflicts(db: db)) ?? []
+        do {
+            return try ConflictResolver.getUnreviewedConflicts(db: db)
+        } catch {
+            errorMessage = userFriendlyError(error, context: "load unreviewed sync conflicts")
+            logger.error("[IOSSyncManager] unreviewed conflict load failed: \(error.localizedDescription)")
+            return []
+        }
     }
 
     /// Mark a single conflict as reviewed.

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -980,7 +980,8 @@ struct Weird_Parts_IOSTests {
         let scheduleURL = repoRoot
             .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleCalendarPage.swift")
         let scheduleSource = try String(contentsOf: scheduleURL, encoding: .utf8)
-        #expect(!scheduleSource.contains("dayEntries = []\n            timeOffEntries = []"), "Selected-day schedule failures must not become an empty day")
+        #expect(scheduleSource.range(of: #"catch\s*\{\s*dayEntries\s*=\s*\[\]\s*timeOffEntries\s*=\s*\[\]"#, options: .regularExpression) == nil, "Selected-day schedule failures must not become an empty day")
+        #expect(scheduleSource.contains("dayDetailError = \"Scheduling service not available\""), "Selected-day service unavailability should render through the day-detail error surface")
         #expect(scheduleSource.contains("dayDetailError = userFriendlyError(error, context: \"load selected day schedule\")"))
         #expect(scheduleSource.contains("ErrorStateView(message: dayDetailError) { loadDayDetail() }"), "Selected-day detail failures should offer a retry")
 
@@ -994,6 +995,7 @@ struct Weird_Parts_IOSTests {
         #expect(syncSource.contains("syncSettingsReadFailed(error, context: \"load auto-sync setting\")"))
         #expect(syncSource.contains("syncSettingsReadFailed(error, context: \"load sync server address\")"))
         #expect(syncSource.contains("syncSettingsReadFailed(error, context: \"load pairing status\")"))
+        #expect(syncSource.contains("guard lastSurfacedSyncReadFailure != failureKey else { return }"), "Repeated sync setting read failures should not re-alert on every SwiftUI render")
         #expect(syncSource.contains("errorMessage = userFriendlyError(error, context: \"load sync conflict count\")"))
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -959,6 +959,44 @@ struct Weird_Parts_IOSTests {
         #expect(source.contains("loadError = userFriendlyError(error, context: \"create supplier channel\")"))
     }
 
+    @Test func silentFailureUmbrellaSurfacesRepresentativeErrors() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        let setupURL = repoRoot
+            .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Auth/CompanySetupWizard.swift")
+        let setupSource = try String(contentsOf: setupURL, encoding: .utf8)
+        #expect(!setupSource.contains("try? appCore.settingsService?.loadSetupDraft()"), "Setup draft load failures must not be swallowed as no saved progress")
+        #expect(setupSource.contains("saveError = userFriendlyError(error, context: \"load saved setup progress\")"))
+
+        let jobsURL = repoRoot
+            .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift")
+        let jobsSource = try String(contentsOf: jobsURL, encoding: .utf8)
+        #expect(!jobsSource.contains("guard let service = appCore.jobsService else { return }"), "Quick status service failures must not silently no-op")
+        #expect(jobsSource.contains("loadError = userFriendlyError(error, context: \"update job status\")"))
+
+        let scheduleURL = repoRoot
+            .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleCalendarPage.swift")
+        let scheduleSource = try String(contentsOf: scheduleURL, encoding: .utf8)
+        #expect(!scheduleSource.contains("dayEntries = []\n            timeOffEntries = []"), "Selected-day schedule failures must not become an empty day")
+        #expect(scheduleSource.contains("dayDetailError = userFriendlyError(error, context: \"load selected day schedule\")"))
+        #expect(scheduleSource.contains("ErrorStateView(message: dayDetailError) { loadDayDetail() }"), "Selected-day detail failures should offer a retry")
+
+        let syncURL = repoRoot
+            .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift")
+        let syncSource = try String(contentsOf: syncURL, encoding: .utf8)
+        #expect(!syncSource.contains("guard let map = try? settingsService?.getSettingsByCategory(\"sync\")"), "Pairing status failures must not silently show unpaired state")
+        #expect(!syncSource.contains("(try? settingsService?.isAutoSyncEnabled()) ?? true"), "Auto-sync setting failures must not default to enabled")
+        #expect(!syncSource.contains("let addr = (try? service.getSettingsByCategory(\"sync\"))?[\"shop_server_address\"]"), "Sync server-address failures must not default to nil silently")
+        #expect(!syncSource.contains("try? ConflictResolver.getConflictStats(db: db)"), "Conflict count failures must not silently show zero conflicts")
+        #expect(syncSource.contains("syncSettingsReadFailed(error, context: \"load auto-sync setting\")"))
+        #expect(syncSource.contains("syncSettingsReadFailed(error, context: \"load sync server address\")"))
+        #expect(syncSource.contains("syncSettingsReadFailed(error, context: \"load pairing status\")"))
+        #expect(syncSource.contains("errorMessage = userFriendlyError(error, context: \"load sync conflict count\")"))
+    }
+
     @Test func manualBackupSidecarCopyFailureIsReportedAndCleanedUp() throws {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("IOSBackupFileCopierTests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary
- surface setup-draft load failures in the company setup wizard instead of treating them as no saved progress
- route quick job status service failures and selected-day schedule detail failures to visible retry/error surfaces
- fail sync settings and conflict-count reads closed with `errorMessage`/logging instead of silent default state
- add a representative iOS regression test guarding the umbrella silent-failure fixes

Closes #1167

## Verification
- `xcodebuild -list -project "Weird Parts IOS/Weird Parts.xcodeproj"`
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'id=F29F2637-4865-4685-92B3-98D2F45EF30C' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/silentFailureUmbrellaSurfacesRepresentativeErrors"`
- `git diff --check`

## CI / local runner note
This PR is intended for the WPR2 local Mac Actions runner path for trusted iOS/Xcode validation (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`).
