### PR TITLE
fix: protect all schedule config edits with dirty tracking

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleConfigPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSScheduleConfigPage.swift
@@ -654,10 +654,27 @@ struct ShiftTemplateEditSheet: View {
     @State private var breakPaid = false
     @State private var overtimeRule = "company_default"
     @State private var showDeleteConfirm = false
+    @State private var showDiscardConfirm = false
 
-    @State private var originalName = ""
+    @State private var baselineSignature = ""
 
-    private var isDirty: Bool { name.trimmingCharacters(in: .whitespaces) != originalName }
+    /// Signature over every persisted field so edits to any of them —
+    /// not just the name — mark the sheet dirty (issue #1248).
+    private var formSignature: String {
+        let days = dayOrder.filter { selectedDays.contains($0) }.joined(separator: ",")
+        return [
+            name.trimmingCharacters(in: .whitespaces),
+            String(selectedHatId),
+            days,
+            Formatters.timeHHmmFormatter.string(from: startTime),
+            Formatters.timeHHmmFormatter.string(from: endTime),
+            String(breakMinutes),
+            String(breakPaid),
+            overtimeRule
+        ].joined(separator: "|")
+    }
+
+    private var isDirty: Bool { formSignature != baselineSignature }
 
     private let dayOrder = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
     private let dayLabels = ["M", "T", "W", "Th", "F", "Sa", "Su"]
@@ -749,7 +766,9 @@ struct ShiftTemplateEditSheet: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button("Cancel") {
+                        if isDirty { showDiscardConfirm = true } else { dismiss() }
+                    }
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") { save() }
@@ -770,13 +789,19 @@ struct ShiftTemplateEditSheet: View {
             } message: {
                 Text("This action cannot be undone.")
             }
+            .confirmationDialog("Discard changes?", isPresented: $showDiscardConfirm, titleVisibility: .visible) {
+                Button("Discard", role: .destructive) { dismiss() }
+                Button("Keep editing", role: .cancel) {}
+            }
         }
     }
 
     private func populateFromExisting() {
+        // Snapshot the baseline after seeding (or after defaults, for new
+        // templates) so untouched sheets never count as dirty.
+        defer { baselineSignature = formSignature }
         guard let t = existing else { return }
         name = t.name
-        originalName = t.name
         selectedHatId = t.hatId ?? 0
         // Parse work days JSON
         if let data = t.workDays.data(using: .utf8),
@@ -834,10 +859,22 @@ struct HolidayEditSheet: View {
     @State private var isPaid = true
     @State private var isRecurring = false
     @State private var showDeleteConfirm = false
+    @State private var showDiscardConfirm = false
 
-    @State private var originalName = ""
+    @State private var baselineSignature = ""
 
-    private var isDirty: Bool { name.trimmingCharacters(in: .whitespaces) != originalName }
+    /// Signature over every persisted field so edits to any of them —
+    /// not just the name — mark the sheet dirty (issue #1248).
+    private var formSignature: String {
+        [
+            name.trimmingCharacters(in: .whitespaces),
+            Formatters.localDateFormatter.string(from: selectedDate),
+            String(isPaid),
+            String(isRecurring)
+        ].joined(separator: "|")
+    }
+
+    private var isDirty: Bool { formSignature != baselineSignature }
 
     var body: some View {
         NavigationStack {
@@ -877,7 +914,9 @@ struct HolidayEditSheet: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button("Cancel") {
+                        if isDirty { showDiscardConfirm = true } else { dismiss() }
+                    }
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") { save() }
@@ -896,13 +935,19 @@ struct HolidayEditSheet: View {
             } message: {
                 Text("This action cannot be undone.")
             }
+            .confirmationDialog("Discard changes?", isPresented: $showDiscardConfirm, titleVisibility: .visible) {
+                Button("Discard", role: .destructive) { dismiss() }
+                Button("Keep editing", role: .cancel) {}
+            }
         }
     }
 
     private func populateFromExisting() {
+        // Snapshot the baseline after seeding (or after defaults, for new
+        // holidays) so untouched sheets never count as dirty.
+        defer { baselineSignature = formSignature }
         guard let h = existing else { return }
         name = h.name
-        originalName = h.name
         isPaid = h.isPaid
         isRecurring = h.isRecurring
         if let d = Formatters.localDateFormatter.date(from: h.date) { selectedDate = d }

--- a/Weird Parts IOS/Weird Parts IOSTests/ScheduleConfigDirtyProtectionRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/ScheduleConfigDirtyProtectionRegressionTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+
+/// Regression coverage for issue #1248: the schedule config edit sheets
+/// (`ShiftTemplateEditSheet`, `HolidayEditSheet`) only compared the name
+/// field when deciding dirtiness, so edits to work days, times, breaks,
+/// overtime rules, holiday dates, or paid/recurring toggles could be
+/// swipe-dismissed or cancelled without any discard protection.
+final class ScheduleConfigDirtyProtectionRegressionTests: XCTestCase {
+    func testDirtyTrackingCoversAllPersistedFieldsNotJustName() throws {
+        let source = try Self.readScheduleConfigSource()
+
+        XCTAssertFalse(
+            source.contains("name.trimmingCharacters(in: .whitespaces) != originalName"),
+            "isDirty must not compare only the name field (issue #1248)."
+        )
+        // Both sheets derive dirtiness from a full-form signature baseline.
+        XCTAssertEqual(
+            source.components(separatedBy: "private var isDirty: Bool { formSignature != baselineSignature }").count - 1,
+            2,
+            "Both schedule config edit sheets should compare a full-form signature against the on-appear baseline."
+        )
+        // Shift template signature covers every persisted field.
+        for field in ["String(selectedHatId)", "Formatters.timeHHmmFormatter.string(from: startTime)",
+                      "Formatters.timeHHmmFormatter.string(from: endTime)", "String(breakMinutes)",
+                      "String(breakPaid)", "overtimeRule"] {
+            XCTAssertTrue(
+                source.contains(field),
+                "Shift template form signature should include \(field)."
+            )
+        }
+        // Holiday signature covers date and both toggles.
+        for field in ["Formatters.localDateFormatter.string(from: selectedDate)",
+                      "String(isPaid)", "String(isRecurring)"] {
+            XCTAssertTrue(
+                source.contains(field),
+                "Holiday form signature should include \(field)."
+            )
+        }
+    }
+
+    func testDirtySheetsRequireExplicitDiscardDecision() throws {
+        let source = try Self.readScheduleConfigSource()
+
+        // Cancel routes through the discard confirmation when dirty (both sheets).
+        XCTAssertEqual(
+            source.components(separatedBy: "if isDirty { showDiscardConfirm = true } else { dismiss() }").count - 1,
+            2,
+            "Cancel on both edit sheets should ask before discarding dirty forms."
+        )
+        // Swipe-dismiss protection stays wired to isDirty (both sheets, at minimum).
+        XCTAssertGreaterThanOrEqual(
+            source.components(separatedBy: ".interactiveDismissDisabled(isDirty)").count - 1,
+            2,
+            "Both edit sheets must keep interactive dismissal disabled while dirty."
+        )
+        XCTAssertEqual(
+            source.components(separatedBy: "\"Discard changes?\"").count - 1,
+            2,
+            "Both edit sheets need a discard confirmation dialog."
+        )
+    }
+
+    func testBaselineSnapshotsAfterPopulatingSoUntouchedSheetsAreClean() throws {
+        let source = try Self.readScheduleConfigSource()
+
+        XCTAssertEqual(
+            source.components(separatedBy: "defer { baselineSignature = formSignature }").count - 1,
+            2,
+            "Both sheets must snapshot the baseline after populating (including the new-item defaults path) so untouched sheets never count as dirty."
+        )
+    }
+
+    private static func readScheduleConfigSource(
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Scheduling")
+            .appendingPathComponent("IOSScheduleConfigPage.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/ScheduleConfigDirtyProtectionRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/ScheduleConfigDirtyProtectionRegressionTests.swift
@@ -19,8 +19,19 @@ final class ScheduleConfigDirtyProtectionRegressionTests: XCTestCase {
             2,
             "Both schedule config edit sheets should compare a full-form signature against the on-appear baseline."
         )
-        // Shift template signature covers every persisted field.
-        for field in ["String(selectedHatId)", "Formatters.timeHHmmFormatter.string(from: startTime)",
+        // Shift template signature covers every persisted field — including
+        // the day selection (the original #1248 data-loss path) and the
+        // trimmed name. The anchored fragment below is the exact head of the
+        // signature array, so a save()-path match cannot satisfy it.
+        XCTAssertTrue(
+            source.contains("let days = dayOrder.filter { selectedDays.contains($0) }.joined(separator: \",\")"),
+            "Shift template form signature must derive from the selected work days."
+        )
+        XCTAssertTrue(
+            source.contains("name.trimmingCharacters(in: .whitespaces),\n            String(selectedHatId),\n            days,"),
+            "Shift template form signature must lead with the trimmed name, hat, and selected days."
+        )
+        for field in ["Formatters.timeHHmmFormatter.string(from: startTime)",
                       "Formatters.timeHHmmFormatter.string(from: endTime)", "String(breakMinutes)",
                       "String(breakPaid)", "overtimeRule"] {
             XCTAssertTrue(


### PR DESCRIPTION
## Summary
Closes #1248.

`ShiftTemplateEditSheet` and `HolidayEditSheet` computed `isDirty` from the **name field only**, so edits to work days, start/end times, break duration/paid, overtime rule, holiday date, or paid/recurring toggles could be swipe-dismissed or cancelled silently.

Following the Dismiss Safety campaign idiom (`formSignature` vs baseline, as in `IOSDailyReportTemplatesPage`):

- Both sheets now build a **full-form signature** over every persisted field and compare it against a baseline snapshotted (via `defer`) after `populateFromExisting()` — which also runs on the new-item defaults path, so untouched sheets never count as dirty.
- **Cancel** asks "Discard changes?" (Discard / Keep editing) when dirty; `.interactiveDismissDisabled(isDirty)` still blocks swipe-dismiss.
- Save/delete behavior unchanged.
- New `ScheduleConfigDirtyProtectionRegressionTests` asserts: no name-only comparison, both sheets use signature dirtiness, every persisted field appears in a signature, and both sheets carry the discard dialog + baseline snapshot.

## Testing
- `xcrun swiftc -parse` on both touched files
- Simulated every regression assertion against the tree (all pass)
- CI path: local self-hosted Mac runner (per repo runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)