### PR TITLE
fix: surface sync read and review failures

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -112,8 +112,21 @@ final class IOSSyncManager {
         let failureKey = "\(context): \(message)"
         guard lastSurfacedSyncReadFailure != failureKey else { return }
         lastSurfacedSyncReadFailure = failureKey
+        syncStatus = .error
         errorMessage = message
         logger.error("[IOSSyncManager] \(context) failed: \(error.localizedDescription)")
+    }
+
+    private func syncReadFailed(_ error: Error, context: String, logMessage: String) {
+        syncStatus = .error
+        errorMessage = userFriendlyError(error, context: context)
+        logger.error("[IOSSyncManager] \(logMessage): \(error.localizedDescription)")
+    }
+
+    private func syncReviewActionFailed(_ message: String) {
+        syncStatus = .error
+        errorMessage = message
+        logger.error("[IOSSyncManager] \(message)")
     }
 
     /// Trims a user-entered or persisted shop server address and rejects blank values.
@@ -659,8 +672,11 @@ final class IOSSyncManager {
         do {
             pendingChanges = try ChangeTracker.getPendingChangeCount(db: db)
         } catch {
-            errorMessage = userFriendlyError(error, context: "load pending sync changes")
-            logger.error("[IOSSyncManager] pending change count refresh failed: \(error.localizedDescription)")
+            syncReadFailed(
+                error,
+                context: "load pending sync changes",
+                logMessage: "pending change count refresh failed"
+            )
         }
     }
 
@@ -673,8 +689,11 @@ final class IOSSyncManager {
             unreviewedConflictCount = stats.unreviewed
             return stats.last24h
         } catch {
-            errorMessage = userFriendlyError(error, context: "load sync conflict count")
-            logger.error("[IOSSyncManager] conflict count refresh failed: \(error.localizedDescription)")
+            syncReadFailed(
+                error,
+                context: "load sync conflict count",
+                logMessage: "conflict count refresh failed"
+            )
             return 0
         }
     }
@@ -685,37 +704,65 @@ final class IOSSyncManager {
         do {
             return try ConflictResolver.getUnreviewedConflicts(db: db)
         } catch {
-            errorMessage = userFriendlyError(error, context: "load unreviewed sync conflicts")
-            logger.error("[IOSSyncManager] unreviewed conflict load failed: \(error.localizedDescription)")
+            syncReadFailed(
+                error,
+                context: "load unreviewed sync conflicts",
+                logMessage: "unreviewed conflict load failed"
+            )
             return []
         }
     }
 
     /// Mark a single conflict as reviewed.
