### PR TITLE
fix: stop abandoned onboarding discovery

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Auth/DevicePairingView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/DevicePairingView.swift
@@ -84,6 +84,9 @@ struct DevicePairingView: View {
         .task {
             await scanForShop()
         }
+        .onDisappear {
+            stopOnboardingDiscoveryIfAbandoned()
+        }
     }
 
     // MARK: - Discovery
@@ -248,11 +251,18 @@ struct DevicePairingView: View {
     // MARK: - Actions
 
     private func scanForShop() async {
+        guard !Task.isCancelled else { return }
         // Enable BT and start first-run join discovery. A brand-new device does
         // not have a local company ID yet; the pairing response verifies the
         // selected shop before storing company settings.
         syncManager.setBluetoothEnabled(true, startDiscovery: false)
+        guard !Task.isCancelled else { return }
         syncManager.startOnboardingPeerDiscovery()
+    }
+
+    private func stopOnboardingDiscoveryIfAbandoned() {
+        guard !navigateToSync else { return }
+        syncManager.stopPeerDiscovery()
     }
 
     private func attemptPairing() async {

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -58,6 +58,8 @@ final class IOSSyncManager {
     private var peerManager: PeerManager?
     private var multipeerManager: MultipeerManager?
     private var multipeerDiscoveryMode: PeerDiscoveryMode?
+    private var peerDiscoveryStartupTask: Task<Void, Never>?
+    private var peerDiscoveryGeneration = 0
     private var lastSurfacedSyncReadFailure: String?
 
     struct PeerInfo: Identifiable, Sendable {
@@ -338,6 +340,11 @@ final class IOSSyncManager {
             return
         }
 
+        peerDiscoveryStartupTask?.cancel()
+        peerDiscoveryStartupTask = nil
+        peerDiscoveryGeneration += 1
+        let startupGeneration = peerDiscoveryGeneration
+
         if mode == .existingCompanySync {
             multipeerManager?.stop()
             multipeerManager = nil
@@ -401,13 +408,16 @@ final class IOSSyncManager {
         // so a fresh device can discover a shop HTTP address before the pairing
         // response verifies and persists the real company ID.
         if let pm = peerManager {
-            Task {
+            peerDiscoveryStartupTask = Task {
                 let deviceId = DeviceIdentity.current
                 let deviceName = UIDevice.current.name
                 do {
+                    guard isCurrentPeerDiscoveryStartup(startupGeneration) else { return }
                     if await pm.getState().running {
+                        guard isCurrentPeerDiscoveryStartup(startupGeneration) else { return }
                         await pm.stopPeerSync()
                     }
+                    guard isCurrentPeerDiscoveryStartup(startupGeneration) else { return }
                     try await pm.startPeerSync(
                         deviceId: deviceId,
                         deviceName: deviceName,
@@ -416,7 +426,11 @@ final class IOSSyncManager {
                         startMultipeer: bluetoothDiscoveryEnabled && mode == .existingCompanySync,
                         startSyncServer: mode == .existingCompanySync
                     )
+                    if !isScanning {
+                        await pm.stopPeerSync()
+                    }
                 } catch {
+                    guard isCurrentPeerDiscoveryStartup(startupGeneration) else { return }
                     handleLanPeerDiscoveryStartupFailure(
                         error,
                         hasActiveMultipeerDiscovery: bluetoothDiscoveryEnabled && mode == .onboardingJoin
@@ -424,6 +438,10 @@ final class IOSSyncManager {
                 }
             }
         }
+    }
+
+    private func isCurrentPeerDiscoveryStartup(_ generation: Int) -> Bool {
+        !Task.isCancelled && isScanning && peerDiscoveryGeneration == generation
     }
 
     func handleLanPeerDiscoveryStartupFailure(
@@ -440,6 +458,9 @@ final class IOSSyncManager {
 
     /// Stop scanning for peers.
     func stopPeerDiscovery() {
+        peerDiscoveryGeneration += 1
+        peerDiscoveryStartupTask?.cancel()
+        peerDiscoveryStartupTask = nil
         isScanning = false
         multipeerManager?.stop()
         multipeerManager = nil

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -497,6 +497,10 @@ struct Weird_Parts_IOSTests {
         #expect(source.contains("startMultipeer: bluetoothDiscoveryEnabled && mode == .existingCompanySync"))
         #expect(source.contains("startSyncServer: mode == .existingCompanySync"))
         #expect(source.contains("if await pm.getState().running"))
+        #expect(source.contains("peerDiscoveryStartupTask?.cancel()"))
+        #expect(source.contains("let startupGeneration = peerDiscoveryGeneration"))
+        #expect(source.contains("guard isCurrentPeerDiscoveryStartup(startupGeneration) else { return }"))
+        #expect(source.contains("if !isScanning"))
         #expect(source.contains("await pm.stopPeerSync()"))
         #expect(source.contains("state: peer.multipeerState == \"connected\" ? \"connected\" : peer.transport"))
         #expect(source.contains("peer.state == \"multipeer\" || (peer.state == \"connected\" && peer.address == nil)"))
@@ -506,6 +510,10 @@ struct Weird_Parts_IOSTests {
         #expect(source.contains("let multipeerOnly = mpPeers.filter { !nonMultipeerIds.contains($0.id) }"))
         #expect(pairingSource.contains("guard let address = peer.address else"))
         #expect(pairingSource.contains("syncManager.stopPeerDiscovery()"))
+        #expect(pairingSource.contains(".onDisappear"))
+        #expect(pairingSource.contains("stopOnboardingDiscoveryIfAbandoned()"))
+        #expect(pairingSource.contains("guard !Task.isCancelled else { return }"))
+        #expect(pairingSource.contains("guard !navigateToSync else { return }"))
         #expect(pairingSource.contains("shop.address"))
     }
 


### PR DESCRIPTION
## Summary
- Stop onboarding peer discovery when Pair Device disappears without an active pairing handoff.
- Preserve discovery during active pairing/navigation into initial sync.
- Extend the existing sync/onboarding source guard test to require the abandon cleanup path.

## Tests
- `xcodebuild -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/onboardingPeerDiscoveryKeepsLanAddressForPairing" test`
- `swift test --filter Sync --skip-build` (from `core/`)

Local runner path: this PR targets the repo-owned self-hosted Mac runner for CI (`runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]`) when required gates run.

Closes #1255
