### PR TITLE
fix: timesheet correction history survives reviewed-period moves (#1097)

### DIFF
--- a/core/Sources/WiredPartCore/Services/ReportsService.swift
+++ b/core/Sources/WiredPartCore/Services/ReportsService.swift
@@ -516,13 +516,27 @@ public final class ReportsService: Sendable {
                     clauses.append("tca.labor_entry_id = ?")
                     args.append(laborEntryId)
                 }
-                if let startDate {
-                    clauses.append("\(Self.localDateSQL("tca.original_clock_in")) >= date(?)")
-                    args.append(startDate)
-                }
-                if let endDate {
-                    clauses.append("\(Self.localDateSQL("tca.original_clock_in")) <= date(?)")
-                    args.append(endDate)
+                // A correction must stay reviewable in any period that contains EITHER
+                // its original work date OR its adjusted work date. Filtering by
+                // original_clock_in alone hides the audit trail when a manager moves an
+                // entry across a date/pay-period boundary: the corrected segment shows
+                // up in the destination period (getTimesheetSegments filters by the
+                // adjusted labor_entries.clock_in) but its history vanished (#1097).
+                if startDate != nil || endDate != nil {
+                    var perColumnRanges: [String] = []
+                    for column in ["tca.original_clock_in", "tca.adjusted_clock_in"] {
+                        var bounds: [String] = []
+                        if let startDate {
+                            bounds.append("\(Self.localDateSQL(column)) >= date(?)")
+                            args.append(startDate)
+                        }
+                        if let endDate {
+                            bounds.append("\(Self.localDateSQL(column)) <= date(?)")
+                            args.append(endDate)
+                        }
+                        perColumnRanges.append("(" + bounds.joined(separator: " AND ") + ")")
+                    }
+                    clauses.append("(" + perColumnRanges.joined(separator: " OR ") + ")")
                 }
 
                 let sql = Self.timesheetCorrectionAuditSQL(whereClause: clauses.joined(separator: " AND "))

--- a/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
@@ -320,6 +320,65 @@ struct ReportsServiceTests {
         #expect(!outsidePeriod.contains { $0.segmentId == laborEntryId })
     }
 
+    @Test("Timesheet correction history survives entry moving into reviewed period")
+    func testTimesheetCorrectionHistorySurvivesMoveIntoReviewedPeriod() throws {
+        try withDenverTimeZone {
+            let env = try E2ETestHelpers.setUp()
+            let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-HIST-MOVE", name: "History Move Job")
+            // Entry originally worked on 2026-04-09 (15:00Z-19:00Z = 09:00-13:00 Denver).
+            let laborEntryId = try env.db.writer.write { db -> Int64 in
+                try db.execute(sql: """
+                    INSERT INTO labor_entries
+                        (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                    VALUES (?, ?, '2026-04-09T15:00:00Z', '2026-04-09T19:00:00Z', 4.0, 0.0, 'completed', datetime('now'))
+                    """, arguments: [env.adminUserId, jobId])
+                return db.lastInsertedRowID
+            }
+
+            // Manager moves the entry across the day boundary to 2026-04-10.
+            _ = try env.reports.saveTimesheetCorrection(
+                ReportsService.TimesheetCorrectionRequest(
+                    laborEntryId: laborEntryId,
+                    adjustedClockIn: "2026-04-10T15:00:00Z",
+                    adjustedClockOut: "2026-04-10T19:00:00Z",
+                    clientPreviewRegularHours: 4.0,
+                    clientPreviewOvertimeHours: 0.0,
+                    reason: "Entry was logged on the wrong day; moved per supervisor note.",
+                    actorUserId: env.adminUserId
+                )
+            )
+
+            // The corrected segment lands in the destination period...
+            let destinationSegments = try env.reports.getTimesheetSegments(
+                startDate: "2026-04-10",
+                endDate: "2026-04-10"
+            )
+            #expect(destinationSegments.contains { $0.id == laborEntryId })
+
+            // ...so its correction history must be reviewable there too (#1097:
+            // filtering by original_clock_in alone hid the audit trail here).
+            let destinationHistory = try env.reports.getTimesheetCorrectionHistory(
+                startDate: "2026-04-10",
+                endDate: "2026-04-10"
+            )
+            #expect(destinationHistory.contains { $0.segmentId == laborEntryId })
+
+            // The origin period keeps the audit trail for the original work date.
+            let originHistory = try env.reports.getTimesheetCorrectionHistory(
+                startDate: "2026-04-09",
+                endDate: "2026-04-09"
+            )
+            #expect(originHistory.contains { $0.segmentId == laborEntryId })
+
+            // Periods touching neither date still return nothing.
+            let unrelatedHistory = try env.reports.getTimesheetCorrectionHistory(
+                startDate: "2026-04-11",
+                endDate: "2026-04-11"
+            )
+            #expect(!unrelatedHistory.contains { $0.segmentId == laborEntryId })
+        }
+    }
+
     // MARK: - Daily Report Summary
 
     @Test("Daily report summary empty on fresh DB")


### PR DESCRIPTION
## Summary
- `ReportsService.getTimesheetCorrectionHistory` filtered audit rows by `original_clock_in` only, while `getTimesheetSegments` filters by the adjusted `labor_entries.clock_in`. When a manager corrected an entry across a date/pay-period boundary, the corrected segment showed up in the destination period but its correction history (reason, actor, original values, approval status) vanished from that review.
- The date-range filter now matches a correction when EITHER its original clock-in OR its adjusted clock-in falls inside the reviewed period, so the audit trail stays reviewable in both the origin and destination periods. Unbounded queries (no date filters) are unchanged.
- Adds a focused regression test (`testTimesheetCorrectionHistorySurvivesMoveIntoReviewedPeriod`) reproducing the issue's exact repro: entry worked 2026-04-09, corrected into 2026-04-10 — destination period must return both the segment and its history, the origin period keeps the history, and unrelated periods stay empty. Verified the test fails at the destination-period expectation without the service change.

## Scope note
This is Batch J part 1 (time-tracking correctness) from `docs/plans/beta-readiness-issue-resolution-2026-07.md`. A stale uncommitted `DashboardService` change (live unpaid-break subtraction, commented against closed #858) was found on this staging branch and **dropped**: #858's fix (break_records-backed breakMinutes, PR #916) is already merged and verified on main, and the extra live-hours adjustment maps to no open issue. Batch J part 2 (#90 re-verify / break-lunch-policy idempotency re-land) ships separately per the plan's iteration sequencing.

## Testing
- `cd core && swift build` — Build complete
- `cd core && swift test --filter ReportsServiceTests` — 51 tests in 1 suite passed (includes the new regression test)
- Red-check: with the service fix stashed, the new test fails at `destinationHistory.contains { $0.segmentId == laborEntryId }` (ReportsServiceTests.swift:364), matching the #1097 repro; passes with the fix restored

## CI routing
PR gates (Artifact Guard, CodeQL compat, Analyze (swift) recovery gate, PR Merge Maintenance) run on `ubuntu-latest` per the hybrid runner policy; Xcode/iOS work stays on the local self-hosted Mac runner. Core-package changes here were verified locally via SwiftPM on the Mac.

Closes #1097

🤖 Generated with [Claude Code](https://claude.com/claude-code)