-    func markConflictReviewed(conflictId: Int64) {
-        guard let db else { return }
+    @discardableResult
+    func markConflictReviewed(conflictId: Int64) -> Bool {
+        guard let db else {
+            syncReviewActionFailed("Sync conflict could not be marked reviewed because the database is unavailable.")
+            return false
+        }
         do {
             try ConflictResolver.markConflictReviewed(db: db, conflictId: conflictId)
+            refreshConflictCount()
+            return true
         } catch {
-            logger.error("[IOSSyncManager] markConflictReviewed failed for id \(conflictId): \(error.localizedDescription)")
+            syncReadFailed(
+                error,
+                context: "mark sync conflict reviewed",
+                logMessage: "markConflictReviewed failed for id \(conflictId)"
+            )
+            return false
         }
-        refreshConflictCount()
     }
 
     /// Mark all unreviewed conflicts as reviewed.
-    func markAllConflictsReviewed() {
-        guard let db else { return }
+    @discardableResult
+    func markAllConflictsReviewed() -> Bool {
+        guard let db else {
+            syncReviewActionFailed("Sync conflicts could not be marked reviewed because the database is unavailable.")
+            return false
+        }
         let conflicts = getUnreviewedConflicts()
+        var allReviewed = true
         for conflict in conflicts {
-            if let id = conflict.id {
-                do {
-                    try ConflictResolver.markConflictReviewed(db: db, conflictId: id)
-                } catch {
-                    logger.error("[IOSSyncManager] markConflictReviewed failed for id \(id): \(error.localizedDescription)")
-                }
+            guard let id = conflict.id else {
+                allReviewed = false
+                syncReviewActionFailed("A sync conflict could not be marked reviewed because its conflict id is missing. Reload conflicts and try again.")
+                continue
+            }
+
+            do {
+                try ConflictResolver.markConflictReviewed(db: db, conflictId: id)
+            } catch {
+                allReviewed = false
+                syncReadFailed(
+                    error,
+                    context: "mark sync conflicts reviewed",
+                    logMessage: "markConflictReviewed failed for id \(id)"
+                )
             }
         }
         refreshConflictCount()
+        return allReviewed
     }
 
     // MARK: - Device Pairing

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -129,6 +129,10 @@ final class IOSSyncManager {
         logger.error("[IOSSyncManager] \(message)")
     }
 
+    func surfaceConflictReviewActionFailure(_ message: String) {
+        syncReviewActionFailed(message)
+    }
+
     /// Trims a user-entered or persisted shop server address and rejects blank values.
     static func normalizedShopServerAddress(_ address: String?) -> String? {
         let trimmed = address?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -741,7 +745,17 @@ final class IOSSyncManager {
             syncReviewActionFailed("Sync conflicts could not be marked reviewed because the database is unavailable.")
             return false
         }
-        let conflicts = getUnreviewedConflicts()
+        let conflicts: [ConflictLogEntry]
+        do {
+            conflicts = try ConflictResolver.getUnreviewedConflicts(db: db)
+        } catch {
+            syncReadFailed(
+                error,
+                context: "load unreviewed sync conflicts before marking reviewed",
+                logMessage: "unreviewed conflict load failed before markAllConflictsReviewed"
+            )
+            return false
+        }
         var allReviewed = true
         for conflict in conflicts {
             guard let id = conflict.id else {

--- a/Weird Parts IOS/Weird Parts IOS/Sync/SyncConflictReviewPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/SyncConflictReviewPage.swift
@@ -45,7 +45,7 @@ struct SyncConflictReviewPage: View {
                         Button("Accept All") {
                             guard conflicts.allSatisfy({ $0.id != nil }) else {
                                 actionError = "One or more sync conflicts cannot be reviewed because their conflict id is missing. Reload conflicts and try again."
-                                syncManager.errorMessage = actionError
+                                syncManager.surfaceConflictReviewActionFailure(actionError ?? "Sync conflict action failed.")
                                 return
                             }
                             if syncManager.markAllConflictsReviewed() {
@@ -284,7 +284,7 @@ struct SyncConflictReviewPage: View {
     private func markReviewed(_ conflict: ConflictLogEntry) {
         guard let id = conflict.id else {
             actionError = "This sync conflict cannot be reviewed because its conflict id is missing. Reload conflicts and try again."
-            syncManager.errorMessage = actionError
+            syncManager.surfaceConflictReviewActionFailure(actionError ?? "Sync conflict action failed.")
             return
         }
         if syncManager.markConflictReviewed(conflictId: id) {
@@ -326,7 +326,7 @@ struct SyncConflictReviewPage: View {
     private func requestAIMerge(_ conflict: ConflictLogEntry) async {
         guard let conflictId = conflict.id else {
             actionError = "AI merge cannot start because this sync conflict id is missing. Reload conflicts and try again."
-            syncManager.errorMessage = actionError
+            syncManager.surfaceConflictReviewActionFailure(actionError ?? "Sync conflict action failed.")
             return
         }
         isRequestingAI = true

--- a/Weird Parts IOS/Weird Parts IOS/Sync/SyncConflictReviewPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/SyncConflictReviewPage.swift
@@ -14,6 +14,7 @@ struct SyncConflictReviewPage: View {
     @State private var isLoading = true
     @State private var aiResolutions: [Int64: AIConflictResolution] = [:]
     @State private var isRequestingAI = false
+    @State private var actionError: String?
 
     private var syncManager: IOSSyncManager { appCore.syncManager }
 
@@ -42,11 +43,27 @@ struct SyncConflictReviewPage: View {
                 if !conflicts.isEmpty {
                     ToolbarItem(placement: .primaryAction) {
                         Button("Accept All") {
-                            syncManager.markAllConflictsReviewed()
-                            conflicts = []
+                            guard conflicts.allSatisfy({ $0.id != nil }) else {
+                                actionError = "One or more sync conflicts cannot be reviewed because their conflict id is missing. Reload conflicts and try again."
+                                syncManager.errorMessage = actionError
+                                return
+                            }
+                            if syncManager.markAllConflictsReviewed() {
+                                conflicts = []
+                            } else {
+                                actionError = syncManager.errorMessage ?? "Sync conflicts could not be marked reviewed."
+                            }
                         }
                     }
                 }
+            }
+            .alert("Sync conflict action failed", isPresented: Binding(
+                get: { actionError != nil },
+                set: { if !$0 { actionError = nil } }
+            )) {
+                Button("OK", role: .cancel) { actionError = nil }
+            } message: {
+                Text(actionError ?? "The sync conflict action could not be completed.")
             }
             .onAppear { loadConflicts() }
         }
@@ -265,9 +282,16 @@ struct SyncConflictReviewPage: View {
     }
 
     private func markReviewed(_ conflict: ConflictLogEntry) {
-        guard let id = conflict.id else { return }
-        syncManager.markConflictReviewed(conflictId: id)
-        conflicts.removeAll { $0.id == id }
+        guard let id = conflict.id else {
+            actionError = "This sync conflict cannot be reviewed because its conflict id is missing. Reload conflicts and try again."
+            syncManager.errorMessage = actionError
+            return
+        }
+        if syncManager.markConflictReviewed(conflictId: id) {
+            conflicts.removeAll { $0.id == id }
+        } else {
+            actionError = syncManager.errorMessage ?? "Sync conflict could not be marked reviewed."
+        }
     }
 
     private func loadConflicts() {
@@ -300,7 +324,11 @@ struct SyncConflictReviewPage: View {
     // MARK: - AI Merge
 
     private func requestAIMerge(_ conflict: ConflictLogEntry) async {
-        guard let conflictId = conflict.id else { return }
+        guard let conflictId = conflict.id else {
+            actionError = "AI merge cannot start because this sync conflict id is missing. Reload conflicts and try again."
+            syncManager.errorMessage = actionError
+            return
+        }
         isRequestingAI = true
 
         let aiService = FoundationModelsService()

--- a/Weird Parts IOS/Weird Parts IOSTests/SyncManagerFailureSurfacingRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SyncManagerFailureSurfacingRegressionTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+
+final class SyncManagerFailureSurfacingRegressionTests: XCTestCase {
+    func testSyncReadFailuresMoveManagerIntoVisibleErrorState() throws {
+        let source = try Self.readSyncManagerSource()
+
+        XCTAssertFalse(
+            source.contains("try? ChangeTracker.getPendingChangeCount(db: db)"),
+            "Pending-change query failures must not be hidden as a zero-count state."
+        )
+        XCTAssertFalse(
+            source.contains("try? ConflictResolver.getConflictStats(db: db)"),
+            "Conflict-count query failures must not be hidden as a zero-conflict state."
+        )
+        XCTAssertFalse(
+            source.contains("try? ConflictResolver.getUnreviewedConflicts(db: db)"),
+            "Conflict-list query failures must not be hidden as an empty review list."
+        )
+        XCTAssertTrue(
+            source.contains("private func syncReadFailed(_ error: Error, context: String, logMessage: String)") &&
+                source.contains("syncStatus = .error") &&
+                source.contains("errorMessage = userFriendlyError(error, context: context)"),
+            "Sync read failures should route through a helper that exposes a recoverable sync error state."
+        )
+        XCTAssertTrue(
+            source.contains("context: \"load pending sync changes\"") &&
+                source.contains("context: \"load sync conflict count\"") &&
+                source.contains("context: \"load unreviewed sync conflicts\""),
+            "Pending-count, conflict-count, and conflict-list reads should all surface contextual user-facing errors."
+        )
+    }
+
+    func testConflictReviewActionsDoNotSilentlySkipMissingIdsOrFailedWrites() throws {
+        let managerSource = try Self.readSyncManagerSource()
+        let reviewSource = try Self.readConflictReviewSource()
+
+        XCTAssertFalse(
+            reviewSource.contains("guard let id = conflict.id else { return }"),
+            "Conflict-review rows with missing IDs must show an error instead of making Accept a silent no-op."
+        )
+        XCTAssertFalse(
+            reviewSource.contains("guard let conflictId = conflict.id else { return }"),
+            "AI merge requests with missing IDs must show an error instead of silently doing nothing."
+        )
+        XCTAssertTrue(
+            reviewSource.contains("@State private var actionError: String?") &&
+                reviewSource.contains(".alert(\"Sync conflict action failed\"") &&
+                reviewSource.contains("conflict id is missing"),
+            "The review page should present a visible recovery message for corrupt/id-less conflict rows."
+        )
+        XCTAssertTrue(
+            managerSource.contains("@discardableResult\n    func markConflictReviewed(conflictId: Int64) -> Bool") &&
+                managerSource.contains("@discardableResult\n    func markAllConflictsReviewed() -> Bool"),
+            "Review actions should return success/failure so the UI only removes rows after a confirmed write."
+        )
+        XCTAssertTrue(
+            managerSource.contains("syncReviewActionFailed(\"A sync conflict could not be marked reviewed because its conflict id is missing") &&
+                managerSource.contains("context: \"mark sync conflict reviewed\"") &&
+                managerSource.contains("context: \"mark sync conflicts reviewed\""),
+            "Manager-level conflict review failures should be promoted into the same visible sync error surface."
+        )
+    }
+
+    private static func repoRoot(file: StaticString = #filePath) -> URL {
+        URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private static func readSyncManagerSource(file: StaticString = #filePath) throws -> String {
+        let sourceURL = repoRoot(file: file)
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Sync")
+            .appendingPathComponent("IOSSyncManager.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    private static func readConflictReviewSource(file: StaticString = #filePath) throws -> String {
+        let sourceURL = repoRoot(file: file)
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Sync")
+            .appendingPathComponent("SyncConflictReviewPage.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/SyncManagerFailureSurfacingRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SyncManagerFailureSurfacingRegressionTests.swift
@@ -56,8 +56,14 @@ final class SyncManagerFailureSurfacingRegressionTests: XCTestCase {
         XCTAssertTrue(
             managerSource.contains("syncReviewActionFailed(\"A sync conflict could not be marked reviewed because its conflict id is missing") &&
                 managerSource.contains("context: \"mark sync conflict reviewed\"") &&
-                managerSource.contains("context: \"mark sync conflicts reviewed\""),
+                managerSource.contains("context: \"mark sync conflicts reviewed\"") &&
+                managerSource.contains("surfaceConflictReviewActionFailure"),
             "Manager-level conflict review failures should be promoted into the same visible sync error surface."
+        )
+        XCTAssertTrue(
+            managerSource.contains("conflicts = try ConflictResolver.getUnreviewedConflicts(db: db)") &&
+                managerSource.contains("context: \"load unreviewed sync conflicts before marking reviewed\""),
+            "Accept All must fail visibly if the conflict list cannot be read before writes start."
         )
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -1004,7 +1004,7 @@ struct Weird_Parts_IOSTests {
         #expect(syncSource.contains("syncSettingsReadFailed(error, context: \"load sync server address\")"))
         #expect(syncSource.contains("syncSettingsReadFailed(error, context: \"load pairing status\")"))
         #expect(syncSource.contains("guard lastSurfacedSyncReadFailure != failureKey else { return }"), "Repeated sync setting read failures should not re-alert on every SwiftUI render")
-        #expect(syncSource.contains("errorMessage = userFriendlyError(error, context: \"load sync conflict count\")"))
+        #expect(syncSource.contains("context: \"load sync conflict count\""))
     }
 
     @Test func manualBackupSidecarCopyFailureIsReportedAndCleanedUp() throws {


### PR DESCRIPTION
## Summary
- promote sync settings/read failures into `syncStatus = .error` with user-facing error messages instead of normal-looking default states
- make conflict review writes return success so rows are only removed after a confirmed DB update
- show a conflict-review alert when a corrupt/id-less conflict row cannot be accepted or sent to AI merge
- add source regression coverage for sync read failure and conflict-review no-op paths

Closes #1143

## Tests
- `xcodebuild -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -only-testing:"Weird Parts IOSTests/SyncManagerFailureSurfacingRegressionTests" test`
- `xcodebuild -scheme "WiredPart-iOS" -destination 'generic/platform=iOS Simulator' build 2>&1 | grep -E "error:|warning:|BUILD SUCCEEDED|BUILD FAILED"`

## Local runner path
- Verified locally on this Mac with Xcode/iOS Simulator; PR CI should use the repo local self-hosted Mac runner labels for trusted iOS gates.