### PR TITLE
fix: add standard filter bar to core list gaps

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
@@ -76,6 +76,9 @@ struct JobsListPage: View {
     @State private var statusCounts: [String: Int] = [:]
     @State private var isLoading = true
     @State private var searchText = ""
+    @State private var dateRange: ReportDateRange = .thisWeek
+    @State private var customStart = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
+    @State private var customEnd = Date()
     @State private var statusFilter: JobStatusFilter = .active
     @State private var sortOption: JobSort = .recentActivity
     @State private var loadError: String?
@@ -88,6 +91,7 @@ struct JobsListPage: View {
         VStack(spacing: 0) {
             OnboardingBanner(pageId: "jobs-list")
             SkippedModuleHint(moduleId: "jobs")
+            StandardFilterBar(selectedRange: $dateRange, customStart: $customStart, customEnd: $customEnd)
             smartCards
             jobsList
         }
@@ -181,6 +185,9 @@ struct JobsListPage: View {
             }
         }
         .onChange(of: searchText) { loadJobs() }
+        .onChange(of: dateRange) { applyFilterAndSort() }
+        .onChange(of: customStart) { applyFilterAndSort() }
+        .onChange(of: customEnd) { applyFilterAndSort() }
         .onChange(of: sortOption) { applyFilterAndSort() }
         .refreshable { loadJobs() }
         .task { loadJobs() }
@@ -661,6 +668,10 @@ struct JobsListPage: View {
             }
         }
 
+        filtered = filtered.filter { job in
+            dateStringFallsInSelectedRange(job.startDate ?? job.dueDate)
+        }
+
         // Continuous jobs: only show to assigned workers or managers
         // (We don't have assignment info on JobListItem, so we skip this client-side filter
         //  and rely on the server query. Managers see all.)
@@ -677,5 +688,30 @@ struct JobsListPage: View {
         }
 
         jobs = filtered
