### PR TITLE
fix: validate fleet numeric text fields

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/FleetNumericFieldParser.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/FleetNumericFieldParser.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Shared validation for optional Fleet integer text fields.
+///
+/// Blank input is treated as omitted, but malformed non-empty input is rejected so pasted
+/// text or hardware-keyboard input cannot be silently dropped by `Int(...)` returning nil.
+enum FleetNumericFieldParser {
+    struct ValidationError: LocalizedError, Equatable {
+        let fieldName: String
+
+        nonisolated var errorDescription: String? {
+            "\(fieldName) must be a whole number."
+        }
+    }
+
+    nonisolated static func optionalWholeNumber(_ rawValue: String, fieldName: String) throws -> Int? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        guard trimmed.allSatisfy(\.isWholeNumber), let value = Int(trimmed) else {
+            throw ValidationError(fieldName: fieldName)
+        }
+
+        return value
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSCreateVehicleSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSCreateVehicleSheet.swift
@@ -130,6 +130,17 @@ struct IOSCreateVehicleSheet: View {
             errorMessage = "Not signed in."
             return
         }
+        let parsedYear: Int?
+        do {
+            parsedYear = try FleetNumericFieldParser.optionalWholeNumber(
+                yearText,
+                fieldName: "Year"
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+            return
+        }
+
         isSaving = true
         errorMessage = nil
 
@@ -141,7 +152,7 @@ struct IOSCreateVehicleSheet: View {
                 vehicleType: vehicleType,
                 make: make.isEmpty ? nil : make,
                 model: model.isEmpty ? nil : model,
-                year: Int(yearText),
+                year: parsedYear,
                 color: color.isEmpty ? nil : color,
                 vin: vin.isEmpty ? nil : vin,
                 licensePlate: licensePlate.isEmpty ? nil : licensePlate,

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/PreTripInspectionView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/PreTripInspectionView.swift
@@ -356,6 +356,17 @@ struct PreTripInspectionView: View {
             return
         }
 
+        let parsedOdometer: Int?
+        do {
+            parsedOdometer = try FleetNumericFieldParser.optionalWholeNumber(
+                odometerReading,
+                fieldName: "Odometer"
+            )
+        } catch {
+            saveError = error.localizedDescription
+            return
+        }
+
         isSaving = true
         saveError = nil
 
@@ -375,7 +386,7 @@ struct PreTripInspectionView: View {
                     )
                 },
                 notes: generalNotes.isEmpty ? nil : generalNotes,
-                odometerReading: Int(odometerReading),
+                odometerReading: parsedOdometer,
                 fuelLevel: fuelLevel
             )
 

--- a/Weird Parts IOS/Weird Parts IOSTests/FleetNumericFieldParserTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/FleetNumericFieldParserTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Weird_Parts
+
+final class FleetNumericFieldParserTests: XCTestCase {
+    func testOptionalWholeNumberAllowsBlankAsNil() throws {
+        XCTAssertNil(try FleetNumericFieldParser.optionalWholeNumber("", fieldName: "Odometer"))
+        XCTAssertNil(try FleetNumericFieldParser.optionalWholeNumber("   \n", fieldName: "Year"))
+    }
+
+    func testOptionalWholeNumberParsesTrimmedDigits() throws {
+        XCTAssertEqual(try FleetNumericFieldParser.optionalWholeNumber(" 12345 ", fieldName: "Odometer"), 12345)
+        XCTAssertEqual(try FleetNumericFieldParser.optionalWholeNumber("2024", fieldName: "Year"), 2024)
+    }
+
+    func testOptionalWholeNumberRejectsMalformedNonEmptyText() throws {
+        XCTAssertThrowsError(try FleetNumericFieldParser.optionalWholeNumber("12O34", fieldName: "Odometer")) { error in
+            XCTAssertEqual(error.localizedDescription, "Odometer must be a whole number.")
+        }
+
+        XCTAssertThrowsError(try FleetNumericFieldParser.optionalWholeNumber("12,345", fieldName: "Odometer"))
+        XCTAssertThrowsError(try FleetNumericFieldParser.optionalWholeNumber("2024x", fieldName: "Year"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add a shared Fleet numeric text parser that allows blank optional values but rejects malformed non-empty input.
- Validate pre-trip odometer text before saving so invalid pasted/hardware-keyboard text shows an error instead of saving as nil.
- Validate create-vehicle year text with the same guard, closing the adjacent Fleet numeric-input defect.
- Add focused iOS unit coverage for blank, valid trimmed digits, and malformed text.

Closes #1175
Closes #1172

## Tests
- `xcodebuild -scheme "WiredPart-iOS" -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:"Weird Parts IOSTests/FleetNumericFieldParserTests" test`
- `xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build`

## CI / runner note
- Local Mac/Xcode path was verified before opening the PR. Repo CI should use the self-hosted local Mac runner labels for trusted iOS checks where required.

## Paperclip tracking
- Tracked in WEI-4216
- Closure audit: WEI-4610