### PR TITLE
fix: confirm walking path clear and add stop-removal undo

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepWalkingPath.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepWalkingPath.swift
@@ -93,7 +93,7 @@ struct WizardStepWalkingPath: View {
                 .accessibilityIdentifier("walkingPathUndoBar")
             }
         }
-        .onDisappear { undoDismissTask?.cancel() }
+        .onDisappear { discardPendingUndo() }
     }
 
     private func stopList(showPreviewActions: Bool = true) -> some View {
@@ -349,10 +349,19 @@ struct WizardStepWalkingPath: View {
         saveStops(pathStops)
         // Removal persists immediately, so give the user a short undo
         // window instead of a heavier per-stop confirmation (issue #1198).
-        undoDismissTask = Task {
+        // MainActor-confined: the closure mutates view @State.
+        undoDismissTask = Task { @MainActor in
             try? await Task.sleep(for: .seconds(5))
             if !Task.isCancelled { lastRemovedStop = nil }
         }
+    }
+
+    /// Drops any pending undo state — used when the undo would no longer be
+    /// meaningful (path cleared) or the view is going away.
+    private func discardPendingUndo() {
+        undoDismissTask?.cancel()
+        undoDismissTask = nil
+        lastRemovedStop = nil
     }
 
     private func undoRemoveStop() {
@@ -393,8 +402,11 @@ struct WizardStepWalkingPath: View {
         }
     }
 
-    /// Performs the confirmed destructive clear of the saved path.
+    /// Performs the confirmed destructive clear of the saved path. Any
+    /// pending single-stop undo is discarded — undoing into a cleared path
+    /// would silently resurrect a stop the user just chose to wipe.
     private func clearSavedPath() {
+        discardPendingUndo()
         pathStops = []
         saveStops([])
     }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepWalkingPath.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepWalkingPath.swift
@@ -15,6 +15,9 @@ struct WizardStepWalkingPath: View {
     @State private var showingAddStops = false
     @State private var isLoading = true
     @State private var isSaving = false
+    @State private var showClearConfirm = false
+    @State private var lastRemovedStop: (areaId: Int64, index: Int)?
+    @State private var undoDismissTask: Task<Void, Never>?
 
     private var displayedStops: [Int64] { previewStops ?? pathStops }
     private var areaById: [Int64: WalkingPathAreaInfo] { Dictionary(uniqueKeysWithValues: allAreas.map { ($0.id, $0) }) }
@@ -62,6 +65,35 @@ struct WizardStepWalkingPath: View {
                 onAdd: addStops
             )
         }
+        // Clearing a SAVED path is destructive and persists immediately —
+        // it must never happen from a single accidental tap (issue #1198).
+        .confirmationDialog("Clear walking path?", isPresented: $showClearConfirm, titleVisibility: .visible) {
+            Button("Clear saved path", role: .destructive) { clearSavedPath() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("All \(pathStops.count) saved path stop\(pathStops.count == 1 ? "" : "s") will be removed immediately. The next audit will have no walking path until you rebuild it.")
+        }
+        // Brief undo affordance after removing a single saved stop.
+        .overlay(alignment: .bottom) {
+            if lastRemovedStop != nil {
+                HStack(spacing: 8) {
+                    Image(systemName: "trash")
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                    Text("Stop removed")
+                        .font(.subheadline)
+                    Spacer(minLength: 8)
+                    Button("Undo") { undoRemoveStop() }
+                        .fontWeight(.semibold)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+                .padding()
+                .accessibilityIdentifier("walkingPathUndoBar")
+            }
+        }
+        .onDisappear { undoDismissTask?.cancel() }
     }
 
     private func stopList(showPreviewActions: Bool = true) -> some View {
@@ -310,7 +342,24 @@ struct WizardStepWalkingPath: View {
     }
 
     private func removeStop(_ areaId: Int64) {
-        pathStops.removeAll { $0 == areaId }
+        guard let index = pathStops.firstIndex(of: areaId) else { return }
+        undoDismissTask?.cancel()
+        lastRemovedStop = (areaId, index)
+        pathStops.remove(at: index)
+        saveStops(pathStops)
+        // Removal persists immediately, so give the user a short undo
+        // window instead of a heavier per-stop confirmation (issue #1198).
+        undoDismissTask = Task {
+            try? await Task.sleep(for: .seconds(5))
+            if !Task.isCancelled { lastRemovedStop = nil }
+        }
+    }
+
+    private func undoRemoveStop() {
+        undoDismissTask?.cancel()
+        guard let removed = lastRemovedStop else { return }
+        lastRemovedStop = nil
+        pathStops.insert(removed.areaId, at: min(removed.index, pathStops.count))
         saveStops(pathStops)
     }
 
@@ -333,13 +382,21 @@ struct WizardStepWalkingPath: View {
         saveStops(pathStops)
     }
 
+    /// Entry point for the Clear/Dismiss button. Preview dismissal is cheap
+    /// and stays immediate; clearing the SAVED path requires confirmation
+    /// because it persists destructively right away (issue #1198).
     private func clearPath() {
         if isPreviewing {
             previewStops = nil
         } else {
-            pathStops = []
-            saveStops([])
+            showClearConfirm = true
         }
+    }
+
+    /// Performs the confirmed destructive clear of the saved path.
+    private func clearSavedPath() {
+        pathStops = []
+        saveStops([])
     }
 
     private func saveStops(_ stops: [Int64]) {

--- a/Weird Parts IOS/Weird Parts IOSTests/WalkingPathClearConfirmationRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WalkingPathClearConfirmationRegressionTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+
+/// Regression coverage for issue #1198: the walking-path editor's Clear
+/// action wiped and immediately persisted the saved path (and removed
+/// individual stops) with no confirmation or undo affordance.
+final class WalkingPathClearConfirmationRegressionTests: XCTestCase {
+    func testClearingSavedPathRequiresConfirmation() throws {
+        let source = try Self.readWalkingPathSource()
+
+        // Clear must route through the confirmation flag, never persist directly.
+        XCTAssertTrue(
+            source.contains("showClearConfirm = true"),
+            "Clearing a saved path must ask for confirmation before persisting (issue #1198)."
+        )
+        XCTAssertTrue(
+            source.contains("\"Clear walking path?\""),
+            "The confirmation dialog must state that the saved path is being cleared."
+        )
+        XCTAssertTrue(
+            source.contains("Button(\"Clear saved path\", role: .destructive) { clearSavedPath() }"),
+            "Only the explicit destructive confirmation button may call the persisting clear."
+        )
+        // The unconfirmed one-tap clear+persist must not exist anymore.
+        XCTAssertFalse(
+            source.contains("pathStops = []\n            saveStops([])"),
+            "clearPath() must not clear and persist in one unconfirmed step."
+        )
+    }
+
+    func testPreviewDismissalStaysImmediate() throws {
+        let source = try Self.readWalkingPathSource()
+
+        XCTAssertTrue(
+            source.contains("if isPreviewing {\n            previewStops = nil\n        } else {\n            showClearConfirm = true\n        }"),
+            "Dismissing a non-persisted preview must stay immediate and must not show the saved-path warning."
+        )
+    }
+
+    func testRemovingSingleStopOffersUndo() throws {
+        let source = try Self.readWalkingPathSource()
+
+        XCTAssertTrue(
+            source.contains("lastRemovedStop = (areaId, index)"),
+            "Removing a saved stop should record it for undo."
+        )
+        XCTAssertTrue(
+            source.contains("Button(\"Undo\") { undoRemoveStop() }"),
+            "The undo bar must restore the removed stop."
+        )
+        XCTAssertTrue(
+            source.contains("pathStops.insert(removed.areaId, at: min(removed.index, pathStops.count))"),
+            "Undo must restore the stop at its original position (clamped)."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityIdentifier(\"walkingPathUndoBar\")"),
+            "The undo bar needs a stable accessibility identifier for UI tests."
+        )
+    }
+
+    private static func readWalkingPathSource(
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Warehouse")
+            .appendingPathComponent("WizardStepWalkingPath.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/WalkingPathClearConfirmationRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WalkingPathClearConfirmationRegressionTests.swift
@@ -20,10 +20,24 @@ final class WalkingPathClearConfirmationRegressionTests: XCTestCase {
             source.contains("Button(\"Clear saved path\", role: .destructive) { clearSavedPath() }"),
             "Only the explicit destructive confirmation button may call the persisting clear."
         )
-        // The unconfirmed one-tap clear+persist must not exist anymore.
+        // The Clear entry point must not persist anything itself — extraction
+        // of the actual method body avoids matching the (legitimate)
+        // clearSavedPath() implementation elsewhere in the file.
+        let clearPathBody = try Self.methodBody(named: "clearPath", in: source)
         XCTAssertFalse(
-            source.contains("pathStops = []\n            saveStops([])"),
+            clearPathBody.contains("saveStops"),
             "clearPath() must not clear and persist in one unconfirmed step."
+        )
+        XCTAssertTrue(
+            clearPathBody.contains("showClearConfirm = true"),
+            "clearPath() must route saved-path clears through the confirmation flag."
+        )
+        // The confirmed clear must drop any pending single-stop undo so a
+        // stale undo bar can't resurrect a stop into the freshly cleared path.
+        let clearSavedPathBody = try Self.methodBody(named: "clearSavedPath", in: source)
+        XCTAssertTrue(
+            clearSavedPathBody.contains("discardPendingUndo()"),
+            "clearSavedPath() must discard any pending stop-removal undo."
         )
     }
 
@@ -55,6 +69,39 @@ final class WalkingPathClearConfirmationRegressionTests: XCTestCase {
             source.contains(".accessibilityIdentifier(\"walkingPathUndoBar\")"),
             "The undo bar needs a stable accessibility identifier for UI tests."
         )
+        XCTAssertTrue(
+            source.contains("undoDismissTask = Task { @MainActor in"),
+            "The undo auto-dismiss task must be MainActor-confined since it mutates view @State."
+        )
+        XCTAssertTrue(
+            source.contains(".onDisappear { discardPendingUndo() }"),
+            "Leaving the view must drop pending undo state, not just cancel its dismiss timer."
+        )
+    }
+
+    /// Extracts the brace-balanced body of the named function.
+    private static func methodBody(named methodName: String, in source: String) throws -> String {
+        guard let nameRange = source.range(of: "func \(methodName)(") else {
+            throw XCTSkip("Expected method \(methodName) in source")
+        }
+        guard let openBrace = source[nameRange.upperBound...].firstIndex(of: "{") else {
+            throw XCTSkip("Expected opening brace for \(methodName)")
+        }
+
+        var depth = 0
+        var index = openBrace
+        while index < source.endIndex {
+            let char = source[index]
+            if char == "{" { depth += 1 }
+            if char == "}" { depth -= 1 }
+            let next = source.index(after: index)
+            if depth == 0 {
+                return String(source[openBrace..<next])
+            }
+            index = next
+        }
+
+        throw XCTSkip("Expected closing brace for \(methodName)")
     }
 
     private static func readWalkingPathSource(


### PR DESCRIPTION
## Summary
Closes #1198.

The warehouse walking-path editor persisted destructive edits instantly: one tap on `Clear` wiped the saved audit path (`saveStops([])`), and removing a single stop persisted immediately — no confirmation, no undo.

Per the acceptance criteria:
- **Clear (saved path)** now routes through a confirmation dialog that states how many saved stops will be removed and that the next audit will have no walking path. Only the explicit destructive button performs the persisting clear.
- **Preview dismissal stays immediate** — dismissing a non-persisted suggested path never shows the saved-path warning (same `clearPath()` entry point, branch on `isPreviewing`).
- **Single-stop removal** gets a 5-second **Undo** bar (dashboard checklist-toast idiom) that reinserts the stop at its original position and re-saves — lighter than a per-stop confirmation while still making the persisted edit recoverable.
- `WalkingPathClearConfirmationRegressionTests` locks in: confirmation-gated clear, no one-tap clear+persist, immediate preview dismissal, and the undo path.

## Testing
- `xcrun swiftc -parse` on both touched files
- Simulated every regression assertion against the tree (ALL OK)
- CI path: local self-hosted Mac runner (per repo runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)