### PR TITLE
fix: surface Part Match photo import failures

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Scanning/IOSCameraMatchView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Scanning/IOSCameraMatchView.swift
@@ -128,11 +128,38 @@ struct IOSCameraMatchView: View {
         }
         .onChange(of: photoPickerItem) { _, item in
             Task {
-                if let data = try? await item?.loadTransferable(type: Data.self),
-                   let uiImage = UIImage(data: data) {
-                    selectedImage = uiImage
-                }
+                await loadSelectedPhoto(item)
             }
+        }
+    }
+
+    // MARK: - Photo Import
+
+    @MainActor
+    private func loadSelectedPhoto(_ item: PhotosPickerItem?) async {
+        guard let item else { return }
+
+        errorMessage = nil
+        matchResults = []
+
+        do {
+            guard let data = try await item.loadTransferable(type: Data.self) else {
+                selectedImage = nil
+                errorMessage = "Could not load that photo. Try another image or use Camera."
+                return
+            }
+
+            guard let uiImage = UIImage(data: data) else {
+                selectedImage = nil
+                errorMessage = "Could not read that photo. Try another image or use Camera."
+                return
+            }
+
+            selectedImage = uiImage
+            errorMessage = nil
+        } catch {
+            selectedImage = nil
+            errorMessage = "Could not load that photo. Try another image or use Camera."
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/PartMatchPhotoImportFailureTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PartMatchPhotoImportFailureTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+/// Regression tests for GH #1081: Part Match photo imports must not fail silently.
+final class PartMatchPhotoImportFailureTests: XCTestCase {
+    func testPhotoImportUsesExplicitFailureHandling() throws {
+        let source = try Self.readPartMatchSource()
+
+        XCTAssertFalse(
+            source.contains("try? await item?.loadTransferable(type: Data.self)") ||
+                source.contains("try? await item.loadTransferable(type: Data.self)"),
+            "Part Match photo import must not swallow photo-library transfer errors with try?."
+        )
+        XCTAssertTrue(
+            source.contains("@MainActor") &&
+                source.contains("private func loadSelectedPhoto(_ item: PhotosPickerItem?) async") &&
+                source.contains("do {") &&
+                source.contains("} catch {") &&
+                source.contains("try await item.loadTransferable(type: Data.self)"),
+            "Photo import should use a main-actor explicit do/catch load path so failures can be surfaced to the user safely."
+        )
+    }
+
+    func testPhotoImportShowsActionableErrorsAndClearsStaleState() throws {
+        let source = try Self.readPartMatchSource()
+
+        XCTAssertTrue(
+            source.contains("errorMessage = \"Could not load that photo. Try another image or use Camera.\"") &&
+                source.contains("errorMessage = \"Could not read that photo. Try another image or use Camera.\""),
+            "Photo transfer and decode failures must show actionable Part Match error copy."
+        )
+        XCTAssertGreaterThanOrEqual(
+            source.components(separatedBy: "selectedImage = nil").count - 1,
+            2,
+            "Photo transfer/decode failures must clear any stale selected image instead of leaving the old image visible."
+        )
+        XCTAssertTrue(
+            source.contains("matchResults = []"),
+            "Starting a new photo import must clear stale match results."
+        )
+        XCTAssertTrue(
+            source.contains("selectedImage = uiImage") && source.contains("errorMessage = nil"),
+            "A successful import should select the new image and clear stale errors."
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func readPartMatchSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Scanning")
+            .appendingPathComponent("IOSCameraMatchView.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- replaces the Part Match photo-library `try?` import with explicit transfer/decode handling
- shows actionable error copy when Photos transfer fails or bytes cannot decode
- clears stale selected image/match results on failed imports so users do not unknowingly match an old photo
- adds a regression guard for the Part Match photo import failure path

Closes #1081

## Verification
- `xcodebuild test -project 'Weird Parts IOS/Weird Parts.xcodeproj' -scheme 'Weird Parts' -destination 'id=F29F2637-4865-4685-92B3-98D2F45EF30C' -derivedDataPath .tmp/DerivedData-WEI4327 -only-testing:'Weird Parts IOSTests/PartMatchPhotoImportFailureTests'` — passed on local Mac iOS simulator runner path
- `cd core && swift test --filter ImageMatcherTests` — 11 tests passed
- `cd core && swift test` — 2224 tests passed
