### PR TITLE
fix: job edit no longer assigns default stage template implicitly (#1105)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSEditJobSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSEditJobSheet.swift
@@ -129,7 +129,10 @@ struct IOSEditJobSheet: View {
 
                 Section("Stage Template") {
                     if stageTemplates.isEmpty {
-                        Text("No stage templates available. Create one in Settings → Job Stage Templates.")
+                        // Copy reflects the stageCount > 0 filter in
+                        // loadStageTemplates(): stage-less templates exist but
+                        // are not offerable here.
+                        Text("No stage templates with stages available. Create or complete one in Settings → Job Stage Templates.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     } else {
@@ -143,7 +146,7 @@ struct IOSEditJobSheet: View {
                             if job.stageTemplateId == nil {
                                 Text("No Workflow").tag(Int64?.none)
                             }
-                            ForEach(stageTemplates.filter { $0.stageCount > 0 }) { template in
+                            ForEach(stageTemplates) { template in
                                 Text(template.name).tag(Int64?.some(template.id))
                             }
                         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSEditJobSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSEditJobSheet.swift
@@ -51,6 +51,11 @@ struct IOSEditJobSheet: View {
         _notes = State(initialValue: job.notes ?? "")
         _budgetLimit = State(initialValue: job.budgetLimit.map { String($0) } ?? "")
         _estimatedHours = State(initialValue: job.estimatedHours.map { String($0) } ?? "")
+        // Baseline mirrors the job's saved workflow — including nil for jobs
+        // without one. The picker is the only thing that mutates this, so a
+        // template change is persisted only when the user explicitly picks a
+        // different option (issue #1105: never draft the default template).
+        _selectedStageTemplateId = State(initialValue: job.stageTemplateId)
     }
 
     private var isValid: Bool {
@@ -128,16 +133,24 @@ struct IOSEditJobSheet: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     } else {
-                        Picker("Workflow", selection: Binding(
-                            get: { selectedStageTemplateId ?? stageTemplates.first?.id ?? 0 },
-                            set: { selectedStageTemplateId = $0 }
-                        )) {
+                        Picker("Workflow", selection: $selectedStageTemplateId) {
+                            // Jobs without a workflow get an explicit "No Workflow"
+                            // choice so opening the editor never pre-drafts the
+                            // default template (issue #1105). Jobs that already
+                            // have a workflow keep the template-only list — the
+                            // service has no unassign path, so removal stays
+                            // unsupported here.
+                            if job.stageTemplateId == nil {
+                                Text("No Workflow").tag(Int64?.none)
+                            }
                             ForEach(stageTemplates.filter { $0.stageCount > 0 }) { template in
-                                Text(template.name).tag(template.id)
+                                Text(template.name).tag(Int64?.some(template.id))
                             }
                         }
                         if selectedStageTemplateId != job.stageTemplateId {
-                            Text("Saving will preview and confirm the template change so the current stage is preserved when possible.")
+                            Text(job.stageTemplateId == nil
+                                ? "Saving will confirm assigning this workflow. The job will start at the workflow's first stage."
+                                : "Saving will preview and confirm the template change so the current stage is preserved when possible.")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -174,14 +187,18 @@ struct IOSEditJobSheet: View {
             .interactiveDismissDisabled(isSaving)
             .task { loadStageTemplates() }
             .confirmationDialog(
-                "Change stage template?",
+                job.stageTemplateId == nil ? "Assign workflow?" : "Change stage template?",
                 isPresented: $showingTemplateChangeConfirmation,
                 titleVisibility: .visible
             ) {
-                Button("Change Template") { saveJob(applyTemplateChange: true) }
+                Button(job.stageTemplateId == nil ? "Assign Workflow" : "Change Template") {
+                    saveJob(applyTemplateChange: true)
+                }
                 Button("Cancel", role: .cancel) { }
             } message: {
-                Text("The job will move to the selected workflow. If its current stage is not in that template, it will move to the first stage in the new template.")
+                Text(job.stageTemplateId == nil
+                    ? "This job currently has no workflow. It will be assigned the selected workflow and start at its first stage."
+                    : "The job will move to the selected workflow. If its current stage is not in that template, it will move to the first stage in the new template.")
             }
         }
     }
@@ -195,9 +212,9 @@ struct IOSEditJobSheet: View {
         }
         do {
             stageTemplates = try service.listJobStageTemplates().filter { $0.stageCount > 0 }
-            if selectedStageTemplateId == nil {
-                selectedStageTemplateId = job.stageTemplateId ?? stageTemplates.first(where: { $0.isDefault })?.id ?? stageTemplates.first?.id
-            }
+            // Deliberately no default here: selectedStageTemplateId keeps the
+            // baseline set in init (nil for workflow-less jobs), so saving an
+            // unrelated edit never assigns the default/first template (#1105).
         } catch {
             errorMessage = userFriendlyError(error, context: "load stage templates")
         }

--- a/Weird Parts IOS/Weird Parts IOSTests/IOSEditJobSheetRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/IOSEditJobSheetRegressionTests.swift
@@ -49,10 +49,42 @@ final class IOSEditJobSheetRegressionTests: XCTestCase {
             "Edit job sheet should validate estimated hours and budget limit before updateJob so malformed text cannot be silently ignored."
         )
         XCTAssertTrue(
-            source.contains("guard Double(trimmed) != nil else")
+            source.contains("guard let number = Double(trimmed), number.isFinite else")
                 && source.contains("must be a plain number, like 8 or 8.5")
                 && source.contains("Clear the field to remove it."),
             "Malformed numeric input should show a clear error while still allowing users to clear an optional value."
+        )
+    }
+
+    /// Issue #1105: opening Edit Job on a workflow-less job must not draft the
+    /// default/first stage template. The picker baseline mirrors the job's saved
+    /// (possibly nil) template, an explicit "No Workflow" option represents that
+    /// state, and only a deliberate picker change routes through the
+    /// template-change confirmation on save.
+    func testEditingWorkflowLessJobDoesNotDraftDefaultStageTemplate() throws {
+        let source = try Self.readEditJobSheetSource()
+
+        XCTAssertTrue(
+            source.contains("_selectedStageTemplateId = State(initialValue: job.stageTemplateId)"),
+            "Picker baseline must mirror the job's saved template (nil included) so unrelated edits never register a template change."
+        )
+        XCTAssertFalse(
+            source.contains("stageTemplates.first(where: { $0.isDefault })?.id ?? stageTemplates.first?.id"),
+            "Edit sheet must not fall back to the default/first template for jobs without a workflow — that silently assigns a workflow on save."
+        )
+        XCTAssertTrue(
+            source.contains("Picker(\"Workflow\", selection: $selectedStageTemplateId)")
+                && source.contains("Text(\"No Workflow\").tag(Int64?.none)"),
+            "Workflow picker should bind the optional selection directly and show an explicit \"No Workflow\" option for jobs without a template."
+        )
+        XCTAssertFalse(
+            source.contains("selectedStageTemplateId ?? stageTemplates.first?.id ?? 0"),
+            "Picker display must not coerce a nil selection to the first template — that shows a workflow the user never chose."
+        )
+        XCTAssertTrue(
+            source.contains("if selectedStageTemplateId != job.stageTemplateId && !applyTemplateChange {")
+                && source.contains("showingTemplateChangeConfirmation = true"),
+            "Template assignment must stay behind the explicit change-confirmation path, keyed off the user's picker selection vs the saved baseline."
         )
     }
 


### PR DESCRIPTION
## Summary

Fixes #1105 (beta push Batch I, `docs/plans/beta-readiness-issue-resolution-2026-07.md`): opening **Edit Job** on a job with no workflow (`stage_template_id` NULL — legacy/imported jobs) auto-selected the default/first stage template, so saving an unrelated edit (notes, customer name, budget, hours...) routed through the template-change confirmation and could silently assign a workflow + stage.

Changes in `Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSEditJobSheet.swift`:

- **Baseline mirrors the saved job.** `selectedStageTemplateId` is initialized in `init` to `job.stageTemplateId` (nil included). `loadStageTemplates()` no longer falls back to the default/first template.
- **Explicit "No Workflow" state.** Workflow-less jobs show a "No Workflow" option selected in the picker (direct optional binding, no coercion to the first template). The template is only persisted when the user deliberately changes the picker — selection vs saved baseline, matching the sheet's existing changed-vs-original save idioms.
- **Deliberate assignment copy.** Assigning a workflow to a job that had none gets its own confirmation ("Assign workflow?" / starts at the first stage), distinct from the change-template dialog.
- **Removal semantics unchanged (noted per issue triage).** Jobs that already have a workflow keep a template-only picker. `JobsService.assignJobStageTemplate` takes a non-optional `templateId` — there is no unassign path in the service, and issue #1105 (no comments) does not request one, so removal stays unsupported here rather than inventing new semantics.

No core/`JobsService` changes — the bug was entirely in the SwiftUI edit-sheet state wiring.

## Testing

- New regression test `testEditingWorkflowLessJobDoesNotDraftDefaultStageTemplate` in `Weird Parts IOS/Weird Parts IOSTests/IOSEditJobSheetRegressionTests.swift`: asserts the nil-preserving baseline, the explicit "No Workflow" nil-tag option, absence of both default-fallback bug patterns, and that assignment stays behind the explicit confirmation path. All asserted strings verified against code lines (not comments).
- Also repaired a stale assertion in the same suite: it still expected `guard Double(trimmed) != nil else`, which a3acafac6 (#1346) rewrote to `guard let number = Double(trimmed), number.isFinite else` — the suite was red on main before this PR.
- `xcrun swiftc -parse` clean on both edited files.
- Core untouched; issue author's focused run of `swift test --filter JobsServiceTests` (139 tests) was already green against unmodified core.

## CI routing

PR gates run on **ubuntu-latest** (cloud); Xcode/iOS build + test verification stays on the **local Mac runner** (hybrid CI routing per repo policy).

Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
