### PR TITLE
fix: align leaderboard podium and ranks with active search

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseLeaderboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseLeaderboardPage.swift
@@ -38,6 +38,12 @@ struct IOSWarehouseLeaderboardPage: View {
         }
     }
 
+    /// The user's position in the overall (unfiltered) leaderboard, so a
+    /// search-narrowed list never renumbers matches from #1 (issue #1244).
+    private func overallRank(of rating: UserWarehouseRating) -> Int {
+        (leaderboard.firstIndex(where: { $0.userId == rating.userId }) ?? 0) + 1
+    }
+
     private var isManager: Bool {
         appCore.hasPermission("manage_warehouse")
     }
@@ -101,8 +107,10 @@ struct IOSWarehouseLeaderboardPage: View {
     @ViewBuilder
     private var leaderboardContent: some View {
         List {
-            // Top 3 podium
-            if leaderboard.count >= 3 {
+            // Top 3 podium — overall standings only. Hidden while a search is
+            // active so a narrowed Rankings list never sits under an
+            // unrelated overall podium (issue #1244).
+            if searchText.isEmpty, leaderboard.count >= 3 {
                 Section {
                     HStack(alignment: .bottom, spacing: 12) {
                         Spacer()
@@ -115,10 +123,12 @@ struct IOSWarehouseLeaderboardPage: View {
                 }
             }
 
-            // Full list
-            Section("Rankings") {
-                ForEach(Array(filteredLeaderboard.enumerated()), id: \.element.userId) { index, rating in
-                    leaderboardRow(rank: index + 1, rating: rating)
+            // Full list — retitled during search so the narrowed scope is clear
+            Section(searchText.isEmpty ? "Rankings" : "Search Results") {
+                ForEach(filteredLeaderboard, id: \.userId) { rating in
+                    // Rank stays the user's overall standing even in filtered
+                    // results — a search match must not be renumbered as #1.
+                    leaderboardRow(rank: overallRank(of: rating), rating: rating)
                         .contentShape(Rectangle())
                         .onTapGesture {
                             if isManager {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseLeaderboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseLeaderboardPage.swift
@@ -38,10 +38,13 @@ struct IOSWarehouseLeaderboardPage: View {
         }
     }
 
-    /// The user's position in the overall (unfiltered) leaderboard, so a
+    /// Each user's position in the overall (unfiltered) leaderboard, so a
     /// search-narrowed list never renumbers matches from #1 (issue #1244).
-    private func overallRank(of rating: UserWarehouseRating) -> Int {
-        (leaderboard.firstIndex(where: { $0.userId == rating.userId }) ?? 0) + 1
+    /// Built once per render — O(1) row lookups instead of a linear scan per
+    /// row — and returns nil (row omitted) rather than fabricating a rank if
+    /// a rating somehow isn't in the overall list.
+    private var overallRankByUserId: [Int64: Int] {
+        Dictionary(uniqueKeysWithValues: leaderboard.enumerated().map { ($0.element.userId, $0.offset + 1) })
     }
 
     private var isManager: Bool {
@@ -125,16 +128,19 @@ struct IOSWarehouseLeaderboardPage: View {
 
             // Full list — retitled during search so the narrowed scope is clear
             Section(searchText.isEmpty ? "Rankings" : "Search Results") {
+                let ranks = overallRankByUserId
                 ForEach(filteredLeaderboard, id: \.userId) { rating in
                     // Rank stays the user's overall standing even in filtered
                     // results — a search match must not be renumbered as #1.
-                    leaderboardRow(rank: overallRank(of: rating), rating: rating)
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            if isManager {
-                                activeSheet = .userDetail(rating)
+                    if let rank = ranks[rating.userId] {
+                        leaderboardRow(rank: rank, rating: rating)
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                if isManager {
+                                    activeSheet = .userDetail(rating)
+                                }
                             }
-                        }
+                    }
                 }
             }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/WarehouseLeaderboardSearchRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WarehouseLeaderboardSearchRegressionTests.swift
@@ -22,16 +22,20 @@ final class WarehouseLeaderboardSearchRegressionTests: XCTestCase {
         let source = try Self.readLeaderboardSource()
 
         XCTAssertTrue(
-            source.contains("leaderboardRow(rank: overallRank(of: rating), rating: rating)"),
-            "Filtered rows must display the user's overall rank, not a renumbered filtered position."
+            source.contains("if let rank = ranks[rating.userId] {"),
+            "Filtered rows must display the user's overall rank and omit rows with no known rank instead of fabricating one."
         )
         XCTAssertTrue(
-            source.contains("leaderboard.firstIndex(where: { $0.userId == rating.userId })"),
-            "overallRank must be derived from the unfiltered leaderboard."
+            source.contains("Dictionary(uniqueKeysWithValues: leaderboard.enumerated().map { ($0.element.userId, $0.offset + 1) })"),
+            "Overall ranks must be derived once from the unfiltered leaderboard (O(1) per-row lookup)."
         )
         XCTAssertFalse(
             source.contains("leaderboardRow(rank: index + 1"),
             "Rows must not be renumbered from the filtered array's indices."
+        )
+        XCTAssertFalse(
+            source.contains("?? 0) + 1"),
+            "Rank lookups must not fall back to fabricating rank #1 for unknown users."
         )
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/WarehouseLeaderboardSearchRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WarehouseLeaderboardSearchRegressionTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+/// Regression coverage for issue #1244: the Warehouse Leaderboard podium
+/// stayed bound to the unfiltered top three while the Rankings list
+/// narrowed under a search, showing unrelated users above the results —
+/// and filtered rows were renumbered from #1, misstating overall rank.
+final class WarehouseLeaderboardSearchRegressionTests: XCTestCase {
+    func testPodiumIsHiddenWhileSearchIsActive() throws {
+        let source = try Self.readLeaderboardSource()
+
+        XCTAssertTrue(
+            source.contains("if searchText.isEmpty, leaderboard.count >= 3 {"),
+            "The overall podium must be hidden while a search is active (issue #1244)."
+        )
+        XCTAssertTrue(
+            source.contains("Section(searchText.isEmpty ? \"Rankings\" : \"Search Results\")"),
+            "The list section should be retitled during search so the narrowed scope is clear."
+        )
+    }
+
+    func testFilteredRowsKeepOverallRank() throws {
+        let source = try Self.readLeaderboardSource()
+
+        XCTAssertTrue(
+            source.contains("leaderboardRow(rank: overallRank(of: rating), rating: rating)"),
+            "Filtered rows must display the user's overall rank, not a renumbered filtered position."
+        )
+        XCTAssertTrue(
+            source.contains("leaderboard.firstIndex(where: { $0.userId == rating.userId })"),
+            "overallRank must be derived from the unfiltered leaderboard."
+        )
+        XCTAssertFalse(
+            source.contains("leaderboardRow(rank: index + 1"),
+            "Rows must not be renumbered from the filtered array's indices."
+        )
+    }
+
+    private static func readLeaderboardSource(
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Warehouse")
+            .appendingPathComponent("IOSWarehouseLeaderboardPage.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1244.

The Warehouse Leaderboard podium stayed bound to the unfiltered top three while the Rankings list narrowed under a search — showing unrelated users above the results. Filtered rows were also renumbered from #1, misstating a searched worker's real standing.

Per the issue's acceptance criteria (hidden-with-clear-copy option):
- The **overall podium is hidden while a search is active** — it represents overall standings, and re-ranking a filtered subset would be misleading.
- The list section is retitled **"Search Results"** during search so the narrowed scope is explicit.
- Filtered rows now show the user's **overall rank** (`overallRank(of:)` derived from the unfiltered leaderboard) instead of being renumbered from #1 — this directly addresses the "ranked differently than shown" confusion in the impact statement. Unfiltered behavior is identical to before.
- Empty/one/two-result searches show no podium and correct overall ranks.
- `WarehouseLeaderboardSearchRegressionTests` locks all three behaviors in.

## Testing
- `xcrun swiftc -parse` on both touched files
- Simulated every regression assertion against the tree (all OK)
- CI path: local self-hosted Mac runner (per repo runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)