### PR TITLE
fix: skip malformed labor chart dates instead of showing today

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/DashboardView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/DashboardView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Charts
 import Combine
+import os
 import WiredPartCore
 
 /// Main dashboard view with KPI cards, charts, alerts, and quick actions.
@@ -11,6 +12,8 @@ import WiredPartCore
 struct DashboardView: View {
     @EnvironmentObject private var appCore: AppCore
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    private let logger = Logger(subsystem: "com.wiredpart.ios", category: "DashboardView")
 
     // KPI + alerts state
     @State private var stats = DashboardStats()
@@ -1060,10 +1063,15 @@ struct DashboardView: View {
             return
         }
         do {
-            // Labor hours for past 7 days
+            // Labor hours for past 7 days. Skip rows whose stored date does
+            // not parse — falling back to Date() mislabeled malformed rows as
+            // today in the seven-day chart (issue #1247).
             let laborRows = try service.getLaborChartData()
-            let laborDays = laborRows.map { row in
-                let date = Formatters.localDateFormatter.date(from: row.dateString) ?? Date()
+            let laborDays = laborRows.compactMap { row -> LaborDayData? in
+                guard let date = Formatters.localDateFormatter.date(from: row.dateString) else {
+                    logger.error("[Dashboard] Skipping labor chart row with malformed date: \(row.dateString, privacy: .public)")
+                    return nil
+                }
                 return LaborDayData(
                     dayLabel: Formatters.dayOfWeekFormatter.string(from: date),
                     date: row.dateString,

--- a/Weird Parts IOS/Weird Parts IOSTests/DashboardLaborChartDateRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/DashboardLaborChartDateRegressionTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+/// Regression coverage for issue #1247: the Dashboard labor-hours chart
+/// converted any unparseable `LaborChartRow.dateString` into `Date()`,
+/// silently mislabeling malformed historical rows as today.
+final class DashboardLaborChartDateRegressionTests: XCTestCase {
+    func testLaborChartSkipsMalformedDatesInsteadOfDefaultingToToday() throws {
+        let source = try Self.readDashboardViewSource()
+
+        XCTAssertFalse(
+            source.contains("date(from: row.dateString) ?? Date()"),
+            "Labor chart rows must not fall back to Date() — that displays malformed rows as today (issue #1247)."
+        )
+        XCTAssertTrue(
+            source.contains("let laborDays = laborRows.compactMap { row -> LaborDayData? in"),
+            "Labor chart mapping should compactMap so malformed rows are skipped, not remapped."
+        )
+        XCTAssertTrue(
+            source.contains("guard let date = Formatters.localDateFormatter.date(from: row.dateString) else"),
+            "Labor chart mapping should guard on date parsing and bail out for malformed rows."
+        )
+        XCTAssertTrue(
+            source.contains("Skipping labor chart row with malformed date"),
+            "Skipped malformed rows should be logged so bad data stays diagnosable."
+        )
+    }
+
+    private static func readDashboardViewSource(
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Dashboard")
+            .appendingPathComponent("DashboardView.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1247.

The Dashboard labor-hours chart converted any unparseable `LaborChartRow.dateString` into `Date()`, so malformed historical rows silently rendered as **today** in the seven-day chart.

Per the issue's acceptance criteria:
- Removed the `?? Date()` fallback — mapping now `compactMap`s with a `guard` on date parsing, so malformed rows are **skipped**, and each skip is logged via `os.Logger` (`DashboardView` category, public payload) so bad data stays diagnosable.
- Valid rows render exactly as before.
- Added `DashboardLaborChartDateRegressionTests`, which fails if the `Date()` fallback ever returns.

## Testing
- `xcrun swiftc -parse` on both touched files
- Simulated every regression assertion against the tree (all pass); verified zero `?? Date()` occurrences remain in DashboardView
- CI path: local self-hosted Mac runner (per repo runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)