### PR TITLE
fix: validate onboarding stock target hierarchy

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep6.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep6.swift
@@ -180,6 +180,7 @@ struct WarehouseWizardStep6: View {
             // Collect unique assigned parts across all areas
             var seenPartIds: Set<Int64> = []
             var parts: [PartForTargets] = []
+            targetValues = [:]
 
             for area in areas {
                 let contents = try service.getAreaContents(areaId: area.id)
@@ -217,20 +218,38 @@ struct WarehouseWizardStep6: View {
         }
     }
 
+    private func validateTargetHierarchy(_ values: WizardTargetValue, partName: String) throws {
+        guard values.min <= values.target else {
+            throw PartsService.PartsError.invalidInput("\(partName): MIN must be less than or equal to TARGET.")
+        }
+        guard values.target <= values.max else {
+            throw PartsService.PartsError.invalidInput("\(partName): TARGET must be less than or equal to MAX.")
+        }
+    }
+
     private func saveAllTargets() {
         guard let service = appCore.partsService else { stepError = "Parts service not available"; return }
         saveSuccess = false
 
         do {
-            for (partId, values) in targetValues {
+            for part in assignedParts {
+                if let values = targetValues[part.id] {
+                    try validateTargetHierarchy(values, partName: part.name)
+                }
+            }
+
+            for part in assignedParts {
+                guard let values = targetValues[part.id] else { continue }
                 try service.updatePart(
-                    id: partId,
+                    id: part.id,
                     minStockLevel: values.min,
                     maxStockLevel: values.max,
                     targetStockLevel: values.target
                 )
             }
             saveSuccess = true
+        } catch PartsService.PartsError.invalidInput(let message) {
+            stepError = message
         } catch {
             stepError = userFriendlyError(error, context: "save stock targets")
         }

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -1247,6 +1247,22 @@ public final class PartsService: Sendable {
         }
     }
 
+    private func validateStockTargetHierarchy(
+        minStockLevel: Int?,
+        maxStockLevel: Int?,
+        targetStockLevel: Int?
+    ) throws {
+        if let minStockLevel, let targetStockLevel, minStockLevel > targetStockLevel {
+            throw PartsError.invalidInput("Minimum stock must be less than or equal to target stock.")
+        }
+        if let targetStockLevel, let maxStockLevel, targetStockLevel > maxStockLevel {
+            throw PartsError.invalidInput("Target stock must be less than or equal to maximum stock.")
+        }
+        if let minStockLevel, let maxStockLevel, minStockLevel > maxStockLevel {
+            throw PartsError.invalidInput("Minimum stock must be less than or equal to maximum stock.")
+        }
+    }
+
     /// Create a new part. Returns the inserted row ID.
     @discardableResult
     public func createPart(
@@ -1286,6 +1302,11 @@ public final class PartsService: Sendable {
         if let m = minStockLevel { try Validators.requireNonNegative(m, field: "Min stock") }
         if let m = maxStockLevel { try Validators.requireNonNegative(m, field: "Max stock") }
         if let t = targetStockLevel { try Validators.requireNonNegative(t, field: "Target stock") }
+        try validateStockTargetHierarchy(
+            minStockLevel: minStockLevel,
+            maxStockLevel: maxStockLevel,
+            targetStockLevel: targetStockLevel
+        )
         if let r = reorderPoint { try Validators.requireNonNegative(r, field: "Reorder point") }
 
         // Guard: all referenced FK parents must exist and not be tombstoned.
@@ -1381,9 +1402,24 @@ public final class PartsService: Sendable {
         shelfLocation: String? = nil,
         binLocation: String? = nil
     ) throws {
-        // Read current values for change detection (non-fatal if fails)
-        let currentRow = try? db.writer.read { dbConn in
+        // Read current values for effective stock-target validation and audit change detection.
+        let currentRow = try db.writer.read { dbConn in
             try Row.fetchOne(dbConn, sql: "SELECT * FROM parts WHERE id = ?", arguments: [id])
+        }
+
+        if minStockLevel != nil || maxStockLevel != nil || targetStockLevel != nil {
+            if let m = minStockLevel { try Validators.requireNonNegative(m, field: "Min stock") }
+            if let m = maxStockLevel { try Validators.requireNonNegative(m, field: "Max stock") }
+            if let t = targetStockLevel { try Validators.requireNonNegative(t, field: "Target stock") }
+
+            let effectiveMin: Int? = minStockLevel ?? currentRow?["min_stock_level"]
+            let effectiveMax: Int? = maxStockLevel ?? currentRow?["max_stock_level"]
+            let effectiveTarget: Int? = targetStockLevel ?? currentRow?["target_stock_level"]
+            try validateStockTargetHierarchy(
+                minStockLevel: effectiveMin,
+                maxStockLevel: effectiveMax,
+                targetStockLevel: effectiveTarget
+            )
         }
 
         try db.writer.write { dbConn in

--- a/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
@@ -413,7 +413,7 @@ struct OrdersServiceTests {
             categoryId: catId,
             name: "Consolidated Demand Wire",
             minStockLevel: 5,
-            maxStockLevel: 6,
+            maxStockLevel: 12,
             targetStockLevel: 12
         )
         let supplierId = try E2ETestHelpers.seedSupplier(env, name: "Demand Supplier")

--- a/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
@@ -62,6 +62,58 @@ struct PartsServiceExtTests {
         try env.parts.deletePart(id: partId)
     }
 
+    @Test("Part stock targets require MIN <= TARGET <= MAX")
+    func testPartStockTargetHierarchyValidation() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "StockTargetValidation")
+
+        #expect(throws: PartsService.PartsError.invalidInput("Minimum stock must be less than or equal to target stock.")) {
+            _ = try env.parts.createPart(
+                categoryId: catId,
+                name: "Invalid New Stock Targets",
+                code: "INV-STOCK-NEW",
+                minStockLevel: 10,
+                maxStockLevel: 20,
+                targetStockLevel: 5
+            )
+        }
+
+        let partId = try env.parts.createPart(
+            categoryId: catId,
+            name: "Valid Stock Targets",
+            code: "VALID-STOCK",
+            minStockLevel: 2,
+            maxStockLevel: 10,
+            targetStockLevel: 5
+        )
+
+        #expect(throws: PartsService.PartsError.invalidInput("Target stock must be less than or equal to maximum stock.")) {
+            try env.parts.updatePart(id: partId, targetStockLevel: 12)
+        }
+
+        let unchanged = try env.parts.getPart(id: partId).part
+        #expect(unchanged.minStockLevel == 2)
+        #expect(unchanged.targetStockLevel == 5)
+        #expect(unchanged.maxStockLevel == 10)
+
+        try env.parts.updatePart(id: partId, minStockLevel: 4, maxStockLevel: 12, targetStockLevel: 8)
+        let updated = try env.parts.getPart(id: partId).part
+        #expect(updated.minStockLevel == 4)
+        #expect(updated.targetStockLevel == 8)
+        #expect(updated.maxStockLevel == 12)
+
+        let minMaxOnlyPartId = try env.parts.createPart(
+            categoryId: catId,
+            name: "Min Max Only Stock Targets",
+            code: "MIN-MAX-ONLY",
+            minStockLevel: 2,
+            maxStockLevel: 10
+        )
+        #expect(throws: PartsService.PartsError.invalidInput("Minimum stock must be less than or equal to maximum stock.")) {
+            try env.parts.updatePart(id: minMaxOnlyPartId, minStockLevel: 12)
+        }
+    }
+
     @Test("auto-add-to-wishlist flag defaults off and can be toggled by catalog editor")
     func testAutoAddToWishlistWhenLowToggle() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Adds central PartsService validation for stock target hierarchy so MIN/TARGET/MAX updates cannot persist inverted values.
- Pre-validates Warehouse onboarding target rows before saving so the wizard shows a clear part-specific error and avoids partial saves.
- Updates regression coverage and an existing procurement test fixture to use a valid stock target hierarchy.

Closes #1176

## Verification
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/guard-tracked-artifacts.py`
- `cd core && swift test --filter PartsServiceExtTests/testPartStockTargetHierarchyValidation`
- `cd core && swift test` (2221 tests / 67 suites)
- `xcodebuild -scheme WiredPart-iOS -destination 'generic/platform=iOS Simulator' build`

## CI / runner note
Local iOS/macOS validation used the repo's local Mac/Xcode test path; PR CI should run on the self-hosted Mac runner labels for trusted repo events.
