### PR TITLE
fix: validate settings hydration before save

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSAIConfigPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSAIConfigPage.swift
@@ -12,6 +12,7 @@ struct IOSAIConfigPage: View {
     @State private var availabilityStatus: AIAvailability?
     @State private var aiLanguage = "en"
     @State private var onboardAIMVPEnabled = false
+    @State private var loadError: String?
     @State private var saveError: String?
     // Fix #192: gate the form behind a loading state so defaults don't flash
     // before loadSettings() populates the actual values.
@@ -33,6 +34,9 @@ struct IOSAIConfigPage: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .navigationTitle("AI Configuration")
                 .task { loadSettings() }
+        } else if let loadError {
+            ErrorStateView(message: loadError)
+                .navigationTitle("AI Configuration")
         } else {
             loadedForm
         }
@@ -202,17 +206,26 @@ struct IOSAIConfigPage: View {
     private func loadSettings() {
         defer { isLoading = false }   // Fix #192: drop the loading gate once load completes
         guard let service = appCore.settingsService else {
-            saveError = "Service not available"
+            loadError = "Service not available"
             return
         }
-        let map = (try? service.getSettingsByCategory("ai")) ?? [:]
-        aiEnabled = (map["ai_enabled"] ?? "true") == "true"
-        selectedModel = map["ai_model"] ?? "foundation"
-        aiLanguage = map["ai_language"] ?? "en"
-        let aiMVPSetting = map[OnboardAIFeatureFlag.onboardingMVP] ?? (UserDefaults.standard.bool(forKey: OnboardAIFeatureFlag.onboardingMVP) ? "true" : "false")
-        onboardAIMVPEnabled = aiMVPSetting == "true"
-        UserDefaults.standard.set(onboardAIMVPEnabled, forKey: OnboardAIFeatureFlag.onboardingMVP)
-        checkAvailability()
+        do {
+            let map = try service.getSettingsByCategory("ai")
+            var parser = SettingsValueParser()
+            aiEnabled = parser.bool(map, key: "ai_enabled", default: true)
+            selectedModel = map["ai_model"] ?? "foundation"
+            aiLanguage = map["ai_language"] ?? "en"
+            onboardAIMVPEnabled = parser.bool(
+                map,
+                key: OnboardAIFeatureFlag.onboardingMVP,
+                default: UserDefaults.standard.bool(forKey: OnboardAIFeatureFlag.onboardingMVP)
+            )
+            try parser.throwIfInvalid()
+            UserDefaults.standard.set(onboardAIMVPEnabled, forKey: OnboardAIFeatureFlag.onboardingMVP)
+            checkAvailability()
+        } catch {
+            loadError = settingsHydrationMessage(error)
+        }
     }
 
     private func saveSetting(_ key: String, value: String) {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSAuditSettingsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSAuditSettingsPage.swift
@@ -193,22 +193,24 @@ struct IOSAuditSettingsPage: View {
         do {
             let map = try service.getSettingsByCategory("audit")
 
-            enableAutoScheduling = try SettingsValueParser.bool(map, key: "audit_auto_scheduling", default: true)
+            var parser = SettingsValueParser()
+            enableAutoScheduling = parser.bool(map, key: "audit_auto_scheduling", default: true)
             defaultAuditType = map["audit_default_type"] ?? "cycle_count"
-            maxConcurrentAudits = try SettingsValueParser.int(map, key: "audit_max_concurrent", default: 1)
+            maxConcurrentAudits = parser.int(map, key: "audit_max_concurrent", default: 1)
 
-            allowSpeedMode = try SettingsValueParser.bool(map, key: "audit_allow_speed_mode", default: true)
-            speedModeRequiresQR = try SettingsValueParser.bool(map, key: "audit_speed_requires_qr", default: true)
-            speedModeTimeLimit = try SettingsValueParser.int(map, key: "audit_speed_time_limit", default: 10)
+            allowSpeedMode = parser.bool(map, key: "audit_allow_speed_mode", default: true)
+            speedModeRequiresQR = parser.bool(map, key: "audit_speed_requires_qr", default: true)
+            speedModeTimeLimit = parser.int(map, key: "audit_speed_time_limit", default: 10)
 
-            verificationThreshold = try SettingsValueParser.int(map, key: "audit_verification_threshold", default: 2)
-            misplacementPenalty = try SettingsValueParser.double(map, key: "audit_misplacement_penalty", default: 1.5)
+            verificationThreshold = parser.int(map, key: "audit_verification_threshold", default: 2)
+            misplacementPenalty = parser.double(map, key: "audit_misplacement_penalty", default: 1.5)
 
-            keepHistoryMonths = try SettingsValueParser.int(map, key: "audit_keep_history_months", default: 12)
-            autoArchive = try SettingsValueParser.bool(map, key: "audit_auto_archive", default: true)
-            includeInDailyReport = try SettingsValueParser.bool(map, key: "audit_include_in_daily_report", default: false)
+            keepHistoryMonths = parser.int(map, key: "audit_keep_history_months", default: 12)
+            autoArchive = parser.bool(map, key: "audit_auto_archive", default: true)
+            includeInDailyReport = parser.bool(map, key: "audit_include_in_daily_report", default: false)
+            try parser.throwIfInvalid()
         } catch {
-            loadError = userFriendlyError(error, context: "load")
+            loadError = settingsHydrationMessage(error)
         }
         isLoading = false
         isDirty = false

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDispatchPreferencesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDispatchPreferencesPage.swift
@@ -181,22 +181,24 @@ struct IOSDispatchPreferencesPage: View {
         do {
             let map = try service.getSettingsByCategory("dispatch")
 
-            enableAISuggestions = try SettingsValueParser.bool(map, key: "dispatch_ai_suggestions_enabled", default: true)
-            enableAILearning = try SettingsValueParser.bool(map, key: "dispatch_ai_learning_enabled", default: true)
-            showConfidenceScores = try SettingsValueParser.bool(map, key: "dispatch_show_confidence_scores", default: false)
+            var parser = SettingsValueParser()
+            enableAISuggestions = parser.bool(map, key: "dispatch_ai_suggestions_enabled", default: true)
+            enableAILearning = parser.bool(map, key: "dispatch_ai_learning_enabled", default: true)
+            showConfidenceScores = parser.bool(map, key: "dispatch_show_confidence_scores", default: false)
 
-            enableFlexSelfAssign = try SettingsValueParser.bool(map, key: "dispatch_flex_self_assign_enabled", default: false)
-            requireManagerApproval = try SettingsValueParser.bool(map, key: "dispatch_flex_require_approval", default: true)
+            enableFlexSelfAssign = parser.bool(map, key: "dispatch_flex_self_assign_enabled", default: false)
+            requireManagerApproval = parser.bool(map, key: "dispatch_flex_require_approval", default: true)
 
-            startAnytimeTarget = try SettingsValueParser.int(map, key: "dispatch_pipeline_start_anytime_target", default: 3)
-            scheduleNeededTarget = try SettingsValueParser.int(map, key: "dispatch_pipeline_schedule_needed_target", default: 2)
-            favoriteGCTarget = try SettingsValueParser.int(map, key: "dispatch_pipeline_favorite_gc_target", default: 1)
+            startAnytimeTarget = parser.int(map, key: "dispatch_pipeline_start_anytime_target", default: 3)
+            scheduleNeededTarget = parser.int(map, key: "dispatch_pipeline_schedule_needed_target", default: 2)
+            favoriteGCTarget = parser.int(map, key: "dispatch_pipeline_favorite_gc_target", default: 1)
 
             defaultView = map["dispatch_default_view"] ?? "week"
-            crewHistoryMonths = try SettingsValueParser.int(map, key: "dispatch_crew_history_months", default: 3)
+            crewHistoryMonths = parser.int(map, key: "dispatch_crew_history_months", default: 3)
             crewContinuityWeight = map["dispatch_crew_continuity_weight"] ?? "medium"
+            try parser.throwIfInvalid()
         } catch {
-            loadError = userFriendlyError(error, context: "load")
+            loadError = settingsHydrationMessage(error)
         }
         isLoading = false
         isDirty = false

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSForecastSettingsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSForecastSettingsPage.swift
@@ -272,26 +272,28 @@ struct IOSForecastSettingsPage: View {
         do {
             let map = try service.getSettingsByCategory("forecast")
 
+            var parser = SettingsValueParser()
             for loc in locationTypes {
                 method[loc] = map["forecast_\(loc)_method"] ?? (loc == "shop" ? "adu" : "apw")
-                lookbackDays[loc] = try SettingsValueParser.int(map, key: "forecast_\(loc)_lookback_days", default: loc == "shop" ? 90 : 42)
-                minDataDays[loc] = try SettingsValueParser.int(map, key: "forecast_\(loc)_min_data_days", default: loc == "shop" ? 14 : 7)
-                apwWindow[loc] = try SettingsValueParser.int(map, key: "forecast_\(loc)_apw_window", default: 2)
+                lookbackDays[loc] = parser.int(map, key: "forecast_\(loc)_lookback_days", default: loc == "shop" ? 90 : 42)
+                minDataDays[loc] = parser.int(map, key: "forecast_\(loc)_min_data_days", default: loc == "shop" ? 14 : 7)
+                apwWindow[loc] = parser.int(map, key: "forecast_\(loc)_apw_window", default: 2)
             }
 
-            commonMinMult = try SettingsValueParser.double(map, key: "forecast_common_min_mult", default: 1.0)
-            commonTargetMult = try SettingsValueParser.double(map, key: "forecast_common_target_mult", default: 1.5)
-            commonMaxMult = try SettingsValueParser.double(map, key: "forecast_common_max_mult", default: 2.0)
-            criticalMinMult = try SettingsValueParser.double(map, key: "forecast_critical_min_mult", default: 1.5)
-            criticalTargetMult = try SettingsValueParser.double(map, key: "forecast_critical_target_mult", default: 2.0)
-            criticalMaxMult = try SettingsValueParser.double(map, key: "forecast_critical_max_mult", default: 3.0)
+            commonMinMult = parser.double(map, key: "forecast_common_min_mult", default: 1.0)
+            commonTargetMult = parser.double(map, key: "forecast_common_target_mult", default: 1.5)
+            commonMaxMult = parser.double(map, key: "forecast_common_max_mult", default: 2.0)
+            criticalMinMult = parser.double(map, key: "forecast_critical_min_mult", default: 1.5)
+            criticalTargetMult = parser.double(map, key: "forecast_critical_target_mult", default: 2.0)
+            criticalMaxMult = parser.double(map, key: "forecast_critical_max_mult", default: 3.0)
 
-            freeSpaceThreshold = try SettingsValueParser.double(map, key: "forecast_free_space_threshold", default: 20)
-            autoRecalcDaily = try SettingsValueParser.bool(map, key: "forecast_auto_recalc_daily", default: true)
-            recalcHour = try SettingsValueParser.int(map, key: "forecast_recalc_hour", default: 2)
-            categorySuggestionMonths = try SettingsValueParser.int(map, key: "forecast_category_suggestion_months", default: 6)
+            freeSpaceThreshold = parser.double(map, key: "forecast_free_space_threshold", default: 20)
+            autoRecalcDaily = parser.bool(map, key: "forecast_auto_recalc_daily", default: true)
+            recalcHour = parser.int(map, key: "forecast_recalc_hour", default: 2)
+            categorySuggestionMonths = parser.int(map, key: "forecast_category_suggestion_months", default: 6)
+            try parser.throwIfInvalid()
         } catch {
-            loadError = userFriendlyError(error, context: "load")
+            loadError = settingsHydrationMessage(error)
         }
         isLoading = false
         resetDirtyTracking()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSOrganizationThresholdsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSOrganizationThresholdsPage.swift
@@ -223,22 +223,24 @@ struct IOSOrganizationThresholdsPage: View {
         do {
             let map = try service.getSettingsByCategory("org")
 
-            baseDecayRate = try SettingsValueParser.double(map, key: "org_base_decay_rate", default: 0.1)
-            movementDecayFactor = try SettingsValueParser.double(map, key: "org_movement_decay_factor", default: 0.5)
+            var parser = SettingsValueParser()
+            baseDecayRate = parser.double(map, key: "org_base_decay_rate", default: 0.1)
+            movementDecayFactor = parser.double(map, key: "org_movement_decay_factor", default: 0.5)
 
-            auditThreshold = try SettingsValueParser.double(map, key: "org_audit_threshold", default: 80)
-            maxRecsPerDay = try SettingsValueParser.int(map, key: "org_max_recs_per_day", default: 1)
-            recCooldownDays = try SettingsValueParser.int(map, key: "org_rec_cooldown_days", default: 60)
+            auditThreshold = parser.double(map, key: "org_audit_threshold", default: 80)
+            maxRecsPerDay = parser.int(map, key: "org_max_recs_per_day", default: 1)
+            recCooldownDays = parser.int(map, key: "org_rec_cooldown_days", default: 60)
 
-            votingTimeoutDays = try SettingsValueParser.int(map, key: "org_voting_timeout_days", default: 7)
-            minVotesRequired = try SettingsValueParser.int(map, key: "org_min_votes_required", default: 2)
-            autoApproveUnanimous = try SettingsValueParser.bool(map, key: "org_auto_approve_unanimous", default: true)
+            votingTimeoutDays = parser.int(map, key: "org_voting_timeout_days", default: 7)
+            minVotesRequired = parser.int(map, key: "org_min_votes_required", default: 2)
+            autoApproveUnanimous = parser.bool(map, key: "org_auto_approve_unanimous", default: true)
 
-            targetScore = try SettingsValueParser.double(map, key: "org_target_score", default: 85)
-            showOnDashboard = try SettingsValueParser.bool(map, key: "org_show_on_dashboard", default: true)
-            includeInDailyReport = try SettingsValueParser.bool(map, key: "org_include_in_daily_report", default: false)
+            targetScore = parser.double(map, key: "org_target_score", default: 85)
+            showOnDashboard = parser.bool(map, key: "org_show_on_dashboard", default: true)
+            includeInDailyReport = parser.bool(map, key: "org_include_in_daily_report", default: false)
+            try parser.throwIfInvalid()
         } catch {
-            loadError = userFriendlyError(error, context: "load")
+            loadError = settingsHydrationMessage(error)
         }
         isLoading = false
         resetDirtyTracking()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSToolPoliciesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSToolPoliciesPage.swift
@@ -179,22 +179,24 @@ struct IOSToolPoliciesPage: View {
         do {
             let map = try service.getSettingsByCategory("tool_policy")
 
-            maxCheckoutDays = try SettingsValueParser.int(map, key: "tool_policy_max_checkout_days", default: 30)
-            overdueNotificationDays = try SettingsValueParser.int(map, key: "tool_policy_overdue_notification_days", default: 7)
-            autoExtendOnActiveJob = try SettingsValueParser.bool(map, key: "tool_policy_auto_extend_active_job", default: true)
+            var parser = SettingsValueParser()
+            maxCheckoutDays = parser.int(map, key: "tool_policy_max_checkout_days", default: 30)
+            overdueNotificationDays = parser.int(map, key: "tool_policy_overdue_notification_days", default: 7)
+            autoExtendOnActiveJob = parser.bool(map, key: "tool_policy_auto_extend_active_job", default: true)
 
-            requireCheckoutCondition = try SettingsValueParser.bool(map, key: "tool_policy_require_checkout_condition", default: true)
-            requireReturnCondition = try SettingsValueParser.bool(map, key: "tool_policy_require_return_condition", default: true)
-            requireDamagePhoto = try SettingsValueParser.bool(map, key: "tool_policy_require_damage_photo", default: false)
+            requireCheckoutCondition = parser.bool(map, key: "tool_policy_require_checkout_condition", default: true)
+            requireReturnCondition = parser.bool(map, key: "tool_policy_require_return_condition", default: true)
+            requireDamagePhoto = parser.bool(map, key: "tool_policy_require_damage_photo", default: false)
 
-            maintenanceAfterCheckouts = try SettingsValueParser.int(map, key: "tool_policy_maintenance_after_checkouts", default: 50)
-            maintenanceReminderDays = try SettingsValueParser.int(map, key: "tool_policy_maintenance_reminder_days", default: 14)
+            maintenanceAfterCheckouts = parser.int(map, key: "tool_policy_maintenance_after_checkouts", default: 50)
+            maintenanceReminderDays = parser.int(map, key: "tool_policy_maintenance_reminder_days", default: 14)
 
-            allowTrades = try SettingsValueParser.bool(map, key: "tool_policy_allow_trades", default: true)
-            tradeTimeoutDays = try SettingsValueParser.int(map, key: "tool_policy_trade_timeout_days", default: 7)
-            requireTradeCondition = try SettingsValueParser.bool(map, key: "tool_policy_require_trade_condition", default: true)
+            allowTrades = parser.bool(map, key: "tool_policy_allow_trades", default: true)
+            tradeTimeoutDays = parser.int(map, key: "tool_policy_trade_timeout_days", default: 7)
+            requireTradeCondition = parser.bool(map, key: "tool_policy_require_trade_condition", default: true)
+            try parser.throwIfInvalid()
         } catch {
-            loadError = userFriendlyError(error, context: "load")
+            loadError = settingsHydrationMessage(error)
         }
         isLoading = false
         isDirty = false

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/SettingsHydrationMessage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/SettingsHydrationMessage.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+func settingsHydrationMessage(_ error: Error) -> String {
+    if let hydrationError = error as? SettingsHydrationError {
+        return hydrationError.localizedDescription
+    }
+    return userFriendlyError(error, context: "load")
+}

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/SettingsValueParser.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/SettingsValueParser.swift
@@ -1,49 +1,69 @@
 import Foundation
 
-/// Parses persisted SettingsService values without hiding corrupt saved configuration.
-///
-/// Missing keys intentionally use page defaults. Present-but-malformed values throw so
-/// settings pages surface a visible load error instead of silently overwriting the
-/// existing stored value on the next save.
-enum SettingsValueParser {
-    enum ParseError: LocalizedError, Equatable {
-        case invalidValue(key: String, value: String, expectedType: String)
+/// Parses persisted SettingsService values without silently treating malformed saved values as missing.
+/// Missing keys use the supplied UI default. Present-but-invalid keys are collected so settings pages
+/// can stop loading and warn the owner before a later save overwrites the corrupt stored value.
+struct SettingsValueParser {
+    private(set) var invalidEntries: [SettingsHydrationError.InvalidEntry] = []
 
-        var errorDescription: String? {
-            switch self {
-            case let .invalidValue(key, value, expectedType):
-                return "Saved setting \"\(key)\" has invalid \(expectedType) value \"\(value)\". Fix or reset this setting before saving."
-            }
+    mutating func int(_ settings: [String: String], key: String, default defaultValue: Int) -> Int {
+        guard let rawValue = settings[key] else { return defaultValue }
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let parsed = Int(value) else {
+            recordInvalid(key: key, value: rawValue, expectedType: "whole number")
+            return defaultValue
         }
+        return parsed
     }
 
-    static func int(_ map: [String: String], key: String, default defaultValue: Int) throws -> Int {
-        guard let rawValue = map[key] else { return defaultValue }
-        let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let parsedValue = Int(trimmedValue) else {
-            throw ParseError.invalidValue(key: key, value: rawValue, expectedType: "whole-number")
+    mutating func double(_ settings: [String: String], key: String, default defaultValue: Double) -> Double {
+        guard let rawValue = settings[key] else { return defaultValue }
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let parsed = Double(value) else {
+            recordInvalid(key: key, value: rawValue, expectedType: "number")
+            return defaultValue
         }
-        return parsedValue
+        return parsed
     }
 
-    static func double(_ map: [String: String], key: String, default defaultValue: Double) throws -> Double {
-        guard let rawValue = map[key] else { return defaultValue }
-        let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let parsedValue = Double(trimmedValue) else {
-            throw ParseError.invalidValue(key: key, value: rawValue, expectedType: "decimal-number")
-        }
-        return parsedValue
-    }
-
-    static func bool(_ map: [String: String], key: String, default defaultValue: Bool) throws -> Bool {
-        guard let rawValue = map[key] else { return defaultValue }
-        switch rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "true":
-            return true
-        case "false":
-            return false
+    mutating func bool(_ settings: [String: String], key: String, default defaultValue: Bool) -> Bool {
+        guard let rawValue = settings[key] else { return defaultValue }
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch value {
+        case "true": return true
+        case "false": return false
         default:
-            throw ParseError.invalidValue(key: key, value: rawValue, expectedType: "true/false")
+            recordInvalid(key: key, value: rawValue, expectedType: "true or false")
+            return defaultValue
         }
+    }
+
+    func throwIfInvalid() throws {
+        guard !invalidEntries.isEmpty else { return }
+        throw SettingsHydrationError(invalidEntries: invalidEntries)
+    }
+
+    private mutating func recordInvalid(key: String, value: String, expectedType: String) {
+        invalidEntries.append(.init(key: key, value: value, expectedType: expectedType))
+    }
+}
+
+struct SettingsHydrationError: LocalizedError, Equatable {
+    struct InvalidEntry: Equatable {
+        let key: String
+        let value: String
+        let expectedType: String
+    }
+
+    let invalidEntries: [InvalidEntry]
+
+    var errorDescription: String? {
+        let listedEntries = invalidEntries
+            .prefix(5)
+            .map { "\($0.key)=\"\($0.value)\" (expected \($0.expectedType))" }
+            .joined(separator: ", ")
+        let extraCount = invalidEntries.count - 5
+        let suffix = extraCount > 0 ? ", and \(extraCount) more" : ""
+        return "Saved settings contain invalid values and were not overwritten. Fix these stored values before saving: \(listedEntries)\(suffix)."
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/SettingsSaveButtonValidationTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SettingsSaveButtonValidationTests.swift
@@ -226,45 +226,43 @@ final class SettingsSaveButtonValidationTests: XCTestCase {
         )
     }
 
-    // MARK: - Settings persisted value parsing
+    // MARK: - Settings Hydration
 
-    func testSettingsPagesUseStrictPersistedValueParser() throws {
+    func testSettingsPagesSurfaceMalformedStoredValuesBeforeSaveableFormLoads() throws {
+        let helper = try Self.readSettingsSource("SettingsValueParser.swift")
+        XCTAssertTrue(helper.contains("struct SettingsValueParser"))
+        XCTAssertTrue(helper.contains("throw SettingsHydrationError"))
+        XCTAssertTrue(helper.contains("Saved settings contain invalid values and were not overwritten"))
+
         let pages = [
+            "IOSAIConfigPage.swift",
+            "IOSOrganizationThresholdsPage.swift",
+            "IOSForecastSettingsPage.swift",
+            "IOSToolPoliciesPage.swift",
             "IOSAuditSettingsPage.swift",
             "IOSDispatchPreferencesPage.swift",
-            "IOSForecastSettingsPage.swift",
-            "IOSOrganizationThresholdsPage.swift",
-            "IOSToolPoliciesPage.swift",
         ]
 
         for page in pages {
             let source = try Self.readSettingsSource(page)
+
             XCTAssertTrue(
-                source.contains("try SettingsValueParser."),
-                "\(page) must parse persisted numeric and boolean settings through SettingsValueParser so malformed saved values surface as load errors."
+                source.contains("var parser = SettingsValueParser()"),
+                "\(page) should hydrate persisted settings through the typed settings parser."
+            )
+            XCTAssertTrue(
+                source.contains("try parser.throwIfInvalid()"),
+                "\(page) should validate malformed persisted settings before showing a saveable form."
+            )
+            XCTAssertTrue(
+                source.contains("loadError = settingsHydrationMessage(error)"),
+                "\(page) should route malformed saved settings into the visible loadError state."
             )
             XCTAssertFalse(
-                source.contains("Int(map[") || source.contains("Double(map[") || source.contains("] ?? \"true\") == \"true\"") || source.contains("] ?? \"false\") == \"true\""),
-                "\(page) must not silently coerce malformed persisted settings to fallback defaults."
+                source.contains("Int(map[") || source.contains("Double(map[") || source.contains(") == \"true\""),
+                "\(page) must not silently default malformed stored numeric or boolean settings."
             )
         }
-    }
-
-    func testSettingsValueParserDistinguishesMissingFromMalformedValues() throws {
-        let source = try Self.readSettingsSource("SettingsValueParser.swift")
-
-        XCTAssertTrue(
-            source.contains("guard let rawValue = map[key] else { return defaultValue }"),
-            "SettingsValueParser must continue allowing missing values to use page defaults."
-        )
-        XCTAssertTrue(
-            source.contains("throw ParseError.invalidValue") && source.contains("Saved setting") && source.contains("Fix or reset this setting before saving"),
-            "SettingsValueParser must throw a visible validation error for present-but-malformed values before a page can overwrite them."
-        )
-        XCTAssertTrue(
-            source.contains("case \"true\"") && source.contains("case \"false\"") && source.contains("expectedType: \"true/false\""),
-            "SettingsValueParser must validate persisted booleans instead of treating every non-true value as false."
-        )
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
- Add a shared SettingsValueParser for iOS settings pages that treats missing keys as defaults but reports present malformed numeric/boolean values.
- Gate AI, organization, forecast, tool policy, audit, and dispatch settings forms behind a visible load error when persisted values are invalid, preventing defaulted values from being saved over corrupted configuration.
- Extend settings regression coverage so hydration paths keep using the parser instead of silent Int/Double/bool fallback expressions.

Closes #1179

## Tests
- `swift test --filter SettingsServiceTests`
- `xcodebuild -scheme "Weird Parts" -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:"Weird Parts IOSTests/SettingsSaveButtonValidationTests/testSettingsPagesSurfaceMalformedStoredValuesBeforeSaveableFormLoads" test`

## CI / local runner path
This PR is ready for the repo local self-hosted Mac runner path for iOS/Xcode validation (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`).