### PR TITLE
fix: adapt onboarding for accessibility text

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Auth/OnboardingWelcomeView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/OnboardingWelcomeView.swift
@@ -9,6 +9,7 @@ import WiredPartCore
 /// - **Join Existing Business** → DevicePairingView
 struct OnboardingWelcomeView: View {
     @EnvironmentObject private var appCore: AppCore
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     enum OnboardingPath {
         case createNew
@@ -17,109 +18,85 @@ struct OnboardingWelcomeView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                Spacer()
-
-                // Logo & Branding
-                VStack(spacing: 12) {
-                    Image(systemName: "wrench.and.screwdriver.fill")
-                        .decorativeIconFont(72)
-                        .foregroundStyle(Color.accentColor)
-                        .symbolRenderingMode(.hierarchical)
-
-                    Text("WiredPart")
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
-
-                    Text("The all-in-one platform for your trade business")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 40)
-                }
-
-                Spacer()
-
-                // Path Selection
-                VStack(spacing: 16) {
-                    Text("Get Started")
-                        .font(.title2)
-                        .fontWeight(.semibold)
-
-                    // Create New Business
-                    NavigationLink(value: OnboardingPath.createNew) {
-                        HStack(spacing: 16) {
-                            Image(systemName: "building.2.fill")
-                                .font(.title2)
-                                .foregroundStyle(Color.accentColor)
-                                .frame(width: 44, height: 44)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 10)
-                                        .fill(Color.accentColor.opacity(0.15))
-                                )
-
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Create New Business")
-                                    .font(.headline)
-                                    .foregroundStyle(.primary)
-                                Text("Set up a new company from scratch")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-
-                            Spacer()
-
-                            Image(systemName: "chevron.right")
-                                .font(.caption)
-                                .foregroundStyle(.tertiary)
+            GeometryReader { proxy in
+                ScrollView {
+                    VStack(spacing: dynamicTypeSize.isAccessibilitySize ? 28 : 0) {
+                        if !dynamicTypeSize.isAccessibilitySize {
+                            Spacer(minLength: 24)
                         }
-                        .padding(16)
-                        .dsCard()
-                    }
-                    .buttonStyle(.plain)
 
-                    // Join Existing Business
-                    NavigationLink(value: OnboardingPath.joinExisting) {
-                        HStack(spacing: 16) {
-                            Image(systemName: "link.circle.fill")
-                                .font(.title2)
+                        // Logo & Branding
+                        VStack(spacing: 12) {
+                            Image(systemName: "wrench.and.screwdriver.fill")
+                                .decorativeIconFont(dynamicTypeSize.isAccessibilitySize ? 56 : 72)
                                 .foregroundStyle(Color.accentColor)
-                                .frame(width: 44, height: 44)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 10)
-                                        .fill(Color.accentColor.opacity(0.15))
-                                )
+                                .symbolRenderingMode(.hierarchical)
+                                .accessibilityHidden(true)
 
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Join Existing Business")
-                                    .font(.headline)
-                                    .foregroundStyle(.primary)
-                                Text("Connect to a shop computer on your network")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
+                            Text("WiredPart")
+                                .font(.largeTitle)
+                                .fontWeight(.bold)
+                                .multilineTextAlignment(.center)
+                                .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
 
-                            Spacer()
-
-                            Image(systemName: "chevron.right")
-                                .font(.caption)
-                                .foregroundStyle(.tertiary)
+                            Text("The all-in-one platform for your trade business")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .multilineTextAlignment(.center)
+                                .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .padding(.horizontal, dynamicTypeSize.isAccessibilitySize ? 24 : 40)
                         }
-                        .padding(16)
-                        .dsCard()
+                        .padding(.top, dynamicTypeSize.isAccessibilitySize ? 24 : 0)
+
+                        if !dynamicTypeSize.isAccessibilitySize {
+                            Spacer(minLength: 24)
+                        }
+
+                        // Path Selection
+                        VStack(spacing: 16) {
+                            Text("Get Started")
+                                .font(.title2)
+                                .fontWeight(.semibold)
+                                .multilineTextAlignment(.center)
+                                .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
+
+                            NavigationLink(value: OnboardingPath.createNew) {
+                                onboardingPathRow(
+                                    icon: "building.2.fill",
+                                    title: "Create New Business",
+                                    subtitle: "Set up a new company from scratch"
+                                )
+                            }
+                            .buttonStyle(.plain)
+
+                            NavigationLink(value: OnboardingPath.joinExisting) {
+                                onboardingPathRow(
+                                    icon: "link.circle.fill",
+                                    title: "Join Existing Business",
+                                    subtitle: "Connect to a shop computer on your network"
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        .padding(.horizontal, dynamicTypeSize.isAccessibilitySize ? 16 : 24)
+
+                        if !dynamicTypeSize.isAccessibilitySize {
+                            Spacer(minLength: 24)
+                        }
+
+                        Text("Your data stays on your devices. No cloud account required.")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .multilineTextAlignment(.center)
+                            .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.horizontal, dynamicTypeSize.isAccessibilitySize ? 24 : 32)
+                            .padding(.bottom, dynamicTypeSize.isAccessibilitySize ? 32 : 24)
                     }
-                    .buttonStyle(.plain)
+                    .frame(maxWidth: .infinity)
+                    .frame(minHeight: proxy.size.height)
                 }
-                .padding(.horizontal, 24)
-
-                Spacer()
-
-                Text("Your data stays on your devices. No cloud account required.")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 32)
-                    .padding(.bottom, 24)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color(.systemBackground))
@@ -134,6 +111,45 @@ struct OnboardingWelcomeView: View {
                 }
             }
         }
