### PR TITLE
fix: dismiss-first sheet ordering (#735, #736) + trade-sheet dirty tracking (#714)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
@@ -331,10 +331,11 @@ struct PricingBulkEditSheet: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
             Button("Done") {
-                Task {
-                    await onComplete()
-                    dismiss()
-                }
+                // Dismiss-first ordering (issue #736): close the sheet
+                // immediately on confirmation, then run the parent refresh
+                // (same idiom as PricingOverrideFlow's completion screen).
+                dismiss()
+                Task { await onComplete() }
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.large)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/SmartDeleteSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/SmartDeleteSheet.swift
@@ -181,8 +181,11 @@ struct SmartDeleteSheet: View {
                 entityType: entityType, entityId: entityId, entityName: entityName,
                 reason: reason.isEmpty ? nil : reason, scheduledBy: nil
             )
-            await onComplete()
+            // Dismiss-first ordering (issue #735): close the sheet as soon
+            // as the delete succeeds; the parent refresh runs after the
+            // dismissal so it can't delay the close or race a stale sheet.
             dismiss()
+            await onComplete()
         } catch {
             self.error = userFriendlyError(error, context: "delete parts")
         }
@@ -205,8 +208,11 @@ struct SmartDeleteSheet: View {
             case "color": try service.deleteColor(id: entityId)
             default: break
             }
-            await onComplete()
+            // Dismiss-first ordering (issue #735): close the sheet as soon
+            // as the delete succeeds; the parent refresh runs after the
+            // dismissal so it can't delay the close or race a stale sheet.
             dismiss()
+            await onComplete()
         } catch {
             self.error = userFriendlyError(error, context: "delete parts")
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolDetailPage.swift
@@ -1339,8 +1339,21 @@ struct ToolTradeSheet: View {
     @State private var employees: [PeopleService.EmployeeListItem] = []
     @State private var isSaving = false
     @State private var saveError: String?
-    @State private var isDirty = false
-    @State private var showDiscardAlert = false
+    @State private var showDiscardConfirm = false
+
+    @State private var baselineSignature = ""
+
+    /// Signature over every user-entered field — including the trade
+    /// recipient — so changing any of them marks the sheet dirty (issue #714).
+    private var formSignature: String {
+        [
+            selectedUser.map(String.init) ?? "",
+            condition.rawValue,
+            notes.trimmingCharacters(in: .whitespacesAndNewlines)
+        ].joined(separator: "|")
+    }
+
+    private var isDirty: Bool { formSignature != baselineSignature }
 
     var body: some View {
         NavigationStack {
@@ -1359,11 +1372,9 @@ struct ToolTradeSheet: View {
                         }
                     }
                     .pickerStyle(.segmented)
-                    .onChange(of: condition) { _, _ in isDirty = true }
 
                     TextField("Notes (optional)", text: $notes, axis: .vertical)
                         .lineLimit(2...4)
-                        .onChange(of: notes) { _, _ in isDirty = true }
                 } header: {
                     Text("Condition Check (Required)")
                 }
@@ -1403,7 +1414,7 @@ struct ToolTradeSheet: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") {
-                        if isDirty { showDiscardAlert = true } else { dismiss() }
+                        if isDirty { showDiscardConfirm = true } else { dismiss() }
                     }
                     .disabled(isSaving)
                 }
@@ -1414,12 +1425,13 @@ struct ToolTradeSheet: View {
                     .disabled(selectedUser == nil || isSaving)
                 }
             }
-            .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            .confirmationDialog("Discard changes?", isPresented: $showDiscardConfirm, titleVisibility: .visible) {
                 Button("Discard", role: .destructive) { dismiss() }
-                Button("Keep Editing", role: .cancel) {}
-            } message: {
-                Text("Your unsaved changes will be lost.")
+                Button("Keep editing", role: .cancel) {}
             }
+            // Snapshot the baseline from the untouched defaults so a
+            // pristine sheet never counts as dirty (issue #714).
+            .onAppear { baselineSignature = formSignature }
             .task { loadEmployees() }
         }
     }
@@ -1447,7 +1459,9 @@ struct ToolTradeSheet: View {
                 condition: condition.rawValue,
                 notes: notes.isEmpty ? nil : notes
             )
