### PR TITLE
fix: reject floor plan grid shrinks that orphan features or zones

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Shared/UserFriendlyError.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/UserFriendlyError.swift
@@ -23,6 +23,15 @@ func userFriendlyError(_ error: Error, context: String = "load data") -> String 
         return "A saved clock entry has an invalid timestamp. Ask an admin to review the timesheet before using today's hours."
     }
 
+    if let warehouseError = error as? WarehouseService.WarehouseError,
+       case .gridShrinkWouldOrphanItems(let features, let zones) = warehouseError {
+        // Fixed counts only — no row contents (see security note above).
+        var stranded: [String] = []
+        if features > 0 { stranded.append("\(features) feature\(features == 1 ? "" : "s")") }
+        if zones > 0 { stranded.append("\(zones) zone\(zones == 1 ? "" : "s")") }
+        return "Can't shrink the grid: \(stranded.joined(separator: " and ")) would fall outside the new size. Move or remove them first."
+    }
+
     let raw = error.localizedDescription
     if raw.contains("no such table") {
         return "This feature isn't set up yet. Contact your admin."

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -4272,24 +4272,48 @@ public final class WarehouseService: Sendable {
             throw WarehouseError.invalidDimension
         }
         try db.writer.write { dbConn in
-            let orphanedFeatures = try WarehouseFloorFeature
-                .filter(Column("floor_plan_id") == floorPlanId && Column("deleted_at") == nil)
-                .fetchAll(dbConn)
-                .filter { $0.gridX + $0.gridWidth > cols || $0.gridY + $0.gridHeight > rows }
-            let orphanedZones = try WarehouseZone
-                .filter(Column("floor_plan_id") == floorPlanId && Column("deleted_at") == nil)
-                .fetchAll(dbConn)
-                .filter { $0.gridX + $0.gridWidth > cols || $0.gridY + $0.gridHeight > rows }
-            guard orphanedFeatures.isEmpty, orphanedZones.isEmpty else {
+            // COUNT(*) in SQL rather than fetching full rows; a missing table
+            // (partially-migrated DB) counts as zero, matching the service's
+            // isTableNotFoundError => empty convention.
+            let orphanedFeatures = try orphanCount(
+                table: "warehouse_floor_features",
+                floorPlanId: floorPlanId, rows: rows, cols: cols, dbConn: dbConn
+            )
+            let orphanedZones = try orphanCount(
+                table: "warehouse_zones",
+                floorPlanId: floorPlanId, rows: rows, cols: cols, dbConn: dbConn
+            )
+            guard orphanedFeatures == 0, orphanedZones == 0 else {
                 throw WarehouseError.gridShrinkWouldOrphanItems(
-                    features: orphanedFeatures.count,
-                    zones: orphanedZones.count
+                    features: orphanedFeatures,
+                    zones: orphanedZones
                 )
             }
             try dbConn.execute(
                 sql: "UPDATE warehouse_floor_plans SET grid_rows = ?, grid_cols = ?, updated_at = datetime('now') WHERE id = ?",
                 arguments: [rows, cols, floorPlanId]
             )
+        }
+    }
+
+    /// Counts active rows in `table` that would fall outside a `rows` x `cols`
+    /// grid. Missing tables count as zero (partially-migrated DBs).
+    private func orphanCount(
+        table: String, floorPlanId: Int64, rows: Int, cols: Int, dbConn: Database
+    ) throws -> Int {
+        do {
+            return try Int.fetchOne(
+                dbConn,
+                sql: """
+                SELECT COUNT(*) FROM \(table)
+                WHERE floor_plan_id = ? AND deleted_at IS NULL
+                  AND (grid_x + grid_width > ? OR grid_y + grid_height > ?)
+                """,
+                arguments: [floorPlanId, cols, rows]
+            ) ?? 0
+        } catch {
+            if isTableNotFoundError(error) { return 0 }
+            throw error
         }
     }
 

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -41,6 +41,9 @@ public final class WarehouseService: Sendable {
         case jobReturnItemNotFound(Int64)
         case stagingBoxNotFound(Int64)
         case stagingTagNotFound(Int64)
+        /// A grid shrink would leave existing floor features/zones outside
+        /// the new bounds (issue #1240). Counts identify how many of each.
+        case gridShrinkWouldOrphanItems(features: Int, zones: Int)
     }
 
     // =========================================================================
@@ -4259,11 +4262,30 @@ public final class WarehouseService: Sendable {
     }
 
     /// Save user-defined grid dimensions to a floor plan (PE-040 — wizard dimensions form).
+    ///
+    /// Rejects shrinks that would strand existing features or zones outside
+    /// the new bounds (issue #1240) — placement validation only guards the
+    /// add/update paths, so an unchecked grid update was a bypass that could
+    /// persist an impossible floor plan.
     public func updateFloorPlanGrid(floorPlanId: Int64, rows: Int, cols: Int) throws {
         guard (1...20).contains(rows), (1...20).contains(cols) else {
             throw WarehouseError.invalidDimension
         }
         try db.writer.write { dbConn in
+            let orphanedFeatures = try WarehouseFloorFeature
+                .filter(Column("floor_plan_id") == floorPlanId && Column("deleted_at") == nil)
+                .fetchAll(dbConn)
+                .filter { $0.gridX + $0.gridWidth > cols || $0.gridY + $0.gridHeight > rows }
+            let orphanedZones = try WarehouseZone
+                .filter(Column("floor_plan_id") == floorPlanId && Column("deleted_at") == nil)
+                .fetchAll(dbConn)
+                .filter { $0.gridX + $0.gridWidth > cols || $0.gridY + $0.gridHeight > rows }
+            guard orphanedFeatures.isEmpty, orphanedZones.isEmpty else {
+                throw WarehouseError.gridShrinkWouldOrphanItems(
+                    features: orphanedFeatures.count,
+                    zones: orphanedZones.count
+                )
+            }
             try dbConn.execute(
                 sql: "UPDATE warehouse_floor_plans SET grid_rows = ?, grid_cols = ?, updated_at = datetime('now') WHERE id = ?",
                 arguments: [rows, cols, floorPlanId]

--- a/core/Tests/WiredPartCoreTests/WarehouseFloorPlanTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseFloorPlanTests.swift
@@ -806,4 +806,78 @@ struct WarehouseFloorPlanTests {
             "getAllPartConfidenceLevels must return the same total as 11 per-level calls")
         #expect(all.count >= 2, "both inserted records should be present")
     }
+
+    // MARK: - Grid Shrink Safety (issue #1240)
+
+    @Test("Grid shrink is rejected when a feature would fall out of bounds")
+    func testGridShrinkRejectedForOrphanedFeature() throws {
+        let env = try freshEnv()
+
+        let plan = try env.warehouse.createFloorPlan(name: "Shrink Guard", widthInches: 200, lengthInches: 200)
+        try env.warehouse.updateFloorPlanGrid(floorPlanId: plan.id!, rows: 4, cols: 4)
+        _ = try env.warehouse.addFloorFeature(
+            floorPlanId: plan.id!, featureType: "office", label: "Back office",
+            gridX: 3, gridY: 3, gridWidth: 1, gridHeight: 1
+        )
+
+        #expect(throws: WarehouseService.WarehouseError.gridShrinkWouldOrphanItems(features: 1, zones: 0)) {
+            try env.warehouse.updateFloorPlanGrid(floorPlanId: plan.id!, rows: 2, cols: 2)
+        }
+
+        // The plan must keep its previous, consistent grid.
+        let unchanged = try env.warehouse.getFloorPlan(id: plan.id!)
+        #expect(unchanged?.gridRows == 4)
+        #expect(unchanged?.gridCols == 4)
+    }
+
+    @Test("Grid shrink is rejected when a zone would fall out of bounds")
+    func testGridShrinkRejectedForOrphanedZone() throws {
+        let env = try freshEnv()
+
+        let plan = try env.warehouse.createFloorPlan(name: "Zone Guard", widthInches: 200, lengthInches: 200)
+        try env.warehouse.updateFloorPlanGrid(floorPlanId: plan.id!, rows: 8, cols: 8)
+        _ = try env.warehouse.addZone(
+            floorPlanId: plan.id!, zoneType: "staging", label: "Staging",
+            gridX: 4, gridY: 4, gridWidth: 4, gridHeight: 4
+        )
+
+        #expect(throws: WarehouseService.WarehouseError.gridShrinkWouldOrphanItems(features: 0, zones: 1)) {
+            try env.warehouse.updateFloorPlanGrid(floorPlanId: plan.id!, rows: 4, cols: 4)
+        }
+    }
+
+    @Test("Grid shrink succeeds when everything still fits")
+    func testGridShrinkAllowedWhenContentsFit() throws {
+        let env = try freshEnv()
+
+        let plan = try env.warehouse.createFloorPlan(name: "Safe Shrink", widthInches: 200, lengthInches: 200)
+        try env.warehouse.updateFloorPlanGrid(floorPlanId: plan.id!, rows: 8, cols: 8)
+        _ = try env.warehouse.addFloorFeature(
+            floorPlanId: plan.id!, featureType: "door", label: "Entry",
+            gridX: 0, gridY: 0, gridWidth: 1, gridHeight: 1
+        )
+
+        try env.warehouse.updateFloorPlanGrid(floorPlanId: plan.id!, rows: 4, cols: 4)
+        let shrunk = try env.warehouse.getFloorPlan(id: plan.id!)
+        #expect(shrunk?.gridRows == 4)
+        #expect(shrunk?.gridCols == 4)
+    }
+
+    @Test("Grid shrink ignores soft-deleted features")
+    func testGridShrinkIgnoresSoftDeletedFeatures() throws {
+        let env = try freshEnv()
+
+        let plan = try env.warehouse.createFloorPlan(name: "Deleted Guard", widthInches: 200, lengthInches: 200)
+        try env.warehouse.updateFloorPlanGrid(floorPlanId: plan.id!, rows: 4, cols: 4)
+        let feature = try env.warehouse.addFloorFeature(
+            floorPlanId: plan.id!, featureType: "office", label: "Old office",
+            gridX: 3, gridY: 3, gridWidth: 1, gridHeight: 1
+        )
+        try env.warehouse.deleteFloorFeature(id: feature.id!)
+
+        try env.warehouse.updateFloorPlanGrid(floorPlanId: plan.id!, rows: 2, cols: 2)
+        let shrunk = try env.warehouse.getFloorPlan(id: plan.id!)
+        #expect(shrunk?.gridRows == 2)
+        #expect(shrunk?.gridCols == 2)
+    }
 }


