### PR TITLE
ci: unjam merge-train CI, bound tracker-sync curls, guard junk paths

### DIFF
--- a/.github/workflows/artifact-guard.yml
+++ b/.github/workflows/artifact-guard.yml
@@ -12,6 +12,9 @@ concurrency:
   group: artifact-guard-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   tracked-artifacts:
     name: Tracked artifact guard

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,7 @@ name: "CodeQL Security Scan"
 # GITHUB FLOW handles general code quality.
 
 on:
+  workflow_dispatch: # re-fire a missed weekly full scan manually
   push:
     branches: ["main"]
   pull_request:

--- a/.github/workflows/pr-merge-maintenance.yml
+++ b/.github/workflows/pr-merge-maintenance.yml
@@ -40,7 +40,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      GH_TOKEN: ${{ github.token }}
+      # Use a PAT when configured: GITHUB_TOKEN-authored update-branch merge
+      # commits leave PR checks stuck at action_required (bot-actor approval),
+      # which jammed the train on #1343-#1346. Falls back to github.token
+      # until the owner creates the fine-grained PAT (Contents + PRs, R/W).
+      GH_TOKEN: ${{ secrets.PR_MAINTENANCE_PAT || github.token }}
       PR_MAINTENANCE_BASE: main
       PR_MAINTENANCE_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true && '1' || '0' }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,10 @@ docs/github-flow-heartbeat.md.bak
 # GitHub issue fisher run outputs are operational evidence, not source.
 docs/github-issue-fisher/*
 !docs/github-issue-fisher/.gitkeep
+
+# Agent/tooling junk that has appeared at the repo root (2026-07-02 audit) —
+# ignore so the artifact guard's tracked-file check stays the only gate needed.
+=
+[object Object]/
+.playwright-mcp/
+docs/testing/artifacts/

--- a/scripts/paperclip-github-tracker-sync.sh
+++ b/scripts/paperclip-github-tracker-sync.sh
@@ -112,11 +112,24 @@ fi
 STAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 WEB_URL="${PAPERCLIP_WEB_URL:-}"
 
-ISSUES_JSON="$(curl -fsS \
+# Bounded curls: the configured PAPERCLIP_API_URL can be a trycloudflare
+# tunnel that goes NXDOMAIN mid-life; without timeouts these curls hung until
+# the 10-minute workflow timeout cancelled every run (15/15 cancelled). If the
+# configured URL is unreachable, fall back to the local Paperclip instance —
+# the runner lives on the same Mac.
+CURL_OPTS=(-fsS --connect-timeout 10 --max-time 120 --retry 2)
+if ! curl "${CURL_OPTS[@]}" -o /dev/null "$PAPERCLIP_API_URL/api/health" 2>/dev/null; then
+  echo "warn: $PAPERCLIP_API_URL unreachable, falling back to http://localhost:3100" >&2
+  PAPERCLIP_API_URL="http://localhost:3100"
+fi
+
+echo "tracker-sync: fetching issues/agents from $PAPERCLIP_API_URL" >&2
+
+ISSUES_JSON="$(curl "${CURL_OPTS[@]}" \
   -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
   "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/issues?status=todo,in_progress,in_review,blocked")"
 
-AGENTS_JSON="$(curl -fsS \
+AGENTS_JSON="$(curl "${CURL_OPTS[@]}" \
   -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
   "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agents")"
 

--- a/scripts/pr-merge-maintenance.sh
+++ b/scripts/pr-merge-maintenance.sh
@@ -148,8 +148,27 @@ while IFS= read -r pr; do
   if [[ "$mergeable" == "CONFLICTING" || "$merge_state" == "DIRTY" ]]; then
     echo "    skip: has merge conflicts — engineer must resolve first"; continue; fi
 
+  # --- Resolve UNKNOWN mergeability before acting ---
+  # The list endpoint returns mergeable_state only when GitHub has it cached;
+  # treating UNKNOWN as BEHIND made the train "rebase" an up-to-date branch
+  # forever (update-branch no-ops, the state never changes, nothing merges).
+  # A single-PR GET forces GitHub to compute mergeability; poll briefly.
+  if [[ "$merge_state" == "UNKNOWN" ]]; then
+    for _attempt in 1 2 3 4 5; do
+      merge_state="$(gh api "repos/$REPO/pulls/$number" \
+        --jq '(.mergeable_state // "unknown") | ascii_upcase' 2>/dev/null || echo "UNKNOWN")"
+      [[ "$merge_state" != "UNKNOWN" ]] && break
+      sleep 3
+    done
+    echo "    resolved mergeability: state=$merge_state"
+    if [[ "$merge_state" == "UNKNOWN" ]]; then
+      echo "    skip: mergeability still computing — next run retries"; continue; fi
+    if [[ "$merge_state" == "DIRTY" ]]; then
+      echo "    skip: has merge conflicts — engineer must resolve first"; continue; fi
+  fi
+
   # --- Rebase if behind ---
-  if [[ "$merge_state" == "BEHIND" || "$merge_state" == "UNKNOWN" ]]; then
+  if [[ "$merge_state" == "BEHIND" ]]; then
     echo "==> PR #$number is BEHIND main — rebasing now (one action, then done)"
     if run_or_log gh pr update-branch "$number" --repo "$REPO"; then
       echo "    Rebased. CodeQL will re-run on the new head. Exiting — next run handles merge."


### PR DESCRIPTION
## Summary
CI fixes from the 2026-07-02 beta-readiness audit (§6 of docs/plans/beta-readiness-issue-resolution-2026-07.md, merged in #1345).

- **PR Merge Maintenance**: `GH_TOKEN: ${{ secrets.PR_MAINTENANCE_PAT || github.token }}` — GITHUB_TOKEN-authored update-branch merge commits leave PR checks stuck at `action_required` (bot-actor approval), which jammed the train on #1343–#1346 until owner-actor reruns cleared them. Falls back safely until the owner mints the fine-grained PAT (Contents + Pull requests, R/W).
- **Paperclip Tracker Sync**: bounded curls (`--connect-timeout 10 --max-time 120 --retry 2`) + health-check fallback to `http://localhost:3100` — unbounded curls against a dead trycloudflare tunnel cancelled 15/15 recent runs at the 10-min workflow timeout. Runs on the local Mac runner which shares the host with Paperclip.
- **CodeQL**: `workflow_dispatch` so a missed weekly full scan (e.g. Mon 06-29) can be re-fired manually.
- **Artifact Guard**: least-privilege `permissions: contents: read`.
- **.gitignore**: root junk observed in the audit (`=`, `[object Object]/`, `.playwright-mcp/`, `docs/testing/artifacts/`).

## CI routing
No runner changes: these gates stay on `ubuntu-latest` per the hybrid policy; Xcode jobs remain on the local Mac runner (`[self-hosted, macOS, ARM64, xcode, ios, local-mac]`). Tracker-sync verified locally with `bash -n`; its live path can be tested post-merge via `gh workflow run 'Paperclip Tracker Sync'` on the local runner.

## Owner follow-ups (non-blocking)
- Mint `PR_MAINTENANCE_PAT` (fine-grained: Contents + Pull requests, R/W) and add as a repo secret — until then the fallback token keeps current behavior.
- Optionally repoint the `PAPERCLIP_API_URL` secret at `http://localhost:3100` (secret changes were left to the owner; the script-level fallback covers the outage case either way).

Closes nothing directly; unblocks the merge train and scheduled syncs for the issue-resolution push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)