### PR TITLE
fix: clamp malformed panel schedule totalSpaces

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -1406,7 +1406,9 @@ struct IOSNotebookDetailPage: View {
                 for entry in section.entries where entry.blockType == "panel_schedule" {
                     if let data = entry.blockData?.data(using: .utf8),
                        let schedule = try? JSONDecoder().decode(PanelSchedule.self, from: data) {
-                        panelSchedule = schedule
+                        // Clamp malformed/synced totalSpaces before rendering —
+                        // a negative value traps range construction (#1239).
+                        panelSchedule = schedule.clampingTotalSpacesToSupportedRange()
                         return
                     }
                 }
@@ -1418,7 +1420,7 @@ struct IOSNotebookDetailPage: View {
                 for entry in section.entries where entry.blockType == "panel_schedule" {
                     if let data = entry.blockData?.data(using: .utf8),
                        let schedule = try? JSONDecoder().decode(PanelSchedule.self, from: data) {
-                        panelSchedule = schedule
+                        panelSchedule = schedule.clampingTotalSpacesToSupportedRange()
                         return
                     }
                 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
@@ -104,8 +104,9 @@ struct PanelScheduleBuilder: View {
             .padding(.vertical, 4)
             .background(.gray.opacity(0.1))
 
-            // Circuit rows
-            ForEach(0..<(schedule.totalSpaces / 2), id: \.self) { row in
+            // Circuit rows — max() keeps the range valid even if a malformed
+            // negative totalSpaces slips past load-path clamping (#1239).
+            ForEach(0..<max(schedule.totalSpaces / 2, 0), id: \.self) { row in
                 let leftSpace = row * 2 + 1
                 let rightSpace = row * 2 + 2
                 let leftCircuit = schedule.circuits.first { $0.spaceNumber == leftSpace }
@@ -346,7 +347,9 @@ private struct PanelSettingsSheet: View {
     @Binding var schedule: PanelSchedule
     @Environment(\.dismiss) private var dismiss
 
-    private let spaceOptions = [2, 4, 8, 12, 16, 20, 24, 30, 42]
+    // Single source of truth lives on the model so decode-time clamping and
+    // the picker can never drift apart.
+    private let spaceOptions = PanelSchedule.supportedTotalSpaces
     private let ampOptions = [100, 125, 150, 200, 225, 400, 600]
 
     var body: some View {

--- a/core/Sources/WiredPartCore/Models/Notebooks/PanelScheduleModels.swift
+++ b/core/Sources/WiredPartCore/Models/Notebooks/PanelScheduleModels.swift
@@ -34,6 +34,40 @@ public struct PanelSchedule: Codable, Identifiable, Sendable {
         self.circuits = circuits
     }
 
+    /// The panel sizes the schedule builder UI supports selecting.
+    public static let supportedTotalSpaces = [2, 4, 8, 12, 16, 20, 24, 30, 42]
+
+    /// The fallback panel size used when a decoded value is unusable.
+    public static let defaultTotalSpaces = 20
+
+    /// Clamps a raw `totalSpaces` value onto a supported panel size.
+    ///
+    /// Panel schedules are decoded from notebook block JSON and sync payloads,
+    /// so malformed values (negative, zero, or out-of-range) can reach the
+    /// model. Rendering `0..<(totalSpaces / 2)` with a negative value traps at
+    /// runtime (issue #1239), so every load path must normalize first.
+    ///
+    /// - Non-positive values fall back to the default panel size (20) so any
+    ///   existing circuits stay visible and repairable.
+    /// - Values between supported sizes round **up** to the next size so no
+    ///   in-range circuit becomes hidden.
+    /// - Values above the largest supported size clamp down to it (42).
+    public static func normalizedTotalSpaces(_ raw: Int) -> Int {
+        guard raw > 0 else { return defaultTotalSpaces }
+        guard let clamped = supportedTotalSpaces.first(where: { $0 >= raw }) else {
+            return supportedTotalSpaces.max() ?? defaultTotalSpaces
+        }
+        return clamped
+    }
+
+    /// Returns a copy whose `totalSpaces` is clamped to a supported panel size.
+    /// Apply this to every schedule decoded from JSON before rendering it.
+    public func clampingTotalSpacesToSupportedRange() -> PanelSchedule {
+        var normalized = self
+        normalized.totalSpaces = Self.normalizedTotalSpaces(totalSpaces)
+        return normalized
+    }
+
     /// Returns a copy safe to persist for the current panel size.
     ///
     /// Users can shrink `totalSpaces` from the builder settings while stale circuit
@@ -51,10 +85,12 @@ public struct PanelSchedule: Codable, Identifiable, Sendable {
     /// Returns a copy safe to persist after panel builder edits.
     ///
     /// A circuit marked spare should not retain active breaker/load metadata that
-    /// will be hidden by the grid and exports. Normalize both the visible panel
-    /// range and the per-circuit spare payload before writing notebook JSON.
+    /// will be hidden by the grid and exports. Normalize the panel size, the
+    /// visible panel range, and the per-circuit spare payload before writing
+    /// notebook JSON. Clamping runs first so pruning uses the repaired size.
     public func normalizedForPersistence() -> PanelSchedule {
-        var normalized = pruningCircuitsOutsideTotalSpaces()
+        var normalized = clampingTotalSpacesToSupportedRange()
+            .pruningCircuitsOutsideTotalSpaces()
         normalized.circuits = normalized.circuits.map { $0.normalizedForPersistence() }
         return normalized
     }

--- a/core/Tests/WiredPartCoreTests/PanelScheduleTests.swift
+++ b/core/Tests/WiredPartCoreTests/PanelScheduleTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import WiredPartCore
 
@@ -79,5 +80,57 @@ struct PanelScheduleTests {
         #expect(circuit.wire == nil)
         #expect(circuit.conduit == nil)
         #expect(circuit.isFedFrom == nil)
+    }
+
+    @Test("Malformed totalSpaces values clamp to supported panel sizes",
+          arguments: [
+            (-2, 20),   // negative → default (issue #1239 crash repro)
+            (0, 20),    // zero → default
+            (3, 4),     // between sizes → round up
+            (15, 16),   // odd → next even supported size
+            (18, 20),   // between sizes → round up
+            (30, 30),   // supported value unchanged
+            (43, 42),   // above max → clamp down
+            (999, 42)   // absurd → clamp down
+          ])
+    func malformedTotalSpacesClampsToSupportedSize(raw: Int, expected: Int) {
+        #expect(PanelSchedule.normalizedTotalSpaces(raw) == expected)
+
+        let schedule = PanelSchedule(totalSpaces: raw)
+        let clamped = schedule.clampingTotalSpacesToSupportedRange()
+        #expect(clamped.totalSpaces == expected)
+        #expect(PanelSchedule.supportedTotalSpaces.contains(clamped.totalSpaces))
+
+        // The exact expression the builder renders must be constructible —
+        // a negative upper bound used to trap here (issue #1239).
+        let rows = 0..<max(clamped.totalSpaces / 2, 0)
+        #expect(!rows.isEmpty)
+    }
+
+    @Test("Decoding malformed JSON totalSpaces stays renderable and persistable")
+    func decodedMalformedTotalSpacesIsRepairable() throws {
+        let json = """
+        {"id":"p1","panelName":"Panel A","panelType":"Load Center",
+         "totalSpaces":-2,"mainBreakerAmps":200,"voltage":240,"phase":1,
+         "circuits":[
+            {"id":"c1","spaceNumber":1,"breakerAmps":20,"breakerType":"Single",
+             "circuitDescription":"Office","isSpare":false},
+            {"id":"c2","spaceNumber":21,"breakerAmps":15,"breakerType":"Single",
+             "circuitDescription":"Out of range","isSpare":false}
+         ]}
+        """
+        let decoded = try JSONDecoder().decode(PanelSchedule.self, from: Data(json.utf8))
+        #expect(decoded.totalSpaces == -2)
+
+        // Load path: clamping repairs the size without dropping circuits.
+        let display = decoded.clampingTotalSpacesToSupportedRange()
+        #expect(display.totalSpaces == 20)
+        #expect(display.circuits.count == 2)
+
+        // Save path: persistence clamps first, then prunes against the
+        // repaired size — never against the malformed one.
+        let persisted = decoded.normalizedForPersistence()
+        #expect(persisted.totalSpaces == 20)
+        #expect(persisted.circuits.map(\.spaceNumber) == [1])
     }
 }


### PR DESCRIPTION
## Summary
Closes #1239.

A malformed/synced `panel_schedule` block with negative `totalSpaces` (e.g. `-2`) crashed the panel schedule editor: `ForEach(0..<(totalSpaces / 2))` traps constructing a range with lowerBound > upperBound.

Fix is layered per the issue's acceptance criteria:

1. **Model (core):** `PanelSchedule.normalizedTotalSpaces` clamps raw values onto `supportedTotalSpaces` — non-positive → default 20 (keeps circuits visible/repairable), in-between values round **up** (never hides an in-range circuit), oversized → 42.
2. **Load paths:** both notebook decode sites apply `clampingTotalSpacesToSupportedRange()` before rendering.
3. **Save path:** `normalizedForPersistence()` clamps **before** pruning, so a repaired size is persisted and pruning runs against it — not the malformed value.
4. **View defense-in-depth:** the grid range uses `max(totalSpaces / 2, 0)`, and the builder's picker now sources `PanelSchedule.supportedTotalSpaces` so picker options and clamp targets can't drift.

## Testing
- `swift test --filter PanelScheduleTests` — **5 tests pass**, including 8 parameterized clamp cases (`-2, 0, 3, 15, 18, 30, 43, 999`) and a malformed-JSON decode → display → persist round-trip
- `xcrun swiftc -parse` on all touched files
- CI path: local self-hosted Mac runner (per repo runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)