### PR TITLE
fix: compare delivery ETAs as local calendar days

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Shared/DeliveryTimelineBar.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/DeliveryTimelineBar.swift
@@ -21,6 +21,9 @@ struct DeliveryTimelineBar: View {
     let orderDate: Date?
     let expectedDate: Date?
     let isReceived: Bool
+    /// Injectable clock so the calendar-day logic is testable at fixed
+    /// instants (e.g. late evening) instead of only the test-runtime moment.
+    var now: () -> Date = { Date() }
 
     /// Convenience init accepting ISO-8601 date strings (common in the codebase).
     init(orderDateString: String?, expectedDateString: String?, isReceived: Bool = false) {
@@ -49,7 +52,7 @@ struct DeliveryTimelineBar: View {
         let cal = Calendar.current
         return cal.dateComponents(
             [.day],
-            from: cal.startOfDay(for: Date()),
+            from: cal.startOfDay(for: now()),
             to: cal.startOfDay(for: expected)
         ).day
     }
@@ -58,7 +61,7 @@ struct DeliveryTimelineBar: View {
     var progress: Double {
         guard let order = orderDate, let expected = expectedDate else { return 0 }
         let total = expected.timeIntervalSince(order)
-        let elapsed = Date().timeIntervalSince(order)
+        let elapsed = now().timeIntervalSince(order)
         guard total > 0 else { return 1.0 }
         return min(max(elapsed / total, 0), 1.0)
     }
@@ -89,7 +92,7 @@ struct DeliveryTimelineBar: View {
         return max(0, cal.dateComponents(
             [.day],
             from: cal.startOfDay(for: order),
-            to: cal.startOfDay(for: Date())
+            to: cal.startOfDay(for: now())
         ).day ?? 0)
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Shared/DeliveryTimelineBar.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/DeliveryTimelineBar.swift
@@ -39,9 +39,19 @@ struct DeliveryTimelineBar: View {
     // MARK: - Computed Properties
 
     /// Days remaining until expected delivery (negative = overdue).
+    ///
+    /// Both sides are normalized to local calendar-day boundaries so a
+    /// date-only ETA behaves as a date: an ETA of today reads "Due today"
+    /// until local midnight, and tomorrow's ETA never reads as due today
+    /// (issue #1204).
     var daysRemaining: Int? {
         guard let expected = expectedDate else { return nil }
-        return Calendar.current.dateComponents([.day], from: Date(), to: expected).day
+        let cal = Calendar.current
+        return cal.dateComponents(
+            [.day],
+            from: cal.startOfDay(for: Date()),
+            to: cal.startOfDay(for: expected)
+        ).day
     }
 
     /// Progress from 0.0 to 1.0 based on elapsed time vs total expected time.
@@ -72,10 +82,15 @@ struct DeliveryTimelineBar: View {
         return "\(days)d remaining"
     }
 
-    /// Days elapsed since order date.
+    /// Days elapsed since order date, in local calendar days.
     var daysElapsed: Int {
         guard let order = orderDate else { return 0 }
-        return max(0, Calendar.current.dateComponents([.day], from: order, to: Date()).day ?? 0)
+        let cal = Calendar.current
+        return max(0, cal.dateComponents(
+            [.day],
+            from: cal.startOfDay(for: order),
+            to: cal.startOfDay(for: Date())
+        ).day ?? 0)
     }
 
     // MARK: - Body
@@ -110,11 +125,13 @@ struct DeliveryTimelineBar: View {
 
     // MARK: - Helpers
 
-    /// Parse an ISO-8601 date string (first 10 characters) into a Date.
+    /// Parse a date string (first 10 characters, yyyy-MM-dd) as a LOCAL
+    /// calendar date. ISO8601DateFormatter(.withFullDate) returned midnight
+    /// UTC, which shifted same-day ETAs into "overdue" late in the local day
+    /// for timezones west of UTC (issue #1204). Matches the parsing idiom in
+    /// TimelinePriorityColor.
     private static func parseDate(_ str: String?) -> Date? {
         guard let str, !str.isEmpty else { return nil }
-        let fmt = ISO8601DateFormatter()
-        fmt.formatOptions = [.withFullDate]
-        return fmt.date(from: String(str.prefix(10)))
+        return Formatters.localDateFormatter.date(from: String(str.prefix(10)))
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/DeliveryTimelineBarDateTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/DeliveryTimelineBarDateTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import Weird_Parts
+
+/// Regression coverage for issue #1204: date-only ETAs were parsed as
+/// midnight UTC and compared against the current instant, so a same-day
+/// expected delivery flipped to "overdue" late in the local day (for
+/// timezones west of UTC) and tomorrow's ETA could read as due today.
+final class DeliveryTimelineBarDateTests: XCTestCase {
+    private func localDateString(daysFromToday: Int) -> String {
+        let date = Calendar.current.date(byAdding: .day, value: daysFromToday, to: Date()) ?? Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+
+    func testSameDayETAIsDueTodayRegardlessOfTimeOfDay() {
+        let bar = DeliveryTimelineBar(
+            orderDateString: localDateString(daysFromToday: -3),
+            expectedDateString: localDateString(daysFromToday: 0)
+        )
+        XCTAssertEqual(bar.daysRemaining, 0, "An ETA of today's local date must count as due today until local midnight.")
+        XCTAssertEqual(bar.statusText, "Due today")
+    }
+
+    func testTomorrowETAIsOneDayRemaining() {
+        let bar = DeliveryTimelineBar(
+            orderDateString: localDateString(daysFromToday: -3),
+            expectedDateString: localDateString(daysFromToday: 1)
+        )
+        XCTAssertEqual(bar.daysRemaining, 1, "Tomorrow's ETA must never read as due today, even late in the local day.")
+        XCTAssertEqual(bar.statusText, "1d remaining")
+    }
+
+    func testYesterdayETAIsOneDayOverdue() {
+        let bar = DeliveryTimelineBar(
+            orderDateString: localDateString(daysFromToday: -5),
+            expectedDateString: localDateString(daysFromToday: -1)
+        )
+        XCTAssertEqual(bar.daysRemaining, -1)
+        XCTAssertEqual(bar.statusText, "1d overdue")
+    }
+
+    func testFullDatetimeStringsKeepCalendarDaySemantics() {
+        // The string init only reads the first 10 characters (the date part),
+        // so a trailing time component must not shift the calendar day.
+        let bar = DeliveryTimelineBar(
+            orderDateString: "\(localDateString(daysFromToday: -1))T23:59:59Z",
+            expectedDateString: "\(localDateString(daysFromToday: 0))T00:00:00Z"
+        )
+        XCTAssertEqual(bar.daysRemaining, 0)
+        XCTAssertEqual(bar.daysElapsed, 1)
+    }
+
+    func testMissingETAShowsNoETA() {
+        let bar = DeliveryTimelineBar(orderDateString: localDateString(daysFromToday: -2), expectedDateString: nil)
+        XCTAssertNil(bar.daysRemaining)
+        XCTAssertEqual(bar.statusText, "No ETA")
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/DeliveryTimelineBarDateTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/DeliveryTimelineBarDateTests.swift
@@ -5,36 +5,62 @@ import XCTest
 /// midnight UTC and compared against the current instant, so a same-day
 /// expected delivery flipped to "overdue" late in the local day (for
 /// timezones west of UTC) and tomorrow's ETA could read as due today.
+///
+/// All tests inject a fixed clock through `DeliveryTimelineBar.now`, so
+/// they are deterministic and genuinely exercise multiple times of day —
+/// including instants just before local midnight.
 final class DeliveryTimelineBarDateTests: XCTestCase {
-    private func localDateString(daysFromToday: Int) -> String {
-        let date = Calendar.current.date(byAdding: .day, value: daysFromToday, to: Date()) ?? Date()
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: date)
+    /// Single reference instant captured once per test case so a midnight
+    /// rollover mid-test cannot skew date strings against assertions.
+    private let reference = Date()
+    private let calendar = Calendar.current
+
+    private func dateString(daysFromReference: Int) -> String {
+        let date = calendar.date(byAdding: .day, value: daysFromReference, to: reference) ?? reference
+        return Formatters.localDateFormatter.string(from: date)
     }
 
-    func testSameDayETAIsDueTodayRegardlessOfTimeOfDay() {
-        let bar = DeliveryTimelineBar(
-            orderDateString: localDateString(daysFromToday: -3),
-            expectedDateString: localDateString(daysFromToday: 0)
-        )
-        XCTAssertEqual(bar.daysRemaining, 0, "An ETA of today's local date must count as due today until local midnight.")
-        XCTAssertEqual(bar.statusText, "Due today")
+    /// A fixed instant at the given hour of the reference day.
+    private func instant(hour: Int, daysFromReference: Int = 0) -> Date {
+        let day = calendar.date(byAdding: .day, value: daysFromReference, to: reference) ?? reference
+        return calendar.date(bySettingHour: hour, minute: 30, second: 0, of: day) ?? day
     }
 
-    func testTomorrowETAIsOneDayRemaining() {
-        let bar = DeliveryTimelineBar(
-            orderDateString: localDateString(daysFromToday: -3),
-            expectedDateString: localDateString(daysFromToday: 1)
+    private func makeBar(
+        order: String?, expected: String?, at now: Date
+    ) -> DeliveryTimelineBar {
+        var bar = DeliveryTimelineBar(orderDateString: order, expectedDateString: expected)
+        bar.now = { now }
+        return bar
+    }
+
+    func testSameDayETAIsDueTodayAtEveryHourOfTheDay() {
+        for hour in [0, 9, 18, 23] {
+            let bar = makeBar(
+                order: dateString(daysFromReference: -3),
+                expected: dateString(daysFromReference: 0),
+                at: instant(hour: hour)
+            )
+            XCTAssertEqual(bar.daysRemaining, 0, "ETA of today must be due today at \(hour):30, not overdue.")
+            XCTAssertEqual(bar.statusText, "Due today")
+        }
+    }
+
+    func testTomorrowETAIsOneDayRemainingEvenLateEvening() {
+        let bar = makeBar(
+            order: dateString(daysFromReference: -3),
+            expected: dateString(daysFromReference: 1),
+            at: instant(hour: 23)
         )
-        XCTAssertEqual(bar.daysRemaining, 1, "Tomorrow's ETA must never read as due today, even late in the local day.")
+        XCTAssertEqual(bar.daysRemaining, 1, "Tomorrow's ETA must never read as due today, even at 23:30.")
         XCTAssertEqual(bar.statusText, "1d remaining")
     }
 
     func testYesterdayETAIsOneDayOverdue() {
-        let bar = DeliveryTimelineBar(
-            orderDateString: localDateString(daysFromToday: -5),
-            expectedDateString: localDateString(daysFromToday: -1)
+        let bar = makeBar(
+            order: dateString(daysFromReference: -5),
+            expected: dateString(daysFromReference: -1),
+            at: instant(hour: 9)
         )
         XCTAssertEqual(bar.daysRemaining, -1)
         XCTAssertEqual(bar.statusText, "1d overdue")
@@ -43,16 +69,17 @@ final class DeliveryTimelineBarDateTests: XCTestCase {
     func testFullDatetimeStringsKeepCalendarDaySemantics() {
         // The string init only reads the first 10 characters (the date part),
         // so a trailing time component must not shift the calendar day.
-        let bar = DeliveryTimelineBar(
-            orderDateString: "\(localDateString(daysFromToday: -1))T23:59:59Z",
-            expectedDateString: "\(localDateString(daysFromToday: 0))T00:00:00Z"
+        let bar = makeBar(
+            order: "\(dateString(daysFromReference: -1))T23:59:59Z",
+            expected: "\(dateString(daysFromReference: 0))T00:00:00Z",
+            at: instant(hour: 18)
         )
         XCTAssertEqual(bar.daysRemaining, 0)
         XCTAssertEqual(bar.daysElapsed, 1)
     }
 
     func testMissingETAShowsNoETA() {
-        let bar = DeliveryTimelineBar(orderDateString: localDateString(daysFromToday: -2), expectedDateString: nil)
+        let bar = makeBar(order: dateString(daysFromReference: -2), expected: nil, at: instant(hour: 12))
         XCTAssertNil(bar.daysRemaining)
         XCTAssertEqual(bar.statusText, "No ETA")
     }


### PR DESCRIPTION
## Summary
Closes #1204.

`DeliveryTimelineBar` parsed date-only ETAs as **midnight UTC** and compared them to `Date()` as instants, so a same-day expected delivery flipped to red "overdue" late in the local day (west of UTC), and tomorrow's ETA could read "Due today" in the evening.

- `parseDate` now uses `Formatters.localDateFormatter` (local-timezone `yyyy-MM-dd`), matching the existing idiom in `TimelinePriorityColor`.
- `daysRemaining`/`daysElapsed` normalize both sides to `startOfDay`, giving true calendar-day semantics: today's ETA is "Due today" until local midnight at 00:30, 09:30, 18:30, and 23:30 alike.
- `DeliveryTimelineBarDateTests` are **behavior tests** (`@testable import`) covering same-day, tomorrow-evening, yesterday-overdue, datetime-suffix truncation, and missing-ETA cases.

## Testing
- Standalone harness mirroring the fixed logic: same-day ETA = 0 days at hours 0/9/18/23, tomorrow@18:00 = 1, yesterday@18:00 = −1 — ALL CHECKS PASSED (the issue's exact probe scenario)
- `xcrun swiftc -parse` on both touched files
- CI path: local self-hosted Mac runner (per repo runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)