### PR TITLE
fix: validate JPO suggestion quantities

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOCreationPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOCreationPage.swift
@@ -61,6 +61,7 @@ struct IOSJPOCreationPage: View {
     @State private var confirmOriginalQty: Int = 1
     @State private var confirmSource = ""  // "companion" or "ai"
     @State private var showConfirmDialog = false
+    @State private var confirmValidationMessage: String?
 
     // MARK: - State
 
@@ -197,21 +198,31 @@ struct IOSJPOCreationPage: View {
         ) {
             TextField("Quantity", value: $confirmQty, format: .number)
                 .keyboardType(.numberPad)
+                .onChange(of: confirmQty) {
+                    confirmValidationMessage = Self.cartQuantityValidationMessage(for: confirmQty)
+                }
             Button("Cancel", role: .cancel) { }
             Button("Add to Cart") {
                 if let part = confirmingPart {
-                    addToCart(part: part, quantity: confirmQty)
-                    recordSuggestionFeedback(
-                        partId: part.id ?? 0,
-                        suggestedQty: confirmOriginalQty,
-                        acceptedQty: confirmQty,
-                        source: confirmSource
-                    )
+                    if validateCartQuantity(confirmQty) {
+                        addToCart(part: part, quantity: confirmQty)
+                        recordSuggestionFeedback(
+                            partId: part.id ?? 0,
+                            suggestedQty: confirmOriginalQty,
+                            acceptedQty: confirmQty,
+                            source: confirmSource
+                        )
+                    }
                 }
             }
+            .disabled(confirmQty <= 0)
         } message: {
             let stock = getShopStock(partId: confirmingPart?.id ?? 0)
-            Text("Suggested: \(confirmOriginalQty). Shop stock: \(stock). Adjust if needed.")
+            if let confirmValidationMessage {
+                Text("\(confirmValidationMessage) Suggested: \(confirmOriginalQty). Shop stock: \(stock).")
+            } else {
+                Text("Suggested: \(confirmOriginalQty). Shop stock: \(stock). Adjust if needed.")
+            }
         }
         .alert("Different Job", isPresented: $showJobVerification) {
             // "Yes" intentionally has no body — selectedJobId is already set to the
@@ -789,8 +800,21 @@ struct IOSJPOCreationPage: View {
 
     // MARK: - Cart Logic
 
+    private static func cartQuantityValidationMessage(for quantity: Int) -> String? {
+        quantity > 0 ? nil : "Quantity must be at least 1."
+    }
+
+    private func validateCartQuantity(_ quantity: Int) -> Bool {
+        if let message = Self.cartQuantityValidationMessage(for: quantity) {
+            submitError = message
+            return false
+        }
+        return true
+    }
+
     private func addToCart(part: Part, quantity: Int = 1) {
         guard let partId = part.id else { return }
+        guard validateCartQuantity(quantity) else { return }
 
         // Already in cart — increment
         if let idx = cartItems.firstIndex(where: { $0.partId == partId }) {
@@ -838,6 +862,7 @@ struct IOSJPOCreationPage: View {
     // MARK: - Suggestion Confirm + Feedback
 
     private func prepareSuggestionConfirm(partId: Int64, suggestedQty: Int, source: String) {
+        guard validateCartQuantity(suggestedQty) else { return }
         guard let service = appCore.partsService,
               let details = try? service.getPart(id: partId) else {
             submitError = "Parts service not available"
@@ -846,6 +871,7 @@ struct IOSJPOCreationPage: View {
         confirmingPart = details.part
         confirmQty = suggestedQty
         confirmOriginalQty = suggestedQty
+        confirmValidationMessage = Self.cartQuantityValidationMessage(for: suggestedQty)
         confirmSource = source
         showConfirmDialog = true
     }
@@ -1042,7 +1068,9 @@ struct IOSJPOCreationPage: View {
                     guard parts.count >= 3 else { return nil }
                     let name = parts[0].trimmingCharacters(in: .whitespaces)
                     let reason = parts[1].trimmingCharacters(in: .whitespaces)
-                    let qty = Int(parts[2].trimmingCharacters(in: .whitespaces)) ?? 1
+                    guard let qty = Int(parts[2].trimmingCharacters(in: .whitespaces)), qty > 0 else {
+                        return nil
+                    }
                     // Try to match to a real part in catalog
                     let matchedPart = try? service.searchParts(query: name, limit: 1).first
                     return AISuggestion(
@@ -1072,6 +1100,9 @@ struct IOSJPOCreationPage: View {
         submitError = nil
 
         do {
+            if let invalidLine = cartItems.first(where: { $0.quantity <= 0 }) {
+                throw OrdersService.OrdersError.invalidQuantity(invalidLine.quantity)
+            }
             let lines = cartItems.map { (partId: $0.partId, quantity: $0.quantity) }
             let jpoId = try service.createJPOWithLines(
                 jobId: jobId,

--- a/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests.swift
@@ -217,6 +217,40 @@ final class OrdersSessionUnavailableRegressionTests: XCTestCase {
         )
     }
 
+    func testJPOSuggestionQuantitiesAreValidatedBeforeCartMutation() throws {
+        let jpoCreationSource = try Self.readOrdersSource(named: "IOSJPOCreationPage.swift")
+
+        XCTAssertTrue(
+            jpoCreationSource.contains("private static func cartQuantityValidationMessage(for quantity: Int) -> String?") &&
+                jpoCreationSource.contains("quantity > 0 ? nil : \"Quantity must be at least 1.\""),
+            "JPO creation should centralize positive quantity validation for search, companion, AI, confirmation, and submit paths."
+        )
+        XCTAssertTrue(
+            jpoCreationSource.contains("guard validateCartQuantity(quantity) else { return }") &&
+                jpoCreationSource.contains("guard validateCartQuantity(suggestedQty) else { return }"),
+            "addToCart and suggestion confirmation should reject zero or negative quantities before mutating cart state."
+        )
+        XCTAssertTrue(
+            jpoCreationSource.contains(".disabled(confirmQty <= 0)") &&
+                jpoCreationSource.contains("confirmValidationMessage = Self.cartQuantityValidationMessage(for: confirmQty)"),
+            "The suggestion confirmation alert should block invalid Add actions and show inline validation feedback."
+        )
+        XCTAssertTrue(
+            jpoCreationSource.contains("guard let qty = Int(parts[2].trimmingCharacters(in: .whitespaces)), qty > 0 else") &&
+                jpoCreationSource.contains("return nil"),
+            "AI suggestion parsing should reject malformed, zero, or negative quantities instead of silently coercing them to one."
+        )
+        XCTAssertFalse(
+            jpoCreationSource.contains("Int(parts[2].trimmingCharacters(in: .whitespaces)) ?? 1"),
+            "Malformed AI quantities must not be silently treated as valid quantity-one suggestions."
+        )
+        XCTAssertTrue(
+            jpoCreationSource.contains("cartItems.first(where: { $0.quantity <= 0 })") &&
+                jpoCreationSource.contains("throw OrdersService.OrdersError.invalidQuantity(invalidLine.quantity)"),
+            "Submit should fail closed if any invalid cart quantity reaches the final order creation path."
+        )
+    }
+
     private static func readOrdersSource(named filename: String, file: StaticString = #filePath) throws -> String {
         let testFileURL = URL(fileURLWithPath: "\(file)")
         let projectRoot = testFileURL

--- a/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
@@ -2543,18 +2543,21 @@ struct OrdersServiceTests {
         }
     }
 
-    @Test("createJPOWithLines rejects zero-quantity line")
-    func testCreateJPOWithLines_rejectsZeroQuantity() throws {
+    @Test("createJPOWithLines rejects non-positive line quantities")
+    func testCreateJPOWithLines_rejectsNonPositiveQuantities() throws {
         let env = try E2ETestHelpers.setUp()
         let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-ZQ-86", name: "Zero Qty Job")
         let catId = try E2ETestHelpers.seedCategory(env, name: "ZQCAT86")
         let partId = try E2ETestHelpers.seedPart(env, name: "ZQ Part", categoryId: catId)
-        #expect(throws: OrdersService.OrdersError.invalidQuantity(0)) {
-            try env.orders.createJPOWithLines(
-                jobId: jobId, requestedBy: env.adminUserId,
-                priority: "normal", deliveryOption: "standard",
-                notes: nil, lines: [(partId: partId, quantity: 0)]
-            )
+
+        for quantity in [0, -1] {
+            #expect(throws: OrdersService.OrdersError.invalidQuantity(quantity)) {
+                try env.orders.createJPOWithLines(
+                    jobId: jobId, requestedBy: env.adminUserId,
+                    priority: "normal", deliveryOption: "standard",
+                    notes: nil, lines: [(partId: partId, quantity: quantity)]
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Validate JPO suggestion quantities through one shared positive-quantity guard before confirmation, cart mutation, and submit.
- Reject malformed, zero, and negative AI suggestion quantities instead of silently coercing malformed output to 1.
- Add regression coverage for the iOS JPO suggestion guard and extend the core JPO line test to cover negative quantities.

Closes #1180

## Verification
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `cd core && swift test --filter OrdersServiceTests/testCreateJPOWithLines_rejectsNonPositiveQuantities`
- `xcodebuild -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/OrdersSessionUnavailableRegressionTests/testJPOSuggestionQuantitiesAreValidatedBeforeCartMutation" test`
- `cd core && swift test` (2224 tests / 67 suites passed)

## Local runner / CI note
Verified local self-hosted Mac runner `IA-Mac-WPR2` is online with labels `self-hosted, macOS, ARM64, xcode, ios, local-mac`; repo workflows use those labels for trusted PR validation.