### PR TITLE
fix: correct margin pricing preview history

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsPricingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsPricingPage.swift
@@ -1089,7 +1089,7 @@ struct PricingEditSheet: View {
             } else if pricingMode == "markup" {
                 _ = try ManualPricingInputValidator.parsePercent(markupText, fieldName: "Markup")
             } else {
-                _ = try ManualPricingInputValidator.parsePercent(marginText, fieldName: "Margin")
+                _ = try ManualPricingInputValidator.parseMarginPercent(marginText, fieldName: "Margin")
             }
             return nil
         } catch {
@@ -1101,8 +1101,12 @@ struct PricingEditSheet: View {
         if useFixedPrice, let fixed = try? ManualPricingInputValidator.parseMoney(fixedPriceText, fieldName: "Fixed Price") {
             return max(fixed, row.weightedAvgCost) // never below cost
         }
+        if pricingMode != "markup" {
+            let margin = (try? ManualPricingInputValidator.parseMarginPercent(marginText, fieldName: "Margin")) ?? row.effectiveMargin
+            return Self.sellPrice(weightedAvgCost: row.weightedAvgCost, marginPercent: margin)
+        }
         let markup = (try? ManualPricingInputValidator.parsePercent(markupText, fieldName: "Markup")) ?? row.effectiveMarkup
-        return row.weightedAvgCost * (1 + max(markup, 0) / 100)
+        return Self.sellPrice(weightedAvgCost: row.weightedAvgCost, markupPercent: markup)
     }
 
     private var previewMargin: Double {
@@ -1114,6 +1118,35 @@ struct PricingEditSheet: View {
     private var previewMarkup: Double {
         guard row.weightedAvgCost > 0 else { return 0 }
         return ((previewSellPrice - row.weightedAvgCost) / row.weightedAvgCost) * 100
+    }
+
+    static func sellPrice(weightedAvgCost: Double, markupPercent: Double) -> Double {
+        weightedAvgCost * (1 + max(markupPercent, 0) / 100)
+    }
+
+    static func sellPrice(weightedAvgCost: Double, marginPercent: Double) -> Double {
+        let safeMargin = max(marginPercent, 0)
+        guard safeMargin < 100 else { return weightedAvgCost }
+        return weightedAvgCost / (1 - safeMargin / 100)
+    }
+
+    static func priceChangeLogFields(
+        pricingMode: String,
+        useFixedPrice: Bool,
+        fixedSellPrice: Double,
+        markupText: String,
+        marginText: String,
+        currentMarkup: Double,
+        currentMargin: Double,
+        currentSellPrice: Double
+    ) throws -> (changeType: String, oldValue: Double, newValue: Double) {
+        if useFixedPrice {
+            return ("fixed_price_change", currentSellPrice, fixedSellPrice)
+        }
+        if pricingMode == "markup" {
+            return ("markup_change", currentMarkup, try ManualPricingInputValidator.parsePercent(markupText, fieldName: "Markup"))
+        }
+        return ("margin_change", currentMargin, try ManualPricingInputValidator.parseMarginPercent(marginText, fieldName: "Margin"))
     }
 
     var body: some View {
@@ -1286,7 +1319,7 @@ struct PricingEditSheet: View {
                                 }
                                 Spacer()
                                 if let oldVal = entry.oldValue, let newVal = entry.newValue {
-                                    Text(String(format: "$%.2f → $%.2f", oldVal, newVal))
+                                    Text(Self.formatPriceHistoryValues(changeType: entry.changeType, oldValue: oldVal, newValue: newVal))
                                         .font(.caption)
                                         .monospaced()
                                 }
@@ -1375,16 +1408,27 @@ struct PricingEditSheet: View {
                 let markup = try ManualPricingInputValidator.parsePercent(markupText, fieldName: "Markup")
                 _ = try service.setPricingTier(partId: row.id, markupPercent: markup)
             } else {
-                let margin = try ManualPricingInputValidator.parsePercent(marginText, fieldName: "Margin")
+                let margin = try ManualPricingInputValidator.parseMarginPercent(marginText, fieldName: "Margin")
                 _ = try service.setPricingTier(partId: row.id, marginPercent: margin)
             }
+
+            let logFields = try Self.priceChangeLogFields(
+                pricingMode: pricingMode,
+                useFixedPrice: useFixedPrice,
+                fixedSellPrice: previewSellPrice,
+                markupText: markupText,
+                marginText: marginText,
+                currentMarkup: row.effectiveMarkup,
+                currentMargin: row.effectiveMargin,
+                currentSellPrice: row.sellPrice
+            )
 
             // Log the change
             try service.logPriceChange(
                 partId: row.id,
-                changeType: "markup_change",
-                oldValue: row.effectiveMarkup,
-                newValue: Double(markupText) ?? row.effectiveMarkup,
+                changeType: logFields.changeType,
+                oldValue: logFields.oldValue,
+                newValue: logFields.newValue,
                 oldSellPrice: row.sellPrice,
                 newSellPrice: previewSellPrice,
                 source: "manual"
@@ -1396,5 +1440,12 @@ struct PricingEditSheet: View {
             saveError = userFriendlyError(error, context: "save data")
         }
         isSaving = false
+    }
+
+    static func formatPriceHistoryValues(changeType: String, oldValue: Double, newValue: Double) -> String {
+        if changeType == "markup_change" || changeType == "margin_change" {
+            return String(format: "%.1f%% → %.1f%%", oldValue, newValue)
+        }
+        return String(format: "$%.2f → $%.2f", oldValue, newValue)
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -1378,6 +1378,57 @@ struct Weird_Parts_IOSTests {
         #expect(!PricingBulkEditSheet.isValidNonNegativePercent("not a number"))
     }
 
+    @Test func manualPricingMarginPreviewUsesVisibleMarginInput() throws {
+        let source = try Self.readPartsSource("PartsPricingPage.swift")
+
+        #expect(source.contains("parseMarginPercent(marginText, fieldName: \"Margin\")"))
+        #expect(source.contains("return Self.sellPrice(weightedAvgCost: row.weightedAvgCost, marginPercent: margin)"))
+        #expect(source.contains("return Self.sellPrice(weightedAvgCost: row.weightedAvgCost, markupPercent: markup)"))
+
+        let marginSellPrice = PricingEditSheet.sellPrice(weightedAvgCost: 100, marginPercent: 25)
+        let staleMarkupSellPrice = PricingEditSheet.sellPrice(weightedAvgCost: 100, markupPercent: 80)
+
+        #expect(abs(marginSellPrice - 133.3333333333) < 0.0001)
+        #expect(marginSellPrice != staleMarkupSellPrice)
+    }
+
+    @Test func manualPricingMarginHistoryLogsMarginValues() throws {
+        let fields = try PricingEditSheet.priceChangeLogFields(
+            pricingMode: "margin",
+            useFixedPrice: false,
+            fixedSellPrice: 0,
+            markupText: "80",
+            marginText: "25",
+            currentMarkup: 80,
+            currentMargin: 10,
+            currentSellPrice: 110
+        )
+
+        #expect(fields.changeType == "margin_change")
+        #expect(fields.oldValue == 10)
+        #expect(fields.newValue == 25)
+        #expect(PricingEditSheet.formatPriceHistoryValues(changeType: fields.changeType, oldValue: fields.oldValue, newValue: fields.newValue) == "10.0% → 25.0%")
+    }
+
+    @Test func manualPricingRejectsImpossibleMarginPercent() {
+        #expect(throws: ManualPricingInputValidator.ValidationError.percentTooHigh(fieldName: "Margin", maxExclusive: 100)) {
+            try ManualPricingInputValidator.parseMarginPercent("100", fieldName: "Margin")
+        }
+    }
+
+    static func readPartsSource(_ filename: String, file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Parts")
+            .appendingPathComponent(filename)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
     static func warehouseMovement(id: Int64, reason: String, createdAt: String?) -> WarehouseService.MovementRow {
         WarehouseService.MovementRow(
             id: id,

--- a/core/Sources/WiredPartCore/ManualPricingInputValidator.swift
+++ b/core/Sources/WiredPartCore/ManualPricingInputValidator.swift
@@ -10,6 +10,7 @@ public enum ManualPricingInputValidator {
         case required(fieldName: String)
         case invalidNumber(fieldName: String)
         case negative(fieldName: String)
+        case percentTooHigh(fieldName: String, maxExclusive: Double)
 
         public var errorDescription: String? {
             switch self {
@@ -19,6 +20,8 @@ public enum ManualPricingInputValidator {
                 return "\(fieldName) must be a valid number. Keep your entered value and fix it before saving."
             case .negative(let fieldName):
                 return "\(fieldName) must be zero or greater. Keep your entered value and fix it before saving."
+            case .percentTooHigh(let fieldName, let maxExclusive):
+                return "\(fieldName) must be less than \(String(format: "%.0f", maxExclusive))%. Keep your entered value and fix it before saving."
             }
         }
     }
@@ -29,6 +32,14 @@ public enum ManualPricingInputValidator {
 
     public static func parsePercent(_ rawValue: String, fieldName: String) throws -> Double {
         try parseNonNegativeDecimal(rawValue, fieldName: fieldName)
+    }
+
+    public static func parseMarginPercent(_ rawValue: String, fieldName: String) throws -> Double {
+        let value = try parsePercent(rawValue, fieldName: fieldName)
+        guard value < 100 else {
+            throw ValidationError.percentTooHigh(fieldName: fieldName, maxExclusive: 100)
+        }
+        return value
     }
 
     private static func parseNonNegativeDecimal(_ rawValue: String, fieldName: String) throws -> Double {

--- a/core/Tests/WiredPartCoreTests/ManualPricingInputValidatorTests.swift
+++ b/core/Tests/WiredPartCoreTests/ManualPricingInputValidatorTests.swift
@@ -39,4 +39,17 @@ final class ManualPricingInputValidatorTests: XCTestCase {
         XCTAssertEqual(try ManualPricingInputValidator.parsePercent("0", fieldName: "Markup"), 0)
         XCTAssertEqual(try ManualPricingInputValidator.parsePercent("12.5", fieldName: "Markup"), 12.5)
     }
+
+    func testManualMarginRejectsOneHundredPercentAndAbove() throws {
+        XCTAssertEqual(try ManualPricingInputValidator.parseMarginPercent("25", fieldName: "Margin"), 25)
+
+        XCTAssertThrowsError(
+            try ManualPricingInputValidator.parseMarginPercent("100", fieldName: "Margin")
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Margin must be less than 100%. Keep your entered value and fix it before saving."
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Fix margin-mode manual pricing preview to derive sell price from the visible margin field with the standard `cost / (1 - margin/100)` formula.
- Validate manual margin inputs as `< 100%` so impossible margin values are blocked before save.
- Log margin-mode manual pricing edits as `margin_change` with old/new margin values, and show markup/margin history values as percentages instead of dollars.

Closes #1187

## Tests
- `swift test --filter ManualPricingInputValidatorTests`
- `xcodebuild -scheme "WiredPart-iOS" -destination 'id=F29F2637-4865-4685-92B3-98D2F45EF30C' -parallel-testing-enabled NO -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/manualPricingMarginPreviewUsesVisibleMarginInput()" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/manualPricingMarginHistoryLogsMarginValues()" -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/manualPricingRejectsImpossibleMarginPercent()" test`
- `swift test` (core: 2224 Swift Testing tests + 4 XCTest tests passed before adding the extra validator test; focused validator rerun passed 5 XCTest tests after adding it)
- `python3 scripts/guard-tracked-artifacts.py`
- `git diff --check`
- `xcodebuild -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build` (succeeded; existing warnings only)

## Local runner path
This PR is ready for the repo's local self-hosted Mac Actions runner path (`self-hosted, macOS, ARM64, xcode, ios, local-mac`) for required PR validation.