### PR TITLE
fix: surface distinct multipeer connecting state

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/BluetoothPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/BluetoothPage.swift
@@ -81,14 +81,21 @@ struct BluetoothPage: View {
                             } else if peer.state == "connecting" {
                                 ProgressView()
                                     .controlSize(.small)
+                                    .accessibilityLabel("Status: Connecting")
                             } else if peer.state == "multipeer" {
                                 Text("Waiting")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
-                            } else {
+                            } else if peer.state == "connected" {
                                 Image(systemName: "checkmark.circle.fill")
                                     .foregroundStyle(.green)
                                     .accessibilityLabel("Status: Connected")
+                            } else {
+                                // Neutral fallback for other unsyncable states
+                                // (e.g. a LAN peer without a usable address).
+                                Text("Unavailable")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
                             }
                         }
                         .frame(minHeight: 48)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/BluetoothPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/BluetoothPage.swift
@@ -69,16 +69,26 @@ struct BluetoothPage: View {
 
                             Spacer()
 
-                            if peer.state == "connected" {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundStyle(.green)
-                                    .accessibilityLabel("Status: Connected")
-                            } else {
+                            // Mirror IOSPeerBrowser: Sync is gated by the explicit
+                            // per-peer capability and targets the selected peer —
+                            // unconnected Multipeer rows must not fire a global sync.
+                            if peer.isManuallySyncable {
                                 Button("Sync") {
-                                    Task { await syncManager.syncNow() }
+                                    Task { await syncManager.syncWithPeer(peerDeviceId: peer.id) }
                                 }
                                 .buttonStyle(.bordered)
                                 .controlSize(.small)
+                            } else if peer.state == "connecting" {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else if peer.state == "multipeer" {
+                                Text("Waiting")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            } else {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(.green)
+                                    .accessibilityLabel("Status: Connected")
                             }
                         }
                         .frame(minHeight: 48)
@@ -133,6 +143,7 @@ struct BluetoothPage: View {
     private func peerIcon(_ state: String) -> String {
         switch state {
         case "connected": return "desktopcomputer"
+        case "connecting": return "arrow.triangle.2.circlepath"
         case "multipeer": return "antenna.radiowaves.left.and.right"
         case "lan": return "network"
         default: return "desktopcomputer.and.arrow.down"
@@ -142,6 +153,7 @@ struct BluetoothPage: View {
     private func peerColor(_ state: String) -> Color {
         switch state {
         case "connected": return .green
+        case "connecting": return .orange
         case "multipeer": return .blue
         case "lan": return Color.accentColor
         default: return .secondary
@@ -151,6 +163,7 @@ struct BluetoothPage: View {
     private func peerTransportLabel(_ state: String) -> String {
         switch state {
         case "connected": return "Connected"
+        case "connecting": return "Connecting"
         case "multipeer": return "Bluetooth / Wi-Fi Direct"
         case "lan": return "Local Network"
         default: return state.capitalized

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
@@ -138,13 +138,21 @@ struct IOSPeerBrowser: View {
                         } else if peer.state == "connecting" {
                             ProgressView()
                                 .scaleEffect(0.7)
+                                .accessibilityLabel("Status: Connecting")
                         } else if peer.state == "multipeer" {
                             Text("Waiting")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
-                        } else {
+                        } else if peer.state == "connected" {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(.green)
+                                .accessibilityLabel("Status: Connected")
+                        } else {
+                            // Neutral fallback for other unsyncable states
+                            // (e.g. a LAN peer without a usable address).
+                            Text("Unavailable")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
                     }
                     .frame(minHeight: 56)

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -604,7 +604,9 @@ final class IOSSyncManager {
             return PeerInfo(
                 id: peer.deviceId,
                 name: peer.deviceName,
-                state: peer.multipeerState == "connected" ? "connected" : peer.transport,
+                state: peer.transport == "multipeer"
+                    ? Self.multipeerDisplayState(peer.multipeerState)
+                    : (peer.multipeerState == "connected" ? "connected" : peer.transport),
                 discoveredAt: peer.discoveredAt,
                 address: address,
                 isManuallySyncable: Self.isManuallySyncablePeer(
@@ -626,7 +628,7 @@ final class IOSSyncManager {
             PeerInfo(
                 id: peer.deviceId,
                 name: peer.deviceName,
-                state: peer.state.rawValue == "connected" ? "connected" : "multipeer",
+                state: Self.multipeerDisplayState(peer.state.rawValue),
                 discoveredAt: peer.discoveredAt,
                 address: nil,
                 isManuallySyncable: Self.isManuallySyncablePeer(
@@ -651,7 +653,20 @@ final class IOSSyncManager {
     }
 
     private func isMultipeerDiscoveredPeer(_ peer: PeerInfo) -> Bool {
-        peer.state == "multipeer" || (peer.state == "connected" && peer.address == nil)
+        peer.state == "multipeer" || peer.state == "connecting"
+            || (peer.state == "connected" && peer.address == nil)
+    }
+
+    /// Maps a raw Multipeer connection state ("found"/"connecting"/"connected")
+    /// onto a `PeerInfo` display state. `connecting` stays distinct so the peer
+    /// browser can show an in-progress row instead of a generic waiting state;
+    /// `found` (and any future states) collapse to the waiting "multipeer" row.
+    private static func multipeerDisplayState(_ multipeerState: String?) -> String {
+        switch multipeerState {
+        case "connected": return "connected"
+        case "connecting": return "connecting"
+        default: return "multipeer"
+        }
     }
 
     private func formattedPeerAddress(host: String, port: Int) -> String? {

--- a/Weird Parts IOS/Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests.swift
@@ -110,6 +110,14 @@ final class PeerBrowserTargetedSyncRegressionTests: XCTestCase {
             browserSource.contains("peer.state == \"connecting\""),
             "The peer browser should keep a distinct in-progress branch for connecting peers."
         )
+        XCTAssertTrue(
+            browserSource.contains("else if peer.state == \"connected\""),
+            "The connected checkmark must be gated on the explicit connected state, not shown as a fallback for arbitrary unsyncable states."
+        )
+        XCTAssertTrue(
+            browserSource.contains("Text(\"Unavailable\")"),
+            "Unsyncable states that are neither connecting, waiting, nor connected need a neutral fallback row."
+        )
     }
 
     func testBluetoothPageRowsUseTargetedSyncAndConnectingState() throws {
@@ -130,6 +138,14 @@ final class PeerBrowserTargetedSyncRegressionTests: XCTestCase {
         XCTAssertTrue(
             source.contains("case \"connecting\": return \"Connecting\""),
             "Bluetooth page should label the connecting display state explicitly."
+        )
+        XCTAssertTrue(
+            source.contains("else if peer.state == \"connected\""),
+            "The connected checkmark must be gated on the explicit connected state, not shown as a fallback for arbitrary unsyncable states."
+        )
+        XCTAssertTrue(
+            source.contains("accessibilityLabel(\"Status: Connecting\")"),
+            "The in-progress spinner needs an accessibility label so VoiceOver users can read the row status."
         )
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PeerBrowserTargetedSyncRegressionTests.swift
@@ -82,6 +82,71 @@ final class PeerBrowserTargetedSyncRegressionTests: XCTestCase {
         )
     }
 
+    func testMultipeerConnectingStateStaysAlignedWithBrowserBranches() throws {
+        let syncSource = try Self.readSyncManagerSource()
+
+        // IOSSyncManager must emit "connecting" as a distinct display state
+        // (issue #1317: it previously collapsed found/connecting into "multipeer",
+        // leaving the browser's connecting branch unreachable).
+        XCTAssertTrue(
+            syncSource.contains("case \"connecting\": return \"connecting\""),
+            "multipeerDisplayState should preserve the connecting state instead of collapsing it into the waiting row."
+        )
+        XCTAssertTrue(
+            syncSource.contains("state: Self.multipeerDisplayState(peer.state.rawValue)"),
+            "Multipeer peer rows should derive their display state through multipeerDisplayState."
+        )
+        XCTAssertTrue(
+            syncSource.contains("? Self.multipeerDisplayState(peer.multipeerState)"),
+            "PeerManager-merged multipeer rows should also derive their display state through multipeerDisplayState."
+        )
+        XCTAssertTrue(
+            syncSource.contains("peer.state == \"multipeer\" || peer.state == \"connecting\""),
+            "isMultipeerDiscoveredPeer must treat connecting rows as Multipeer-discovered so merge/removal bookkeeping stays correct."
+        )
+
+        let browserSource = try Self.readPeerBrowserSource()
+        XCTAssertTrue(
+            browserSource.contains("peer.state == \"connecting\""),
+            "The peer browser should keep a distinct in-progress branch for connecting peers."
+        )
+    }
+
+    func testBluetoothPageRowsUseTargetedSyncAndConnectingState() throws {
+        let source = try Self.readBluetoothPageSource()
+
+        XCTAssertTrue(
+            source.contains("if peer.isManuallySyncable"),
+            "Bluetooth page rows should gate Sync on the explicit per-peer capability, matching IOSPeerBrowser."
+        )
+        XCTAssertTrue(
+            source.contains("syncManager.syncWithPeer(peerDeviceId: peer.id)"),
+            "Bluetooth page row Sync must target the selected peer."
+        )
+        XCTAssertFalse(
+            source.contains("Task { await syncManager.syncNow() }"),
+            "Bluetooth page rows must not dispatch the global syncNow fan-out path."
+        )
+        XCTAssertTrue(
+            source.contains("case \"connecting\": return \"Connecting\""),
+            "Bluetooth page should label the connecting display state explicitly."
+        )
+    }
+
+    private static func readBluetoothPageSource(
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Settings")
+            .appendingPathComponent("BluetoothPage.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
     private static func readPeerBrowserSource(
         file: StaticString = #filePath
     ) throws -> String {


### PR DESCRIPTION
## Summary
Closes #1317.

`IOSSyncManager` collapsed Multipeer `found` and `connecting` states into a single `"multipeer"` display state, which made `IOSPeerBrowser`'s `connecting` progress branch unreachable and left the row-level state model misleading.

This PR takes **option 1** from the issue (preserve `connecting` as a distinct display state) since the browser UI already had a purpose-built in-progress branch for it:

- New `multipeerDisplayState()` helper maps `connected`/`connecting` distinctly and collapses `found` (and future states) to the waiting `"multipeer"` row — used in **both** merge paths (`handleMultipeerPeersChanged` and the PeerManager-merged path in `handlePeerStateChange`).
- `isMultipeerDiscoveredPeer()` now treats `connecting` rows as Multipeer-discovered so merge/removal bookkeeping can't leave stale duplicate rows.
- **Same-class fix:** `BluetoothPage` peer rows still had the pre-#1237 pattern — a row-level Sync button on unconnected peers dispatching **global** `syncNow()`. Rows now mirror `IOSPeerBrowser`: gated on `peer.isManuallySyncable`, targeting `syncWithPeer(peerDeviceId:)`, with explicit connecting/waiting states.
- Extended `PeerBrowserTargetedSyncRegressionTests` with two tests keeping produced peer states and browser/Bluetooth-page branches aligned.

## Testing
- `xcrun swiftc -parse` on all touched files
- Simulated every new regression-test assertion against the working tree (all pass)
- CI path: local self-hosted Mac runner (per repo runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)