### PR TITLE
ci: cloud-runner PR gates + per-ref concurrency groups

### DIFF
--- a/.github/workflows/artifact-guard.yml
+++ b/.github/workflows/artifact-guard.yml
@@ -15,20 +15,12 @@ concurrency:
 jobs:
   tracked-artifacts:
     name: Tracked artifact guard
-    # WPR2 is a private repo with a repo-specific local Mac runner. Keep even
-    # lightweight required PR checks on that runner so PRs do not get blocked by
-    # cloud Actions billing/hosted-runner availability.
-    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
+    # Pure-python guard — no Xcode needed. Owner authorized cloud-runner spend
+    # (2026-07-02) so lightweight PR gates run on hosted Linux in parallel
+    # instead of queueing behind the single local Mac runner.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Verify self-hosted macOS runner
-        shell: bash
-        run: |
-          test "$RUNNER_OS" = "macOS"
-          test "$(uname -s)" = "Darwin"
-          echo "Runner: $RUNNER_NAME"
-          echo "Architecture: $RUNNER_ARCH"
-
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/artifact-guard.yml
+++ b/.github/workflows/artifact-guard.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches: ["main"]
 
+# One queued run per ref — a new push supersedes the queued/in-flight run for
+# the same branch instead of stacking duplicates on the single local runner.
+concurrency:
+  group: artifact-guard-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tracked-artifacts:
     name: Tracked artifact guard

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,27 +32,36 @@ jobs:
   required-codeql-compat:
     name: CodeQL
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    # Required compatibility context for the private WPR2 repo. Route through
-    # the local Mac runner instead of cloud runners so PRs do not get blocked by
-    # billing/hosted-runner availability.
-    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
+    # Echo-only compatibility context — no Xcode needed. Owner authorized
+    # cloud-runner spend (2026-07-02) so this gate never queues behind the Mac.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Verify self-hosted macOS runner
-        shell: bash
-        run: |
-          test "$RUNNER_OS" = "macOS"
-          test "$(uname -s)" = "Darwin"
-          echo "Runner: $RUNNER_NAME"
-          echo "Architecture: $RUNNER_ARCH"
-
       - name: Required CodeQL compatibility gate
         run: |
           echo "Compatibility check for the legacy required CodeQL context."
           echo "The Swift scanner job remains named Analyze (swift)."
 
+  # PR-level required gate. The full Swift analysis hangs on GitHub-hosted
+  # macOS and is too slow to gate every PR, so PRs get this fast hosted-Linux
+  # gate under the same required check name, while push/schedule events run
+  # the real analysis on the local Mac runner (job below). The two jobs' `if`
+  # conditions are mutually exclusive, so the "Analyze (swift)" check context
+  # resolves exactly once per event.
+  analyze-pr-gate:
+    name: Analyze (swift)
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Swift CodeQL PR recovery gate
+        run: |
+          echo "Skipping Swift CodeQL on pull_request because the GitHub-hosted Swift build is hanging."
+          echo "Full Swift CodeQL still runs on push and schedule events."
+
   analyze:
     name: Analyze (${{ matrix.language }})
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'pull_request'
     # Swift CodeQL requires macOS; WPR2 uses the local self-hosted Mac runner.
     runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
     timeout-minutes: 60
@@ -79,17 +88,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # PR CodeQL is currently hanging inside Swift builds on GitHub-hosted
-      # macOS runners. Keep the required Analyze (swift) PR gate green while
-      # retaining full Swift CodeQL analysis on push and schedule events.
-      - name: Swift CodeQL PR recovery gate
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "Skipping Swift CodeQL on pull_request because the GitHub-hosted Swift build is hanging."
-          echo "Full Swift CodeQL still runs on push and schedule events."
-
       - name: Initialize CodeQL
-        if: github.event_name != 'pull_request'
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
@@ -99,13 +98,11 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Build Swift package outside repository
-        if: github.event_name != 'pull_request'
         # Keep SwiftPM dependency checkouts out of $GITHUB_WORKSPACE so CodeQL
         # does not report third-party package internals as application alerts.
         run: swift build --package-path core --scratch-path "$RUNNER_TEMP/wiredpart-swiftpm-build"
 
       - name: Perform CodeQL Analysis
-        if: github.event_name != 'pull_request'
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"
@@ -113,7 +110,6 @@ jobs:
           upload: never
 
       - name: Upload CodeQL SARIF artifact
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: codeql-${{ matrix.language }}-sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,13 @@ on:
   schedule:
     - cron: "33 2 * * 1"
 
+# One queued run per ref — a new push supersedes the queued/in-flight run for
+# the same branch instead of stacking duplicate CodeQL analyses (10-20 min
+# each) on the single local runner. Scheduled runs keep their own group.
+concurrency:
+  group: codeql-${{ github.ref }}-${{ github.event_name == 'schedule' && 'scheduled' || 'ci' }}
+  cancel-in-progress: true
+
 jobs:
   required-codeql-compat:
     name: CodeQL

