### PR TITLE
fix: confirm successful saves on four settings editors

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSAuditSettingsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSAuditSettingsPage.swift
@@ -46,6 +46,7 @@ struct IOSAuditSettingsPage: View {
     ]
 
     @State private var isDirty = false
+    @State private var saveSuccessMessage: String?
 
     private var hasValidSettings: Bool {
         misplacementPenalty > 0
@@ -155,6 +156,17 @@ struct IOSAuditSettingsPage: View {
                 Label("History", systemImage: "clock.arrow.circlepath")
             }
 
+            // Save success confirmation (issue #1214 — same pattern as
+            // IOSToolPoliciesPage) — cleared on the next edit or error.
+            if let saveSuccessMessage {
+                Section {
+                    Label(saveSuccessMessage, systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(.caption)
+                }
+                .accessibilityIdentifier("auditSettingsSaveSuccessMessage")
+            }
+
             // Save
             Section {
                 Button { saveSettings() } label: {
@@ -168,17 +180,17 @@ struct IOSAuditSettingsPage: View {
         }
         // Fix #149: dismiss keyboard when scrolling audit settings
         .scrollDismissesKeyboard(.interactively)
-        .onChange(of: enableAutoScheduling) { _, _ in isDirty = true }
-        .onChange(of: defaultAuditType) { _, _ in isDirty = true }
-        .onChange(of: maxConcurrentAudits) { _, _ in isDirty = true }
-        .onChange(of: allowSpeedMode) { _, _ in isDirty = true }
-        .onChange(of: speedModeRequiresQR) { _, _ in isDirty = true }
-        .onChange(of: speedModeTimeLimit) { _, _ in isDirty = true }
-        .onChange(of: verificationThreshold) { _, _ in isDirty = true }
-        .onChange(of: misplacementPenalty) { _, _ in isDirty = true }
-        .onChange(of: keepHistoryMonths) { _, _ in isDirty = true }
-        .onChange(of: autoArchive) { _, _ in isDirty = true }
-        .onChange(of: includeInDailyReport) { _, _ in isDirty = true }
+        .onChange(of: enableAutoScheduling) { _, _ in markDirty() }
+        .onChange(of: defaultAuditType) { _, _ in markDirty() }
+        .onChange(of: maxConcurrentAudits) { _, _ in markDirty() }
+        .onChange(of: allowSpeedMode) { _, _ in markDirty() }
+        .onChange(of: speedModeRequiresQR) { _, _ in markDirty() }
+        .onChange(of: speedModeTimeLimit) { _, _ in markDirty() }
+        .onChange(of: verificationThreshold) { _, _ in markDirty() }
+        .onChange(of: misplacementPenalty) { _, _ in markDirty() }
+        .onChange(of: keepHistoryMonths) { _, _ in markDirty() }
+        .onChange(of: autoArchive) { _, _ in markDirty() }
+        .onChange(of: includeInDailyReport) { _, _ in markDirty() }
     }
 
     // MARK: - Actions
@@ -239,8 +251,17 @@ struct IOSAuditSettingsPage: View {
             try service.upsertSettingsMap(data, category: "audit")
             saveError = nil
             isDirty = false
+            saveSuccessMessage = "Audit settings saved."
         } catch {
             saveError = userFriendlyError(error, context: "save data")
+            saveSuccessMessage = nil
         }
+    }
+
+    /// New edits invalidate the last save confirmation along with marking
+    /// the form dirty (issue #1214).
+    private func markDirty() {
+        isDirty = true
+        saveSuccessMessage = nil
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDispatchPreferencesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDispatchPreferencesPage.swift
@@ -34,6 +34,7 @@ struct IOSDispatchPreferencesPage: View {
     @State private var crewContinuityWeight: String = "medium"
 
     @State private var isDirty = false
+    @State private var saveSuccessMessage: String?
 
     private enum ActiveSheet: Identifiable {
         case help
@@ -145,6 +146,17 @@ struct IOSDispatchPreferencesPage: View {
                 Text("Crew continuity weight controls how strongly the system prefers keeping the same crew on a job.")
             }
 
+            // Save success confirmation (issue #1214 — same pattern as
+            // IOSToolPoliciesPage) — cleared on the next edit or error.
+            if let saveSuccessMessage {
+                Section {
+                    Label(saveSuccessMessage, systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(.caption)
+                }
+                .accessibilityIdentifier("dispatchPreferencesSaveSuccessMessage")
+            }
+
             // Save
             Section {
                 Button { saveSettings() } label: {
@@ -156,17 +168,17 @@ struct IOSDispatchPreferencesPage: View {
                 .accessibilityHint(isDirty ? "" : "Make changes to enable saving.")
             }
         }
-        .onChange(of: enableAISuggestions) { _, _ in isDirty = true }
-        .onChange(of: enableAILearning) { _, _ in isDirty = true }
-        .onChange(of: showConfidenceScores) { _, _ in isDirty = true }
-        .onChange(of: enableFlexSelfAssign) { _, _ in isDirty = true }
-        .onChange(of: requireManagerApproval) { _, _ in isDirty = true }
-        .onChange(of: startAnytimeTarget) { _, _ in isDirty = true }
-        .onChange(of: scheduleNeededTarget) { _, _ in isDirty = true }
-        .onChange(of: favoriteGCTarget) { _, _ in isDirty = true }
-        .onChange(of: defaultView) { _, _ in isDirty = true }
-        .onChange(of: crewHistoryMonths) { _, _ in isDirty = true }
-        .onChange(of: crewContinuityWeight) { _, _ in isDirty = true }
+        .onChange(of: enableAISuggestions) { _, _ in markDirty() }
+        .onChange(of: enableAILearning) { _, _ in markDirty() }
+        .onChange(of: showConfidenceScores) { _, _ in markDirty() }
+        .onChange(of: enableFlexSelfAssign) { _, _ in markDirty() }
+        .onChange(of: requireManagerApproval) { _, _ in markDirty() }
+        .onChange(of: startAnytimeTarget) { _, _ in markDirty() }
+        .onChange(of: scheduleNeededTarget) { _, _ in markDirty() }
+        .onChange(of: favoriteGCTarget) { _, _ in markDirty() }
+        .onChange(of: defaultView) { _, _ in markDirty() }
+        .onChange(of: crewHistoryMonths) { _, _ in markDirty() }
+        .onChange(of: crewContinuityWeight) { _, _ in markDirty() }
     }
 
     // MARK: - Actions
@@ -227,8 +239,17 @@ struct IOSDispatchPreferencesPage: View {
             try service.upsertSettingsMap(data, category: "dispatch")
             saveError = nil
             isDirty = false
+            saveSuccessMessage = "Dispatch preferences saved."
         } catch {
             saveError = userFriendlyError(error, context: "save data")
+            saveSuccessMessage = nil
         }
+    }
+
+    /// New edits invalidate the last save confirmation along with marking
+    /// the form dirty (issue #1214).
+    private func markDirty() {
+        isDirty = true
+        saveSuccessMessage = nil
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSOrganizationThresholdsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSOrganizationThresholdsPage.swift
@@ -13,6 +13,7 @@ struct IOSOrganizationThresholdsPage: View {
     @State private var isLoading = true
     @State private var loadError: String?
     @State private var saveError: String?
+    @State private var saveSuccessMessage: String?
     @State private var activeSheet: ActiveSheet?
 
     // Confidence Decay
@@ -102,6 +103,8 @@ struct IOSOrganizationThresholdsPage: View {
         .onChange(of: formSignature) { _, _ in
             guard !isLoading else { return }
             hasUnsavedChanges = formSignature != baselineFormSignature
+            // New edits invalidate the last save confirmation (issue #1214).
+            if hasUnsavedChanges { saveSuccessMessage = nil }
         }
         .confirmationDialog(
             "Discard changes?",
@@ -196,6 +199,17 @@ struct IOSOrganizationThresholdsPage: View {
                 Label("Organization Rating", systemImage: "star.circle")
             }
 
+            // Save success confirmation (issue #1214 — same pattern as
+            // IOSToolPoliciesPage) — cleared on the next edit or error.
+            if let saveSuccessMessage {
+                Section {
+                    Label(saveSuccessMessage, systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(.caption)
+                }
+                .accessibilityIdentifier("organizationThresholdsSaveSuccessMessage")
+            }
+
             // Save
             Section {
                 Button { saveSettings() } label: {
@@ -269,8 +283,10 @@ struct IOSOrganizationThresholdsPage: View {
             try service.upsertSettingsMap(data, category: "org")
             saveError = nil
             resetDirtyTracking()
+            saveSuccessMessage = "Organization thresholds saved."
         } catch {
             saveError = userFriendlyError(error, context: "save data")
+            saveSuccessMessage = nil
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSPreTripChecklistPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSPreTripChecklistPage.swift
@@ -49,6 +49,7 @@ struct IOSPreTripChecklistPage: View {
     @State private var selectedVehicleType: String = "all"
     @State private var checklists: [String: VehicleChecklist] = [:]
     @State private var isDirty = false
+    @State private var saveSuccessMessage: String?
 
     @State private var showAddItem = false
     @State private var addItemSectionId: String?
@@ -222,6 +223,17 @@ struct IOSPreTripChecklistPage: View {
                 }
             }
 
+            // Save success confirmation (issue #1214 — same pattern as
+            // IOSToolPoliciesPage) — cleared on the next edit or error.
+            if let saveSuccessMessage {
+                Section {
+                    Label(saveSuccessMessage, systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(.caption)
+                }
+                .accessibilityIdentifier("preTripChecklistSaveSuccessMessage")
+            }
+
             // Save
             Section {
                 Button { saveSettings() } label: {
@@ -235,7 +247,11 @@ struct IOSPreTripChecklistPage: View {
         }
         // Fix #149: dismiss keyboard when scrolling checklist editor
         .scrollDismissesKeyboard(.interactively)
-        .onChange(of: checklists) { _, _ in isDirty = true }
+        .onChange(of: checklists) { _, _ in
+            // New edits invalidate the last save confirmation (issue #1214).
+            isDirty = true
+            saveSuccessMessage = nil
+        }
         .alert("Add Item", isPresented: $showAddItem) {
             TextField("Item name", text: $newItemName)
             Toggle("Critical item", isOn: $newItemCritical)
@@ -350,8 +366,10 @@ struct IOSPreTripChecklistPage: View {
             try service.upsertSetting(key: "pretrip_checklist_config", value: json, category: "pretrip")
             saveError = nil
             isDirty = false
+            saveSuccessMessage = "Checklist saved."
         } catch {
             saveError = userFriendlyError(error, context: "save data")
+            saveSuccessMessage = nil
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/SettingsSaveConfirmationRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SettingsSaveConfirmationRegressionTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+
+/// Regression coverage for issue #1214: several settings editors persisted
+/// successfully but showed no positive confirmation — the Save button just
+/// went disabled, indistinguishable from an unsaved form.
+///
+/// Each page below must follow the IOSToolPoliciesPage pattern: a green
+/// success label after a successful save, cleared on the next edit or error.
+final class SettingsSaveConfirmationRegressionTests: XCTestCase {
+    private static let pages: [(file: String, message: String, identifier: String)] = [
+        ("IOSAuditSettingsPage", "Audit settings saved.", "auditSettingsSaveSuccessMessage"),
+        ("IOSDispatchPreferencesPage", "Dispatch preferences saved.", "dispatchPreferencesSaveSuccessMessage"),
+        ("IOSOrganizationThresholdsPage", "Organization thresholds saved.", "organizationThresholdsSaveSuccessMessage"),
+        ("IOSPreTripChecklistPage", "Checklist saved.", "preTripChecklistSaveSuccessMessage"),
+    ]
+
+    func testEachPageShowsSuccessConfirmationAfterSave() throws {
+        for page in Self.pages {
+            let source = try Self.readSettingsSource(page.file)
+
+            XCTAssertTrue(
+                source.contains("@State private var saveSuccessMessage: String?"),
+                "\(page.file) needs the saveSuccessMessage state (issue #1214)."
+            )
+            XCTAssertTrue(
+                source.contains("saveSuccessMessage = \"\(page.message)\""),
+                "\(page.file) must set its success message after a successful save."
+            )
+            XCTAssertTrue(
+                source.contains(".accessibilityIdentifier(\"\(page.identifier)\")"),
+                "\(page.file) must render the success label with a stable accessibility identifier."
+            )
+            XCTAssertTrue(
+                source.contains("Label(saveSuccessMessage, systemImage: \"checkmark.circle.fill\")"),
+                "\(page.file) should render the shared green success label pattern."
+            )
+        }
+    }
+
+    func testSuccessMessageClearsOnErrorAndNewEdits() throws {
+        for page in Self.pages {
+            let source = try Self.readSettingsSource(page.file)
+
+            // Every catch path must drop the stale success message.
+            XCTAssertTrue(
+                source.contains("saveError = userFriendlyError(error, context: \"save data\")\n            saveSuccessMessage = nil"),
+                "\(page.file) must clear the success message when a save fails."
+            )
+            // New edits must clear it too (markDirty helper or inline).
+            XCTAssertTrue(
+                source.contains("saveSuccessMessage = nil }")
+                    || source.contains("private func markDirty() {")
+                    || source.contains("isDirty = true\n            saveSuccessMessage = nil"),
+                "\(page.file) must clear the success message when the user edits again."
+            )
+        }
+    }
+
+    private static func readSettingsSource(
+        _ pageName: String,
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Settings")
+            .appendingPathComponent("\(pageName).swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/SettingsSaveConfirmationRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SettingsSaveConfirmationRegressionTests.swift
@@ -41,19 +41,51 @@ final class SettingsSaveConfirmationRegressionTests: XCTestCase {
         for page in Self.pages {
             let source = try Self.readSettingsSource(page.file)
 
-            // Every catch path must drop the stale success message.
+            // The save routine must both set the success message (happy path)
+            // and clear it (failure path) — asserted on the extracted method
+            // body so indentation/ordering changes can't break the test.
+            let saveBody = try Self.methodBody(named: "saveSettings", in: source)
             XCTAssertTrue(
-                source.contains("saveError = userFriendlyError(error, context: \"save data\")\n            saveSuccessMessage = nil"),
-                "\(page.file) must clear the success message when a save fails."
+                saveBody.contains("saveSuccessMessage = \"\(page.message)\""),
+                "\(page.file).saveSettings() must set the success message on success."
             )
-            // New edits must clear it too (markDirty helper or inline).
             XCTAssertTrue(
-                source.contains("saveSuccessMessage = nil }")
-                    || source.contains("private func markDirty() {")
-                    || source.contains("isDirty = true\n            saveSuccessMessage = nil"),
+                saveBody.contains("saveSuccessMessage = nil"),
+                "\(page.file).saveSettings() must clear the success message when a save fails."
+            )
+            // New edits must clear it too (markDirty helper or the page's
+            // dirty hook), somewhere outside the save routine.
+            let outsideSave = source.replacingOccurrences(of: saveBody, with: "")
+            XCTAssertTrue(
+                outsideSave.contains("saveSuccessMessage = nil"),
                 "\(page.file) must clear the success message when the user edits again."
             )
         }
+    }
+
+    /// Extracts the brace-balanced body of the named function.
+    private static func methodBody(named methodName: String, in source: String) throws -> String {
+        guard let nameRange = source.range(of: "func \(methodName)(") else {
+            throw XCTSkip("Expected method \(methodName) in source")
+        }
+        guard let openBrace = source[nameRange.upperBound...].firstIndex(of: "{") else {
+            throw XCTSkip("Expected opening brace for \(methodName)")
+        }
+
+        var depth = 0
+        var index = openBrace
+        while index < source.endIndex {
+            let char = source[index]
+            if char == "{" { depth += 1 }
+            if char == "}" { depth -= 1 }
+            let next = source.index(after: index)
+            if depth == 0 {
+                return String(source[openBrace..<next])
+            }
+            index = next
+        }
+
+        throw XCTSkip("Expected closing brace for \(methodName)")
     }
 
     private static func readSettingsSource(


### PR DESCRIPTION
## Summary
Closes #1214.

Four settings editors persisted successfully but gave no positive confirmation — the Save button just went disabled, indistinguishable from an unsaved form, prompting repeat taps on safety-sensitive configuration screens.

All four now follow the existing `IOSToolPoliciesPage` pattern the issue pointed at:
- **Audit Settings** → "Audit settings saved." · **Dispatch Preferences** → "Dispatch preferences saved." · **Organization Thresholds** → "Organization thresholds saved." · **Pre-Trip Checklist** → "Checklist saved."
- Green `checkmark.circle.fill` label rendered in its own section above Save, each with a stable accessibility identifier.
- The message clears on the **next edit** (new `markDirty()` helper on the two isDirty-flag pages; the signature/collection dirty hooks on the other two) and on any **save error**.
- Existing error handling, validation gates, and dirty/discard guards untouched.
- `SettingsSaveConfirmationRegressionTests` sweeps all four pages for state, message, identifier, label pattern, and both clear paths.

## Testing
- `xcrun swiftc -parse` on all five touched files
- Simulated every regression assertion against the tree (ALL OK, all four pages)
- CI path: local self-hosted Mac runner (per repo runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)