+    }
+
+    private func onboardingPathRow(icon: String, title: String, subtitle: String) -> some View {
+        HStack(alignment: dynamicTypeSize.isAccessibilitySize ? .top : .center, spacing: 16) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 44, height: 44)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color.accentColor.opacity(0.15))
+                )
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .layoutPriority(1)
+
+            if !dynamicTypeSize.isAccessibilitySize {
+                Spacer(minLength: 8)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
+            }
+        }
+        .padding(16)
+        .dsCard()
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/OnboardingAX5LayoutRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/OnboardingAX5LayoutRegressionTests.swift
@@ -1,6 +1,31 @@
 import XCTest
 
 final class OnboardingAX5LayoutRegressionTests: XCTestCase {
+    func testInitialGetStartedScreenWrapsAndScrollsAtAccessibilitySizes() throws {
+        let source = try Self.readSource("Auth/OnboardingWelcomeView.swift")
+
+        XCTAssertTrue(
+            source.contains("@Environment(\\.dynamicTypeSize) private var dynamicTypeSize"),
+            "Initial Get Started screen should read Dynamic Type so it can adapt before labels truncate."
+        )
+        XCTAssertTrue(
+            source.contains("ScrollView {"),
+            "Initial Get Started content should scroll at AX5 instead of clipping the privacy footer."
+        )
+        XCTAssertTrue(
+            source.contains("HStack(alignment: dynamicTypeSize.isAccessibilitySize ? .top : .center"),
+            "Onboarding action rows should top-align when titles and subtitles wrap at accessibility sizes."
+        )
+        XCTAssertTrue(
+            source.contains(".lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)"),
+            "Onboarding subtitles/footer should remove restrictive line clamps at accessibility sizes."
+        )
+        XCTAssertTrue(
+            source.contains(".fixedSize(horizontal: false, vertical: true)"),
+            "Wrapped onboarding copy should keep its full vertical height instead of compressing inside rows."
+        )
+    }
+
     func testWelcomeOverlayUsesScrollableWrappedAccessibilityRows() throws {
         let source = try Self.readSource("Auth/NewUserWelcomeView.swift")
 


### PR DESCRIPTION
## Summary
- make the first-run Get Started onboarding screen scrollable within the available safe viewport
- allow the app subtitle, action titles/subtitles, and privacy footer to wrap at accessibility Dynamic Type sizes
- top-align onboarding action rows and hide decorative chevrons at accessibility sizes so labels keep width
- add a source regression test for the AX5 wrapping/scrolling safeguards

Closes #850

## Tests
- `xcodebuild test -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/OnboardingAX5LayoutRegressionTests"`
- `git diff --check`

## CI / local runner
- Local self-hosted Mac runner path checked via Actions runner API: `IA-Mac-WPR2` online with `self-hosted, macOS, ARM64, xcode, ios, local-mac` labels.
