### PR TITLE
fix: harden AI text editor cancellation handling

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/AI/IOSAITextEditor.swift
+++ b/Weird Parts IOS/Weird Parts IOS/AI/IOSAITextEditor.swift
@@ -258,8 +258,7 @@ struct IOSAITextEditor: View {
     }
 
     private func enhance(mode: EnhanceMode) async {
-        debounceTask?.cancel()
-        suggestion = ""
+        cancelSuggestionRequest()
         isEnhancing = true
         aiErrorMessage = nil
         defer { isEnhancing = false }
@@ -284,8 +283,7 @@ struct IOSAITextEditor: View {
     }
 
     private func preFill() async {
-        debounceTask?.cancel()
-        suggestion = ""
+        cancelSuggestionRequest()
         isEnhancing = true
         aiErrorMessage = nil
         defer { isEnhancing = false }
@@ -306,6 +304,13 @@ struct IOSAITextEditor: View {
             )
             showAIErrorAlert = true
         }
+    }
+
+    private func cancelSuggestionRequest() {
+        debounceTask?.cancel()
+        debounceTask = nil
+        suggestion = ""
+        isLoadingSuggestion = false
     }
 
     private func failureMessage(for operation: String, result: AIResult, fallback: String) -> String {

--- a/Weird Parts IOS/Weird Parts IOSTests/IOSAITextEditorFailureRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/IOSAITextEditorFailureRegressionTests.swift
@@ -67,7 +67,7 @@ final class IOSAITextEditorFailureRegressionTests: XCTestCase {
         let preFillSection = try Self.section(
             named: "private func preFill",
             in: source,
-            endingBefore: "private func failureMessage"
+            endingBefore: "private func cancelSuggestionRequest"
         )
 
         XCTAssertTrue(
@@ -76,10 +76,8 @@ final class IOSAITextEditorFailureRegressionTests: XCTestCase {
             "Enhance and pre-fill should reset loading with defer so failure branches cannot leave stale spinner state."
         )
         XCTAssertTrue(
-            enhanceSection.contains("debounceTask?.cancel()") &&
-                preFillSection.contains("debounceTask?.cancel()") &&
-                enhanceSection.contains("suggestion = \"\"") &&
-                preFillSection.contains("suggestion = \"\""),
+            enhanceSection.contains("cancelSuggestionRequest()") &&
+                preFillSection.contains("cancelSuggestionRequest()"),
             "User-triggered AI actions should cancel pending autocomplete work so stale suggestion failures cannot overwrite their feedback."
         )
         XCTAssertTrue(
@@ -88,6 +86,42 @@ final class IOSAITextEditorFailureRegressionTests: XCTestCase {
                 enhanceSection.contains("guard !Task.isCancelled else { return }") &&
                 preFillSection.contains("guard !Task.isCancelled else { return }"),
             "Enhance and pre-fill should ignore cancelled AI results before mutating visible UI state."
+        )
+    }
+
+    func testUserTriggeredAIRequestsCancelAutocompleteAndIgnoreCancellation() throws {
+        let source = try Self.readAITextEditorSource()
+        let enhanceSection = try Self.section(
+            named: "private func enhance",
+            in: source,
+            endingBefore: "private func preFill"
+        )
+        let preFillSection = try Self.section(
+            named: "private func preFill",
+            in: source,
+            endingBefore: "private func cancelSuggestionRequest"
+        )
+        let cancelSuggestionSection = try Self.section(
+            named: "private func cancelSuggestionRequest",
+            in: source,
+            endingBefore: "private func failureMessage"
+        )
+
+        XCTAssertTrue(
+            enhanceSection.contains("cancelSuggestionRequest()") &&
+                preFillSection.contains("cancelSuggestionRequest()"),
+            "User-triggered AI actions should cancel pending autocomplete so stale suggestion failures cannot overwrite the active alert."
+        )
+        XCTAssertTrue(
+            enhanceSection.contains("guard !Task.isCancelled else { return }") &&
+                preFillSection.contains("guard !Task.isCancelled else { return }"),
+            "Enhance and pre-fill should ignore cancellation results before setting error state or showing alerts."
+        )
+        XCTAssertTrue(
+            cancelSuggestionSection.contains("debounceTask?.cancel()") &&
+                cancelSuggestionSection.contains("suggestion = \"\"") &&
+                cancelSuggestionSection.contains("isLoadingSuggestion = false"),
+            "Cancelling autocomplete should clear pending task, visible suggestion, and loading state together."
         )
     }
 


### PR DESCRIPTION
## Summary
- Follow-up to PR #1302 for GH #1078: carries the post-review cancellation hardening commit that landed on the issue branch after PR #1302 merged.
- Centralizes autocomplete cancellation in `cancelSuggestionRequest()` so enhancement/pre-fill actions clear stale suggestion state consistently.
- Extends the iOS regression test to guard the helper and ensure user-triggered AI actions cancel pending autocomplete work.

Refs #1078

## Tests
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath .tmp/DerivedData-WEI4328-final -only-testing:"Weird Parts IOSTests/IOSAITextEditorFailureRegressionTests"`

## CI / local runner note
This PR should validate on the repo's trusted self-hosted Mac/iOS runner path (`self-hosted, macOS, ARM64, xcode, ios, local-mac`) for required WPR2 iOS checks.
