### PR TITLE
ci: require Copilot review before merge-maintenance auto-merges

### DIFF
--- a/scripts/pr-merge-maintenance.sh
+++ b/scripts/pr-merge-maintenance.sh
@@ -191,13 +191,29 @@ while IFS= read -r pr; do
   #     Copilot can review — so the merge must wait for the review explicitly.
   #     Set PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW=0 to bypass (not recommended). ---
   if [[ "${PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW:-1}" == "1" ]]; then
-    copilot_reviews="$(gh api "repos/$REPO/pulls/$number/reviews" \
-      --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length' 2>/dev/null || echo "0")"
+    # A GraphQL API failure must FAIL CLOSED (never merge on unknown review
+    # state). We probe once and treat empty/failed output as "not satisfied".
+    review_state="$(gh api graphql -f query="query { repository(owner: \"$repo_owner\", name: \"$repo_name\") { pullRequest(number: $number) { latestReviews: reviews(first: 100) { nodes { author { login } } } reviewThreads(first: 100) { totalCount nodes { isResolved } } } } }" 2>/dev/null || echo "")"
+
+    if [[ -z "$review_state" ]]; then
+      echo "    skip: could not read review state (API failure) — not merging on unknown review status"
+      continue
+    fi
+
+    # Match the Copilot reviewer by login prefix — GitHub returns
+    # 'copilot-pull-request-reviewer[bot]' (or similar) here, so an exact
+    # 'Copilot' match would never fire.
+    copilot_reviews="$(jq '[.data.repository.pullRequest.latestReviews.nodes[]? | select((.author.login // "") | ascii_downcase | startswith("copilot"))] | length' <<<"$review_state" 2>/dev/null || echo "0")"
+    if [[ ! "$copilot_reviews" =~ ^[0-9]+$ ]]; then copilot_reviews="0"; fi
+
     if [[ "$copilot_reviews" -eq 0 ]]; then
-      # Request the review if it is not already pending, then wait for it.
-      pending_copilot="$(gh api "repos/$REPO/pulls/$number" \
-        --jq '([.requested_reviewers[]?.login] | index("Copilot")) // -1' 2>/dev/null || echo "-1")"
-      if [[ "$pending_copilot" == "-1" ]]; then
+      # Request the review if a Copilot reviewer is not already requested, then
+      # wait. Match by login prefix (bot logins vary: 'Copilot',
+      # 'copilot-pull-request-reviewer[bot]', …).
+      already_requested="$(gh api "repos/$REPO/pulls/$number" \
+        --jq '[.requested_reviewers[]?.login | select((. // "") | ascii_downcase | startswith("copilot"))] | length' 2>/dev/null || echo "0")"
+      if [[ ! "$already_requested" =~ ^[0-9]+$ ]]; then already_requested="0"; fi
+      if [[ "$already_requested" -eq 0 ]]; then
         run_or_log gh api -X POST "repos/$REPO/pulls/$number/requested_reviewers" \
           -f 'reviewers[]=copilot-pull-request-reviewer[bot]' >/dev/null 2>&1 || true
         echo "    skip: requested Copilot review — waiting for it before merge"
@@ -208,9 +224,16 @@ while IFS= read -r pr; do
     fi
 
     # Copilot has reviewed — block on any unresolved review thread so findings
-    # are addressed and resolved before the merge, not after.
-    unresolved="$(gh api graphql -f query="query { repository(owner: \"$repo_owner\", name: \"$repo_name\") { pullRequest(number: $number) { reviewThreads(first: 100) { nodes { isResolved } } } } }" \
-      --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null || echo "0")"
+    # are addressed and resolved before the merge, not after. If the thread
+    # count exceeds the page we fetched, fail closed (can't prove resolution).
+    thread_total="$(jq '.data.repository.pullRequest.reviewThreads.totalCount // 0' <<<"$review_state" 2>/dev/null || echo "0")"
+    if [[ ! "$thread_total" =~ ^[0-9]+$ ]]; then thread_total="0"; fi
+    if [[ "$thread_total" -gt 100 ]]; then
+      echo "    skip: $thread_total review threads exceed the 100 fetched — cannot confirm resolution, not merging"
+      continue
+    fi
+    unresolved="$(jq '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved == false)] | length' <<<"$review_state" 2>/dev/null || echo "1")"
+    if [[ ! "$unresolved" =~ ^[0-9]+$ ]]; then unresolved="1"; fi
     if [[ "$unresolved" -gt 0 ]]; then
       echo "    skip: $unresolved unresolved Copilot review thread(s) — must be addressed before merge"
       continue

--- a/scripts/pr-merge-maintenance.sh
+++ b/scripts/pr-merge-maintenance.sh
@@ -195,7 +195,9 @@ while IFS= read -r pr; do
     # state). We probe once and treat empty/failed output as "not satisfied".
     # Review nodes carry author login + state so a PENDING/DISMISSED review
     # cannot satisfy the gate.
-    review_state="$(gh api graphql -f query="query { repository(owner: \"$repo_owner\", name: \"$repo_name\") { pullRequest(number: $number) { latestReviews: reviews(first: 100) { nodes { author { login } state } } reviewThreads(first: 100) { totalCount nodes { isResolved } } } } }" 2>/dev/null || echo "")"
+    # reviews(last: 100) — the MOST RECENT reviews, so a Copilot review is
+    # never missed on PRs whose total review history exceeds one page.
+    review_state="$(gh api graphql -f query="query { repository(owner: \"$repo_owner\", name: \"$repo_name\") { pullRequest(number: $number) { latestReviews: reviews(last: 100) { nodes { author { login } state } } reviewThreads(first: 100) { totalCount nodes { isResolved } } } } }" 2>/dev/null || echo "")"
 
     if [[ -z "$review_state" ]]; then
       echo "    skip: could not read review state (API failure) — not merging on unknown review status"
@@ -220,9 +222,14 @@ while IFS= read -r pr; do
         --jq '[.requested_reviewers[]?.login | select(. == "Copilot" or . == "copilot-pull-request-reviewer[bot]")] | length' 2>/dev/null || echo "0")"
       if [[ ! "$already_requested" =~ ^[0-9]+$ ]]; then already_requested="0"; fi
       if [[ "$already_requested" -eq 0 ]]; then
-        run_or_log gh api -X POST "repos/$REPO/pulls/$number/requested_reviewers" \
-          -f 'reviewers[]=copilot-pull-request-reviewer[bot]' >/dev/null 2>&1 || true
-        echo "    skip: requested Copilot review — waiting for it before merge"
+        # Surface request failures honestly — a silently failed request would
+        # stall the train with a log line claiming the review was requested.
+        if run_or_log gh api -X POST "repos/$REPO/pulls/$number/requested_reviewers" \
+          -f 'reviewers[]=copilot-pull-request-reviewer[bot]' >/dev/null; then
+          echo "    skip: requested Copilot review — waiting for it before merge"
+        else
+          echo "    skip: FAILED to request Copilot review (API error above) — PR needs a manual review request"
+        fi
       else
         echo "    skip: Copilot review pending — waiting before merge"
       fi

--- a/scripts/pr-merge-maintenance.sh
+++ b/scripts/pr-merge-maintenance.sh
@@ -193,25 +193,31 @@ while IFS= read -r pr; do
   if [[ "${PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW:-1}" == "1" ]]; then
     # A GraphQL API failure must FAIL CLOSED (never merge on unknown review
     # state). We probe once and treat empty/failed output as "not satisfied".
-    review_state="$(gh api graphql -f query="query { repository(owner: \"$repo_owner\", name: \"$repo_name\") { pullRequest(number: $number) { latestReviews: reviews(first: 100) { nodes { author { login } } } reviewThreads(first: 100) { totalCount nodes { isResolved } } } } }" 2>/dev/null || echo "")"
+    # Review nodes carry author login + state so a PENDING/DISMISSED review
+    # cannot satisfy the gate.
+    review_state="$(gh api graphql -f query="query { repository(owner: \"$repo_owner\", name: \"$repo_name\") { pullRequest(number: $number) { latestReviews: reviews(first: 100) { nodes { author { login } state } } reviewThreads(first: 100) { totalCount nodes { isResolved } } } } }" 2>/dev/null || echo "")"
 
     if [[ -z "$review_state" ]]; then
       echo "    skip: could not read review state (API failure) — not merging on unknown review status"
       continue
     fi
 
-    # Match the Copilot reviewer by login prefix — GitHub returns
-    # 'copilot-pull-request-reviewer[bot]' (or similar) here, so an exact
-    # 'Copilot' match would never fire.
-    copilot_reviews="$(jq '[.data.repository.pullRequest.latestReviews.nodes[]? | select((.author.login // "") | ascii_downcase | startswith("copilot"))] | length' <<<"$review_state" 2>/dev/null || echo "0")"
+    # A satisfying Copilot review is an EXACT bot login (no prefix spoofing by a
+    # 'copilot*' human account) whose state is a real submitted review
+    # (COMMENTED/APPROVED/CHANGES_REQUESTED — never PENDING/DISMISSED).
+    copilot_reviews="$(jq '[.data.repository.pullRequest.latestReviews.nodes[]?
+      | select((.author.login // "") == "copilot-pull-request-reviewer[bot]")
+      | select(.state == "COMMENTED" or .state == "APPROVED" or .state == "CHANGES_REQUESTED")] | length' <<<"$review_state" 2>/dev/null || echo "0")"
     if [[ ! "$copilot_reviews" =~ ^[0-9]+$ ]]; then copilot_reviews="0"; fi
 
     if [[ "$copilot_reviews" -eq 0 ]]; then
-      # Request the review if a Copilot reviewer is not already requested, then
-      # wait. Match by login prefix (bot logins vary: 'Copilot',
-      # 'copilot-pull-request-reviewer[bot]', …).
+      # Request the review only if the Copilot bot is not already a requested
+      # reviewer. Match the two exact logins GitHub uses for this bot across
+      # API surfaces ('Copilot' in requested_reviewers,
+      # 'copilot-pull-request-reviewer[bot]' in reviews) — no prefix match, so a
+      # similarly-named human can't suppress the request.
       already_requested="$(gh api "repos/$REPO/pulls/$number" \
-        --jq '[.requested_reviewers[]?.login | select((. // "") | ascii_downcase | startswith("copilot"))] | length' 2>/dev/null || echo "0")"
+        --jq '[.requested_reviewers[]?.login | select(. == "Copilot" or . == "copilot-pull-request-reviewer[bot]")] | length' 2>/dev/null || echo "0")"
       if [[ ! "$already_requested" =~ ^[0-9]+$ ]]; then already_requested="0"; fi
       if [[ "$already_requested" -eq 0 ]]; then
         run_or_log gh api -X POST "repos/$REPO/pulls/$number/requested_reviewers" \
@@ -223,9 +229,10 @@ while IFS= read -r pr; do
       continue
     fi
 
-    # Copilot has reviewed — block on any unresolved review thread so findings
-    # are addressed and resolved before the merge, not after. If the thread
-    # count exceeds the page we fetched, fail closed (can't prove resolution).
+    # Copilot has reviewed — block on any unresolved review thread (from any
+    # reviewer) so findings are addressed and resolved before the merge, not
+    # after. If the thread count exceeds the page we fetched, fail closed
+    # (can't prove resolution).
     thread_total="$(jq '.data.repository.pullRequest.reviewThreads.totalCount // 0' <<<"$review_state" 2>/dev/null || echo "0")"
     if [[ ! "$thread_total" =~ ^[0-9]+$ ]]; then thread_total="0"; fi
     if [[ "$thread_total" -gt 100 ]]; then
@@ -235,7 +242,7 @@ while IFS= read -r pr; do
     unresolved="$(jq '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved == false)] | length' <<<"$review_state" 2>/dev/null || echo "1")"
     if [[ ! "$unresolved" =~ ^[0-9]+$ ]]; then unresolved="1"; fi
     if [[ "$unresolved" -gt 0 ]]; then
-      echo "    skip: $unresolved unresolved Copilot review thread(s) — must be addressed before merge"
+      echo "    skip: $unresolved unresolved review thread(s) (any reviewer) — must be resolved before merge"
       continue
     fi
   fi

--- a/scripts/pr-merge-maintenance.sh
+++ b/scripts/pr-merge-maintenance.sh
@@ -116,6 +116,7 @@ if [[ "$inspected" -lt "$total" ]]; then
 fi
 
 repo_owner="${REPO%%/*}"
+repo_name="${REPO##*/}"
 
 # Walk PRs in order (oldest first = lowest number first).
 # Pick the FIRST one we can act on and do exactly that one action, then exit.
@@ -185,9 +186,40 @@ while IFS= read -r pr; do
     fi
   fi
 
+  # --- Copilot review gate (owner directive: every PR gets a Copilot review
+  #     before merge). Cloud PR checks now go green in seconds — faster than
+  #     Copilot can review — so the merge must wait for the review explicitly.
+  #     Set PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW=0 to bypass (not recommended). ---
+  if [[ "${PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW:-1}" == "1" ]]; then
+    copilot_reviews="$(gh api "repos/$REPO/pulls/$number/reviews" \
+      --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length' 2>/dev/null || echo "0")"
+    if [[ "$copilot_reviews" -eq 0 ]]; then
+      # Request the review if it is not already pending, then wait for it.
+      pending_copilot="$(gh api "repos/$REPO/pulls/$number" \
+        --jq '([.requested_reviewers[]?.login] | index("Copilot")) // -1' 2>/dev/null || echo "-1")"
+      if [[ "$pending_copilot" == "-1" ]]; then
+        run_or_log gh api -X POST "repos/$REPO/pulls/$number/requested_reviewers" \
+          -f 'reviewers[]=copilot-pull-request-reviewer[bot]' >/dev/null 2>&1 || true
+        echo "    skip: requested Copilot review — waiting for it before merge"
+      else
+        echo "    skip: Copilot review pending — waiting before merge"
+      fi
+      continue
+    fi
+
+    # Copilot has reviewed — block on any unresolved review thread so findings
+    # are addressed and resolved before the merge, not after.
+    unresolved="$(gh api graphql -f query="query { repository(owner: \"$repo_owner\", name: \"$repo_name\") { pullRequest(number: $number) { reviewThreads(first: 100) { nodes { isResolved } } } } }" \
+      --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null || echo "0")"
+    if [[ "$unresolved" -gt 0 ]]; then
+      echo "    skip: $unresolved unresolved Copilot review thread(s) — must be addressed before merge"
+      continue
+    fi
+  fi
+
   # --- Ready to merge ---
   if [[ "$merge_state" == "CLEAN" || "$merge_state" == "HAS_HOOKS" || "$merge_state" == "BLOCKED" ]]; then
-    echo "==> PR #$number is CLEAN and checks pass — merging now (squash)"
+    echo "==> PR #$number is CLEAN, checks pass, Copilot review satisfied — merging now (squash)"
     if run_or_log gh pr merge "$number" --repo "$REPO" --squash --delete-branch --auto; then
       echo "    Merged (or auto-merge queued). Push to $BASE will trigger next run."
     else


### PR DESCRIPTION
## Summary
Closes #1341.

**Problem:** After #1332 routed PR gates to cloud runners, CI goes green in ~seconds — faster than Copilot can review. The `pr-merge-maintenance.sh` train-feeder merges any checks-green PR, so it merged **#1340 before Copilot reviewed it**, bypassing the owner's standing 'Copilot review every PR before merge' gate. (#1340 itself was low-risk and self-tested, but the process must hold.)

**Fix:** Before merging a checks-green PR, the script now:
1. Requires a submitted `copilot-pull-request-reviewer[bot]` review — requests one and waits (skips this run) if absent.
2. Blocks on any unresolved review thread (GraphQL `reviewThreads`), so Copilot findings are addressed **and resolved** before merge, not after.
3. Gate is on by default; `PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW=0` bypasses for emergencies.

This keeps the fast cloud train **and** the review gate — the train now waits the ~minutes Copilot needs, then merges automatically once the review is clean and threads are resolved.

## Testing
- `bash -n` syntax check passes
- Logic trace: no Copilot review → request + skip; review present + unresolved threads → skip; review present + 0 unresolved → merge (existing path). `repo_name` added for the GraphQL query owner/name.
- This PR will itself be gated by the current (pre-fix) maintenance behavior, so it also gets a manual Copilot review before I merge it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)