### PR TITLE
fix: present settings data export share sheet

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
@@ -99,17 +99,20 @@ struct IOSDataExportPage: View {
                 Button { activeSheet = .help } label: {
                     Image(systemName: "questionmark.circle")
                 }
+                .disabled(isExporting)
                 .accessibilityLabel("Help")
             }
         }
-        .sheet(item: $activeSheet) { _ in
-            PageHelpSheet(title: "Data Export Help", sections: [
-                ("What This Page Does", "Exports the local database or specific tables as CSV or JSON files. You can also export the full SQLite database file."),
-                ("How to Use It", "Select a format (CSV or JSON), check the tables you want to export, then tap Export. Use 'Export Full Database' for a complete SQLite backup. Exported files are saved to the app's Documents folder."),
-            ])
-        }
-        .sheet(isPresented: $showShareSheet) {
-            ReportShareSheet(items: exportURLs)
+        .sheet(item: $activeSheet) { sheet in
+            switch sheet {
+            case .help:
+                PageHelpSheet(title: "Data Export Help", sections: [
+                    ("What This Page Does", "Exports the local database or specific tables as CSV or JSON files. You can also export the full SQLite database file."),
+                    ("How to Use It", "Select a format (CSV or JSON), check the tables you want to export, then tap Export. Use 'Export Full Database' for a complete SQLite backup. Exported files are saved to the app's Documents folder."),
+                ])
+            case .share(let urls):
+                ReportShareSheet(items: urls)
+            }
         }
         .task { if canExport { loadData() } }
     }
