### PR TITLE
fix: validate stock target hierarchy

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep6.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseWizardStep6.swift
@@ -123,6 +123,12 @@ struct WarehouseWizardStep6: View {
                         targetInput("MAX", partId: part.id, keyPath: \.max)
                     }
 
+                    if let values = targetValues[part.id], !isValidTargetHierarchy(values) {
+                        Text("Targets must be non-negative and ordered MIN ≤ TARGET ≤ MAX.")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+
                     let suggestion = aiSuggestion(for: part)
                     Button {
                         targetValues[part.id] = suggestion
@@ -220,6 +226,15 @@ struct WarehouseWizardStep6: View {
     private func saveAllTargets() {
         guard let service = appCore.partsService else { stepError = "Parts service not available"; return }
         saveSuccess = false
+        stepError = nil
+
+        if let invalidPart = assignedParts.first(where: { part in
+            guard let values = targetValues[part.id] else { return false }
+            return !isValidTargetHierarchy(values)
+        }), let values = targetValues[invalidPart.id] {
+            stepError = "\(invalidPart.name) targets must be non-negative and ordered MIN ≤ TARGET ≤ MAX (currently \(values.min)/\(values.target)/\(values.max))."
+            return
+        }
 
         do {
             for (partId, values) in targetValues {
@@ -234,5 +249,10 @@ struct WarehouseWizardStep6: View {
         } catch {
             stepError = userFriendlyError(error, context: "save stock targets")
         }
+    }
+
+    private func isValidTargetHierarchy(_ values: WizardTargetValue) -> Bool {
+        values.min >= 0 && values.target >= 0 && values.max >= 0 &&
+        values.min <= values.target && values.target <= values.max
     }
 }

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -407,6 +407,26 @@ public final class PartsService: Sendable {
         }
     }
 
+    private func validateStockTargetHierarchy(
+        minStockLevel: Int?,
+        targetStockLevel: Int?,
+        maxStockLevel: Int?
+    ) throws {
+        if let minStockLevel { try Validators.requireNonNegative(minStockLevel, field: "Min stock") }
+        if let targetStockLevel { try Validators.requireNonNegative(targetStockLevel, field: "Target stock") }
+        if let maxStockLevel { try Validators.requireNonNegative(maxStockLevel, field: "Max stock") }
+
+        if let minStockLevel, let targetStockLevel, minStockLevel > targetStockLevel {
+            throw PartsError.invalidInput("Stock targets must be in order: MIN ≤ TARGET ≤ MAX")
+        }
+        if let targetStockLevel, let maxStockLevel, targetStockLevel > maxStockLevel {
+            throw PartsError.invalidInput("Stock targets must be in order: MIN ≤ TARGET ≤ MAX")
+        }
+        if let minStockLevel, let maxStockLevel, minStockLevel > maxStockLevel {
+            throw PartsError.invalidInput("Stock targets must be in order: MIN ≤ TARGET ≤ MAX")
+        }
+    }
+
     // =========================================================================
     // MARK: - 1. Hierarchy (Category / Style / Type / Color) CRUD
     // =========================================================================
@@ -1283,9 +1303,11 @@ public final class PartsService: Sendable {
         try Validators.requireNonNegative(companyCostPrice, field: "Cost price")
         try Validators.requireNonNegative(companyMarkupPercent, field: "Markup percent")
         if let w = weightLbs { try Validators.requireNonNegative(w, field: "Weight") }
-        if let m = minStockLevel { try Validators.requireNonNegative(m, field: "Min stock") }
-        if let m = maxStockLevel { try Validators.requireNonNegative(m, field: "Max stock") }
-        if let t = targetStockLevel { try Validators.requireNonNegative(t, field: "Target stock") }
+        try validateStockTargetHierarchy(
+            minStockLevel: minStockLevel,
+            targetStockLevel: targetStockLevel,
+            maxStockLevel: maxStockLevel
+        )
         if let r = reorderPoint { try Validators.requireNonNegative(r, field: "Reorder point") }
 
         // Guard: all referenced FK parents must exist and not be tombstoned.
@@ -1386,6 +1408,15 @@ public final class PartsService: Sendable {
             try Row.fetchOne(dbConn, sql: "SELECT * FROM parts WHERE id = ?", arguments: [id])
         }
 
+        if minStockLevel != nil || targetStockLevel != nil || maxStockLevel != nil {
+            guard let currentRow else { throw PartsError.partNotFound(id) }
+            try validateStockTargetHierarchy(
+                minStockLevel: minStockLevel ?? (currentRow["min_stock_level"] as Int?),
+                targetStockLevel: targetStockLevel ?? (currentRow["target_stock_level"] as Int?),
+                maxStockLevel: maxStockLevel ?? (currentRow["max_stock_level"] as Int?)
+            )
+        }
+
         try db.writer.write { dbConn in
             var setClauses: [String] = []
             var args: [DatabaseValueConvertible?] = []
@@ -1460,6 +1491,7 @@ public final class PartsService: Sendable {
             }
         }
     }
+
 
     public func getAutoAddToWishlistWhenLow(partId: Int64) throws -> Bool {
         try db.writer.read { dbConn in
@@ -6885,6 +6917,15 @@ public final class PartsService: Sendable {
                     try Validators.requireText(row.code, field: "Part code", limit: Validators.Limits.code)
                     try Validators.requireNonNegative(cost, field: "Cost price")
                     try Validators.requireNonNegative(markup, field: "Markup percent")
+                    do {
+                        try validateStockTargetHierarchy(
+                            minStockLevel: minStock,
+                            targetStockLevel: targetStock,
+                            maxStockLevel: maxStock
+                        )
+                    } catch PartsError.invalidInput(let message) {
+                        throw PartsError.invalidInput("Invalid stock targets at row \(row.rowNumber): \(message)")
+                    }
 
                     try dbConn.execute(sql: """
                         INSERT INTO parts (
@@ -6924,6 +6965,25 @@ public final class PartsService: Sendable {
                     let minStock = try parseImportWholeNumber(row.fields["min_stock"], header: "min_stock", rowNumber: row.rowNumber)
                     let targetStock = try parseImportWholeNumber(row.fields["target_stock"], header: "target_stock", rowNumber: row.rowNumber)
                     let maxStock = try parseImportWholeNumber(row.fields["max_stock"], header: "max_stock", rowNumber: row.rowNumber)
+
+                    if minStock != nil || targetStock != nil || maxStock != nil {
+                        guard let current = try Row.fetchOne(
+                            dbConn,
+                            sql: "SELECT min_stock_level, target_stock_level, max_stock_level FROM parts WHERE id = ? AND deleted_at IS NULL",
+                            arguments: [conflict.existingPartId]
+                        ) else {
+                            throw PartsError.partNotFound(conflict.existingPartId)
+                        }
+                        do {
+                            try validateStockTargetHierarchy(
+                                minStockLevel: minStock ?? (current["min_stock_level"] as Int?),
+                                targetStockLevel: targetStock ?? (current["target_stock_level"] as Int?),
+                                maxStockLevel: maxStock ?? (current["max_stock_level"] as Int?)
+                            )
+                        } catch PartsError.invalidInput(let message) {
+                            throw PartsError.invalidInput("Invalid stock targets at row \(row.rowNumber): \(message)")
+                        }
+                    }
 
                     var clauses = [
                         "name = ?",

--- a/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
@@ -413,7 +413,7 @@ struct OrdersServiceTests {
             categoryId: catId,
             name: "Consolidated Demand Wire",
             minStockLevel: 5,
-            maxStockLevel: 6,
+            maxStockLevel: 20,
             targetStockLevel: 12
         )
         let supplierId = try E2ETestHelpers.seedSupplier(env, name: "Demand Supplier")

--- a/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceExtTests.swift
@@ -62,6 +62,55 @@ struct PartsServiceExtTests {
         try env.parts.deletePart(id: partId)
     }
 
+    @Test("updatePart rejects invalid stock target hierarchy")
+    func testUpdatePartRejectsInvalidStockTargetHierarchy() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "Stock Target Validation")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Invalid Target Part", categoryId: catId)
+
+        #expect(throws: PartsService.PartsError.invalidInput("Stock targets must be in order: MIN ≤ TARGET ≤ MAX")) {
+            try env.parts.updatePart(
+                id: partId,
+                minStockLevel: 10,
+                maxStockLevel: 1,
+                targetStockLevel: 2
+            )
+        }
+
+        let unchanged = try env.parts.getPart(id: partId).part
+        #expect(unchanged.minStockLevel == nil)
+        #expect(unchanged.targetStockLevel == nil)
+        #expect(unchanged.maxStockLevel == nil)
+
+        try env.parts.updatePart(
+            id: partId,
+            minStockLevel: 2,
+            maxStockLevel: 10,
+            targetStockLevel: 5
+        )
+
+        let updated = try env.parts.getPart(id: partId).part
+        #expect(updated.minStockLevel == 2)
+        #expect(updated.targetStockLevel == 5)
+        #expect(updated.maxStockLevel == 10)
+    }
+
+    @Test("createPart rejects invalid stock target hierarchy")
+    func testCreatePartRejectsInvalidStockTargetHierarchy() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "Create Stock Target Validation")
+
+        #expect(throws: PartsService.PartsError.invalidInput("Stock targets must be in order: MIN ≤ TARGET ≤ MAX")) {
+            try env.parts.createPart(
+                categoryId: catId,
+                name: "Invalid Create Target Part",
+                minStockLevel: 10,
+                maxStockLevel: 1,
+                targetStockLevel: 2
+            )
+        }
+    }
+
     @Test("auto-add-to-wishlist flag defaults off and can be toggled by catalog editor")
     func testAutoAddToWishlistWhenLowToggle() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Add central PartsService validation for stock target fields so invalid MIN/TARGET/MAX hierarchies and negative values are rejected before create/update/import writes.
- Surface inline Warehouse onboarding validation before saving invalid target combinations.
- Add regression coverage for create/update rejection and adjust an existing procurement fixture to use a valid stock hierarchy.

Closes #1176

## Tests
- `swift test --filter PartsServiceExtTests/testUpdatePartRejectsInvalidStockTargetHierarchy`
- `swift test --filter OrdersServiceTests/testProcurementDemandConsolidatesWishlistAndForecast`
- `swift test --filter PartsServiceExtTests`
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `cd core && swift test` (2222 tests in 67 suites passed)
- `xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build` (succeeded with existing warnings)

## Local runner / CI note
This PR is ready for the WPR2 local self-hosted Mac runner path (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`) for required iOS/Xcode validation.
