### PR TITLE
fix: validate persisted settings values

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSAuditSettingsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSAuditSettingsPage.swift
@@ -193,20 +193,20 @@ struct IOSAuditSettingsPage: View {
         do {
             let map = try service.getSettingsByCategory("audit")
 
-            enableAutoScheduling = (map["audit_auto_scheduling"] ?? "true") == "true"
+            enableAutoScheduling = try SettingsValueParser.bool(map, key: "audit_auto_scheduling", default: true)
             defaultAuditType = map["audit_default_type"] ?? "cycle_count"
-            maxConcurrentAudits = Int(map["audit_max_concurrent"] ?? "") ?? 1
+            maxConcurrentAudits = try SettingsValueParser.int(map, key: "audit_max_concurrent", default: 1)
 
-            allowSpeedMode = (map["audit_allow_speed_mode"] ?? "true") == "true"
-            speedModeRequiresQR = (map["audit_speed_requires_qr"] ?? "true") == "true"
-            speedModeTimeLimit = Int(map["audit_speed_time_limit"] ?? "") ?? 10
+            allowSpeedMode = try SettingsValueParser.bool(map, key: "audit_allow_speed_mode", default: true)
+            speedModeRequiresQR = try SettingsValueParser.bool(map, key: "audit_speed_requires_qr", default: true)
+            speedModeTimeLimit = try SettingsValueParser.int(map, key: "audit_speed_time_limit", default: 10)
 
-            verificationThreshold = Int(map["audit_verification_threshold"] ?? "") ?? 2
-            misplacementPenalty = Double(map["audit_misplacement_penalty"] ?? "") ?? 1.5
+            verificationThreshold = try SettingsValueParser.int(map, key: "audit_verification_threshold", default: 2)
+            misplacementPenalty = try SettingsValueParser.double(map, key: "audit_misplacement_penalty", default: 1.5)
 
-            keepHistoryMonths = Int(map["audit_keep_history_months"] ?? "") ?? 12
-            autoArchive = (map["audit_auto_archive"] ?? "true") == "true"
-            includeInDailyReport = (map["audit_include_in_daily_report"] ?? "false") == "true"
+            keepHistoryMonths = try SettingsValueParser.int(map, key: "audit_keep_history_months", default: 12)
+            autoArchive = try SettingsValueParser.bool(map, key: "audit_auto_archive", default: true)
+            includeInDailyReport = try SettingsValueParser.bool(map, key: "audit_include_in_daily_report", default: false)
         } catch {
             loadError = userFriendlyError(error, context: "load")
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDispatchPreferencesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDispatchPreferencesPage.swift
@@ -181,19 +181,19 @@ struct IOSDispatchPreferencesPage: View {
         do {
             let map = try service.getSettingsByCategory("dispatch")
 
-            enableAISuggestions = (map["dispatch_ai_suggestions_enabled"] ?? "true") == "true"
-            enableAILearning = (map["dispatch_ai_learning_enabled"] ?? "true") == "true"
-            showConfidenceScores = (map["dispatch_show_confidence_scores"] ?? "false") == "true"
+            enableAISuggestions = try SettingsValueParser.bool(map, key: "dispatch_ai_suggestions_enabled", default: true)
+            enableAILearning = try SettingsValueParser.bool(map, key: "dispatch_ai_learning_enabled", default: true)
+            showConfidenceScores = try SettingsValueParser.bool(map, key: "dispatch_show_confidence_scores", default: false)
 
-            enableFlexSelfAssign = (map["dispatch_flex_self_assign_enabled"] ?? "false") == "true"
-            requireManagerApproval = (map["dispatch_flex_require_approval"] ?? "true") == "true"
+            enableFlexSelfAssign = try SettingsValueParser.bool(map, key: "dispatch_flex_self_assign_enabled", default: false)
+            requireManagerApproval = try SettingsValueParser.bool(map, key: "dispatch_flex_require_approval", default: true)
 
-            startAnytimeTarget = Int(map["dispatch_pipeline_start_anytime_target"] ?? "") ?? 3
-            scheduleNeededTarget = Int(map["dispatch_pipeline_schedule_needed_target"] ?? "") ?? 2
-            favoriteGCTarget = Int(map["dispatch_pipeline_favorite_gc_target"] ?? "") ?? 1
+            startAnytimeTarget = try SettingsValueParser.int(map, key: "dispatch_pipeline_start_anytime_target", default: 3)
+            scheduleNeededTarget = try SettingsValueParser.int(map, key: "dispatch_pipeline_schedule_needed_target", default: 2)
+            favoriteGCTarget = try SettingsValueParser.int(map, key: "dispatch_pipeline_favorite_gc_target", default: 1)
 
             defaultView = map["dispatch_default_view"] ?? "week"
-            crewHistoryMonths = Int(map["dispatch_crew_history_months"] ?? "") ?? 3
+            crewHistoryMonths = try SettingsValueParser.int(map, key: "dispatch_crew_history_months", default: 3)
             crewContinuityWeight = map["dispatch_crew_continuity_weight"] ?? "medium"
         } catch {
             loadError = userFriendlyError(error, context: "load")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSForecastSettingsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSForecastSettingsPage.swift
@@ -274,22 +274,22 @@ struct IOSForecastSettingsPage: View {
 
             for loc in locationTypes {
                 method[loc] = map["forecast_\(loc)_method"] ?? (loc == "shop" ? "adu" : "apw")
-                lookbackDays[loc] = Int(map["forecast_\(loc)_lookback_days"] ?? "") ?? (loc == "shop" ? 90 : 42)
-                minDataDays[loc] = Int(map["forecast_\(loc)_min_data_days"] ?? "") ?? (loc == "shop" ? 14 : 7)
-                apwWindow[loc] = Int(map["forecast_\(loc)_apw_window"] ?? "") ?? 2
+                lookbackDays[loc] = try SettingsValueParser.int(map, key: "forecast_\(loc)_lookback_days", default: loc == "shop" ? 90 : 42)
+                minDataDays[loc] = try SettingsValueParser.int(map, key: "forecast_\(loc)_min_data_days", default: loc == "shop" ? 14 : 7)
+                apwWindow[loc] = try SettingsValueParser.int(map, key: "forecast_\(loc)_apw_window", default: 2)
             }
 
-            commonMinMult = Double(map["forecast_common_min_mult"] ?? "") ?? 1.0
-            commonTargetMult = Double(map["forecast_common_target_mult"] ?? "") ?? 1.5
-            commonMaxMult = Double(map["forecast_common_max_mult"] ?? "") ?? 2.0
-            criticalMinMult = Double(map["forecast_critical_min_mult"] ?? "") ?? 1.5
-            criticalTargetMult = Double(map["forecast_critical_target_mult"] ?? "") ?? 2.0
-            criticalMaxMult = Double(map["forecast_critical_max_mult"] ?? "") ?? 3.0
+            commonMinMult = try SettingsValueParser.double(map, key: "forecast_common_min_mult", default: 1.0)
+            commonTargetMult = try SettingsValueParser.double(map, key: "forecast_common_target_mult", default: 1.5)
+            commonMaxMult = try SettingsValueParser.double(map, key: "forecast_common_max_mult", default: 2.0)
+            criticalMinMult = try SettingsValueParser.double(map, key: "forecast_critical_min_mult", default: 1.5)
+            criticalTargetMult = try SettingsValueParser.double(map, key: "forecast_critical_target_mult", default: 2.0)
+            criticalMaxMult = try SettingsValueParser.double(map, key: "forecast_critical_max_mult", default: 3.0)
 
-            freeSpaceThreshold = Double(map["forecast_free_space_threshold"] ?? "") ?? 20
-            autoRecalcDaily = (map["forecast_auto_recalc_daily"] ?? "true") == "true"
-            recalcHour = Int(map["forecast_recalc_hour"] ?? "") ?? 2
-            categorySuggestionMonths = Int(map["forecast_category_suggestion_months"] ?? "") ?? 6
+            freeSpaceThreshold = try SettingsValueParser.double(map, key: "forecast_free_space_threshold", default: 20)
+            autoRecalcDaily = try SettingsValueParser.bool(map, key: "forecast_auto_recalc_daily", default: true)
+            recalcHour = try SettingsValueParser.int(map, key: "forecast_recalc_hour", default: 2)
+            categorySuggestionMonths = try SettingsValueParser.int(map, key: "forecast_category_suggestion_months", default: 6)
         } catch {
             loadError = userFriendlyError(error, context: "load")
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSOrganizationThresholdsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSOrganizationThresholdsPage.swift
@@ -223,20 +223,20 @@ struct IOSOrganizationThresholdsPage: View {
         do {
             let map = try service.getSettingsByCategory("org")
 
-            baseDecayRate = Double(map["org_base_decay_rate"] ?? "") ?? 0.1
-            movementDecayFactor = Double(map["org_movement_decay_factor"] ?? "") ?? 0.5
+            baseDecayRate = try SettingsValueParser.double(map, key: "org_base_decay_rate", default: 0.1)
+            movementDecayFactor = try SettingsValueParser.double(map, key: "org_movement_decay_factor", default: 0.5)
 
-            auditThreshold = Double(map["org_audit_threshold"] ?? "") ?? 80
-            maxRecsPerDay = Int(map["org_max_recs_per_day"] ?? "") ?? 1
-            recCooldownDays = Int(map["org_rec_cooldown_days"] ?? "") ?? 60
+            auditThreshold = try SettingsValueParser.double(map, key: "org_audit_threshold", default: 80)
+            maxRecsPerDay = try SettingsValueParser.int(map, key: "org_max_recs_per_day", default: 1)
+            recCooldownDays = try SettingsValueParser.int(map, key: "org_rec_cooldown_days", default: 60)
 
-            votingTimeoutDays = Int(map["org_voting_timeout_days"] ?? "") ?? 7
-            minVotesRequired = Int(map["org_min_votes_required"] ?? "") ?? 2
-            autoApproveUnanimous = (map["org_auto_approve_unanimous"] ?? "true") == "true"
+            votingTimeoutDays = try SettingsValueParser.int(map, key: "org_voting_timeout_days", default: 7)
+            minVotesRequired = try SettingsValueParser.int(map, key: "org_min_votes_required", default: 2)
+            autoApproveUnanimous = try SettingsValueParser.bool(map, key: "org_auto_approve_unanimous", default: true)
 
-            targetScore = Double(map["org_target_score"] ?? "") ?? 85
-            showOnDashboard = (map["org_show_on_dashboard"] ?? "true") == "true"
-            includeInDailyReport = (map["org_include_in_daily_report"] ?? "false") == "true"
+            targetScore = try SettingsValueParser.double(map, key: "org_target_score", default: 85)
+            showOnDashboard = try SettingsValueParser.bool(map, key: "org_show_on_dashboard", default: true)
+            includeInDailyReport = try SettingsValueParser.bool(map, key: "org_include_in_daily_report", default: false)
         } catch {
             loadError = userFriendlyError(error, context: "load")
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSToolPoliciesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSToolPoliciesPage.swift
@@ -179,20 +179,20 @@ struct IOSToolPoliciesPage: View {
         do {
             let map = try service.getSettingsByCategory("tool_policy")
 
-            maxCheckoutDays = Int(map["tool_policy_max_checkout_days"] ?? "") ?? 30
-            overdueNotificationDays = Int(map["tool_policy_overdue_notification_days"] ?? "") ?? 7
-            autoExtendOnActiveJob = (map["tool_policy_auto_extend_active_job"] ?? "true") == "true"
+            maxCheckoutDays = try SettingsValueParser.int(map, key: "tool_policy_max_checkout_days", default: 30)
+            overdueNotificationDays = try SettingsValueParser.int(map, key: "tool_policy_overdue_notification_days", default: 7)
+            autoExtendOnActiveJob = try SettingsValueParser.bool(map, key: "tool_policy_auto_extend_active_job", default: true)
 
-            requireCheckoutCondition = (map["tool_policy_require_checkout_condition"] ?? "true") == "true"
-            requireReturnCondition = (map["tool_policy_require_return_condition"] ?? "true") == "true"
-            requireDamagePhoto = (map["tool_policy_require_damage_photo"] ?? "false") == "true"
+            requireCheckoutCondition = try SettingsValueParser.bool(map, key: "tool_policy_require_checkout_condition", default: true)
+            requireReturnCondition = try SettingsValueParser.bool(map, key: "tool_policy_require_return_condition", default: true)
+            requireDamagePhoto = try SettingsValueParser.bool(map, key: "tool_policy_require_damage_photo", default: false)
 
-            maintenanceAfterCheckouts = Int(map["tool_policy_maintenance_after_checkouts"] ?? "") ?? 50
-            maintenanceReminderDays = Int(map["tool_policy_maintenance_reminder_days"] ?? "") ?? 14
+            maintenanceAfterCheckouts = try SettingsValueParser.int(map, key: "tool_policy_maintenance_after_checkouts", default: 50)
+            maintenanceReminderDays = try SettingsValueParser.int(map, key: "tool_policy_maintenance_reminder_days", default: 14)
 
-            allowTrades = (map["tool_policy_allow_trades"] ?? "true") == "true"
-            tradeTimeoutDays = Int(map["tool_policy_trade_timeout_days"] ?? "") ?? 7
-            requireTradeCondition = (map["tool_policy_require_trade_condition"] ?? "true") == "true"
+            allowTrades = try SettingsValueParser.bool(map, key: "tool_policy_allow_trades", default: true)
+            tradeTimeoutDays = try SettingsValueParser.int(map, key: "tool_policy_trade_timeout_days", default: 7)
+            requireTradeCondition = try SettingsValueParser.bool(map, key: "tool_policy_require_trade_condition", default: true)
         } catch {
             loadError = userFriendlyError(error, context: "load")
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/SettingsValueParser.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/SettingsValueParser.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Parses persisted SettingsService values without hiding corrupt saved configuration.
+///
+/// Missing keys intentionally use page defaults. Present-but-malformed values throw so
+/// settings pages surface a visible load error instead of silently overwriting the
+/// existing stored value on the next save.
+enum SettingsValueParser {
+    enum ParseError: LocalizedError, Equatable {
+        case invalidValue(key: String, value: String, expectedType: String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .invalidValue(key, value, expectedType):
+                return "Saved setting \"\(key)\" has invalid \(expectedType) value \"\(value)\". Fix or reset this setting before saving."
+            }
+        }
+    }
+
+    static func int(_ map: [String: String], key: String, default defaultValue: Int) throws -> Int {
+        guard let rawValue = map[key] else { return defaultValue }
+        let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let parsedValue = Int(trimmedValue) else {
+            throw ParseError.invalidValue(key: key, value: rawValue, expectedType: "whole-number")
+        }
+        return parsedValue
+    }
+
+    static func double(_ map: [String: String], key: String, default defaultValue: Double) throws -> Double {
+        guard let rawValue = map[key] else { return defaultValue }
+        let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let parsedValue = Double(trimmedValue) else {
+            throw ParseError.invalidValue(key: key, value: rawValue, expectedType: "decimal-number")
+        }
+        return parsedValue
+    }
+
+    static func bool(_ map: [String: String], key: String, default defaultValue: Bool) throws -> Bool {
+        guard let rawValue = map[key] else { return defaultValue }
+        switch rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "true":
+            return true
+        case "false":
+            return false
+        default:
+            throw ParseError.invalidValue(key: key, value: rawValue, expectedType: "true/false")
+        }
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/SettingsSaveButtonValidationTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SettingsSaveButtonValidationTests.swift
@@ -226,6 +226,47 @@ final class SettingsSaveButtonValidationTests: XCTestCase {
         )
     }
 
+    // MARK: - Settings persisted value parsing
+
+    func testSettingsPagesUseStrictPersistedValueParser() throws {
+        let pages = [
+            "IOSAuditSettingsPage.swift",
+            "IOSDispatchPreferencesPage.swift",
+            "IOSForecastSettingsPage.swift",
+            "IOSOrganizationThresholdsPage.swift",
+            "IOSToolPoliciesPage.swift",
+        ]
+
+        for page in pages {
+            let source = try Self.readSettingsSource(page)
+            XCTAssertTrue(
+                source.contains("try SettingsValueParser."),
+                "\(page) must parse persisted numeric and boolean settings through SettingsValueParser so malformed saved values surface as load errors."
+            )
+            XCTAssertFalse(
+                source.contains("Int(map[") || source.contains("Double(map[") || source.contains("] ?? \"true\") == \"true\"") || source.contains("] ?? \"false\") == \"true\""),
+                "\(page) must not silently coerce malformed persisted settings to fallback defaults."
+            )
+        }
+    }
+
+    func testSettingsValueParserDistinguishesMissingFromMalformedValues() throws {
+        let source = try Self.readSettingsSource("SettingsValueParser.swift")
+
+        XCTAssertTrue(
+            source.contains("guard let rawValue = map[key] else { return defaultValue }"),
+            "SettingsValueParser must continue allowing missing values to use page defaults."
+        )
+        XCTAssertTrue(
+            source.contains("throw ParseError.invalidValue") && source.contains("Saved setting") && source.contains("Fix or reset this setting before saving"),
+            "SettingsValueParser must throw a visible validation error for present-but-malformed values before a page can overwrite them."
+        )
+        XCTAssertTrue(
+            source.contains("case \"true\"") && source.contains("case \"false\"") && source.contains("expectedType: \"true/false\""),
+            "SettingsValueParser must validate persisted booleans instead of treating every non-true value as false."
+        )
+    }
+
     // MARK: - Helpers
 
     private static func readSettingsSource(_ filename: String, file: StaticString = #filePath) throws -> String {


### PR DESCRIPTION
## Summary
- Adds a shared SettingsValueParser that distinguishes missing persisted settings from present-but-malformed Int/Double/Bool values.
- Applies strict persisted-value parsing to audit, dispatch, forecast, organization threshold, and tool policy settings pages so corrupt saved values surface as load errors instead of being silently defaulted and overwritten.
- Adds regression coverage that the affected settings pages use the strict parser and that malformed booleans are not treated as false.

Closes #1179

## Verification
- PASS: `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,id=F29F2637-4865-4685-92B3-98D2F45EF30C' -only-testing:'Weird Parts IOSTests/SettingsSaveButtonValidationTests/testSettingsPagesUseStrictPersistedValueParser' -only-testing:'Weird Parts IOSTests/SettingsSaveButtonValidationTests/testSettingsValueParserDistinguishesMissingFromMalformedValues'`
- BUILD COVERAGE: the targeted test command built the app and test bundles successfully before running the focused tests.
- NOTE: the broader `SettingsSaveButtonValidationTests` suite currently fails on `testDailyReportTemplatesPageHasIsDirtyGuard()`, which is unrelated to this settings hydration fix; the new regression tests above pass.
