### PR TITLE
fix: stop cart placement from overwriting part notes

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/CartManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/CartManager.swift
@@ -82,7 +82,7 @@ struct CartSheetView: View {
                     EmptyStateView(
                         icon: "cart",
                         title: "Cart is Empty",
-                        message: "Add parts or bins from any list to update their recorded locations in bulk."
+                        message: "Add parts from any list to update their recorded shelf locations in bulk. Bins can be marked placed for reference."
                     )
                 } else {
                     cartList
@@ -180,7 +180,7 @@ struct CartSheetView: View {
         VStack(spacing: 8) {
             // Be explicit about what "placing" does so this flow can't be
             // mistaken for an inventory ledger movement (issue #1253).
-            Text("Placing updates each part's recorded shelf location. To move stock quantities between locations, use Guided Movement.")
+            Text(placementScopeCaption)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -200,10 +200,25 @@ struct CartSheetView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(placedItems.count == cartManager.itemCount ? .green : .blue)
-            .disabled(isPlacingItems || placements.values.allSatisfy { $0.trimmingCharacters(in: .whitespaces).isEmpty })
+            // Match the save path's trimming exactly — a mismatch here would
+            // enable the button for newline-only input that then places nothing.
+            .disabled(isPlacingItems || placements.values.allSatisfy {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            })
         }
         .padding()
         .background(Color(.secondarySystemBackground))
+    }
+
+    /// Caption describing exactly what "placing" persists for the current
+    /// cart contents. Bins are only marked placed for reference, so a
+    /// bins-only cart must not claim shelf locations are being updated.
+    private var placementScopeCaption: String {
+        let hasParts = cartManager.items.contains { $0.partId != nil }
+        if hasParts {
+            return "Placing updates each part's recorded shelf location. To move stock quantities between locations, use Guided Movement."
+        }
+        return "Bins are marked placed for reference only. To move stock quantities between locations, use Guided Movement."
     }
 
     private func placeAllItems() {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/CartManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/CartManager.swift
@@ -290,7 +290,7 @@ struct CartSheetView: View {
             var placed: Set<UUID> = []
 
             for item in items {
-                guard currentPlacements[item.id]?.trimmingCharacters(in: .whitespaces).isEmpty == false else { continue }
+                guard currentPlacements[item.id]?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else { continue }
                 placed.insert(item.id)
             }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/CartManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/CartManager.swift
@@ -2,7 +2,12 @@ import SwiftUI
 import Combine
 import WiredPartCore
 
-/// Item in the warehouse cart — a part or bin being moved to a new location.
+/// Item in the warehouse cart — a part or bin whose recorded shelf location
+/// is being updated in bulk.
+///
+/// Note: cart placement updates location *metadata* on the part record.
+/// It does not create inventory ledger movements — quantity moves between
+/// structured locations go through the Guided Movement wizard.
 struct CartItem: Identifiable, Equatable, Sendable {
     let id = UUID()
     let partId: Int64?
@@ -16,12 +21,12 @@ struct CartItem: Identifiable, Equatable, Sendable {
     }
 }
 
-/// Global cart manager for moving multiple bins/parts at once.
+/// Global cart manager for updating recorded locations of multiple bins/parts at once.
 ///
 /// Usage:
 /// - Inject as `@StateObject` at the warehouse router level
 /// - Any bin/part list can add items via `addToCart()`
-/// - Cart sheet shows items and allows placing to new locations
+/// - Cart sheet shows items and allows recording new shelf locations
 @MainActor
 final class CartManager: ObservableObject {
     @Published var items: [CartItem] = []
@@ -77,7 +82,7 @@ struct CartSheetView: View {
                     EmptyStateView(
                         icon: "cart",
                         title: "Cart is Empty",
-                        message: "Add parts or bins from any list to move them in bulk."
+                        message: "Add parts or bins from any list to update their recorded locations in bulk."
                     )
                 } else {
                     cartList
@@ -173,6 +178,13 @@ struct CartSheetView: View {
 
     private var placeAllButton: some View {
         VStack(spacing: 8) {
+            // Be explicit about what "placing" does so this flow can't be
+            // mistaken for an inventory ledger movement (issue #1253).
+            Text("Placing updates each part's recorded shelf location. To move stock quantities between locations, use Guided Movement.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
             if isPlacingItems {
                 ProgressView("Placing items\u{2026}")
                     .font(.caption)
@@ -224,12 +236,16 @@ struct CartSheetView: View {
             var errorMsg: String?
 
             for item in items {
-                guard let location = currentPlacements[item.id],
-                      !location.trimmingCharacters(in: .whitespaces).isEmpty else { continue }
+                guard let location = currentPlacements[item.id]?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                      !location.isEmpty else { continue }
 
                 if let partId = item.partId {
                     do {
-                        try service.updatePart(id: partId, notes: "Location: \(location)")
+                        // Record the new location in the part's dedicated
+                        // shelf_location column. Never write to `notes` here —
+                        // that destroyed free-form part notes (issue #1253).
+                        try service.updatePart(id: partId, shelfLocation: location)
                         placed.insert(item.id)
                     } catch {
                         failedPartIDs.insert(item.id)

--- a/Weird Parts IOS/Weird Parts IOSTests/CartPlacementShelfLocationRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/CartPlacementShelfLocationRegressionTests.swift
@@ -35,6 +35,10 @@ final class CartPlacementShelfLocationRegressionTests: XCTestCase {
             source.contains("use Guided Movement"),
             "The cart sheet should point users at Guided Movement for real inventory ledger moves."
         )
+        XCTAssertTrue(
+            source.contains("Bins are marked placed for reference only."),
+            "A bins-only cart must not claim shelf locations are being updated (bins are reference-only)."
+        )
     }
 
     func testCartPlacementTrimsLocationBeforeSaving() throws {
@@ -45,6 +49,10 @@ final class CartPlacementShelfLocationRegressionTests: XCTestCase {
                 && source.contains(".trimmingCharacters(in: .whitespacesAndNewlines)")
                 && source.contains("!location.isEmpty"),
             "Cart placement should trim the entered location and skip whitespace-only values."
+        )
+        XCTAssertFalse(
+            source.contains("in: .whitespaces)"),
+            "All cart trimming must use .whitespacesAndNewlines — a looser character set on the enable check lets newline-only input enable Place All and then place nothing."
         )
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/CartPlacementShelfLocationRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/CartPlacementShelfLocationRegressionTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+
+/// Regression coverage for issue #1253: warehouse cart placement destroyed
+/// free-form part notes by writing a synthetic "Location: ..." string into
+/// `parts.notes` while leaving real location metadata untouched.
+///
+/// Cart placement must record the destination in the dedicated
+/// `shelf_location` column and must never write to the part notes field.
+final class CartPlacementShelfLocationRegressionTests: XCTestCase {
+    func testCartPlacementWritesShelfLocationNotNotes() throws {
+        let source = try Self.readCartManagerSource()
+
+        XCTAssertTrue(
+            source.contains("try service.updatePart(id: partId, shelfLocation: location)"),
+            "Cart placement should record the destination in the part's dedicated shelf_location column."
+        )
+        XCTAssertFalse(
+            source.contains("updatePart(id: partId, notes:"),
+            "Cart placement must never write to the part notes field — that destroyed user-entered notes (issue #1253)."
+        )
+        XCTAssertFalse(
+            source.contains("notes: \"Location:"),
+            "Cart placement must not fabricate synthetic Location notes."
+        )
+    }
+
+    func testCartPlacementStatesMetadataScopeInUI() throws {
+        let source = try Self.readCartManagerSource()
+
+        XCTAssertTrue(
+            source.contains("Placing updates each part's recorded shelf location."),
+            "The cart sheet should state that placement updates recorded location metadata, not stock quantities."
+        )
+        XCTAssertTrue(
+            source.contains("use Guided Movement"),
+            "The cart sheet should point users at Guided Movement for real inventory ledger moves."
+        )
+    }
+
+    func testCartPlacementTrimsLocationBeforeSaving() throws {
+        let source = try Self.readCartManagerSource()
+
+        XCTAssertTrue(
+            source.contains("guard let location = currentPlacements[item.id]?")
+                && source.contains(".trimmingCharacters(in: .whitespacesAndNewlines)")
+                && source.contains("!location.isEmpty"),
+            "Cart placement should trim the entered location and skip whitespace-only values."
+        )
+    }
+
+    private static func readCartManagerSource(
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Warehouse")
+            .appendingPathComponent("CartManager.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1253.

Warehouse cart placement wrote a synthetic `"Location: ..."` string into `parts.notes`, destroying user-entered notes while moving no inventory. Per the issue's accepted resolution paths, this takes the **honest-metadata** option:

- Placement now records the destination in the part's dedicated `shelf_location` column (the same column the parts import/export pipeline treats as shelf location) — existing notes are never touched.
- Entered locations are trimmed and whitespace-only values skipped.
- The cart sheet now states explicitly that placing updates the recorded shelf location and points at the **Guided Movement** wizard for real quantity moves — placement can no longer masquerade as an inventory ledger movement.
- New `CartPlacementShelfLocationRegressionTests` locks all of this in.

**Why not route through `executeMovement`:** the core movement API requires structured `locationType/locationId` pairs plus source stock; the cart is a free-text metadata flow with no structured source/destination, so wiring it into ledger movements would mean designing a new picker UI — out of scope for this data-loss fix and better done as deliberate product work.

**Dormant-UI finding (documented, not fixed here):** `CartManager.addToCart` currently has zero call sites — the cart badge on the Warehouse Dashboard always opens an empty sheet. Fixing the data-loss path was still warranted (the code is one wiring away from live), but the missing entry points are a separate feature-wiring decision. Noted on the issue.

## Testing
- `xcrun swiftc -parse` on both touched files
- Simulated every regression-test assertion against the working tree (all pass)
- CI path: local self-hosted Mac runner (per repo runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)