+    }
+
+    private var effectiveStart: Date {
+        dateRange.dateInterval?.start ?? customStart
+    }
+
+    private var effectiveEnd: Date {
+        dateRange.dateInterval?.end ?? customEnd
+    }
+
+    private func dateStringFallsInSelectedRange(_ rawDate: String?) -> Bool {
+        guard let date = parseFilterDate(rawDate) else { return false }
+        return date >= Calendar.current.startOfDay(for: effectiveStart) && date <= endOfDay(for: effectiveEnd)
+    }
+
+    private func endOfDay(for date: Date) -> Date {
+        Calendar.current.dateInterval(of: .day, for: date)?.end.addingTimeInterval(-1) ?? date
+    }
+
+    private func parseFilterDate(_ rawDate: String?) -> Date? {
+        guard let rawDate, !rawDate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return Formatters.sqlDateTimeFormatter.date(from: rawDate)
+            ?? Formatters.iso8601Fractional.date(from: rawDate)
+            ?? Formatters.iso8601Basic.date(from: rawDate)
+            ?? Formatters.localDateFormatter.date(from: String(rawDate.prefix(10)))
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
@@ -257,11 +257,13 @@ struct JobsListPage: View {
     }
 
     private func countFor(_ filter: JobStatusFilter) -> Int {
-        if filter == .all { return allJobs.count }
+        let dateFilteredJobs = allJobs.filter { dateStringFallsInSelectedRange($0.startDate ?? $0.dueDate) }
+        if filter == .all { return dateFilteredJobs.count }
         if filter == .continuous {
-            return allJobs.filter { $0.jobType == "continuous" || $0.status == "continuous" }.count
+            return dateFilteredJobs.filter { $0.jobType == "continuous" || $0.status == "continuous" }.count
         }
-        return statusCounts[filter.queryValue ?? ""] ?? 0
+        guard let queryValue = filter.queryValue else { return dateFilteredJobs.count }
+        return dateFilteredJobs.filter { $0.status == queryValue }.count
     }
 
     private func colorFor(_ filter: JobStatusFilter) -> Color {
@@ -699,7 +701,7 @@ struct JobsListPage: View {
     }
 
     private func dateStringFallsInSelectedRange(_ rawDate: String?) -> Bool {
-        guard let date = parseFilterDate(rawDate) else { return false }
+        guard let date = parseFilterDate(rawDate) else { return true }
         return date >= Calendar.current.startOfDay(for: effectiveStart) && date <= endOfDay(for: effectiveEnd)
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
@@ -702,11 +702,11 @@ struct JobsListPage: View {
 
     private func dateStringFallsInSelectedRange(_ rawDate: String?) -> Bool {
         guard let date = parseFilterDate(rawDate) else { return true }
-        return date >= Calendar.current.startOfDay(for: effectiveStart) && date <= endOfDay(for: effectiveEnd)
+        return date >= Calendar.current.startOfDay(for: effectiveStart) && date < exclusiveEndOfDay(for: effectiveEnd)
     }
 
-    private func endOfDay(for date: Date) -> Date {
-        Calendar.current.dateInterval(of: .day, for: date)?.end.addingTimeInterval(-1) ?? date
+    private func exclusiveEndOfDay(for date: Date) -> Date {
+        Calendar.current.dateInterval(of: .day, for: date)?.end ?? date
     }
 
     private func parseFilterDate(_ rawDate: String?) -> Date? {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
@@ -73,6 +73,8 @@ struct JobsListPage: View {
     @State private var activeSheet: ActiveSheet?
     @State private var jobs: [JobsService.JobListItem] = []
     @State private var allJobs: [JobsService.JobListItem] = []
+    @State private var dateFilteredJobCount = 0
+    @State private var continuousJobCount = 0
     @State private var statusCounts: [String: Int] = [:]
     @State private var isLoading = true
     @State private var searchText = ""
@@ -257,13 +259,10 @@ struct JobsListPage: View {
     }
 
     private func countFor(_ filter: JobStatusFilter) -> Int {
-        let dateFilteredJobs = allJobs.filter { dateStringFallsInSelectedRange($0.startDate ?? $0.dueDate) }
-        if filter == .all { return dateFilteredJobs.count }
-        if filter == .continuous {
-            return dateFilteredJobs.filter { $0.jobType == "continuous" || $0.status == "continuous" }.count
-        }
-        guard let queryValue = filter.queryValue else { return dateFilteredJobs.count }
-        return dateFilteredJobs.filter { $0.status == queryValue }.count
+        if filter == .all { return dateFilteredJobCount }
+        if filter == .continuous { return continuousJobCount }
+        guard let queryValue = filter.queryValue else { return dateFilteredJobCount }
+        return statusCounts[queryValue] ?? 0
     }
 
     private func colorFor(_ filter: JobStatusFilter) -> Color {
@@ -632,12 +631,6 @@ struct JobsListPage: View {
                 status: nil
             )
             stagesByTemplateId = try loadTemplateStageCache(service: service, jobs: allJobs)
-            // Build status counts
-            var counts: [String: Int] = [:]
-            for j in allJobs {
-                counts[j.status, default: 0] += 1
-            }
-            statusCounts = counts
             refreshJobSummaryCache()
             applyFilterAndSort()
         } catch {
@@ -659,7 +652,16 @@ struct JobsListPage: View {
     }
 
     private func applyFilterAndSort() {
-        var filtered = allJobs
+        let dateFiltered = allJobs.filter { job in
+            StandardDateRangeFilter.contains(
+                job.startDate ?? job.dueDate,
+                selectedRange: dateRange,
+                customStart: customStart,
+                customEnd: customEnd
+            )
+        }
+        refreshDateScopedStatusCounts(from: dateFiltered)
+        var filtered = dateFiltered
 
         // Apply status filter
         if let query = statusFilter.queryValue {
@@ -668,10 +670,6 @@ struct JobsListPage: View {
             } else {
                 filtered = filtered.filter { $0.status == query }
             }
-        }
-
-        filtered = filtered.filter { job in
-            dateStringFallsInSelectedRange(job.startDate ?? job.dueDate)
         }
 
         // Continuous jobs: only show to assigned workers or managers
@@ -692,28 +690,10 @@ struct JobsListPage: View {
         jobs = filtered
     }
 
-    private var effectiveStart: Date {
-        dateRange.dateInterval?.start ?? customStart
-    }
-
-    private var effectiveEnd: Date {
-        dateRange.dateInterval?.end ?? customEnd
-    }
-
-    private func dateStringFallsInSelectedRange(_ rawDate: String?) -> Bool {
-        guard let date = parseFilterDate(rawDate) else { return true }
-        return date >= Calendar.current.startOfDay(for: effectiveStart) && date < exclusiveEndOfDay(for: effectiveEnd)
-    }
-
-    private func exclusiveEndOfDay(for date: Date) -> Date {
-        Calendar.current.dateInterval(of: .day, for: date)?.end ?? date
-    }
-
-    private func parseFilterDate(_ rawDate: String?) -> Date? {
-        guard let rawDate, !rawDate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
-        return Formatters.sqlDateTimeFormatter.date(from: rawDate)
-            ?? Formatters.iso8601Fractional.date(from: rawDate)
-            ?? Formatters.iso8601Basic.date(from: rawDate)
-            ?? Formatters.localDateFormatter.date(from: String(rawDate.prefix(10)))
+    private func refreshDateScopedStatusCounts(from dateFilteredJobs: [JobsService.JobListItem]) {
+        dateFilteredJobCount = dateFilteredJobs.count
+        continuousJobCount = dateFilteredJobs.filter { $0.jobType == "continuous" || $0.status == "continuous" }.count
+        statusCounts = Dictionary(grouping: dateFilteredJobs, by: \.status)
+            .mapValues(\.count)
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOsPage.swift
@@ -150,12 +150,16 @@ struct IOSJPOsPage: View {
     // MARK: - Counts
 
     private var pendingCount: Int {
-        allJPOs.filter { $0.status == "pending" }.count
+        dateFilteredJPOs.filter { $0.status == "pending" }.count
     }
 
     private func countForStatus(_ status: String) -> Int {
-        if status == "all" { return allJPOs.count }
-        return allJPOs.filter { $0.status == status }.count
+        if status == "all" { return dateFilteredJPOs.count }
+        return dateFilteredJPOs.filter { $0.status == status }.count
+    }
+
+    private var dateFilteredJPOs: [OrdersService.JPOListItem] {
+        allJPOs.filter { dateStringFallsInSelectedRange($0.createdAt ?? $0.dueDate) }
     }
 
     // MARK: - Status Picker
@@ -234,7 +238,7 @@ struct IOSJPOsPage: View {
     }
 
     private func dateStringFallsInSelectedRange(_ rawDate: String?) -> Bool {
-        guard let date = parseFilterDate(rawDate) else { return false }
+        guard let date = parseFilterDate(rawDate) else { return true }
         return date >= Calendar.current.startOfDay(for: effectiveStart) && date <= endOfDay(for: effectiveEnd)
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOsPage.swift
@@ -15,6 +15,9 @@ struct IOSJPOsPage: View {
     @State private var allJPOs: [OrdersService.JPOListItem] = []
     @State private var isLoading = true
     @State private var searchText = ""
+    @State private var dateRange: ReportDateRange = .thisWeek
+    @State private var customStart = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
+    @State private var customEnd = Date()
     @State private var statusFilter = "all"
     @State private var loadError: String?
     @State private var activeSheet: ActiveSheet?
@@ -38,6 +41,7 @@ struct IOSJPOsPage: View {
     var body: some View {
         VStack(spacing: 0) {
             OnboardingBanner(pageId: "orders-jpos")
+            StandardFilterBar(selectedRange: $dateRange, customStart: $customStart, customEnd: $customEnd)
             statusPicker
 
             // Pending KPI line
@@ -209,6 +213,7 @@ struct IOSJPOsPage: View {
         if statusFilter != "all" {
             result = result.filter { $0.status == statusFilter }
         }
+        result = result.filter { dateStringFallsInSelectedRange($0.createdAt ?? $0.dueDate) }
         // Search filter
         if !searchText.isEmpty {
             let query = searchText.lowercased()
@@ -218,6 +223,31 @@ struct IOSJPOsPage: View {
             }
         }
         return result
+    }
+
+    private var effectiveStart: Date {
+        dateRange.dateInterval?.start ?? customStart
+    }
+
+    private var effectiveEnd: Date {
+        dateRange.dateInterval?.end ?? customEnd
+    }
+
+    private func dateStringFallsInSelectedRange(_ rawDate: String?) -> Bool {
+        guard let date = parseFilterDate(rawDate) else { return false }
+        return date >= Calendar.current.startOfDay(for: effectiveStart) && date <= endOfDay(for: effectiveEnd)
+    }
+
+    private func endOfDay(for date: Date) -> Date {
+        Calendar.current.dateInterval(of: .day, for: date)?.end.addingTimeInterval(-1) ?? date
+    }
+
+    private func parseFilterDate(_ rawDate: String?) -> Date? {
+        guard let rawDate, !rawDate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return Formatters.sqlDateTimeFormatter.date(from: rawDate)
+            ?? Formatters.iso8601Fractional.date(from: rawDate)
+            ?? Formatters.iso8601Basic.date(from: rawDate)
+            ?? Formatters.localDateFormatter.date(from: String(rawDate.prefix(10)))
     }
 
     private func jpoRow(_ jpo: OrdersService.JPOListItem) -> some View {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOsPage.swift
@@ -239,11 +239,11 @@ struct IOSJPOsPage: View {
 
     private func dateStringFallsInSelectedRange(_ rawDate: String?) -> Bool {
         guard let date = parseFilterDate(rawDate) else { return true }
-        return date >= Calendar.current.startOfDay(for: effectiveStart) && date <= endOfDay(for: effectiveEnd)
+        return date >= Calendar.current.startOfDay(for: effectiveStart) && date < exclusiveEndOfDay(for: effectiveEnd)
     }
 
-    private func endOfDay(for date: Date) -> Date {
-        Calendar.current.dateInterval(of: .day, for: date)?.end.addingTimeInterval(-1) ?? date
+    private func exclusiveEndOfDay(for date: Date) -> Date {
+        Calendar.current.dateInterval(of: .day, for: date)?.end ?? date
     }
 
     private func parseFilterDate(_ rawDate: String?) -> Date? {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOsPage.swift
@@ -13,6 +13,8 @@ struct IOSJPOsPage: View {
     // MARK: - State
 
     @State private var allJPOs: [OrdersService.JPOListItem] = []
+    @State private var dateFilteredJPOs: [OrdersService.JPOListItem] = []
+    @State private var dateScopedStatusCounts: [String: Int] = [:]
     @State private var isLoading = true
     @State private var searchText = ""
     @State private var dateRange: ReportDateRange = .thisWeek
@@ -90,6 +92,9 @@ struct IOSJPOsPage: View {
             loadData()
             appCore.onboardingManager?.markCompleted("jpo-view-list")
         }
+        .onChange(of: dateRange) { refreshDateScopedJPOs() }
+        .onChange(of: customStart) { refreshDateScopedJPOs() }
+        .onChange(of: customEnd) { refreshDateScopedJPOs() }
         .onAppear {
             NotificationCenter.default.post(
                 name: .jposPageActive,
@@ -150,16 +155,12 @@ struct IOSJPOsPage: View {
     // MARK: - Counts
 
     private var pendingCount: Int {
-        dateFilteredJPOs.filter { $0.status == "pending" }.count
+        dateScopedStatusCounts["pending"] ?? 0
     }
 
     private func countForStatus(_ status: String) -> Int {
         if status == "all" { return dateFilteredJPOs.count }
-        return dateFilteredJPOs.filter { $0.status == status }.count
-    }
-
-    private var dateFilteredJPOs: [OrdersService.JPOListItem] {
-        allJPOs.filter { dateStringFallsInSelectedRange($0.createdAt ?? $0.dueDate) }
+        return dateScopedStatusCounts[status] ?? 0
     }
 
     // MARK: - Status Picker
@@ -212,12 +213,11 @@ struct IOSJPOsPage: View {
 
     /// JPOs filtered by status and search text.
     private var displayedJPOs: [OrdersService.JPOListItem] {
-        var result = allJPOs
+        var result = dateFilteredJPOs
         // Status filter
         if statusFilter != "all" {
             result = result.filter { $0.status == statusFilter }
         }
-        result = result.filter { dateStringFallsInSelectedRange($0.createdAt ?? $0.dueDate) }
         // Search filter
         if !searchText.isEmpty {
             let query = searchText.lowercased()
@@ -227,31 +227,6 @@ struct IOSJPOsPage: View {
             }
         }
         return result
-    }
-
-    private var effectiveStart: Date {
-        dateRange.dateInterval?.start ?? customStart
-    }
-
-    private var effectiveEnd: Date {
-        dateRange.dateInterval?.end ?? customEnd
-    }
-
-    private func dateStringFallsInSelectedRange(_ rawDate: String?) -> Bool {
-        guard let date = parseFilterDate(rawDate) else { return true }
-        return date >= Calendar.current.startOfDay(for: effectiveStart) && date < exclusiveEndOfDay(for: effectiveEnd)
-    }
-
-    private func exclusiveEndOfDay(for date: Date) -> Date {
-        Calendar.current.dateInterval(of: .day, for: date)?.end ?? date
-    }
-
-    private func parseFilterDate(_ rawDate: String?) -> Date? {
-        guard let rawDate, !rawDate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
-        return Formatters.sqlDateTimeFormatter.date(from: rawDate)
-            ?? Formatters.iso8601Fractional.date(from: rawDate)
-            ?? Formatters.iso8601Basic.date(from: rawDate)
-            ?? Formatters.localDateFormatter.date(from: String(rawDate.prefix(10)))
     }
 
     private func jpoRow(_ jpo: OrdersService.JPOListItem) -> some View {
@@ -334,9 +309,23 @@ struct IOSJPOsPage: View {
         do {
             // Load all JPOs for counts, then filter in-memory
             allJPOs = try service.listJPOs(status: nil, limit: 500)
+            refreshDateScopedJPOs()
         } catch {
             loadError = userFriendlyError(error, context: "load job parts orders")
         }
         isLoading = false
+    }
+
+    private func refreshDateScopedJPOs() {
+        dateFilteredJPOs = allJPOs.filter {
+            StandardDateRangeFilter.contains(
+                $0.createdAt ?? $0.dueDate,
+                selectedRange: dateRange,
+                customStart: customStart,
+                customEnd: customEnd
+            )
+        }
+        dateScopedStatusCounts = Dictionary(grouping: dateFilteredJPOs, by: \.status)
+            .mapValues(\.count)
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
@@ -279,33 +279,13 @@ struct IOSPartsOrderManagementPage: View {
             }()
 
             return poPass && partPass && searchPass
-                && dateStringFallsInSelectedRange(row.orderDate ?? row.expectedDelivery)
+                && StandardDateRangeFilter.contains(
+                    row.orderDate ?? row.expectedDelivery,
+                    selectedRange: dateRange,
+                    customStart: customStart,
+                    customEnd: customEnd
+                )
         }
-    }
-
-    private var effectiveStart: Date {
-        dateRange.dateInterval?.start ?? customStart
-    }
-
-    private var effectiveEnd: Date {
-        dateRange.dateInterval?.end ?? customEnd
-    }
-
-    private func dateStringFallsInSelectedRange(_ rawDate: String?) -> Bool {
-        guard let date = parseFilterDate(rawDate) else { return true }
-        return date >= Calendar.current.startOfDay(for: effectiveStart) && date < exclusiveEndOfDay(for: effectiveEnd)
-    }
-
-    private func exclusiveEndOfDay(for date: Date) -> Date {
-        Calendar.current.dateInterval(of: .day, for: date)?.end ?? date
-    }
-
-    private func parseFilterDate(_ rawDate: String?) -> Date? {
-        guard let rawDate, !rawDate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
-        return Formatters.sqlDateTimeFormatter.date(from: rawDate)
-            ?? Formatters.iso8601Fractional.date(from: rawDate)
-            ?? Formatters.iso8601Basic.date(from: rawDate)
-            ?? Formatters.localDateFormatter.date(from: String(rawDate.prefix(10)))
     }
 
     /// Group filtered rows by PO.

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
@@ -292,7 +292,7 @@ struct IOSPartsOrderManagementPage: View {
     }
 
     private func dateStringFallsInSelectedRange(_ rawDate: String?) -> Bool {
-        guard let date = parseFilterDate(rawDate) else { return false }
+        guard let date = parseFilterDate(rawDate) else { return true }
         return date >= Calendar.current.startOfDay(for: effectiveStart) && date <= endOfDay(for: effectiveEnd)
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
@@ -17,6 +17,9 @@ struct IOSPartsOrderManagementPage: View {
     @State private var allRows: [OrdersService.PartsManagementRow] = []
     @State private var isLoading = true
     @State private var loadError: String?
+    @State private var dateRange: ReportDateRange = .thisWeek
+    @State private var customStart = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
+    @State private var customEnd = Date()
 
     // PO status filters
     @State private var showDraft = true
@@ -79,6 +82,7 @@ struct IOSPartsOrderManagementPage: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            StandardFilterBar(selectedRange: $dateRange, customStart: $customStart, customEnd: $customEnd)
             supplierPicker
             poStatusFilters
             partStatusFilters
@@ -105,6 +109,9 @@ struct IOSPartsOrderManagementPage: View {
         .navigationTitle("Parts Management")
         .searchable(text: $searchText, prompt: "Search parts by name, code, or job...")
         .onChange(of: searchText) { _, _ in postAIContext() }
+        .onChange(of: dateRange) { _, _ in postAIContext() }
+        .onChange(of: customStart) { _, _ in postAIContext() }
+        .onChange(of: customEnd) { _, _ in postAIContext() }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button { activeSheet = .help } label: {
@@ -272,7 +279,33 @@ struct IOSPartsOrderManagementPage: View {
             }()
 
             return poPass && partPass && searchPass
+                && dateStringFallsInSelectedRange(row.orderDate ?? row.expectedDelivery)
         }
+    }
+
+    private var effectiveStart: Date {
+        dateRange.dateInterval?.start ?? customStart
+    }
+
+    private var effectiveEnd: Date {
+        dateRange.dateInterval?.end ?? customEnd
+    }
+
+    private func dateStringFallsInSelectedRange(_ rawDate: String?) -> Bool {
+        guard let date = parseFilterDate(rawDate) else { return false }
+        return date >= Calendar.current.startOfDay(for: effectiveStart) && date <= endOfDay(for: effectiveEnd)
+    }
+
+    private func endOfDay(for date: Date) -> Date {
+        Calendar.current.dateInterval(of: .day, for: date)?.end.addingTimeInterval(-1) ?? date
+    }
+
+    private func parseFilterDate(_ rawDate: String?) -> Date? {
+        guard let rawDate, !rawDate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return Formatters.sqlDateTimeFormatter.date(from: rawDate)
+            ?? Formatters.iso8601Fractional.date(from: rawDate)
+            ?? Formatters.iso8601Basic.date(from: rawDate)
+            ?? Formatters.localDateFormatter.date(from: String(rawDate.prefix(10)))
     }
 
     /// Group filtered rows by PO.

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
@@ -293,11 +293,11 @@ struct IOSPartsOrderManagementPage: View {
 
     private func dateStringFallsInSelectedRange(_ rawDate: String?) -> Bool {
         guard let date = parseFilterDate(rawDate) else { return true }
-        return date >= Calendar.current.startOfDay(for: effectiveStart) && date <= endOfDay(for: effectiveEnd)
+        return date >= Calendar.current.startOfDay(for: effectiveStart) && date < exclusiveEndOfDay(for: effectiveEnd)
     }
 
-    private func endOfDay(for date: Date) -> Date {
-        Calendar.current.dateInterval(of: .day, for: date)?.end.addingTimeInterval(-1) ?? date
+    private func exclusiveEndOfDay(for date: Date) -> Date {
+        Calendar.current.dateInterval(of: .day, for: date)?.end ?? date
     }
 
     private func parseFilterDate(_ rawDate: String?) -> Date? {

--- a/Weird Parts IOS/Weird Parts IOS/Shared/ReportDateRange.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/ReportDateRange.swift
@@ -134,10 +134,10 @@ enum StandardDateRangeFilter {
     }
 
     private static func parse(_ rawDate: String?) -> Date? {
-        guard let rawDate, !rawDate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
-        return Formatters.sqlDateTimeFormatter.date(from: rawDate)
-            ?? Formatters.iso8601Fractional.date(from: rawDate)
-            ?? Formatters.iso8601Basic.date(from: rawDate)
-            ?? Formatters.localDateFormatter.date(from: String(rawDate.prefix(10)))
+        guard let trimmed = rawDate?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else { return nil }
+        return Formatters.sqlDateTimeFormatter.date(from: trimmed)
+            ?? Formatters.iso8601Fractional.date(from: trimmed)
+            ?? Formatters.iso8601Basic.date(from: trimmed)
+            ?? Formatters.localDateFormatter.date(from: String(trimmed.prefix(10)))
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Shared/ReportDateRange.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/ReportDateRange.swift
@@ -110,3 +110,34 @@ enum ReportDateRange: String, CaseIterable, Identifiable {
         return remainder < 0 ? quotient - 1 : quotient
     }
 }
+
+/// Shared evaluator for StandardFilterBar-backed date filtering.
+///
+/// Rows without a parseable date stay visible: the date bar should narrow rows
+/// with known dates, not make undated legacy rows disappear by default.
+enum StandardDateRangeFilter {
+    static func contains(
+        _ rawDate: String?,
+        selectedRange: ReportDateRange,
+        customStart: Date,
+        customEnd: Date,
+        calendar: Calendar = .current
+    ) -> Bool {
+        guard let date = parse(rawDate) else { return true }
+        let interval = selectedRange.dateInterval ?? (start: customStart, end: customEnd)
+        return date >= calendar.startOfDay(for: interval.start)
+            && date < exclusiveEndOfDay(for: interval.end, calendar: calendar)
+    }
+
+    private static func exclusiveEndOfDay(for date: Date, calendar: Calendar) -> Date {
+        calendar.dateInterval(of: .day, for: date)?.end ?? date
+    }
+
+    private static func parse(_ rawDate: String?) -> Date? {
+        guard let rawDate, !rawDate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return Formatters.sqlDateTimeFormatter.date(from: rawDate)
+            ?? Formatters.iso8601Fractional.date(from: rawDate)
+            ?? Formatters.iso8601Basic.date(from: rawDate)
+            ?? Formatters.localDateFormatter.date(from: String(rawDate.prefix(10)))
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/StandardFilterBarRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/StandardFilterBarRegressionTests.swift
@@ -72,6 +72,38 @@ final class StandardFilterBarRegressionTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: reportsURL.path))
     }
 
+    func testCoreJobsAndOrdersPagesUseStandardFilterBarBeforePageSpecificFilters() throws {
+        let jobsSource = try Self.readFeatureSource(pathComponents: ["Jobs", "JobsListPage.swift"])
+        let jposSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSJPOsPage.swift"])
+        let partsManagementSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSPartsOrderManagementPage.swift"])
+
+        XCTAssertLessThan(
+            try XCTUnwrap(jobsSource.range(of: "StandardFilterBar")?.lowerBound),
+            try XCTUnwrap(jobsSource.range(of: "smartCards")?.lowerBound),
+            "Jobs list should place the standard date bar before its status smart cards."
+        )
+        XCTAssertLessThan(
+            try XCTUnwrap(jposSource.range(of: "StandardFilterBar")?.lowerBound),
+            try XCTUnwrap(jposSource.range(of: "statusPicker")?.lowerBound),
+            "JPO list should place the standard date bar before its status chips."
+        )
+        XCTAssertLessThan(
+            try XCTUnwrap(partsManagementSource.range(of: "StandardFilterBar")?.lowerBound),
+            try XCTUnwrap(partsManagementSource.range(of: "supplierPicker")?.lowerBound),
+            "Parts management should place the standard date bar before supplier and status filters."
+        )
+    }
+
+    func testCoreJobsAndOrdersPagesFilterRowsBySelectedStandardDateRange() throws {
+        let jobsSource = try Self.readFeatureSource(pathComponents: ["Jobs", "JobsListPage.swift"])
+        let jposSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSJPOsPage.swift"])
+        let partsManagementSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSPartsOrderManagementPage.swift"])
+
+        XCTAssertTrue(jobsSource.contains("dateStringFallsInSelectedRange(job.startDate ?? job.dueDate)"))
+        XCTAssertTrue(jposSource.contains("dateStringFallsInSelectedRange($0.createdAt ?? $0.dueDate)"))
+        XCTAssertTrue(partsManagementSource.contains("dateStringFallsInSelectedRange(row.orderDate ?? row.expectedDelivery)"))
+    }
+
     @MainActor
     func testPayPeriodRangesUseInjectedAnchorAndLength() throws {
         var calendar = Calendar(identifier: .gregorian)
@@ -163,6 +195,19 @@ final class StandardFilterBarRegressionTests: XCTestCase {
             .appendingPathComponent("Weird Parts IOS")
             .appendingPathComponent("Shared")
             .appendingPathComponent(fileName)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    private static func readFeatureSource(pathComponents: [String], file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        var sourceURL = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+        for component in pathComponents {
+            sourceURL.appendPathComponent(component)
+        }
         return try String(contentsOf: sourceURL, encoding: .utf8)
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/StandardFilterBarRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/StandardFilterBarRegressionTests.swift
@@ -104,6 +104,27 @@ final class StandardFilterBarRegressionTests: XCTestCase {
         XCTAssertTrue(partsManagementSource.contains("dateStringFallsInSelectedRange(row.orderDate ?? row.expectedDelivery)"))
     }
 
+    func testCoreJobsAndOrdersDateFiltersKeepRowsWithoutFilterableDates() throws {
+        let jobsSource = try Self.readFeatureSource(pathComponents: ["Jobs", "JobsListPage.swift"])
+        let jposSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSJPOsPage.swift"])
+        let partsManagementSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSPartsOrderManagementPage.swift"])
+
+        let includeUndatedRows = "guard let date = parseFilterDate(rawDate) else { return true }"
+        XCTAssertTrue(jobsSource.contains(includeUndatedRows))
+        XCTAssertTrue(jposSource.contains(includeUndatedRows))
+        XCTAssertTrue(partsManagementSource.contains(includeUndatedRows))
+    }
+
+    func testCoreJobsAndJPOStatusCountsUseSelectedDateRange() throws {
+        let jobsSource = try Self.readFeatureSource(pathComponents: ["Jobs", "JobsListPage.swift"])
+        let jposSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSJPOsPage.swift"])
+
+        XCTAssertTrue(jobsSource.contains("let dateFilteredJobs = allJobs.filter { dateStringFallsInSelectedRange($0.startDate ?? $0.dueDate) }"))
+        XCTAssertTrue(jposSource.contains("private var dateFilteredJPOs: [OrdersService.JPOListItem]"))
+        XCTAssertTrue(jposSource.contains("dateFilteredJPOs.filter { $0.status == \"pending\" }.count"))
+        XCTAssertTrue(jposSource.contains("return dateFilteredJPOs.filter { $0.status == status }.count"))
+    }
+
     @MainActor
     func testPayPeriodRangesUseInjectedAnchorAndLength() throws {
         var calendar = Calendar(identifier: .gregorian)

--- a/Weird Parts IOS/Weird Parts IOSTests/StandardFilterBarRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/StandardFilterBarRegressionTests.swift
@@ -112,6 +112,8 @@ final class StandardFilterBarRegressionTests: XCTestCase {
 
         XCTAssertTrue(sharedSource.contains("enum StandardDateRangeFilter"))
         XCTAssertTrue(sharedSource.contains("guard let date = parse(rawDate) else { return true }"))
+        XCTAssertTrue(sharedSource.contains("guard let trimmed = rawDate?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else { return nil }"))
+        XCTAssertTrue(sharedSource.contains("Formatters.sqlDateTimeFormatter.date(from: trimmed)"))
     }
 
     func testCoreJobsAndJPOStatusCountsUsePrecomputedSelectedDateRangeCounts() throws {

--- a/Weird Parts IOS/Weird Parts IOSTests/StandardFilterBarRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/StandardFilterBarRegressionTests.swift
@@ -125,6 +125,20 @@ final class StandardFilterBarRegressionTests: XCTestCase {
         XCTAssertTrue(jposSource.contains("return dateFilteredJPOs.filter { $0.status == status }.count"))
     }
 
+    func testCoreJobsAndOrdersDateFiltersUseExclusiveEndOfDay() throws {
+        let jobsSource = try Self.readFeatureSource(pathComponents: ["Jobs", "JobsListPage.swift"])
+        let jposSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSJPOsPage.swift"])
+        let partsManagementSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSPartsOrderManagementPage.swift"])
+
+        let exclusiveRangeCheck = "date < exclusiveEndOfDay(for: effectiveEnd)"
+        XCTAssertTrue(jobsSource.contains(exclusiveRangeCheck))
+        XCTAssertTrue(jposSource.contains(exclusiveRangeCheck))
+        XCTAssertTrue(partsManagementSource.contains(exclusiveRangeCheck))
+        XCTAssertFalse(jobsSource.contains(".end.addingTimeInterval(-1)"))
+        XCTAssertFalse(jposSource.contains(".end.addingTimeInterval(-1)"))
+        XCTAssertFalse(partsManagementSource.contains(".end.addingTimeInterval(-1)"))
+    }
+
     @MainActor
     func testPayPeriodRangesUseInjectedAnchorAndLength() throws {
         var calendar = Calendar(identifier: .gregorian)

--- a/Weird Parts IOS/Weird Parts IOSTests/StandardFilterBarRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/StandardFilterBarRegressionTests.swift
@@ -99,44 +99,38 @@ final class StandardFilterBarRegressionTests: XCTestCase {
         let jposSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSJPOsPage.swift"])
         let partsManagementSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSPartsOrderManagementPage.swift"])
 
-        XCTAssertTrue(jobsSource.contains("dateStringFallsInSelectedRange(job.startDate ?? job.dueDate)"))
-        XCTAssertTrue(jposSource.contains("dateStringFallsInSelectedRange($0.createdAt ?? $0.dueDate)"))
-        XCTAssertTrue(partsManagementSource.contains("dateStringFallsInSelectedRange(row.orderDate ?? row.expectedDelivery)"))
+        XCTAssertTrue(jobsSource.contains("StandardDateRangeFilter.contains("))
+        XCTAssertTrue(jobsSource.contains("job.startDate ?? job.dueDate"))
+        XCTAssertTrue(jposSource.contains("StandardDateRangeFilter.contains("))
+        XCTAssertTrue(jposSource.contains("$0.createdAt ?? $0.dueDate"))
+        XCTAssertTrue(partsManagementSource.contains("StandardDateRangeFilter.contains("))
+        XCTAssertTrue(partsManagementSource.contains("row.orderDate ?? row.expectedDelivery"))
     }
 
-    func testCoreJobsAndOrdersDateFiltersKeepRowsWithoutFilterableDates() throws {
-        let jobsSource = try Self.readFeatureSource(pathComponents: ["Jobs", "JobsListPage.swift"])
-        let jposSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSJPOsPage.swift"])
-        let partsManagementSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSPartsOrderManagementPage.swift"])
+    func testStandardDateRangeFilterKeepsRowsWithoutFilterableDates() throws {
+        let sharedSource = try Self.readSharedSource(named: "ReportDateRange.swift")
 
-        let includeUndatedRows = "guard let date = parseFilterDate(rawDate) else { return true }"
-        XCTAssertTrue(jobsSource.contains(includeUndatedRows))
-        XCTAssertTrue(jposSource.contains(includeUndatedRows))
-        XCTAssertTrue(partsManagementSource.contains(includeUndatedRows))
+        XCTAssertTrue(sharedSource.contains("enum StandardDateRangeFilter"))
+        XCTAssertTrue(sharedSource.contains("guard let date = parse(rawDate) else { return true }"))
     }
 
-    func testCoreJobsAndJPOStatusCountsUseSelectedDateRange() throws {
+    func testCoreJobsAndJPOStatusCountsUsePrecomputedSelectedDateRangeCounts() throws {
         let jobsSource = try Self.readFeatureSource(pathComponents: ["Jobs", "JobsListPage.swift"])
         let jposSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSJPOsPage.swift"])
 
-        XCTAssertTrue(jobsSource.contains("let dateFilteredJobs = allJobs.filter { dateStringFallsInSelectedRange($0.startDate ?? $0.dueDate) }"))
-        XCTAssertTrue(jposSource.contains("private var dateFilteredJPOs: [OrdersService.JPOListItem]"))
-        XCTAssertTrue(jposSource.contains("dateFilteredJPOs.filter { $0.status == \"pending\" }.count"))
-        XCTAssertTrue(jposSource.contains("return dateFilteredJPOs.filter { $0.status == status }.count"))
+        XCTAssertTrue(jobsSource.contains("refreshDateScopedStatusCounts(from: dateFiltered)"))
+        XCTAssertTrue(jobsSource.contains("statusCounts = Dictionary(grouping: dateFilteredJobs, by: \\.status)"))
+        XCTAssertTrue(jposSource.contains("@State private var dateFilteredJPOs: [OrdersService.JPOListItem] = []"))
+        XCTAssertTrue(jposSource.contains("dateScopedStatusCounts = Dictionary(grouping: dateFilteredJPOs, by: \\.status)"))
+        XCTAssertTrue(jposSource.contains("dateScopedStatusCounts[\"pending\"] ?? 0"))
+        XCTAssertTrue(jposSource.contains("return dateScopedStatusCounts[status] ?? 0"))
     }
 
-    func testCoreJobsAndOrdersDateFiltersUseExclusiveEndOfDay() throws {
-        let jobsSource = try Self.readFeatureSource(pathComponents: ["Jobs", "JobsListPage.swift"])
-        let jposSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSJPOsPage.swift"])
-        let partsManagementSource = try Self.readFeatureSource(pathComponents: ["Orders", "IOSPartsOrderManagementPage.swift"])
+    func testStandardDateRangeFilterUsesExclusiveEndOfDay() throws {
+        let sharedSource = try Self.readSharedSource(named: "ReportDateRange.swift")
 
-        let exclusiveRangeCheck = "date < exclusiveEndOfDay(for: effectiveEnd)"
-        XCTAssertTrue(jobsSource.contains(exclusiveRangeCheck))
-        XCTAssertTrue(jposSource.contains(exclusiveRangeCheck))
-        XCTAssertTrue(partsManagementSource.contains(exclusiveRangeCheck))
-        XCTAssertFalse(jobsSource.contains(".end.addingTimeInterval(-1)"))
-        XCTAssertFalse(jposSource.contains(".end.addingTimeInterval(-1)"))
-        XCTAssertFalse(partsManagementSource.contains(".end.addingTimeInterval(-1)"))
+        XCTAssertTrue(sharedSource.contains("date < exclusiveEndOfDay(for: interval.end, calendar: calendar)"))
+        XCTAssertFalse(sharedSource.contains(".end.addingTimeInterval(-1) ?? date"))
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- adds the shared StandardFilterBar to Jobs, JPOs, and Parts Management before page-specific filters
- filters those core list gaps by the selected standard date range while preserving existing status/search/supplier filters
- adds regression coverage that locks StandardFilterBar placement and date-filter wiring for the gap pages

Closes #81
Closes #448

## Verification
- git diff --check
- python3 scripts/guard-tracked-artifacts.py
- xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:"Weird Parts IOSTests/StandardFilterBarRegressionTests" -derivedDataPath .tmp/WEI4333-DerivedData\n\n## Local runner path\n- PR should validate on the local self-hosted Mac runner for iOS/Xcode checks: [self-hosted, macOS, ARM64, xcode, ios, local-mac].