@@ -134,7 +137,16 @@ struct IOSDataExportPage: View {
 
     private enum ActiveSheet: Identifiable {
         case help
-        var id: String { "help" }
+        case share([URL])
+
+        var id: String {
+            switch self {
+            case .help:
+                return "help"
+            case .share(let urls):
+                return "share-\(urls.map(\.path).joined(separator: "|"))"
+            }
+        }
     }
 
     // MARK: - Database Info
@@ -264,14 +276,11 @@ struct IOSDataExportPage: View {
 
     // MARK: - Export Actions
 
-    @State private var exportURLs: [URL] = []
-    @State private var showShareSheet = false
-
     private func performExport() {
         isExporting = true
         exportSuccess = false
         errorMessage = nil
-        exportURLs = []
+        activeSheet = nil
 
         guard let settingsService = appCore.settingsService else {
             errorMessage = "Settings service not available."
@@ -325,10 +334,9 @@ struct IOSDataExportPage: View {
                 return
             }
 
-            exportURLs = urls
             exportSuccess = true
             isExporting = false
-            showShareSheet = true
+            activeSheet = .share(urls)
         } catch {
             errorMessage = userFriendlyError(error, context: "export data")
             isExporting = false
@@ -366,9 +374,8 @@ struct IOSDataExportPage: View {
                     to: destURL
                 )
                 await MainActor.run {
-                    exportURLs = [destURL]
                     exportSuccess = true
-                    showShareSheet = true
+                    activeSheet = .share([destURL])
                     isExporting = false
                 }
             } catch {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
@@ -108,6 +108,9 @@ struct IOSDataExportPage: View {
                 ("How to Use It", "Select a format (CSV or JSON), check the tables you want to export, then tap Export. Use 'Export Full Database' for a complete SQLite backup. Exported files are saved to the app's Documents folder."),
             ])
         }
+        .sheet(isPresented: $showShareSheet) {
+            ReportShareSheet(items: exportURLs)
+        }
         .task { if canExport { loadData() } }
     }
 
@@ -315,13 +318,17 @@ struct IOSDataExportPage: View {
                 urls.append(fileURL)
             }
 
+            guard !urls.isEmpty else {
+                exportSuccess = false
+                errorMessage = "No rows were exported from the selected tables. Choose tables with data or export the full database."
+                isExporting = false
+                return
+            }
+
             exportURLs = urls
             exportSuccess = true
             isExporting = false
-
-            if !urls.isEmpty {
-                showShareSheet = true
-            }
+            showShareSheet = true
         } catch {
             errorMessage = userFriendlyError(error, context: "export data")
             isExporting = false

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -1161,6 +1161,28 @@ struct Weird_Parts_IOSTests {
         #expect(snapshotCall.lowerBound < successState.lowerBound, "Success state must only be set after the GRDB snapshot is complete")
     }
 
+    @Test func dataExportCompletionPresentsShareSheetAndHandlesEmptyTables() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let exportPageURL = repoRoot
+            .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift")
+        let source = try String(contentsOf: exportPageURL, encoding: .utf8)
+
+        #expect(source.contains(".sheet(isPresented: $showShareSheet)"), "Data export completion should present the share sheet")
+        #expect(source.contains("ReportShareSheet(items: exportURLs)"), "The share sheet should receive the generated export file URLs")
+        #expect(source.contains("guard !urls.isEmpty else"), "Selected-table exports with no rows should not claim a transferable export completed")
+        #expect(source.contains("No rows were exported from the selected tables"), "Empty selected-table exports should show a clear user-facing message")
+        let emptyExportGuard = try #require(source.range(of: "guard !urls.isEmpty else"))
+        let selectedExportSuccess = try #require(source.range(of: "exportSuccess = true", range: emptyExportGuard.upperBound..<source.endIndex))
+        let selectedSharePresentation = try #require(source.range(of: "showShareSheet = true", range: selectedExportSuccess.upperBound..<source.endIndex))
+        #expect(selectedExportSuccess.lowerBound < selectedSharePresentation.lowerBound, "Selected-table exports should present sharing only after success is recorded")
+        let fullDatabaseExport = try #require(source.range(of: "private func exportFullDatabase()"))
+        let fullDatabaseSharePresentation = try #require(source.range(of: "showShareSheet = true", range: fullDatabaseExport.lowerBound..<source.endIndex))
+        #expect(fullDatabaseExport.lowerBound < fullDatabaseSharePresentation.lowerBound, "Full database export should also present the generated SQLite snapshot")
+    }
+
     @MainActor
     @Test func shortTermPipelineCallbackFailurePreservesSheetAndFormatsActionError() {
         var reloadCount = 0

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -1170,16 +1170,19 @@ struct Weird_Parts_IOSTests {
             .appendingPathComponent("Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift")
         let source = try String(contentsOf: exportPageURL, encoding: .utf8)
 
-        #expect(source.contains(".sheet(isPresented: $showShareSheet)"), "Data export completion should present the share sheet")
-        #expect(source.contains("ReportShareSheet(items: exportURLs)"), "The share sheet should receive the generated export file URLs")
+        #expect(source.contains(".sheet(item: $activeSheet)"), "Data export should use one active-sheet presenter for help and sharing")
+        #expect(source.contains("case share([URL])"), "Data export completion should carry generated export URLs through the active sheet state")
+        #expect(source.contains("case .share(let urls):"), "The share sheet should receive the generated export file URLs from the active sheet")
+        #expect(source.contains("ReportShareSheet(items: urls)"), "The share sheet should receive the generated export file URLs")
+        #expect(!source.contains("showShareSheet"), "Data export should avoid a second sheet boolean that can race the help sheet")
         #expect(source.contains("guard !urls.isEmpty else"), "Selected-table exports with no rows should not claim a transferable export completed")
         #expect(source.contains("No rows were exported from the selected tables"), "Empty selected-table exports should show a clear user-facing message")
         let emptyExportGuard = try #require(source.range(of: "guard !urls.isEmpty else"))
         let selectedExportSuccess = try #require(source.range(of: "exportSuccess = true", range: emptyExportGuard.upperBound..<source.endIndex))
-        let selectedSharePresentation = try #require(source.range(of: "showShareSheet = true", range: selectedExportSuccess.upperBound..<source.endIndex))
+        let selectedSharePresentation = try #require(source.range(of: "activeSheet = .share(urls)", range: selectedExportSuccess.upperBound..<source.endIndex))
         #expect(selectedExportSuccess.lowerBound < selectedSharePresentation.lowerBound, "Selected-table exports should present sharing only after success is recorded")
         let fullDatabaseExport = try #require(source.range(of: "private func exportFullDatabase()"))
-        let fullDatabaseSharePresentation = try #require(source.range(of: "showShareSheet = true", range: fullDatabaseExport.lowerBound..<source.endIndex))
+        let fullDatabaseSharePresentation = try #require(source.range(of: "activeSheet = .share([destURL])", range: fullDatabaseExport.lowerBound..<source.endIndex))
         #expect(fullDatabaseExport.lowerBound < fullDatabaseSharePresentation.lowerBound, "Full database export should also present the generated SQLite snapshot")
     }
 


### PR DESCRIPTION
## Summary
- present the iOS share sheet when Settings data exports generate files
- keep full database exports sharing the generated SQLite snapshot
- show a clear no-rows message instead of claiming success when selected tables export nothing

## Tests
- xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "platform=iOS Simulator,id=F29F2637-4865-4685-92B3-98D2F45EF30C" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/dataExportCompletionPresentsShareSheetAndHandlesEmptyTables"

Closes #1252