### PR TITLE
fix: export only visible filtered rows in searchable reports

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSDailyReportsSummaryPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSDailyReportsSummaryPage.swift
@@ -49,8 +49,10 @@ struct IOSDailyReportsSummaryPage: View {
         .reportExportToolbar(
             title: "Daily_Summary",
             columns: ["Job", "Workers", "Hours", "Status"],
-            rows: rows.map { [$0.jobName, "\($0.workerCount)",
-                              String(format: "%.1f", $0.totalHours), $0.status] }
+            // Export exactly what's visible — an active search filter must
+            // filter the export too (issue #1243).
+            rows: filteredRows.map { [$0.jobName, "\($0.workerCount)",
+                                      String(format: "%.1f", $0.totalHours), $0.status] }
         )
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
@@ -64,7 +66,8 @@ struct IOSDailyReportsSummaryPage: View {
             PageHelpSheet(title: "Daily Reports Summary Help", sections: [
                 ("What This Page Does", "Shows a quick snapshot of all daily reports across every active job for a single day. You can see how many workers were on each job, total hours logged, and the job status."),
                 ("How to Use It", "Use the left and right arrows to move between days, or tap the date to pick a specific day. Each row shows a job with worker count, hours, and status. The top KPIs give you totals at a glance."),
-                ("Tips", "Check this page at the end of each workday to make sure all jobs have reports filed. If a job shows zero workers, the foreman may not have submitted the daily report yet.")
+                ("Tips", "Check this page at the end of each workday to make sure all jobs have reports filed. If a job shows zero workers, the foreman may not have submitted the daily report yet."),
+                ("Exporting", "Exports include exactly the rows currently visible. If a search is active, only matching rows are exported — clear the search to export everything.")
             ])
         }
         .refreshable { loadData() }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSLaborOverviewPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSLaborOverviewPage.swift
@@ -40,9 +40,11 @@ struct IOSLaborOverviewPage: View {
         .reportExportToolbar(
             title: "Labor_Overview",
             columns: ["Employee", "Regular", "Overtime", "Total", "Days"],
-            rows: timesheetRows.map { [$0.userName, String(format: "%.1f", $0.regularHours),
-                                       String(format: "%.1f", $0.overtimeHours),
-                                       String(format: "%.1f", $0.totalHours), "\($0.daysWorked)"] }
+            // Export exactly what's visible — an active search filter must
+            // filter the export too (issue #1243).
+            rows: filteredTimesheetRows.map { [$0.userName, String(format: "%.1f", $0.regularHours),
+                                               String(format: "%.1f", $0.overtimeHours),
+                                               String(format: "%.1f", $0.totalHours), "\($0.daysWorked)"] }
         )
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
@@ -56,7 +58,8 @@ struct IOSLaborOverviewPage: View {
             PageHelpSheet(title: "Labor Overview Help", sections: [
                 ("What This Page Does", "Gives you a high-level view of labor for the current week. Shows total hours, regular vs overtime, and the number of active workers. Below that, each employee is listed with their individual breakdown."),
                 ("How to Use It", "The top section shows weekly totals. Scroll down to see each employee's regular hours, overtime, and days worked. Pull down to refresh if crews are still clocking in."),
-                ("Tips", "Keep an eye on overtime numbers. If someone is already high mid-week, consider adjusting schedules. This report resets each Monday.")
+                ("Tips", "Keep an eye on overtime numbers. If someone is already high mid-week, consider adjusting schedules. This report resets each Monday."),
+                ("Exporting", "Exports include exactly the rows currently visible. If a search is active, only matching rows are exported — clear the search to export everything.")
             ])
         }
         .refreshable { loadData() }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSProfitabilityPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSProfitabilityPage.swift
@@ -34,11 +34,13 @@ struct IOSProfitabilityPage: View {
             .reportExportToolbar(
                 title: "Profitability",
                 columns: ["Job", "Revenue", "Labor", "Material", "Profit", "Margin"],
-                rows: rows.map { [$0.jobName, String(format: "$%.2f", $0.revenue),
-                                  String(format: "$%.2f", $0.laborCost),
-                                  String(format: "$%.2f", $0.materialCost),
-                                  String(format: "$%.2f", $0.profit),
-                                  String(format: "%.1f%%", $0.margin)] }
+                // Export exactly what's visible — an active search filter must
+                // filter the export too (issue #1243).
+                rows: filteredRows.map { [$0.jobName, String(format: "$%.2f", $0.revenue),
+                                          String(format: "$%.2f", $0.laborCost),
+                                          String(format: "$%.2f", $0.materialCost),
+                                          String(format: "$%.2f", $0.profit),
+                                          String(format: "%.1f%%", $0.margin)] }
             )
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
@@ -52,7 +54,8 @@ struct IOSProfitabilityPage: View {
                 PageHelpSheet(title: "Profitability Help", sections: [
                     ("What This Page Does", "Shows how much profit each job is making. For every job, you see revenue, labor cost, material cost, total profit, and margin percentage. Green means healthy, red means losing money."),
                     ("How to Use It", "Scroll through the list to see all jobs. Use the search bar to find a specific job. The margin badge on the right gives you a quick color-coded indicator: green is 20%+, orange is break-even, red is a loss."),
-                    ("Tips", "Focus on jobs with orange or red margins first. If a job's labor cost is unusually high, check if overtime is driving it up. Export this report to share with management during job reviews.")
+                    ("Tips", "Focus on jobs with orange or red margins first. If a job's labor cost is unusually high, check if overtime is driving it up. Export this report to share with management during job reviews."),
+                    ("Exporting", "Exports include exactly the rows currently visible. If a search is active, only matching rows are exported — clear the search to export everything.")
                 ])
             }
             .searchable(text: $searchText, prompt: "Search jobs...")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
@@ -147,22 +147,22 @@ struct IOSTimesheetsPage: View {
         }
     }
 
+    /// Single employee-search predicate shared by the visible rows and the
+    /// exported segments so the two can never drift apart (issue #1243).
+    private func matchesEmployeeSearch(_ userName: String) -> Bool {
+        userName.lowercased().contains(searchText.lowercased())
+    }
+
     private var filteredRows: [ReportsService.TimesheetRow] {
         guard !searchText.isEmpty else { return rows }
-        let query = searchText.lowercased()
-        return rows.filter {
-            $0.userName.lowercased().contains(query)
-        }
+        return rows.filter { matchesEmployeeSearch($0.userName) }
     }
 
     /// Export segments filtered by the same employee search that drives the
     /// visible list, so exports never include hidden employees (issue #1243).
     private var filteredSegments: [ReportsService.TimesheetSegmentRow] {
         guard !searchText.isEmpty else { return segments }
-        let query = searchText.lowercased()
-        return segments.filter {
-            $0.userName.lowercased().contains(query)
-        }
+        return segments.filter { matchesEmployeeSearch($0.userName) }
     }
 
     private func timesheetRow(_ row: ReportsService.TimesheetRow) -> some View {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Reports/IOSTimesheetsPage.swift
@@ -53,7 +53,9 @@ struct IOSTimesheetsPage: View {
         .reportExportToolbar(
             title: "Timesheets",
             columns: ["Employee", "Job", "Clock In", "Clock Out", "Paid Break", "Paid Lunch", "Unpaid Lunch", "Regular", "Overtime", "Status"],
-            rows: segments.map {
+            // Export exactly what's visible — an active employee search must
+            // filter the exported segments too (issue #1243).
+            rows: filteredSegments.map {
                 [
                     $0.userName, jobLabel($0), formatTimestamp($0.clockIn),
                     $0.clockOut.map(formatTimestamp) ?? "Open",
@@ -78,7 +80,8 @@ struct IOSTimesheetsPage: View {
                 PageHelpSheet(title: "Timesheets Help", sections: [
                     ("What This Page Does", "Lists every employee's timesheet totals for the selected date range. Shows regular hours, overtime hours, total hours, and how many days each person worked."),
                     ("How to Use It", "Set the start and end dates to match the period you want to review. Use the search bar to find a specific employee. Each row shows their name, hours breakdown, and days worked. Export to PDF or CSV using the toolbar button."),
-                    ("Tips", "Run this for each pay period before submitting payroll. If someone's hours seem too low, they may have forgotten to clock in. Compare against daily reports to catch missing entries.")
+                    ("Tips", "Run this for each pay period before submitting payroll. If someone's hours seem too low, they may have forgotten to clock in. Compare against daily reports to catch missing entries."),
+                    ("Exporting", "Exports include exactly the rows currently visible. If a search is active, only that employee's segments are exported — clear the search to export everyone.")
                 ])
             case .correction(let segment):
                 TimesheetCorrectionSheet(
@@ -148,6 +151,16 @@ struct IOSTimesheetsPage: View {
         guard !searchText.isEmpty else { return rows }
         let query = searchText.lowercased()
         return rows.filter {
+            $0.userName.lowercased().contains(query)
+        }
+    }
+
+    /// Export segments filtered by the same employee search that drives the
+    /// visible list, so exports never include hidden employees (issue #1243).
+    private var filteredSegments: [ReportsService.TimesheetSegmentRow] {
+        guard !searchText.isEmpty else { return segments }
+        let query = searchText.lowercased()
+        return segments.filter {
             $0.userName.lowercased().contains(query)
         }
     }

--- a/Weird Parts IOS/Weird Parts IOSTests/ReportExportFilteredRowsRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/ReportExportFilteredRowsRegressionTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+
+/// Regression coverage for issue #1243: searchable report pages rendered a
+/// filtered visible list but exported the unfiltered backing collection, so
+/// a search-narrowed PDF/CSV could include employees/jobs hidden on screen.
+///
+/// Every page below must export the same filtered set its list displays.
+final class ReportExportFilteredRowsRegressionTests: XCTestCase {
+    func testLaborOverviewExportsFilteredRows() throws {
+        let source = try Self.readReportSource("IOSLaborOverviewPage")
+        XCTAssertTrue(
+            source.contains("rows: filteredTimesheetRows.map"),
+            "Labor Overview must export the search-filtered rows the list displays."
+        )
+        XCTAssertFalse(
+            source.contains("rows: timesheetRows.map"),
+            "Labor Overview must not export the unfiltered backing collection."
+        )
+    }
+
+    func testDailySummaryExportsFilteredRows() throws {
+        let source = try Self.readReportSource("IOSDailyReportsSummaryPage")
+        XCTAssertTrue(
+            source.contains("rows: filteredRows.map"),
+            "Daily Summary must export the search-filtered rows the list displays."
+        )
+        XCTAssertFalse(
+            source.contains("rows: rows.map"),
+            "Daily Summary must not export the unfiltered backing collection."
+        )
+    }
+
+    func testTimesheetsExportsFilteredSegments() throws {
+        let source = try Self.readReportSource("IOSTimesheetsPage")
+        XCTAssertTrue(
+            source.contains("rows: filteredSegments.map"),
+            "Timesheets must export segments filtered by the same employee search as the visible list."
+        )
+        XCTAssertFalse(
+            source.contains("rows: segments.map"),
+            "Timesheets must not export the unfiltered segment collection."
+        )
+        // The segment filter must key off the same field the row filter uses.
+        XCTAssertTrue(
+            source.contains("private var filteredSegments: [ReportsService.TimesheetSegmentRow]"),
+            "Timesheets needs a filteredSegments helper mirroring filteredRows."
+        )
+    }
+
+    func testProfitabilityExportsFilteredRows() throws {
+        let source = try Self.readReportSource("IOSProfitabilityPage")
+        XCTAssertTrue(
+            source.contains("rows: filteredRows.map"),
+            "Profitability must export the search-filtered rows the list displays."
+        )
+        XCTAssertFalse(
+            source.contains("rows: rows.map"),
+            "Profitability must not export the unfiltered backing collection."
+        )
+    }
+
+    func testExportBehaviorIsDocumentedInHelpCopy() throws {
+        for page in ["IOSLaborOverviewPage", "IOSDailyReportsSummaryPage",
+                     "IOSTimesheetsPage", "IOSProfitabilityPage"] {
+            let source = try Self.readReportSource(page)
+            XCTAssertTrue(
+                source.contains("(\"Exporting\","),
+                "\(page) help copy should document that exports match the visible filtered rows."
+            )
+        }
+    }
+
+    private static func readReportSource(
+        _ pageName: String,
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Reports")
+            .appendingPathComponent("\(pageName).swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1243.

Four searchable report pages rendered a filtered list but exported the **unfiltered** backing collection — a manager searching for one employee/job before exporting could hand off a PDF/CSV containing hidden rows (risky for timesheets and profitability handoffs).

- **Labor Overview / Daily Summary / Profitability** — exports now use the same `filtered*` sets the lists display.
- **Timesheets** — new `filteredSegments` applies the identical employee query as the visible `filteredRows`, so exported detail segments match the on-screen employees.
- **Help copy** — each page's help sheet gains a consistent "Exporting" section stating exports match the visible filtered rows (per acceptance criteria).
- `ReportExportFilteredRowsRegressionTests` covers all four pages: filtered export present, unfiltered export banned, helper present, help copy present.

This matches the already-correct `IOSBookkeeperExportPage` behavior, resolving the inconsistency the issue called out.

## Testing
- `xcrun swiftc -parse` on all five touched files
- Simulated every regression assertion against the tree (ALL OK)
- CI path: local self-hosted Mac runner (per repo runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)