-            isDirty = false
+            // Re-baseline so the sheet is clean before the parent tears it
+            // down — a successful send must never trip the discard guard.
+            baselineSignature = formSignature
             onComplete()
         } catch {
             saveError = userFriendlyError(error, context: "save data")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolDetailPage.swift
@@ -1451,13 +1451,16 @@ struct ToolTradeSheet: View {
             isSaving = false
             return
         }
+        // Send the trimmed notes — the dirty signature already compares the
+        // trimmed value, and whitespace-only notes should persist as nil.
+        let trimmedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
         do {
             _ = try service.initiateTrade(
                 toolId: tool.id,
                 fromUserId: userId,
                 toUserId: toUserId,
                 condition: condition.rawValue,
-                notes: notes.isEmpty ? nil : notes
+                notes: trimmedNotes.isEmpty ? nil : trimmedNotes
             )
             // Re-baseline so the sheet is clean before the parent tears it
             // down — a successful send must never trip the discard guard.

--- a/Weird Parts IOS/Weird Parts IOSTests/SheetLifecycleRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SheetLifecycleRegressionTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+
+/// Regression coverage for the sheet-lifecycle batch:
+/// - Issue #714: `ToolTradeSheet` let the trade recipient selection be
+///   swipe-dismissed silently because tapping an employee never marked the
+///   sheet dirty. The fix adopts the signature-vs-baseline dirty idiom from
+///   `ShiftTemplateEditSheet` (issue #1248) so every user-entered field —
+///   recipient included — is discard-protected.
+/// - Issue #735: `SmartDeleteSheet` awaited the parent `onComplete()` refresh
+///   before calling `dismiss()`, delaying the close behind parent state
+///   transitions. Both delete paths must dismiss first, then refresh.
+/// - Issue #736: `PricingBulkEditSheet`'s completion Done button deferred
+///   `dismiss()` until after `await onComplete()`. It must dismiss
+///   synchronously and run the refresh in a follow-up Task, matching
+///   `PricingOverrideFlow`'s completion screen.
+final class SheetLifecycleRegressionTests: XCTestCase {
+
+    // MARK: - Issue #714
+
+    func testToolTradeRecipientSelectionIsDirtyProtected() throws {
+        let sheet = try Self.toolTradeSheetSource()
+
+        // The recipient leads the dirty signature — this anchored fragment is
+        // the exact signature head, so a match elsewhere can't satisfy it.
+        XCTAssertTrue(
+            sheet.contains("selectedUser.map(String.init) ?? \"\","),
+            "ToolTradeSheet's form signature must include the selected trade recipient (issue #714)."
+        )
+        XCTAssertTrue(
+            sheet.contains("private var isDirty: Bool { formSignature != baselineSignature }"),
+            "ToolTradeSheet must derive dirtiness from the full-form signature baseline."
+        )
+        // Dirtiness is derived, never manually flagged — a leftover boolean
+        // write would reintroduce the missed-field class of bug.
+        XCTAssertFalse(
+            sheet.contains("isDirty = "),
+            "ToolTradeSheet must not manually assign isDirty; the computed signature covers every field."
+        )
+        // Swipe-dismiss stays blocked while dirty or saving.
+        XCTAssertTrue(
+            sheet.contains(".interactiveDismissDisabled(isDirty || isSaving)"),
+            "ToolTradeSheet must block interactive dismissal while dirty or saving."
+        )
+        // Cancel routes through the discard confirmation when dirty.
+        XCTAssertTrue(
+            sheet.contains("if isDirty { showDiscardConfirm = true } else { dismiss() }"),
+            "Cancel on ToolTradeSheet must ask before discarding a dirty form."
+        )
+        XCTAssertTrue(
+            sheet.contains(".confirmationDialog(\"Discard changes?\", isPresented: $showDiscardConfirm, titleVisibility: .visible)"),
+            "ToolTradeSheet needs the campaign's discard confirmation dialog."
+        )
+        // Untouched sheets never count as dirty.
+        XCTAssertTrue(
+            sheet.contains(".onAppear { baselineSignature = formSignature }"),
+            "ToolTradeSheet must snapshot the baseline from the untouched defaults on appear."
+        )
+        // A successful send re-baselines (clears dirty) before notifying the
+        // parent, so teardown never trips the discard guard.
+        let sendBody = try Self.methodBody(named: "sendTradeRequest", in: sheet)
+        guard let rebaseline = sendBody.range(of: "baselineSignature = formSignature"),
+              let notify = sendBody.range(of: "onComplete()") else {
+            XCTFail("sendTradeRequest() must re-baseline the signature and notify the parent (issue #714).")
+            return
+        }
+        XCTAssertLessThan(
+            rebaseline.lowerBound, notify.lowerBound,
+            "sendTradeRequest() must clear dirtiness before completing (issue #714)."
+        )
+    }
+
+    // MARK: - Issue #735
+
+    func testSmartDeleteSheetDismissesBeforeParentRefresh() throws {
+        let source = try Self.readFeatureSource(["Parts", "SmartDeleteSheet.swift"])
+
+        for method in ["startEmptyShelfMode", "deleteImmediately"] {
+            let body = try Self.methodBody(named: method, in: source)
+            guard let dismissRange = body.range(of: "dismiss()"),
+                  let completeRange = body.range(of: "await onComplete()") else {
+                XCTFail("\(method)() must both dismiss the sheet and run the parent refresh (issue #735).")
+                continue
+            }
+            XCTAssertLessThan(
+                dismissRange.lowerBound, completeRange.lowerBound,
+                "\(method)() must dismiss the sheet before awaiting the parent onComplete refresh (issue #735)."
+            )
+        }
+    }
+
+    // MARK: - Issue #736
+
+    func testPricingBulkEditDoneDismissesBeforeParentRefresh() throws {
+        let source = try Self.readFeatureSource(["Parts", "PricingBulkEditSheet.swift"])
+
+        let doneBody = try Self.braceBalancedBody(after: "Button(\"Done\")", in: source)
+        // Exact fixed shape: synchronous dismiss, then the refresh in a
+        // follow-up Task — the same idiom as PricingOverrideFlow's Done.
+        XCTAssertTrue(
+            doneBody.contains("dismiss()\n                Task { await onComplete() }"),
+            "The completion Done button must dismiss synchronously, then run the parent refresh in a Task (issue #736)."
+        )
+        guard let dismissRange = doneBody.range(of: "dismiss()"),
+              let completeRange = doneBody.range(of: "await onComplete()") else {
+            XCTFail("The completion Done button must both dismiss and refresh (issue #736).")
+            return
+        }
+        XCTAssertLessThan(
+            dismissRange.lowerBound, completeRange.lowerBound,
+            "The completion Done button must not defer dismissal behind the parent refresh (issue #736)."
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Slice of `IOSToolDetailPage.swift` covering only `ToolTradeSheet`, so
+    /// assertions can't be satisfied by the sibling sheets in the same file.
+    private static func toolTradeSheetSource() throws -> String {
+        let source = try readFeatureSource(["Tools", "IOSToolDetailPage.swift"])
+        guard let start = source.range(of: "struct ToolTradeSheet: View") else {
+            throw XCTSkip("Expected ToolTradeSheet in IOSToolDetailPage.swift")
+        }
+        guard let end = source[start.upperBound...].range(of: "struct TradeResponseSheet") else {
+            throw XCTSkip("Expected TradeResponseSheet after ToolTradeSheet")
+        }
+        return String(source[start.lowerBound..<end.lowerBound])
+    }
+
+    /// Extracts the brace-balanced body that follows the first occurrence of
+    /// `anchor` (a `func name(` head, a button label, etc.), so assertions
+    /// stay scoped to the code under test.
+    private static func braceBalancedBody(after anchor: String, in source: String) throws -> String {
+        guard let anchorRange = source.range(of: anchor) else {
+            throw XCTSkip("Expected anchor \(anchor) in source")
+        }
+        guard let openBrace = source[anchorRange.upperBound...].firstIndex(of: "{") else {
+            throw XCTSkip("Expected opening brace after \(anchor)")
+        }
+
+        var depth = 0
+        var index = openBrace
+        while index < source.endIndex {
+            let char = source[index]
+            if char == "{" { depth += 1 }
+            if char == "}" { depth -= 1 }
+            let next = source.index(after: index)
+            if depth == 0 {
+                return String(source[openBrace..<next])
+            }
+            index = next
+        }
+
+        throw XCTSkip("Expected closing brace for \(anchor)")
+    }
+
+    private static func methodBody(named methodName: String, in source: String) throws -> String {
+        try braceBalancedBody(after: "func \(methodName)(", in: source)
+    }
+
+    private static func readFeatureSource(
+        _ pathComponents: [String],
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        var sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+        for component in pathComponents {
+            sourceURL = sourceURL.appendingPathComponent(component)
+        }
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
Parts-area sheet-lifecycle batch from the beta-readiness plan (Batch B + the #714 item of Batch O — same fix class, one PR per the umbrella rule):

- **SmartDeleteSheet (#735)**: `dismiss()` now precedes `await onComplete()` in both delete paths — the parent refresh can no longer delay/fail the sheet close (stale-environment pattern).
- **PricingBulkEditSheet (#736)**: completion **Done** dismisses first, then refreshes the parent.
- **ToolTradeSheet (#714)**: signature-based dirty tracking over recipient/condition/notes replaces the manual `onChange` flags — selecting a recipient now trips the existing `interactiveDismissDisabled(isDirty)` swipe guard; discard confirmation follows the dismiss-safety campaign's `confirmationDialog` convention with baseline re-snapshot on successful save.

## Testing
- `xcrun swiftc -parse` clean on all three files
- Behavior verified by code-path inspection; UI flows exercised in the next local-Mac simulator pass (Xcode jobs stay on the self-hosted local Mac runner per hybrid CI routing; these PR gates run on ubuntu-latest)

Closes #735, closes #736, closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)