### PR TITLE
fix: address empty-state help spacing review

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Shared/EmptyStateView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/EmptyStateView.swift
@@ -60,6 +60,26 @@ struct EmptyStateView: View {
 
     @ScaledMetric(relativeTo: .largeTitle) private var iconSize: CGFloat = 48
 
+    private var hasPrimaryAction: Bool {
+        actionLabel != nil && action != nil
+    }
+
+    private var hasSecondaryAction: Bool {
+        secondaryActionLabel != nil && secondaryAction != nil
+    }
+
+    private var hasHelpAction: Bool {
+        helpLabel != nil && helpAction != nil
+    }
+
+    private var hasPrimaryOrSecondaryAction: Bool {
+        hasPrimaryAction || hasSecondaryAction
+    }
+
+    private var hasAnyAction: Bool {
+        hasPrimaryOrSecondaryAction || hasHelpAction
+    }
+
     var body: some View {
         VStack(spacing: DS.Space.lg) {
             Spacer()
@@ -78,41 +98,41 @@ struct EmptyStateView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, DS.Space.xxxl)
 
-            if (actionLabel != nil && action != nil) ||
-                (secondaryActionLabel != nil && secondaryAction != nil) ||
-                (helpLabel != nil && helpAction != nil) {
-                VStack(spacing: DS.Space.xs) {
-                    HStack(spacing: DS.Space.md) {
-                        if let label = actionLabel, let action = action {
-                            Button(action: action) {
-                                if let icon = actionIcon {
-                                    Label(label, systemImage: icon)
-                                        .fontWeight(.medium)
-                                        .frame(minHeight: 44)
-                                } else {
-                                    Text(label)
-                                        .fontWeight(.medium)
-                                        .frame(minHeight: 44)
+            if hasAnyAction {
+                VStack(spacing: 0) {
+                    if hasPrimaryOrSecondaryAction {
+                        HStack(spacing: DS.Space.md) {
+                            if let label = actionLabel, let action = action {
+                                Button(action: action) {
+                                    if let icon = actionIcon {
+                                        Label(label, systemImage: icon)
+                                            .fontWeight(.medium)
+                                            .frame(minHeight: 44)
+                                    } else {
+                                        Text(label)
+                                            .fontWeight(.medium)
+                                            .frame(minHeight: 44)
+                                    }
                                 }
+                                .buttonStyle(.borderedProminent)
+                                .accessibilityIdentifierIfPresent(actionAccessibilityIdentifier)
                             }
-                            .buttonStyle(.borderedProminent)
-                            .accessibilityIdentifierIfPresent(actionAccessibilityIdentifier)
-                        }
 
-                        if let label = secondaryActionLabel, let action = secondaryAction {
-                            Button(action: action) {
-                                if let icon = secondaryActionIcon {
-                                    Label(label, systemImage: icon)
-                                        .fontWeight(.medium)
-                                        .frame(minHeight: 44)
-                                } else {
-                                    Text(label)
-                                        .fontWeight(.medium)
-                                        .frame(minHeight: 44)
+                            if let label = secondaryActionLabel, let action = secondaryAction {
+                                Button(action: action) {
+                                    if let icon = secondaryActionIcon {
+                                        Label(label, systemImage: icon)
+                                            .fontWeight(.medium)
+                                            .frame(minHeight: 44)
+                                    } else {
+                                        Text(label)
+                                            .fontWeight(.medium)
+                                            .frame(minHeight: 44)
+                                    }
                                 }
+                                .buttonStyle(.bordered)
+                                .accessibilityIdentifierIfPresent(secondaryActionAccessibilityIdentifier)
                             }
-                            .buttonStyle(.bordered)
-                            .accessibilityIdentifierIfPresent(secondaryActionAccessibilityIdentifier)
                         }
                     }
 
@@ -124,6 +144,7 @@ struct EmptyStateView: View {
                         }
                         .buttonStyle(.borderless)
                         .accessibilityIdentifier("emptyStateHelpButton")
+                        .padding(.top, hasPrimaryOrSecondaryAction ? DS.Space.xs : 0)
                     }
                 }
                 .padding(.top, DS.Space.xxs)

--- a/Weird Parts IOS/Weird Parts IOSTests/SaveExitFirstUseStandardsRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SaveExitFirstUseStandardsRegressionTests.swift
@@ -30,10 +30,19 @@ final class SaveExitFirstUseStandardsRegressionTests: XCTestCase {
             "Primary, secondary, and help empty-state actions must remain touch-friendly."
         )
         XCTAssertTrue(
-            source.contains("(actionLabel != nil && action != nil)") &&
-                source.contains("(secondaryActionLabel != nil && secondaryAction != nil)") &&
-                source.contains("(helpLabel != nil && helpAction != nil)"),
+            source.contains("private var hasPrimaryAction: Bool") &&
+                source.contains("actionLabel != nil && action != nil") &&
+                source.contains("private var hasSecondaryAction: Bool") &&
+                source.contains("secondaryActionLabel != nil && secondaryAction != nil") &&
+                source.contains("private var hasHelpAction: Bool") &&
+                source.contains("helpLabel != nil && helpAction != nil"),
             "The empty-state action container should render only when a label/action pair exists, avoiding blank padded action areas."
+        )
+        XCTAssertTrue(
+            source.contains("VStack(spacing: 0)") &&
+                source.contains("if hasPrimaryOrSecondaryAction") &&
+                source.contains(".padding(.top, hasPrimaryOrSecondaryAction ? DS.Space.xs : 0)"),
+            "Help-only empty states should avoid a blank primary-action gap while preserving spacing when create/cancel actions exist."
         )
     }
 


### PR DESCRIPTION
## Summary
- Addresses post-review spacing feedback on the shared `EmptyStateView` help affordance merged for GH #82.
- Uses explicit label/action-pair helpers to decide whether any action row should render.
- Keeps help-only empty states tight by using zero VStack spacing and adding top padding to the help button only when primary/secondary actions are also present.
- Extends the GH #82 regression test to lock the help-only gap behavior.

## Verification
- `git diff --check`
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -only-testing:"Weird Parts IOSTests/SaveExitFirstUseStandardsRegressionTests" -derivedDataPath .tmp/WEI4332-copilot-gap-DerivedData` passed
- `xcodebuild build -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO -derivedDataPath .tmp/WEI4332-copilot-gap-Build-DerivedData` passed

## Local Mac runner path
This PR is intended for the repo-owned local Mac Actions runner path (`self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`) for trusted WPR2 iOS validation.

Follow-up to #82 / #1307.
