### PR TITLE
fix: gate peer browser sync actions

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
@@ -129,7 +129,7 @@ struct IOSPeerBrowser: View {
 
                         Spacer()
 
-                        if peer.state == "found" || peer.state == "multipeer" || peer.state == "lan" {
+                        if peer.isManuallySyncable {
                             Button("Sync") {
                                 Task { await syncManager.syncWithPeer(peerDeviceId: peer.id) }
                             }
@@ -138,6 +138,10 @@ struct IOSPeerBrowser: View {
                         } else if peer.state == "connecting" {
                             ProgressView()
                                 .scaleEffect(0.7)
+                        } else if peer.state == "multipeer" {
+                            Text("Waiting")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         } else {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(.green)

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -68,6 +68,7 @@ final class IOSSyncManager {
         let state: String
         let discoveredAt: String
         let address: String?
+        let isManuallySyncable: Bool
     }
 
     enum PeerDiscoveryMode: Equatable {
@@ -582,12 +583,18 @@ final class IOSSyncManager {
     private func handlePeerStateChange(_ state: PeerManagerState) {
         // Merge LAN peers into our peer list
         let lanPeers = state.peers.map { peer in
-            PeerInfo(
+            let address = formattedPeerAddress(host: peer.host, port: Int(peer.port))
+            return PeerInfo(
                 id: peer.deviceId,
                 name: peer.deviceName,
                 state: peer.multipeerState == "connected" ? "connected" : peer.transport,
                 discoveredAt: peer.discoveredAt,
-                address: formattedPeerAddress(host: peer.host, port: Int(peer.port))
+                address: address,
+                isManuallySyncable: Self.isManuallySyncablePeer(
+                    transport: peer.transport,
+                    multipeerState: peer.multipeerState,
+                    address: address
+                )
             )
         }
 
@@ -604,7 +611,12 @@ final class IOSSyncManager {
                 name: peer.deviceName,
                 state: peer.state.rawValue == "connected" ? "connected" : "multipeer",
                 discoveredAt: peer.discoveredAt,
-                address: nil
+                address: nil,
+                isManuallySyncable: Self.isManuallySyncablePeer(
+                    transport: "multipeer",
+                    multipeerState: peer.state.rawValue,
+                    address: nil
+                )
             )
         }
 
@@ -629,6 +641,17 @@ final class IOSSyncManager {
         guard !host.isEmpty, port > 0 else { return nil }
         let formattedHost = host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host
         return "\(formattedHost):\(port)"
+    }
+
+    private static func isManuallySyncablePeer(
+        transport: String,
+        multipeerState: String?,
+        address: String?
+    ) -> Bool {
+        if transport == "multipeer" {
+            return multipeerState == "connected"
+        }
+        return transport == "lan" && address != nil
     }
 
     private func refreshPendingCount() {

--- a/Weird Parts IOS/Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests.swift
@@ -5,12 +5,24 @@ final class PeerBrowserTargetedSyncRegressionTests: XCTestCase {
         let source = try Self.readPeerBrowserSource()
 
         XCTAssertTrue(
+            source.contains("if peer.isManuallySyncable"),
+            "The row-level Sync button should be gated by an explicit peer sync capability, not display state strings."
+        )
+        XCTAssertTrue(
             source.contains("syncManager.syncWithPeer(peerDeviceId: peer.id)"),
             "Each peer row's Sync button must pass the selected peer ID into IOSSyncManager."
         )
         XCTAssertFalse(
             source.contains("Task { await syncManager.syncNow() }"),
             "A row-level Sync button must not dispatch the global syncNow fan-out path."
+        )
+        XCTAssertFalse(
+            source.contains("peer.state == \"found\" || peer.state == \"multipeer\" || peer.state == \"lan\""),
+            "Unconnected Multipeer rows must not expose an impossible Sync button."
+        )
+        XCTAssertTrue(
+            source.contains("if peer.isManuallySyncable") && source.contains("Text(\"Waiting\")"),
+            "Connected peers and addressable LAN/found rows should stay syncable while unconnected Multipeer rows show a waiting state."
         )
     }
 
@@ -41,6 +53,35 @@ final class PeerBrowserTargetedSyncRegressionTests: XCTestCase {
         )
     }
 
+    func testPeerBrowserOnlyShowsManualSyncForSyncablePeers() throws {
+        let source = try Self.readPeerBrowserSource()
+
+        XCTAssertTrue(
+            source.contains("if peer.isManuallySyncable"),
+            "The row-level Sync button should be gated by explicit sync capability, not by display state strings."
+        )
+        XCTAssertFalse(
+            source.contains("peer.state == \"found\" || peer.state == \"multipeer\" || peer.state == \"lan\""),
+            "Unconnected Multipeer rows must not be grouped with LAN/addressable rows as syncable."
+        )
+        let syncManagerSource = try Self.readSyncManagerSource()
+        XCTAssertTrue(
+            syncManagerSource.contains("let isManuallySyncable: Bool"),
+            "PeerInfo should carry the capability used by the view instead of deriving behavior from presentation state."
+        )
+        XCTAssertTrue(
+            syncManagerSource.contains("isManuallySyncablePeer(") &&
+                syncManagerSource.contains("if transport == \"multipeer\"") &&
+                syncManagerSource.contains("return multipeerState == \"connected\"") &&
+                syncManagerSource.contains("return transport == \"lan\" && address != nil"),
+            "PeerInfo syncability should be derived from transport, Multipeer connection state, and endpoint availability."
+        )
+        XCTAssertTrue(
+            syncManagerSource.contains("isManuallySyncable: Self.isManuallySyncablePeer("),
+            "PeerInfo construction should store a capability boolean for the view instead of making the view switch on presentation state."
+        )
+    }
+
     private static func readPeerBrowserSource(
         file: StaticString = #filePath
     ) throws -> String {
@@ -68,8 +109,8 @@ final class PeerBrowserTargetedSyncRegressionTests: XCTestCase {
     }
 
     private static func methodBody(named methodName: String, in source: String) throws -> String {
-        guard let nameRange = source.range(of: "func \(methodName)(peerDeviceId: String) async") else {
-            throw XCTSkip("Expected method \(methodName)(peerDeviceId: String) async in source")
+        guard let nameRange = source.range(of: "func \(methodName)(") else {
+            throw XCTSkip("Expected method \(methodName) in source")
         }
         guard let openBrace = source[nameRange.upperBound...].firstIndex(of: "{") else {
             throw XCTSkip("Expected opening brace for \(methodName)")


### PR DESCRIPTION
## Summary
- Gate Nearby Devices row-level Sync action through an explicit `PeerInfo.isManuallySyncable` capability instead of display state strings.
- Derive manual syncability in `IOSSyncManager` from transport, Multipeer connection state, and usable endpoint availability.
- Keep connected Multipeer peers and addressable LAN peers manually syncable while showing unconnected Multipeer rows as Waiting.
- Add source-level regression coverage for the syncability gate.

Closes #1237

## Tests
- `swift test --filter PeerManagerTests` from `core/` — passed (17 tests).
- `xcodebuild test -scheme "WiredPart-iOS" -destination 'id=F29F2637-4865-4685-92B3-98D2F45EF30C' -derivedDataPath /tmp/wpr2-dd-1237 -only-testing:"Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests"` — passed on local Mac iOS simulator path (3 tests).
- `python3 scripts/guard-tracked-artifacts.py` — passed.

## Local runner / CI
- Local self-hosted runner checked via GitHub API: `IA-Mac-WPR2` online with labels `self-hosted, macOS, ARM64, xcode, ios, local-mac`.
- PR checks passed: Tracked artifact guard, CodeQL, Analyze (swift).

## Paperclip
- WEI-4336
