### PR TITLE
fix: restore empty-state help affordance

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Shared/EmptyStateView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/EmptyStateView.swift
@@ -78,7 +78,9 @@ struct EmptyStateView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, DS.Space.xxxl)
 
-            if actionLabel != nil || secondaryActionLabel != nil || helpLabel != nil {
+            if (actionLabel != nil && action != nil) ||
+                (secondaryActionLabel != nil && secondaryAction != nil) ||
+                (helpLabel != nil && helpAction != nil) {
                 VStack(spacing: DS.Space.xs) {
                     HStack(spacing: DS.Space.md) {
                         if let label = actionLabel, let action = action {

--- a/Weird Parts IOS/Weird Parts IOS/Shared/EmptyStateView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/EmptyStateView.swift
@@ -24,6 +24,8 @@ struct EmptyStateView: View {
     var secondaryActionIcon: String?
     var secondaryActionAccessibilityIdentifier: String?
     var secondaryAction: (() -> Void)?
+    var helpLabel: String?
+    var helpAction: (() -> Void)?
     var action: (() -> Void)?
 
     init(
@@ -37,6 +39,8 @@ struct EmptyStateView: View {
         secondaryActionIcon: String? = nil,
         secondaryActionAccessibilityIdentifier: String? = nil,
         secondaryAction: (() -> Void)? = nil,
+        helpLabel: String? = nil,
+        helpAction: (() -> Void)? = nil,
         action: (() -> Void)? = nil
     ) {
         self.icon = icon
@@ -49,6 +53,8 @@ struct EmptyStateView: View {
         self.secondaryActionIcon = secondaryActionIcon
         self.secondaryActionAccessibilityIdentifier = secondaryActionAccessibilityIdentifier
         self.secondaryAction = secondaryAction
+        self.helpLabel = helpLabel
+        self.helpAction = helpAction
         self.action = action
     }
 
@@ -72,38 +78,50 @@ struct EmptyStateView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, DS.Space.xxxl)
 
-            if actionLabel != nil || secondaryActionLabel != nil {
-                HStack(spacing: DS.Space.md) {
-                    if let label = actionLabel, let action = action {
-                        Button(action: action) {
-                            if let icon = actionIcon {
-                                Label(label, systemImage: icon)
-                                    .fontWeight(.medium)
-                                    .frame(minHeight: 44)
-                            } else {
-                                Text(label)
-                                    .fontWeight(.medium)
-                                    .frame(minHeight: 44)
+            if actionLabel != nil || secondaryActionLabel != nil || helpLabel != nil {
+                VStack(spacing: DS.Space.xs) {
+                    HStack(spacing: DS.Space.md) {
+                        if let label = actionLabel, let action = action {
+                            Button(action: action) {
+                                if let icon = actionIcon {
+                                    Label(label, systemImage: icon)
+                                        .fontWeight(.medium)
+                                        .frame(minHeight: 44)
+                                } else {
+                                    Text(label)
+                                        .fontWeight(.medium)
+                                        .frame(minHeight: 44)
+                                }
                             }
+                            .buttonStyle(.borderedProminent)
+                            .accessibilityIdentifierIfPresent(actionAccessibilityIdentifier)
                         }
-                        .buttonStyle(.borderedProminent)
-                        .accessibilityIdentifierIfPresent(actionAccessibilityIdentifier)
+
+                        if let label = secondaryActionLabel, let action = secondaryAction {
+                            Button(action: action) {
+                                if let icon = secondaryActionIcon {
+                                    Label(label, systemImage: icon)
+                                        .fontWeight(.medium)
+                                        .frame(minHeight: 44)
+                                } else {
+                                    Text(label)
+                                        .fontWeight(.medium)
+                                        .frame(minHeight: 44)
+                                }
+                            }
+                            .buttonStyle(.bordered)
+                            .accessibilityIdentifierIfPresent(secondaryActionAccessibilityIdentifier)
+                        }
                     }
 
-                    if let label = secondaryActionLabel, let action = secondaryAction {
+                    if let label = helpLabel, let action = helpAction {
                         Button(action: action) {
-                            if let icon = secondaryActionIcon {
-                                Label(label, systemImage: icon)
-                                    .fontWeight(.medium)
-                                    .frame(minHeight: 44)
-                            } else {
-                                Text(label)
-                                    .fontWeight(.medium)
-                                    .frame(minHeight: 44)
-                            }
+                            Label(label, systemImage: "questionmark.circle")
+                                .fontWeight(.medium)
+                                .frame(minHeight: 44)
                         }
-                        .buttonStyle(.bordered)
-                        .accessibilityIdentifierIfPresent(secondaryActionAccessibilityIdentifier)
+                        .buttonStyle(.borderless)
+                        .accessibilityIdentifier("emptyStateHelpButton")
                     }
                 }
                 .padding(.top, DS.Space.xxs)

--- a/Weird Parts IOS/Weird Parts IOSTests/SaveExitFirstUseStandardsRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SaveExitFirstUseStandardsRegressionTests.swift
@@ -29,6 +29,25 @@ final class SaveExitFirstUseStandardsRegressionTests: XCTestCase {
             source.contains(".frame(minHeight: 44)"),
             "Primary, secondary, and help empty-state actions must remain touch-friendly."
         )
+        XCTAssertTrue(
+            source.contains("(actionLabel != nil && action != nil)") &&
+                source.contains("(secondaryActionLabel != nil && secondaryAction != nil)") &&
+                source.contains("(helpLabel != nil && helpAction != nil)"),
+            "The empty-state action container should render only when a label/action pair exists, avoiding blank padded action areas."
+        )
+    }
+
+    func testEmptyStateHelpTaxonomyDocumentsOptionalInlineHelp() throws {
+        let source = try Self.readPlanSource("empty-state-help-link-taxonomy.md")
+
+        XCTAssertTrue(
+            source.contains("optional GH #82 primitive"),
+            "The empty-state taxonomy should describe inline help as optional, not a blanket scanner requirement."
+        )
+        XCTAssertTrue(
+            source.contains("toolbar Help button remains the canonical Category A baseline"),
+            "The taxonomy should keep page toolbar help as the default primary-list pattern."
+        )
     }
 
     func testFormSheetPreservesSaveAndDirtyDismissStandards() throws {
@@ -86,6 +105,19 @@ final class SaveExitFirstUseStandardsRegressionTests: XCTestCase {
         let sourceURL = projectRoot
             .appendingPathComponent("Weird Parts IOS")
             .appendingPathComponent("Shared")
+            .appendingPathComponent(filename)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    private static func readPlanSource(_ filename: String, file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let repoRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+            .deletingLastPathComponent() // repo root
+        let sourceURL = repoRoot
+            .appendingPathComponent("docs")
+            .appendingPathComponent("plans")
             .appendingPathComponent(filename)
         return try String(contentsOf: sourceURL, encoding: .utf8)
     }

--- a/Weird Parts IOS/Weird Parts IOSTests/SaveExitFirstUseStandardsRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SaveExitFirstUseStandardsRegressionTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+/// Regression coverage for GitHub #82's cross-cutting form and first-time-use primitives.
+///
+/// The parent issue is intentionally program-wide, so these tests lock down the shared
+/// standards that individual pages and module lanes depend on: save/dismiss safety,
+/// inline first-time guidance, and contextual help discoverability.
+final class SaveExitFirstUseStandardsRegressionTests: XCTestCase {
+    func testEmptyStateViewProvidesDedicatedHelpAffordanceSlot() throws {
+        let source = try Self.readSharedSource("EmptyStateView.swift")
+
+        XCTAssertTrue(
+            source.contains("var helpLabel: String?") && source.contains("var helpAction: (() -> Void)?"),
+            "EmptyStateView must expose a dedicated helpLabel/helpAction slot so zero-record lists can link to page-specific guidance."
+        )
+        XCTAssertTrue(
+            source.contains("Label(label, systemImage: \"questionmark.circle\")"),
+            "The help affordance should use the questionmark.circle symbol required by the page-help pattern."
+        )
+        XCTAssertTrue(
+            source.contains(".buttonStyle(.borderless)"),
+            "Empty-state help links should render as a secondary/documentation affordance, not compete with the primary create action."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityIdentifier(\"emptyStateHelpButton\")"),
+            "The shared help link needs a stable accessibility identifier for iPhone/iPad QA."
+        )
+        XCTAssertTrue(
+            source.contains(".frame(minHeight: 44)"),
+            "Primary, secondary, and help empty-state actions must remain touch-friendly."
+        )
+    }
+
+    func testFormSheetPreservesSaveAndDirtyDismissStandards() throws {
+        let formSheet = try Self.readSharedSource("FormSheet.swift")
+        let dismissSafety = try Self.readSharedSource("DismissSafety.swift")
+
+        XCTAssertTrue(
+            formSheet.contains("var saveLabel: String = \"Save\""),
+            "Shared form sheets must keep a configurable save label so create flows can opt into Save & Exit naming."
+        )
+        XCTAssertTrue(
+            formSheet.contains(".disabled(!isValid || isSaving)"),
+            "Save actions must stay disabled while invalid or saving."
+        )
+        XCTAssertTrue(
+            formSheet.contains(".disabled(isSaving)"),
+            "Cancel actions must be disabled while saving so in-flight writes cannot be interrupted."
+        )
+        XCTAssertTrue(
+            formSheet.contains("DismissSafety.cancelOrConfirm") && formSheet.contains(".dismissSafety("),
+            "Shared forms must route explicit Cancel and drag-dismiss through the same dirty-state protection."
+        )
+        XCTAssertTrue(
+            dismissSafety.contains(".interactiveDismissDisabled(isDirty || isSaving)"),
+            "Dirty or saving sheets must block drag-dismiss instead of silently dropping changes."
+        )
+        XCTAssertTrue(
+            dismissSafety.contains("Discard Changes") && dismissSafety.contains("Keep Editing"),
+            "Dirty cancel flows must show the required discard/keep-editing choice."
+        )
+    }
+
+    func testHelpContentRegistryKeepsPageSpecificHelpQueryableByAI() throws {
+        let source = try Self.readSharedSource("HelpContentRegistry.swift")
+
+        XCTAssertTrue(
+            source.contains("static let entries") && source.contains("static func formattedHelp(for pageId: String)"),
+            "Page help content must remain centrally queryable for toolbar help and AI assistant context."
+        )
+        XCTAssertTrue(
+            source.contains("static let notificationToPageId"),
+            "Page-active notifications must map back to registry page IDs for contextual AI help."
+        )
+        XCTAssertTrue(
+            source.contains("dashboard-home") && source.contains("jobs-list") && source.contains("orders-pos") && source.contains("warehouse-dashboard"),
+            "The registry should continue covering representative core modules, not just a single page."
+        )
+    }
+
+    private static func readSharedSource(_ filename: String, file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Shared")
+            .appendingPathComponent(filename)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/docs/plans/empty-state-help-link-taxonomy.md
+++ b/docs/plans/empty-state-help-link-taxonomy.md
@@ -137,9 +137,12 @@ taxonomy instead of flagging every site without help-link parameters.
      `EmptyStateView` and a toolbar `Button` whose label contains
      `questionmark.circle`, instead of inspecting `EmptyStateView`
      parameters.
-4. **EmptyStateView API:** Do NOT add `helpLabel:` / `helpAction:`
-   parameters. The page-level toolbar Help button is the canonical pattern;
-   inline duplicates would dilute it.
+4. **EmptyStateView API:** `helpLabel:` / `helpAction:` are available as an
+   optional GH #82 primitive for pages that intentionally need inline first-use
+   guidance. They are not mandatory for every empty state. The page-level
+   toolbar Help button remains the canonical Category A baseline; only add an
+   inline help action when the page-specific design explicitly calls for a
+   secondary documentation affordance.
 
 ---
 


### PR DESCRIPTION
## Summary
- Restores the shared `EmptyStateView` optional inline help affordance for GH #82 first-time-use guidance.
- Gates the action container on label/action pairs so labels without closures do not create blank padded action areas.
- Updates the empty-state help taxonomy to clarify inline help is an optional GH #82 primitive while toolbar Help remains the Category A default.
- Adds focused regression coverage for empty-state help, form save/dirty-dismiss safety, the page help registry, and the help taxonomy.

## Verification
- `git diff --check`
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:"Weird Parts IOSTests/SaveExitFirstUseStandardsRegressionTests" -derivedDataPath .tmp/WEI4332-DerivedData` passed
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPad,OS=26.5' -only-testing:"Weird Parts IOSTests/SaveExitFirstUseStandardsRegressionTests" -derivedDataPath .tmp/WEI4332-iPad-DerivedData` passed
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -only-testing:"Weird Parts IOSTests/SaveExitFirstUseStandardsRegressionTests" -derivedDataPath .tmp/WEI4332-reviewfix-DerivedData` passed
- `xcodebuild build -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO -derivedDataPath .tmp/WEI4332-reviewfix-Build-DerivedData` passed

## Local Mac runner path
This PR is intended for the repo-owned local Mac Actions runner path (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`) for trusted WPR2 iOS validation.

Closes #82.
