### PR TITLE
fix: surface silent load failures on 5 more screens (#1102, #1178, #1174, #1177, #1196)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Chat/CreateChannelSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Chat/CreateChannelSheet.swift
@@ -17,6 +17,12 @@ struct CreateChannelSheet: View {
     // Supplier channel state
     @State private var selectedSupplierId: Int64 = 0
     @State private var suppliers: [PartsService.SupplierWithCount] = []
+    /// Load-error state for the supplier picker (#1102) — a failed supplier
+    /// list load must never render as an empty "Choose..." picker. Cleared on
+    /// each successful load; previously loaded suppliers stay visible on a
+    /// failed refresh.
+    @State private var supplierLoadError: String?
+    @State private var isLoadingSuppliers = false
 
     private var isDM: Bool { channelType == "dm" }
     private var isSupplier: Bool { channelType == "supplier" }
@@ -26,10 +32,37 @@ struct CreateChannelSheet: View {
             Form {
                 if isSupplier {
                     Section("Supplier") {
-                        Picker("Select Supplier", selection: $selectedSupplierId) {
-                            Text("Choose...").tag(Int64(0))
-                            ForEach(suppliers, id: \.supplier.id) { item in
-                                Text(item.supplier.name).tag(item.supplier.id ?? Int64(0))
+                        if let error = supplierLoadError {
+                            // Inline load error with retry (#1102) — distinguishes
+                            // "failed to load suppliers" from "no suppliers exist".
+                            HStack(spacing: 8) {
+                                Label(error, systemImage: "exclamationmark.triangle")
+                                    .font(.caption)
+                                    .foregroundStyle(.red)
+                                Spacer()
+                                Button {
+                                    Task { await loadSuppliers() }
+                                } label: {
+                                    Label("Retry", systemImage: "arrow.clockwise")
+                                        .font(.caption)
+                                }
+                                .accessibilityLabel("Retry loading suppliers")
+                            }
+                        }
+                        if isLoadingSuppliers && suppliers.isEmpty && supplierLoadError == nil {
+                            ProgressView()
+                                .frame(maxWidth: .infinity, alignment: .center)
+                        } else if suppliers.isEmpty && supplierLoadError == nil {
+                            // True empty state — only shown after a successful load.
+                            Text("No suppliers configured")
+                                .foregroundStyle(.secondary)
+                                .font(.caption)
+                        } else if !suppliers.isEmpty {
+                            Picker("Select Supplier", selection: $selectedSupplierId) {
+                                Text("Choose...").tag(Int64(0))
+                                ForEach(suppliers, id: \.supplier.id) { item in
+                                    Text(item.supplier.name).tag(item.supplier.id ?? Int64(0))
+                                }
                             }
                         }
                     }
@@ -128,7 +161,21 @@ struct CreateChannelSheet: View {
 
     @MainActor
     private func loadSuppliers() async {
-        guard isSupplier, let service = appCore.partsService else { return }
-        suppliers = (try? service.listSuppliers()) ?? []
+        guard isSupplier else { return }
+        guard let service = appCore.partsService else {
+            supplierLoadError = "Parts service not available"
+            return
+        }
+        isLoadingSuppliers = true
+        // Explicit do/catch (#1102): a supplier-list failure must surface a
+        // visible, retryable error instead of silently rendering an empty
+        // picker. Previously loaded suppliers are kept on a failed refresh.
+        do {
+            suppliers = try service.listSuppliers()
+            supplierLoadError = nil
+        } catch {
+            supplierLoadError = userFriendlyError(error, context: "load suppliers")
+        }
+        isLoadingSuppliers = false
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSMessageThreadView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSMessageThreadView.swift
@@ -708,10 +708,30 @@ private struct ReferencePickerSheet: View {
     @State private var parts: [PartsService.PartWithDetails] = []
     @State private var pos: [OrdersService.POListItem] = []
     @State private var jobs: [JobsService.JobListItem] = []
+    /// Picker-level load error (#1178) — a failed part/PO/job lookup must
+    /// never render as an empty result list. Cleared on each successful load.
+    @State private var loadError: String?
 
     var body: some View {
         NavigationStack {
             List {
+                if let error = loadError {
+                    // Inline lookup error with retry (#1178) — distinguishes
+                    // "the lookup failed" from a genuine zero-result search.
+                    HStack(spacing: 8) {
+                        Label(error, systemImage: "exclamationmark.triangle")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                        Spacer()
+                        Button {
+                            loadData()
+                        } label: {
+                            Label("Retry", systemImage: "arrow.clockwise")
+                                .font(.caption)
+                        }
+                        .accessibilityLabel("Retry loading references")
+                    }
+                }
                 switch type {
                 case .part:
                     ForEach(parts, id: \.part.id) { item in
@@ -798,17 +818,53 @@ private struct ReferencePickerSheet: View {
         let query = searchText.trimmingCharacters(in: .whitespaces)
         let search: String? = query.isEmpty ? nil : query
 
+        // Explicit do/catch per attachment type (#1178): a DB/service failure
+        // must set a visible, retryable loadError instead of rendering the
+        // same empty list as a genuine zero-result search.
         switch type {
         case .part:
-            parts = (try? appCore.partsService?.listParts(search: search, limit: 50)) ?? []
+            guard let service = appCore.partsService else {
+                parts = []
+                loadError = "Parts service not available"
+                return
+            }
+            do {
+                parts = try service.listParts(search: search, limit: 50)
+                loadError = nil
+            } catch {
+                parts = []
+                loadError = userFriendlyError(error, context: "load parts")
+            }
         case .po:
-            pos = (try? appCore.ordersService?.listPurchaseOrders(limit: 50)) ?? []
-            if let search {
-                let lower = search.lowercased()
-                pos = pos.filter { $0.poNumber.lowercased().contains(lower) || $0.supplierName.lowercased().contains(lower) }
+            guard let service = appCore.ordersService else {
+                pos = []
+                loadError = "Orders service not available"
+                return
+            }
+            do {
+                pos = try service.listPurchaseOrders(limit: 50)
+                if let search {
+                    let lower = search.lowercased()
+                    pos = pos.filter { $0.poNumber.lowercased().contains(lower) || $0.supplierName.lowercased().contains(lower) }
+                }
+                loadError = nil
+            } catch {
+                pos = []
+                loadError = userFriendlyError(error, context: "load purchase orders")
             }
         case .job:
-            jobs = (try? appCore.jobsService?.listJobs(search: search, limit: 50)) ?? []
+            guard let service = appCore.jobsService else {
+                jobs = []
+                loadError = "Jobs service not available"
+                return
+            }
+            do {
+                jobs = try service.listJobs(search: search, limit: 50)
+                loadError = nil
+            } catch {
+                jobs = []
+                loadError = userFriendlyError(error, context: "load jobs")
+            }
         }
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/CreateNotebookSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/CreateNotebookSheet.swift
@@ -39,6 +39,10 @@ struct CreateNotebookSheet: View {
     @State private var isSaving = false
     @State private var saveError: String?
     @State private var jobsLoadError: String?
+    /// Load-error state for the template picker (#1174) — a failed template
+    /// load must never look like "no templates exist", or a field tech can
+    /// silently create a blank notebook missing template-backed sections.
+    @State private var templatesLoadError: String?
     @State private var wasAutoFilled = false
 
     private let typeOptions = ["general", "job", "daily_report", "checklist"]
@@ -94,13 +98,26 @@ struct CreateNotebookSheet: View {
                     }
                 }
 
-                // Template picker
-                if !templates.isEmpty {
+                // Template picker — the section stays visible on a load failure
+                // (#1174) so the error can render; the true "no templates" state
+                // (no section) only applies after a successful empty load.
+                if !templates.isEmpty || templatesLoadError != nil {
                     Section {
-                        Picker("Start from Template", selection: $selectedTemplateId) {
-                            Text("Blank Notebook").tag(nil as Int64?)
-                            ForEach(templates) { template in
-                                Text(template.name).tag(template.id as Int64?)
+                        if let templatesLoadError {
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(templatesLoadError)
+                                    .foregroundStyle(.red)
+                                    .font(.caption)
+                                Button("Retry loading templates") {
+                                    loadTemplates()
+                                }
+                            }
+                        } else {
+                            Picker("Start from Template", selection: $selectedTemplateId) {
+                                Text("Blank Notebook").tag(nil as Int64?)
+                                ForEach(templates) { template in
+                                    Text(template.name).tag(template.id as Int64?)
+                                }
                             }
                         }
                     } header: {
@@ -163,10 +180,17 @@ struct CreateNotebookSheet: View {
 
     private func loadTemplates() {
         guard let service = appCore.notebooksService else {
-            saveError = "Notebooks service not available"
+            templatesLoadError = "Notebooks service not available. Try again after app services finish loading."
             return
         }
-        templates = (try? service.getTemplates(templateType: "job")) ?? []
+        // Explicit do/catch (#1174): template load failures are tracked
+        // separately from saveError and from a genuinely empty template list.
+        do {
+            templates = try service.getTemplates(templateType: "job")
+            templatesLoadError = nil
+        } catch {
+            templatesLoadError = userFriendlyError(error, context: "load notebook templates")
+        }
     }
 
     private func autoFillFromClockEntry() {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateSubcontractorScheduleSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateSubcontractorScheduleSheet.swift
@@ -25,6 +25,12 @@ struct CreateSubcontractorScheduleSheet: View {
     @State private var notes = ""
     @State private var isSaving = false
     @State private var saveError: String?
+    /// Load-error states for the prerequisite pickers (#1177) — a failed job
+    /// or contractor list load must never render as an empty picker with a
+    /// disabled Create/Save button. Tracked separately so the operator knows
+    /// which prerequisite failed.
+    @State private var jobsLoadError: String?
+    @State private var contractorsLoadError: String?
 
     private let statuses = ["scheduled", "confirmed", "completed"]
 
@@ -45,7 +51,22 @@ struct CreateSubcontractorScheduleSheet: View {
         NavigationStack {
             Form {
                 Section("Job") {
-                    if jobs.isEmpty {
+                    if let error = jobsLoadError {
+                        // Inline load error with retry (#1177) — distinguishes
+                        // "failed to load jobs" from "no active jobs exist".
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label(error, systemImage: "exclamationmark.triangle")
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                            Button {
+                                loadJobList()
+                            } label: {
+                                Label("Retry", systemImage: "arrow.clockwise")
+                                    .font(.caption)
+                            }
+                            .accessibilityLabel("Retry loading jobs")
+                        }
+                    } else if jobs.isEmpty {
                         Text("No active jobs")
                             .foregroundStyle(.secondary)
                     } else {
@@ -59,7 +80,22 @@ struct CreateSubcontractorScheduleSheet: View {
                 }
 
                 Section("Subcontractor") {
-                    if contractors.isEmpty {
+                    if let error = contractorsLoadError {
+                        // Inline load error with retry (#1177) — distinguishes
+                        // "failed to load subcontractors" from "none exist".
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label(error, systemImage: "exclamationmark.triangle")
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                            Button {
+                                loadContractorList()
+                            } label: {
+                                Label("Retry", systemImage: "arrow.clockwise")
+                                    .font(.caption)
+                            }
+                            .accessibilityLabel("Retry loading subcontractors")
+                        }
+                    } else if contractors.isEmpty {
                         Text("No active subcontractors")
                             .foregroundStyle(.secondary)
                     } else {
@@ -146,11 +182,37 @@ struct CreateSubcontractorScheduleSheet: View {
             notes = existing.notes ?? ""
         }
 
-        if let jobsService = appCore.jobsService {
-            jobs = (try? jobsService.listJobs(status: "active", limit: 300)) ?? []
+        loadJobList()
+        loadContractorList()
+    }
+
+    /// Loads the active-job picker list with explicit error surfacing (#1177).
+    /// Kept separate from `loadData()` so Retry re-fetches only the list and
+    /// never re-applies `existing` values over in-progress user edits.
+    private func loadJobList() {
+        guard let jobsService = appCore.jobsService else {
+            jobsLoadError = "Jobs service not available. Try again after app services finish loading."
+            return
         }
-        if let peopleService = appCore.peopleService {
-            contractors = (try? peopleService.listContractors()) ?? []
+        do {
+            jobs = try jobsService.listJobs(status: "active", limit: 300)
+            jobsLoadError = nil
+        } catch {
+            jobsLoadError = userFriendlyError(error, context: "load active jobs")
+        }
+    }
+
+    /// Loads the subcontractor picker list with explicit error surfacing (#1177).
+    private func loadContractorList() {
+        guard let peopleService = appCore.peopleService else {
+            contractorsLoadError = "People service not available. Try again after app services finish loading."
+            return
+        }
+        do {
+            contractors = try peopleService.listContractors()
+            contractorsLoadError = nil
+        } catch {
+            contractorsLoadError = userFriendlyError(error, context: "load subcontractors")
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Tools/IOSToolDetailPage.swift
@@ -18,6 +18,11 @@ struct IOSToolDetailPage: View {
     @State private var nextMaintenanceDue: String?
     @State private var isLoading = true
     @State private var loadError: String?
+    /// Scoped sub-section load errors (#1196) — trade/maintenance failures keep
+    /// the rest of the tool detail usable but must be visible: a failed query
+    /// must never render as "no pending trades" or "no maintenance due".
+    @State private var pendingTradesError: String?
+    @State private var maintenanceError: String?
     @State private var activeSheet: ActiveSheet?
     @State private var actionMessage: String?
 
@@ -163,6 +168,31 @@ struct IOSToolDetailPage: View {
                         }
                     }
                     .padding(.vertical, 2)
+                }
+            }
+
+            // Scoped sub-section failure banner (#1196) — the page stays
+            // partially usable, but trade/maintenance load failures render as
+            // a visible, retryable warning instead of clean empty sections.
+            if pendingTradesError != nil || maintenanceError != nil {
+                Section {
+                    if let error = pendingTradesError {
+                        Label(error, systemImage: "exclamationmark.triangle")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                    if let error = maintenanceError {
+                        Label(error, systemImage: "exclamationmark.triangle")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                    Button {
+                        loadAllData()
+                    } label: {
+                        Label("Retry", systemImage: "arrow.clockwise")
+                            .font(.caption)
+                    }
+                    .accessibilityLabel("Retry loading trade and maintenance data")
                 }
             }
 
@@ -761,15 +791,30 @@ struct IOSToolDetailPage: View {
             }
             versionHistory = try service.getToolVersionHistory(toolId: toolId)
             pendingEdits = try service.getPendingEdits(toolId: toolId)
-            // Expire old trades then load pending ones
-            _ = try? service.expireOldTrades()
-            if let userId = appCore.currentUser?.id {
-                pendingTrades = (try? service.getPendingTradesForUser(userId: userId)
-                    .filter { $0.toolId == toolId }) ?? []
+
+            // Expire old trades then load pending ones. Scoped do/catch (#1196):
+            // a failure here keeps the rest of the page usable but surfaces a
+            // visible sub-section error; previously loaded trades stay visible
+            // on a failed refresh.
+            do {
+                _ = try service.expireOldTrades()
+                if let userId = appCore.currentUser?.id {
+                    pendingTrades = try service.getPendingTradesForUser(userId: userId)
+                        .filter { $0.toolId == toolId }
+                }
+                pendingTradesError = nil
+            } catch {
+                pendingTradesError = userFriendlyError(error, context: "load pending trades")
             }
-            // Load maintenance configs and next due
-            maintenanceConfigs = (try? service.getMaintenanceConfigs(toolId: toolId)) ?? []
-            nextMaintenanceDue = try? service.calculateNextMaintenanceDate(toolId: toolId)
+
+            // Load maintenance configs and next due — same scoped surfacing (#1196).
+            do {
+                maintenanceConfigs = try service.getMaintenanceConfigs(toolId: toolId)
+                nextMaintenanceDue = try service.calculateNextMaintenanceDate(toolId: toolId)
+                maintenanceError = nil
+            } catch {
+                maintenanceError = userFriendlyError(error, context: "load maintenance data")
+            }
         } catch {
             loadError = userFriendlyError(error, context: "load tool details")
         }

--- a/Weird Parts IOS/Weird Parts IOSTests/TrackedSilentFailureFixesRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/TrackedSilentFailureFixesRegressionTests.swift
@@ -1,0 +1,291 @@
+import XCTest
+
+/// Regression tests for the tracked silent-load-failure batch —
+/// issues #1102, #1174, #1177, #1178, #1196.
+///
+/// Five screens used to coerce picker/sub-section load failures into empty
+/// states with `try? ... ?? []`, making a real DB/service failure look like
+/// "no data exists". These are source-scan tests following the
+/// SilentLoadFailureSurfacingRegressionTests idiom: each test asserts on code
+/// fragments that exist only in the fix, so a revert back to the silent
+/// pattern fails the suite.
+final class TrackedSilentFailureFixesRegressionTests: XCTestCase {
+
+    // MARK: - #1102 CreateChannelSheet (supplier picker)
+
+    func testSupplierChannelPickerSurfacesSupplierLoadFailure() throws {
+        let source = try Self.readSource(["Features", "Chat", "CreateChannelSheet.swift"])
+
+        XCTAssertTrue(
+            source.contains("@State private var supplierLoadError: String?"),
+            "CreateChannelSheet must carry a dedicated supplierLoadError state for the supplier picker."
+        )
+        XCTAssertTrue(
+            source.contains("supplierLoadError = userFriendlyError(error, context: \"load suppliers\")"),
+            "A supplier list failure must set supplierLoadError via userFriendlyError instead of rendering an empty picker."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityLabel(\"Retry loading suppliers\")"),
+            "The supplier load error row must offer a retry affordance."
+        )
+        XCTAssertTrue(
+            source.contains("Text(\"No suppliers configured\")"),
+            "The true empty state must be rendered distinctly, only after a successful load."
+        )
+        XCTAssertFalse(
+            source.contains("suppliers = (try? service.listSuppliers()) ?? []"),
+            "listSuppliers must not be silently defaulted to []."
+        )
+
+        let body = try Self.methodBody(named: "loadSuppliers", in: source)
+        XCTAssertTrue(
+            body.contains("suppliers = try service.listSuppliers()"),
+            "loadSuppliers must use a throwing read inside do/catch (keeping prior suppliers on a failed refresh)."
+        )
+        XCTAssertTrue(
+            body.contains("supplierLoadError = \"Parts service not available\""),
+            "A missing parts service must surface as a supplier load error, not a silent return."
+        )
+    }
+
+    // MARK: - #1174 CreateNotebookSheet (template picker)
+
+    func testNotebookTemplateLoadFailureSurfacesRetryableError() throws {
+        let source = try Self.readSource(["Features", "Notebooks", "CreateNotebookSheet.swift"])
+
+        XCTAssertTrue(
+            source.contains("@State private var templatesLoadError: String?"),
+            "CreateNotebookSheet must track template load errors separately from saveError."
+        )
+        XCTAssertTrue(
+            source.contains("templatesLoadError = userFriendlyError(error, context: \"load notebook templates\")"),
+            "A template load failure must set templatesLoadError instead of collapsing to an empty template list."
+        )
+        XCTAssertTrue(
+            source.contains("if !templates.isEmpty || templatesLoadError != nil {"),
+            "The template section must stay visible when the load failed so the error can render."
+        )
+        XCTAssertTrue(
+            source.contains("Button(\"Retry loading templates\") {"),
+            "The template load error must offer a retry action."
+        )
+        XCTAssertFalse(
+            source.contains("templates = (try? service.getTemplates(templateType: \"job\")) ?? []"),
+            "getTemplates must not be silently defaulted to []."
+        )
+
+        let body = try Self.methodBody(named: "loadTemplates", in: source)
+        XCTAssertTrue(
+            body.contains("templates = try service.getTemplates(templateType: \"job\")"),
+            "loadTemplates must use a throwing read inside do/catch."
+        )
+        XCTAssertFalse(
+            body.contains("saveError"),
+            "Template load failures must not be routed through saveError."
+        )
+    }
+
+    // MARK: - #1177 CreateSubcontractorScheduleSheet (job/contractor pickers)
+
+    func testSubcontractorScheduleSheetSurfacesJobAndContractorLoadFailures() throws {
+        let source = try Self.readSource(["Features", "Scheduling", "CreateSubcontractorScheduleSheet.swift"])
+
+        XCTAssertTrue(
+            source.contains("@State private var jobsLoadError: String?"),
+            "The sheet must carry a jobsLoadError state for the job picker."
+        )
+        XCTAssertTrue(
+            source.contains("@State private var contractorsLoadError: String?"),
+            "The sheet must carry a contractorsLoadError state so the operator knows which prerequisite failed."
+        )
+        XCTAssertTrue(
+            source.contains("jobsLoadError = userFriendlyError(error, context: \"load active jobs\")"),
+            "A job list failure must set jobsLoadError instead of an empty picker."
+        )
+        XCTAssertTrue(
+            source.contains("contractorsLoadError = userFriendlyError(error, context: \"load subcontractors\")"),
+            "A contractor list failure must set contractorsLoadError instead of an empty picker."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityLabel(\"Retry loading jobs\")"),
+            "The job load error must offer a retry affordance."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityLabel(\"Retry loading subcontractors\")"),
+            "The contractor load error must offer a retry affordance."
+        )
+        XCTAssertFalse(
+            source.contains("jobs = (try? jobsService.listJobs(status: \"active\", limit: 300)) ?? []"),
+            "listJobs must not be silently defaulted to []."
+        )
+        XCTAssertFalse(
+            source.contains("contractors = (try? peopleService.listContractors()) ?? []"),
+            "listContractors must not be silently defaulted to []."
+        )
+
+        let jobsBody = try Self.methodBody(named: "loadJobList", in: source)
+        XCTAssertTrue(
+            jobsBody.contains("jobs = try jobsService.listJobs(status: \"active\", limit: 300)"),
+            "loadJobList must use a throwing read inside do/catch (retry must not re-apply existing values over user edits)."
+        )
+        let contractorsBody = try Self.methodBody(named: "loadContractorList", in: source)
+        XCTAssertTrue(
+            contractorsBody.contains("contractors = try peopleService.listContractors()"),
+            "loadContractorList must use a throwing read inside do/catch."
+        )
+    }
+
+    // MARK: - #1178 IOSMessageThreadView (attach-to-message reference picker)
+
+    func testChatAttachmentPickerSurfacesLookupFailures() throws {
+        let source = try Self.readSource(["Features", "Chat", "IOSMessageThreadView.swift"])
+
+        XCTAssertTrue(
+            source.contains("loadError = userFriendlyError(error, context: \"load parts\")"),
+            "A part lookup failure in the reference picker must set a visible loadError."
+        )
+        XCTAssertTrue(
+            source.contains("loadError = userFriendlyError(error, context: \"load purchase orders\")"),
+            "A PO lookup failure in the reference picker must set a visible loadError."
+        )
+        XCTAssertTrue(
+            source.contains("loadError = userFriendlyError(error, context: \"load jobs\")"),
+            "A job lookup failure in the reference picker must set a visible loadError."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityLabel(\"Retry loading references\")"),
+            "The picker error row must offer a retry affordance."
+        )
+        XCTAssertFalse(
+            source.contains("parts = (try? appCore.partsService?.listParts(search: search, limit: 50)) ?? []"),
+            "listParts must not be silently defaulted to []."
+        )
+        XCTAssertFalse(
+            source.contains("pos = (try? appCore.ordersService?.listPurchaseOrders(limit: 50)) ?? []"),
+            "listPurchaseOrders must not be silently defaulted to []."
+        )
+        XCTAssertFalse(
+            source.contains("jobs = (try? appCore.jobsService?.listJobs(search: search, limit: 50)) ?? []"),
+            "listJobs must not be silently defaulted to []."
+        )
+
+        let body = try Self.methodBody(named: "loadData", in: source)
+        XCTAssertTrue(
+            body.contains("parts = try service.listParts(search: search, limit: 50)"),
+            "The part lookup must be a throwing read inside do/catch."
+        )
+        XCTAssertTrue(
+            body.contains("pos = try service.listPurchaseOrders(limit: 50)"),
+            "The PO lookup must be a throwing read inside do/catch."
+        )
+        XCTAssertTrue(
+            body.contains("jobs = try service.listJobs(search: search, limit: 50)"),
+            "The job lookup must be a throwing read inside do/catch."
+        )
+    }
+
+    // MARK: - #1196 IOSToolDetailPage (pending trades + maintenance sub-loads)
+
+    func testToolDetailSurfacesTradeAndMaintenanceSubLoadFailures() throws {
+        let source = try Self.readSource(["Features", "Tools", "IOSToolDetailPage.swift"])
+
+        XCTAssertTrue(
+            source.contains("@State private var pendingTradesError: String?"),
+            "Tool detail must carry a scoped pendingTradesError state."
+        )
+        XCTAssertTrue(
+            source.contains("@State private var maintenanceError: String?"),
+            "Tool detail must carry a scoped maintenanceError state."
+        )
+        XCTAssertTrue(
+            source.contains("pendingTradesError = userFriendlyError(error, context: \"load pending trades\")"),
+            "Trade expiration/pending-trade failures must set pendingTradesError instead of rendering no pending trades."
+        )
+        XCTAssertTrue(
+            source.contains("maintenanceError = userFriendlyError(error, context: \"load maintenance data\")"),
+            "Maintenance config/next-due failures must set maintenanceError instead of a clean maintenance state."
+        )
+        XCTAssertTrue(
+            source.contains("if pendingTradesError != nil || maintenanceError != nil {"),
+            "The tool content list must render the scoped sub-section failure banner."
+        )
+        XCTAssertTrue(
+            source.contains(".accessibilityLabel(\"Retry loading trade and maintenance data\")"),
+            "The sub-section failure banner must offer a retry affordance."
+        )
+        XCTAssertFalse(
+            source.contains("_ = try? service.expireOldTrades()"),
+            "expireOldTrades must not be swallowed with try?."
+        )
+        XCTAssertFalse(
+            source.contains("maintenanceConfigs = (try? service.getMaintenanceConfigs(toolId: toolId)) ?? []"),
+            "getMaintenanceConfigs must not be silently defaulted to []."
+        )
+        XCTAssertFalse(
+            source.contains("nextMaintenanceDue = try? service.calculateNextMaintenanceDate(toolId: toolId)"),
+            "calculateNextMaintenanceDate must not be swallowed with try?."
+        )
+
+        let body = try Self.methodBody(named: "loadAllData", in: source)
+        XCTAssertTrue(
+            body.contains("_ = try service.expireOldTrades()"),
+            "expireOldTrades must be a throwing call inside the scoped do/catch."
+        )
+        XCTAssertTrue(
+            body.contains("pendingTrades = try service.getPendingTradesForUser(userId: userId)"),
+            "getPendingTradesForUser must be a throwing read (keeping prior trades on a failed refresh)."
+        )
+        XCTAssertTrue(
+            body.contains("maintenanceConfigs = try service.getMaintenanceConfigs(toolId: toolId)"),
+            "getMaintenanceConfigs must be a throwing read inside the scoped do/catch."
+        )
+        XCTAssertTrue(
+            body.contains("nextMaintenanceDue = try service.calculateNextMaintenanceDate(toolId: toolId)"),
+            "calculateNextMaintenanceDate must be a throwing read inside the scoped do/catch."
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Read an app source file relative to the project root, mirroring the
+    /// SilentLoadFailureSurfacingRegressionTests path idiom.
+    private static func readSource(
+        _ pathComponents: [String],
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS (project folder)
+        var sourceURL = projectRoot.appendingPathComponent("Weird Parts IOS")
+        for component in pathComponents {
+            sourceURL = sourceURL.appendingPathComponent(component)
+        }
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    /// Extract a brace-balanced method body so assertions can be scoped to a
+    /// single function instead of the whole file.
+    private static func methodBody(named methodName: String, in source: String) throws -> String {
+        guard let nameRange = source.range(of: "func \(methodName)(") else {
+            throw XCTSkip("Expected method \(methodName) in source")
+        }
+        guard let openBrace = source[nameRange.upperBound...].firstIndex(of: "{") else {
+            throw XCTSkip("Expected opening brace for \(methodName)")
+        }
+
+        var depth = 0
+        var index = openBrace
+        while index < source.endIndex {
+            let char = source[index]
+            if char == "{" { depth += 1 }
+            if char == "}" { depth -= 1 }
+            let next = source.index(after: index)
+            if depth == 0 {
+                return String(source[openBrace..<next])
+            }
+            index = next
+        }
+
+        throw XCTSkip("Expected closing brace for \(methodName)")
+    }
+}


### PR DESCRIPTION
## Summary
Silent-error umbrella wave 2 (Batch L of docs/plans/beta-readiness-issue-resolution-2026-07.md) — the same `loadError` + Retry + honest-empty-state convention #1343 established, applied to the 5 remaining tracked screens:

- **CreateChannelSheet (#1102)**: supplier-picker load failures render an inline retryable error; the "No suppliers configured" empty state only shows after a successful load; previously loaded suppliers survive a failed refresh.
- **IOSMessageThreadView / ReferencePickerSheet (#1178)**: part/PO/job lookup failures surface with Retry instead of rendering as zero search results.
- **CreateNotebookSheet (#1174)**: template load failures visible + retryable (beta-priority notebooks area).
- **CreateSubcontractorScheduleSheet (#1177)**: job/contractor load failures no longer render as empty pickers.
- **IOSToolDetailPage (#1196)**: pending-trade/maintenance failures show scoped sub-section errors with Retry — page stays usable, failures stay visible.

Plus `TrackedSilentFailureFixesRegressionTests` covering all five (code-anchored assertions incl. negative checks on the removed `try?`-to-empty patterns).

## Testing
- `xcrun swiftc -parse` clean on all 6 files
- Rebased onto main after #1349 (shares IOSToolDetailPage; changes are in disjoint sections)
- Full iOS suite runs on the local Mac runner per hybrid CI routing (PR gates on ubuntu-latest)

Closes #1102, closes #1178, closes #1174, closes #1177, closes #1196

🤖 Generated with [Claude Code](https://claude.com/claude-code)