### PR TITLE
fix: surface AI text editor failures

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/AI/IOSAITextEditor.swift
+++ b/Weird Parts IOS/Weird Parts IOS/AI/IOSAITextEditor.swift
@@ -258,6 +258,8 @@ struct IOSAITextEditor: View {
     }
 
     private func enhance(mode: EnhanceMode) async {
+        debounceTask?.cancel()
+        suggestion = ""
         isEnhancing = true
         aiErrorMessage = nil
         defer { isEnhancing = false }
@@ -267,6 +269,7 @@ struct IOSAITextEditor: View {
             mode: mode,
             fieldType: fieldType
         )
+        guard !Task.isCancelled else { return }
 
         if result.success, let enhanced = result.text, !enhanced.isEmpty {
             text = enhanced
@@ -281,6 +284,8 @@ struct IOSAITextEditor: View {
     }
 
     private func preFill() async {
+        debounceTask?.cancel()
+        suggestion = ""
         isEnhancing = true
         aiErrorMessage = nil
         defer { isEnhancing = false }
@@ -289,6 +294,7 @@ struct IOSAITextEditor: View {
             fieldType: fieldType,
             contextData: contextData
         )
+        guard !Task.isCancelled else { return }
 
         if result.success, let draft = result.text, !draft.isEmpty {
             text = draft

--- a/Weird Parts IOS/Weird Parts IOS/AI/IOSAITextEditor.swift
+++ b/Weird Parts IOS/Weird Parts IOS/AI/IOSAITextEditor.swift
@@ -21,6 +21,8 @@ struct IOSAITextEditor: View {
     @State private var isEnhancing = false
     @State private var showEnhanceSheet = false
     @State private var showUnavailableAlert = false
+    @State private var aiErrorMessage: String?
+    @State private var showAIErrorAlert = false
     @State private var aiAvailability: AIAvailability = .notSupported
     @State private var debounceTask: Task<Void, Never>?
 
@@ -93,6 +95,33 @@ struct IOSAITextEditor: View {
                 }
                 .buttonStyle(.plain)
             }
+
+            if let aiErrorMessage {
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                        .accessibilityHidden(true)
+
+                    Text(aiErrorMessage)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Spacer(minLength: 8)
+
+                    Button("Dismiss") {
+                        self.aiErrorMessage = nil
+                    }
+                    .font(.caption)
+                    .buttonStyle(.borderless)
+                    .accessibilityLabel("Dismiss AI error")
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(Color.orange.opacity(0.12))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier("aiTextEditorErrorMessage")
+            }
         }
         .task {
             aiAvailability = aiService.checkAvailability()
@@ -104,6 +133,11 @@ struct IOSAITextEditor: View {
             Button("OK", role: .cancel) { }
         } message: {
             Text(unavailableMessage)
+        }
+        .alert("AI Request Failed", isPresented: $showAIErrorAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(aiErrorMessage ?? "AI could not finish that request. Please try again.")
         }
     }
 
@@ -186,6 +220,7 @@ struct IOSAITextEditor: View {
 
     private func onTextChange(_ newText: String) {
         suggestion = ""
+        aiErrorMessage = nil
         debounceTask?.cancel()
 
         guard aiAvailable, newText.count >= 10 else { return }
@@ -195,15 +230,23 @@ struct IOSAITextEditor: View {
             guard !Task.isCancelled else { return }
 
             isLoadingSuggestion = true
+            defer { isLoadingSuggestion = false }
+
             let result = await aiService.generateCompletion(
                 partialText: newText,
                 fieldType: fieldType,
                 contextData: contextData.isEmpty ? nil : contextData
             )
-            isLoadingSuggestion = false
+            guard !Task.isCancelled else { return }
 
-            if result.success, let completionText = result.text {
+            if result.success, let completionText = result.text, !completionText.isEmpty {
                 suggestion = completionText
+            } else {
+                aiErrorMessage = failureMessage(
+                    for: "AI suggestion",
+                    result: result,
+                    fallback: "AI suggestion failed. Keep typing or try again in a moment."
+                )
             }
         }
     }
@@ -211,32 +254,59 @@ struct IOSAITextEditor: View {
     private func acceptSuggestion() {
         text += suggestion
         suggestion = ""
+        aiErrorMessage = nil
     }
 
     private func enhance(mode: EnhanceMode) async {
         isEnhancing = true
+        aiErrorMessage = nil
+        defer { isEnhancing = false }
+
         let result = await aiService.enhanceText(
             text: text,
             mode: mode,
             fieldType: fieldType
         )
-        isEnhancing = false
 
-        if result.success, let enhanced = result.text {
+        if result.success, let enhanced = result.text, !enhanced.isEmpty {
             text = enhanced
+        } else {
+            aiErrorMessage = failureMessage(
+                for: "AI enhancement",
+                result: result,
+                fallback: "AI enhancement failed. Your original text was kept. Please try again."
+            )
+            showAIErrorAlert = true
         }
     }
 
     private func preFill() async {
         isEnhancing = true
+        aiErrorMessage = nil
+        defer { isEnhancing = false }
+
         let result = await aiService.generatePreFill(
             fieldType: fieldType,
             contextData: contextData
         )
-        isEnhancing = false
 
-        if result.success, let draft = result.text {
+        if result.success, let draft = result.text, !draft.isEmpty {
             text = draft
+        } else {
+            aiErrorMessage = failureMessage(
+                for: "AI pre-fill",
+                result: result,
+                fallback: "AI pre-fill failed. Please try again or enter the text manually."
+            )
+            showAIErrorAlert = true
         }
+    }
+
+    private func failureMessage(for operation: String, result: AIResult, fallback: String) -> String {
+        if result.success {
+            return "\(operation) returned no text. Please try again."
+        }
+
+        return fallback
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/IOSAITextEditorFailureRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/IOSAITextEditorFailureRegressionTests.swift
@@ -75,6 +75,20 @@ final class IOSAITextEditorFailureRegressionTests: XCTestCase {
                 preFillSection.contains("defer { isEnhancing = false }"),
             "Enhance and pre-fill should reset loading with defer so failure branches cannot leave stale spinner state."
         )
+        XCTAssertTrue(
+            enhanceSection.contains("debounceTask?.cancel()") &&
+                preFillSection.contains("debounceTask?.cancel()") &&
+                enhanceSection.contains("suggestion = \"\"") &&
+                preFillSection.contains("suggestion = \"\""),
+            "User-triggered AI actions should cancel pending autocomplete work so stale suggestion failures cannot overwrite their feedback."
+        )
+        XCTAssertTrue(
+            enhanceSection.contains("let result = await aiService.enhanceText") &&
+                preFillSection.contains("let result = await aiService.generatePreFill") &&
+                enhanceSection.contains("guard !Task.isCancelled else { return }") &&
+                preFillSection.contains("guard !Task.isCancelled else { return }"),
+            "Enhance and pre-fill should ignore cancelled AI results before mutating visible UI state."
+        )
     }
 
     func testAITextEditorDoesNotExposeRawAIServiceErrorsToUsers() throws {

--- a/Weird Parts IOS/Weird Parts IOSTests/IOSAITextEditorFailureRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/IOSAITextEditorFailureRegressionTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+
+/// Regression coverage for GitHub #1078 / Paperclip WEI-4328.
+///
+/// The AI text editor must surface failed AI generation paths instead of
+/// silently stopping its spinner and leaving the text unchanged.
+final class IOSAITextEditorFailureRegressionTests: XCTestCase {
+    func testAITextEditorSurfacesFailedEnhanceAndPreFill() throws {
+        let source = try Self.readAITextEditorSource()
+
+        XCTAssertTrue(
+            source.contains("@State private var aiErrorMessage: String?"),
+            "IOSAITextEditor should keep user-visible AI failure state."
+        )
+        XCTAssertTrue(
+            source.contains(".alert(\"AI Request Failed\"") &&
+                source.contains("showAIErrorAlert = true"),
+            "User-triggered AI failures should open an explicit alert instead of silently no-oping."
+        )
+        XCTAssertTrue(
+            source.contains("AI enhancement failed. Your original text was kept. Please try again."),
+            "Enhance failures should explain that the original text was preserved and suggest retrying."
+        )
+        XCTAssertTrue(
+            source.contains("AI pre-fill failed. Please try again or enter the text manually."),
+            "Pre-fill failures should provide actionable fallback guidance."
+        )
+        XCTAssertFalse(
+            source.contains("result.error?.trimmingCharacters"),
+            "Provider/internal AI errors should not be shown directly in user-visible failure copy."
+        )
+    }
+
+    func testAITextEditorSurfacesCompletionFailuresInlineAndAccessible() throws {
+        let source = try Self.readAITextEditorSource()
+        let completionSection = try Self.section(
+            named: "private func onTextChange",
+            in: source,
+            endingBefore: "private func acceptSuggestion"
+        )
+
+        XCTAssertTrue(
+            completionSection.contains("AI suggestion failed. Keep typing or try again in a moment."),
+            "Autocomplete failures should set visible inline feedback instead of leaving suggestion empty with no explanation."
+        )
+        XCTAssertTrue(
+            completionSection.contains("defer { isLoadingSuggestion = false }") &&
+                completionSection.contains("let result = await aiService.generateCompletion") &&
+                completionSection.contains("guard !Task.isCancelled else { return }"),
+            "Autocomplete should reset loading with defer and ignore cancelled debounce completions before surfacing errors."
+        )
+        XCTAssertTrue(
+            source.contains("accessibilityIdentifier(\"aiTextEditorErrorMessage\")") &&
+                source.contains("accessibilityElement(children: .contain)") &&
+                source.contains("accessibilityLabel(\"Dismiss AI error\")"),
+            "The visible AI failure callout should expose the message and Dismiss control separately to VoiceOver users."
+        )
+    }
+
+    func testAITextEditorUsesDeferToResetLoadingForAsyncActions() throws {
+        let source = try Self.readAITextEditorSource()
+        let enhanceSection = try Self.section(
+            named: "private func enhance",
+            in: source,
+            endingBefore: "private func preFill"
+        )
+        let preFillSection = try Self.section(
+            named: "private func preFill",
+            in: source,
+            endingBefore: "private func failureMessage"
+        )
+
+        XCTAssertTrue(
+            enhanceSection.contains("defer { isEnhancing = false }") &&
+                preFillSection.contains("defer { isEnhancing = false }"),
+            "Enhance and pre-fill should reset loading with defer so failure branches cannot leave stale spinner state."
+        )
+    }
+
+    func testAITextEditorDoesNotExposeRawAIServiceErrorsToUsers() throws {
+        let source = try Self.readAITextEditorSource()
+        let failureMessageSection = try Self.section(
+            named: "private func failureMessage",
+            in: source,
+            endingBefore: "}\n}"
+        )
+
+        XCTAssertFalse(
+            failureMessageSection.contains("result.error"),
+            "Visible AI errors should use curated user-facing copy, not raw service/model error text."
+        )
+    }
+
+    private static func section(named startMarker: String, in source: String, endingBefore endMarker: String) throws -> String {
+        guard let start = source.range(of: startMarker) else {
+            XCTFail("Missing section starting with \(startMarker)")
+            return ""
+        }
+        let afterStart = source[start.lowerBound...]
+        guard let end = afterStart.range(of: endMarker) else {
+            XCTFail("Missing section ending before \(endMarker)")
+            return ""
+        }
+        return String(afterStart[..<end.lowerBound])
+    }
+
+    private static func readAITextEditorSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("AI")
+            .appendingPathComponent("IOSAITextEditor.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds visible AI failure state to `IOSAITextEditor` for autocomplete, enhancement, and pre-fill requests.
- Shows an accessible inline callout for AI failures and an alert for user-triggered enhancement/pre-fill failures.
- Uses `defer` to clear enhancement loading state so failed async paths cannot leave stale spinner state.
- Adds iOS regression coverage for the visible failure copy, accessibility hooks, and loading reset guard.

Closes #1078

## Tests
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath .tmp/DerivedData-WEI4328 -only-testing:"Weird Parts IOSTests/IOSAITextEditorFailureRegressionTests"`
- `swift test --filter FoundationModelsServiceTests` from `core/`

## CI / local runner note
This PR is intended to validate on the repo's trusted self-hosted Mac/iOS runner path (`self-hosted, macOS, ARM64, xcode, ios, local-mac`) for required WPR2 iOS checks.