### PR DESCRIPTION
## Summary
Closes #1240.

`updateFloorPlanGrid` validated only the 1...20 range and wrote directly — shrinking a grid below existing floor features/zones persisted an impossible floor plan (feature at (3,3) on a 2×2 grid). The add/update paths already validate placement, so the grid update was the one bypass.

- The shrink check runs **inside the write transaction**: active (non-soft-deleted) features and zones are tested against the new bounds; any stranded item throws the new `WarehouseError.gridShrinkWouldOrphanItems(features:zones:)` and the plan keeps its previous consistent grid.
- `userFriendlyError` maps it to an actionable message ("Can't shrink the grid: 1 feature would fall outside the new size. Move or remove them first.") — counts only, no row contents, per the file's security audit note.
- Chose **reject** over silent migration: auto-moving a user's floor layout would be surprising; the message tells them exactly what to fix.

## Testing
- `swift test --filter WarehouseFloorPlanTests` — **48/48 pass** (44 existing + 4 new: rejected feature shrink w/ grid preserved, rejected zone shrink, allowed fitting shrink, soft-deleted exclusion)
- The issue's exact repro (4×4 → feature at (3,3) → shrink to 2×2) is now the first regression test and throws instead of persisting
- `xcrun swiftc -parse` on the iOS mapping file
- CI path: local self-hosted Mac runner (per repo runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)