--- a/.github/workflows/pr-merge-maintenance.yml
+++ b/.github/workflows/pr-merge-maintenance.yml
@@ -34,9 +34,10 @@ permissions:
 
 jobs:
   maintain-prs:
-    # Merge maintenance must not stall behind GitHub-hosted Actions billing.
-    # Use the WPR2 local Mac runner for repo automation.
-    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
+    # Pure gh/bash automation — no Xcode needed. Owner authorized cloud-runner
+    # spend (2026-07-02); running the train-feeder on hosted Linux means PRs
+    # keep rebasing/merging even while the Mac runner is busy with CodeQL.
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}
@@ -44,14 +45,6 @@ jobs:
       PR_MAINTENANCE_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true && '1' || '0' }}
 
     steps:
-      - name: Verify self-hosted macOS runner
-        shell: bash
-        run: |
-          test "$RUNNER_OS" = "macOS"
-          test "$(uname -s)" = "Darwin"
-          echo "Runner: $RUNNER_NAME"
-          echo "Architecture: $RUNNER_ARCH"
-
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,13 @@ Errors are learning opportunities. When something breaks:
 
 Use one GitHub issue per coherent fix/PR whenever practical. Prefer umbrella issues for cross-cutting bug classes such as shared validation, repeated silent-error handling, common accessibility defects, or scanner findings that can be fixed by one coordinated pass. File separate issues only when the fix owners, risk, acceptance criteria, or release priority are materially different. Every fix should reference and close its issue or update the umbrella checklist it resolves.
 
-## WPR2 PR CI: Local Mac Actions Runner
+## WPR2 PR CI: Hybrid Runners (cloud gates + local Mac for Xcode)
 
-For this repo, do not treat GitHub-hosted Actions billing, `macos-latest`, `ubuntu-latest`, or queued cloud runners as the first PR blocker. The repo has a local self-hosted Mac runner intended for trusted iOS/macOS/Xcode PR build, test, QA work, and repo-owned Actions automation while cloud billing is unavailable.
+Owner authorization (2026-07-02): GitHub Actions cloud-runner budget MAY be spent to keep PR CI fast. The routing policy:
+
+- **`ubuntu-latest` (cloud)** — every PR-gating job that does not need Xcode: Artifact Guard, the CodeQL required-compat gate, the PR-level "Analyze (swift)" recovery gate, and PR Merge Maintenance. These run in parallel and never queue behind the Mac.
+- **Local self-hosted Mac runner** — jobs that genuinely need macOS/Xcode: full Swift CodeQL analysis (push/schedule), iOS build/test/QA work, and Approved PR Autofix (local Codex). Paperclip tracker sync also stays local (it talks to the local Paperclip API).
+- **Hosted `macos-latest` stays avoided** (10× minute cost, and Swift CodeQL previously hung there) unless the owner asks.
 
 Use `docs/runbooks/local-mac-actions-runner.md` as the canonical runner reference instead of duplicating machine-specific details here.
 


### PR DESCRIPTION
## Summary
Two changes that together unblock the PR merge train, per the owner's authorization to spend GitHub Actions budget (2026-07-02):

### 1. Per-ref concurrency groups
Every push previously stacked duplicate Artifact Guard + CodeQL runs on the single local Mac runner (21 queued runs today; 7 stale duplicates cancelled by hand). New pushes now supersede a ref's queued/in-flight runs. The weekly scheduled CodeQL scan keeps its own group so CI traffic can never cancel it.

### 2. Cloud runners for every non-Xcode gate
| Job | Was | Now |
|---|---|---|
| Artifact Guard (pure python) | local Mac | `ubuntu-latest` |
| CodeQL required-compat gate (echo) | local Mac | `ubuntu-latest` |
| **Analyze (swift)** PR gate (echo recovery gate) | local Mac | `ubuntu-latest` via new `analyze-pr-gate` job — same required-check name, mutually exclusive `if` with the full-analysis job so the context resolves exactly once per event |
| PR Merge Maintenance (gh/bash train-feeder) | local Mac | `ubuntu-latest` — keeps rebasing/merging PRs even while the Mac runs CodeQL |
| Full Swift CodeQL analysis (push/schedule) | local Mac | **unchanged** (needs Xcode) |
| Approved PR Autofix (local Codex), Paperclip sync (local API) | local Mac | **unchanged** |

Hosted `macos-latest` stays avoided (10× minute cost; Swift CodeQL previously hung there).

CLAUDE.md's runner-policy section is updated to document the hybrid routing for future agents.

## Testing
- YAML validated (ruby) on all three workflows; scripted assertions verify job routing, the mutually-exclusive `if` pair, and that no self-hosted labels remain on cloud jobs
- `scripts/pr-merge-maintenance.sh` audited for Mac-isms: pure `gh`/bash/jq — cloud-safe
- Net effect: PR gates complete in ~1-2 min in parallel on cloud instead of queueing 10-20 min behind Mac CodeQL runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)