### PR TITLE
fix: hardening trivia — MainActor scan errors, export polish, empty states, Fleet isLoading (#711, #712, #1314, #43, #279-followup)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTelematicsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTelematicsPage.swift
@@ -13,7 +13,9 @@ struct IOSTelematicsPage: View {
     // MARK: - State
 
     @State private var locations: [FleetService.VehicleLocationRow] = []
-    @State private var isLoading = true
+    @State private var isInitialLoading = true
+    @State private var isRefreshing = false
+    @State private var hasLoadedOnce = false
     @State private var loadError: String?
     @State private var searchText = ""
     @State private var activeSheet: ActiveSheet?
@@ -72,22 +74,39 @@ struct IOSTelematicsPage: View {
 
     @ViewBuilder
     private var locationList: some View {
-        if isLoading {
-            ProgressView("Loading GPS data...")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if let error = loadError {
-            ErrorStateView(message: error) { loadData() }
-        } else if filteredLocations.isEmpty {
-            EmptyStateView(
-                icon: "location.slash",
-                title: "No GPS Data",
-                message: "Vehicle location data will appear here once drivers submit GPS updates from their mobile devices."
-            )
-        } else {
-            List(filteredLocations, id: \.id) { location in
-                locationRow(location)
+        Group {
+            if isInitialLoading {
+                ProgressView("Loading GPS data...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = loadError {
+                ErrorStateView(message: error) { loadData() }
+            } else if filteredLocations.isEmpty {
+                EmptyStateView(
+                    icon: "location.slash",
+                    title: "No GPS Data",
+                    message: "Vehicle location data will appear here once drivers submit GPS updates from their mobile devices."
+                )
+            } else {
+                List(filteredLocations, id: \.id) { location in
+                    locationRow(location)
+                }
+                .listStyle(.insetGrouped)
             }
-            .listStyle(.insetGrouped)
+        }
+        .overlay(alignment: .top) {
+            refreshingOverlay
+        }
+    }
+
+    @ViewBuilder
+    private var refreshingOverlay: some View {
+        if isRefreshing {
+            ProgressView()
+                .progressViewStyle(.linear)
+                .padding(.horizontal)
+                .padding(.top, 8)
+                .transition(.opacity)
+                .accessibilityLabel("Refreshing GPS data")
         }
     }
 
@@ -174,18 +193,31 @@ struct IOSTelematicsPage: View {
     private func loadData() {
         guard let service = appCore.fleetService else {
             loadError = "Fleet service not available"
-            isLoading = false
+            hasLoadedOnce = true
+            isInitialLoading = false
+            isRefreshing = false
             return
         }
-        isLoading = locations.isEmpty
-        loadError = nil
 
-        do {
-            locations = try service.listTelematicsData()
-        } catch {
-            loadError = userFriendlyError(error, context: "load telematics data")
+        if hasLoadedOnce {
+            isRefreshing = true
+        } else {
+            isInitialLoading = true
         }
 
-        isLoading = false
+        DispatchQueue.main.async {
+            defer {
+                self.hasLoadedOnce = true
+                self.isInitialLoading = false
+                self.isRefreshing = false
+            }
+
+            self.loadError = nil
+            do {
+                self.locations = try service.listTelematicsData()
+            } catch {
+                self.loadError = userFriendlyError(error, context: "load telematics data")
+            }
+        }
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTrailerLocationsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTrailerLocationsPage.swift
@@ -6,7 +6,9 @@ struct IOSTrailerLocationsPage: View {
     @EnvironmentObject private var appCore: AppCore
 
     @State private var trailers: [FleetService.TrailerListItem] = []
-    @State private var isLoading = true
+    @State private var isInitialLoading = true
+    @State private var isRefreshing = false
+    @State private var hasLoadedOnce = false
     @State private var searchText = ""
     @State private var loadError: String?
     @State private var activeSheet: ActiveSheet?
@@ -18,19 +20,24 @@ struct IOSTrailerLocationsPage: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if isLoading {
-                ProgressView("Loading trailer locations...")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if let error = loadError {
-                ErrorStateView(message: error) { loadData() }
-            } else if filteredTrailers.isEmpty {
-                EmptyStateView(
-                    icon: "box.truck.fill",
-                    title: "No Trailers",
-                    message: searchText.isEmpty ? "No trailers in the system." : "No trailers match your search."
-                )
-            } else {
-                trailerList
+            Group {
+                if isInitialLoading {
+                    ProgressView("Loading trailer locations...")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let error = loadError {
+                    ErrorStateView(message: error) { loadData() }
+                } else if filteredTrailers.isEmpty {
+                    EmptyStateView(
+                        icon: "box.truck.fill",
+                        title: "No Trailers",
+                        message: searchText.isEmpty ? "No trailers in the system." : "No trailers match your search."
+                    )
+                } else {
+                    trailerList
+                }
+            }
+            .overlay(alignment: .top) {
+                refreshingOverlay
             }
         }
         .navigationTitle("Trailer Locations")
@@ -55,6 +62,18 @@ struct IOSTrailerLocationsPage: View {
                     ("Tips", "Use the search bar to find a trailer by number, type, job name, or tow vehicle. Pull down to refresh locations. If a trailer shows the wrong location, update it from the trailer detail page.")
                 ]
             )
+        }
+    }
+
+    @ViewBuilder
+    private var refreshingOverlay: some View {
+        if isRefreshing {
+            ProgressView()
+                .progressViewStyle(.linear)
+                .padding(.horizontal)
+                .padding(.top, 8)
+                .transition(.opacity)
+                .accessibilityLabel("Refreshing trailer locations")
         }
     }
 
@@ -141,16 +160,31 @@ struct IOSTrailerLocationsPage: View {
     private func loadData() {
         guard let fleet = appCore.fleetService else {
             loadError = "Fleet service not available"
-            isLoading = false
+            hasLoadedOnce = true
+            isInitialLoading = false
+            isRefreshing = false
             return
         }
-        isLoading = trailers.isEmpty
-        loadError = nil
-        do {
-            trailers = try fleet.listTrailers()
-        } catch {
-            loadError = userFriendlyError(error, context: "load trailer locations")
+
+        if hasLoadedOnce {
+            isRefreshing = true
+        } else {
+            isInitialLoading = true
         }
-        isLoading = false
+
+        DispatchQueue.main.async {
+            defer {
+                self.hasLoadedOnce = true
+                self.isInitialLoading = false
+                self.isRefreshing = false
+            }
+
+            self.loadError = nil
+            do {
+                self.trailers = try fleet.listTrailers()
+            } catch {
+                self.loadError = userFriendlyError(error, context: "load trailer locations")
+            }
+        }
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTruckToolsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTruckToolsPage.swift
@@ -8,7 +8,9 @@ struct IOSTruckToolsPage: View {
     @EnvironmentObject private var appCore: AppCore
 
     @State private var checkouts: [ToolsService.CheckoutRow] = []
-    @State private var isLoading = true
+    @State private var isInitialLoading = true
+    @State private var isRefreshing = false
+    @State private var hasLoadedOnce = false
     @State private var searchText = ""
     @State private var loadError: String?
     @State private var activeSheet: ActiveSheet?
@@ -20,19 +22,24 @@ struct IOSTruckToolsPage: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if isLoading {
-                ProgressView("Loading truck tools...")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if let error = loadError {
-                ErrorStateView(message: error) { loadData() }
-            } else if filteredCheckouts.isEmpty {
-                EmptyStateView(
-                    icon: "wrench.and.screwdriver",
-                    title: "No Tools on Trucks",
-                    message: searchText.isEmpty ? "No tools are currently checked out to vehicles." : "No tools match your search."
-                )
-            } else {
-                toolsList
+            Group {
+                if isInitialLoading {
+                    ProgressView("Loading truck tools...")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let error = loadError {
+                    ErrorStateView(message: error) { loadData() }
+                } else if filteredCheckouts.isEmpty {
+                    EmptyStateView(
+                        icon: "wrench.and.screwdriver",
+                        title: "No Tools on Trucks",
+                        message: searchText.isEmpty ? "No tools are currently checked out to vehicles." : "No tools match your search."
+                    )
+                } else {
+                    toolsList
+                }
+            }
+            .overlay(alignment: .top) {
+                refreshingOverlay
             }
         }
         .navigationTitle("Truck Tools")
@@ -57,6 +64,18 @@ struct IOSTruckToolsPage: View {
                     ("Tips", "Tools are checked out and returned through the Tools section. If a tool is missing, check this page first to see which truck it was last assigned to. Keep expected return dates updated to avoid overdue notices.")
                 ]
             )
+        }
+    }
+
+    @ViewBuilder
+    private var refreshingOverlay: some View {
+        if isRefreshing {
+            ProgressView()
+                .progressViewStyle(.linear)
+                .padding(.horizontal)
+                .padding(.top, 8)
+                .transition(.opacity)
+                .accessibilityLabel("Refreshing truck tools")
         }
     }
 
@@ -104,17 +123,32 @@ struct IOSTruckToolsPage: View {
     private func loadData() {
         guard let service = appCore.toolsService else {
             loadError = "Tools service not available"
-            isLoading = false
+            hasLoadedOnce = true
+            isInitialLoading = false
+            isRefreshing = false
             return
         }
-        isLoading = checkouts.isEmpty
-        loadError = nil
-        do {
-            // Get active checkouts (tools currently out on trucks)
-            checkouts = try service.listCheckouts(active: true)
-        } catch {
-            loadError = userFriendlyError(error, context: "load truck tools")
+
+        if hasLoadedOnce {
+            isRefreshing = true
+        } else {
+            isInitialLoading = true
         }
-        isLoading = false
+
+        DispatchQueue.main.async {
+            defer {
+                self.hasLoadedOnce = true
+                self.isInitialLoading = false
+                self.isRefreshing = false
+            }
+
+            self.loadError = nil
+            do {
+                // Get active checkouts (tools currently out on trucks)
+                self.checkouts = try service.listCheckouts(active: true)
+            } catch {
+                self.loadError = userFriendlyError(error, context: "load truck tools")
+            }
+        }
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSWishlistPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSWishlistPage.swift
@@ -794,11 +794,14 @@ struct IOSWishlistPage: View {
             // Auto-approval is a WRITE: if it throws, items that policy says should
             // auto-approve silently stay pending. Surface it as a banner (#1335)
             // while still loading the sections below so the page stays usable.
-            var autoApprovalFailure: String?
+            // Capture the raw error here and map it to user-facing copy inside
+            // MainActor.run — userFriendlyError is main-actor-isolated and must
+            // not be called from the detached task itself.
+            var autoApprovalFailure: (any Error)?
             do {
                 _ = try service.processAutoApprovals(byUserId: currentUserId)
             } catch {
-                autoApprovalFailure = userFriendlyError(error, context: "run wishlist auto-approvals")
+                autoApprovalFailure = error
             }
             do {
                 let result = try service.getSectionedItems()
@@ -809,13 +812,13 @@ struct IOSWishlistPage: View {
                 await MainActor.run {
                     sections = result
                     statusCounts = counts
-                    autoApprovalError = autoApprovalFailure
+                    autoApprovalError = autoApprovalFailure.map { userFriendlyError($0, context: "run wishlist auto-approvals") }
                     isLoading = false
                     postAIContext()
                 }
             } catch {
                 await MainActor.run {
-                    autoApprovalError = autoApprovalFailure
+                    autoApprovalError = autoApprovalFailure.map { userFriendlyError($0, context: "run wishlist auto-approvals") }
                     loadError = userFriendlyError(error, context: "load wishlist")
                     isLoading = false
                 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/CategoriesTreeView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/CategoriesTreeView.swift
@@ -203,7 +203,15 @@ struct CategoriesTreeView: View {
                     }
                     .frame(maxWidth: .infinity)
                 } else {
-                    ContentUnavailableView.search(text: searchText)
+                    EmptyStateView(
+                        icon: "magnifyingglass",
+                        title: "No Matches",
+                        message: "No categories, styles, types, or brands match \"\(searchText)\".",
+                        actionLabel: "Clear Search",
+                        actionIcon: "xmark.circle"
+                    ) {
+                        searchText = ""
+                    }
                 }
             } else {
                 ScrollView {
@@ -670,11 +678,11 @@ struct CategoriesTreeView: View {
                             .padding(.leading, DS.Space.lg * 4 + 14)
                             .padding(.vertical, DS.Space.xs)
                     } else if brandSKUs.isEmpty {
-                        ContentUnavailableView {
-                            Label("No SKU Rows Yet", systemImage: "barcode.viewfinder")
-                        } description: {
-                            Text("This type/brand pair has no SKU rows yet.")
-                        }
+                        EmptyStateView(
+                            icon: "barcode.viewfinder",
+                            title: "No SKU Rows Yet",
+                            message: "This type/brand pair has no SKU rows yet."
+                        )
                         .padding(.leading, DS.Space.lg * 4 + 14)
                         .padding(.vertical, DS.Space.xs)
                         .accessibilityIdentifier("emptySKURows_\(typeId)_\(realBrandId)")

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamsPage.swift
@@ -167,7 +167,18 @@ struct IOSTeamsPage: View {
                 showEmployeesPage = true
             }
         } else if filteredTeams.isEmpty {
-            ContentUnavailableView.search(text: searchText)
+            EmptyStateView(
+                icon: "magnifyingglass",
+                title: "No Teams Match",
+                message: searchText.isEmpty
+                    ? "No teams match the selected filter."
+                    : "No teams match \"\(searchText)\".",
+                actionLabel: "Clear Filters",
+                actionIcon: "xmark.circle"
+            ) {
+                searchText = ""
+                filter = .all
+            }
         } else {
             List {
                 Section {

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamsPage.swift
@@ -173,7 +173,7 @@ struct IOSTeamsPage: View {
                 message: searchText.isEmpty
                     ? "No teams match the selected filter."
                     : "No teams match \"\(searchText)\".",
-                actionLabel: "Clear Filters",
+                actionLabel: searchText.isEmpty ? "Clear Filters" : "Clear Search & Filters",
                 actionIcon: "xmark.circle"
             ) {
                 searchText = ""

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDataExportPage.swift
@@ -53,11 +53,63 @@ enum IOSDatabaseExportSnapshotter {
     }
 }
 
+/// Writes selected-table export artifacts (CSV/JSON) into the temporary directory.
+///
+/// Nonisolated so the row fetch, serialization, and file I/O run off the main
+/// actor — large table exports must not freeze the Settings UI (GH #1314).
+enum IOSTableExportWriter {
+    nonisolated static func writeExports(
+        tables: [String],
+        format: String,
+        settingsService: SettingsService
+    ) throws -> [URL] {
+        let tmpDir = FileManager.default.temporaryDirectory
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let dateStr = formatter.string(from: Date())
+        var urls: [URL] = []
+
+        for table in tables {
+            let rows = try settingsService.exportTable(table)
+            guard !rows.isEmpty else { continue }
+
+            let ext = format == "json" ? "json" : "csv"
+            let fileURL = tmpDir.appendingPathComponent("wiredpart-export-\(table)-\(dateStr).\(ext)")
+
+            if format == "json" {
+                let data = try JSONSerialization.data(withJSONObject: rows, options: [.prettyPrinted, .sortedKeys])
+                try data.write(to: fileURL)
+            } else {
+                // CSV
+                guard let firstRow = rows.first as? [String: Any] else { continue }
+                let headers = firstRow.keys.sorted()
+                var csv = headers.joined(separator: ",") + "\n"
+                for row in rows {
+                    guard let dict = row as? [String: Any] else { continue }
+                    let values = headers.map { key -> String in
+                        let val = dict[key] ?? ""
+                        let str = "\(val)"
+                        if str.contains(",") || str.contains("\"") || str.contains("\n") {
+                            return "\"\(str.replacingOccurrences(of: "\"", with: "\"\""))\""
+                        }
+                        return str
+                    }
+                    csv += values.joined(separator: ",") + "\n"
+                }
+                try csv.write(to: fileURL, atomically: true, encoding: .utf8)
+            }
+            urls.append(fileURL)
+        }
+        return urls
+    }
+}
+
 /// Data export page for iOS.
 ///
 /// Provides options to export the local database or specific tables
-/// as CSV files. Exports are saved to the device's documents directory
-/// and can be shared via the iOS share sheet.
+/// as CSV/JSON files. Export artifacts are written to the app's temporary
+/// directory and handed straight to the iOS share sheet; nothing is kept
+/// in the app's Documents folder.
 struct IOSDataExportPage: View {
     @EnvironmentObject private var appCore: AppCore
 
@@ -108,7 +160,7 @@ struct IOSDataExportPage: View {
             case .help:
                 PageHelpSheet(title: "Data Export Help", sections: [
                     ("What This Page Does", "Exports the local database or specific tables as CSV or JSON files. You can also export the full SQLite database file."),
-                    ("How to Use It", "Select a format (CSV or JSON), check the tables you want to export, then tap Export. Use 'Export Full Database' for a complete SQLite backup. Exported files are saved to the app's Documents folder."),
+                    ("How to Use It", "Select a format (CSV or JSON), check the tables you want to export, then tap Export. Use 'Export Full Database' for a complete SQLite backup. The share sheet opens as soon as the export is ready — save the files to the Files app, AirDrop them, or send them to another app from there."),
                 ])
             case .share(let urls):
                 ReportShareSheet(items: urls)
@@ -139,12 +191,13 @@ struct IOSDataExportPage: View {
         case help
         case share([URL])
 
+        // Stable IDs only — never embed file paths in SwiftUI view identity (GH #1314).
         var id: String {
             switch self {
             case .help:
                 return "help"
-            case .share(let urls):
-                return "share-\(urls.map(\.path).joined(separator: "|"))"
+            case .share:
+                return "share"
             }
         }
     }
@@ -251,7 +304,7 @@ struct IOSDataExportPage: View {
 
     private var infoSection: some View {
         Section {
-            Text("Exported files are saved to this app's Documents folder. Use the Files app or share sheet to transfer them to another location.")
+            Text("Exports are created as temporary files and offered through the share sheet right away. Save them to the Files app or another location from the share sheet — they are not stored inside the app.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -288,58 +341,35 @@ struct IOSDataExportPage: View {
             return
         }
 
-        let tmpDir = FileManager.default.temporaryDirectory
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        let dateStr = formatter.string(from: Date())
-        var urls: [URL] = []
+        // Capture value-type inputs on the main actor, then run the heavy row
+        // fetch, serialization, and file I/O off-main (GH #1314). UI state
+        // updates hop back to the MainActor, mirroring exportFullDatabase().
+        let tables = selectedTables.sorted()
+        let format = selectedFormat
 
-        do {
-            for table in selectedTables.sorted() {
-                let rows = try settingsService.exportTable(table)
-                guard !rows.isEmpty else { continue }
-
-                let ext = selectedFormat == "json" ? "json" : "csv"
-                let fileURL = tmpDir.appendingPathComponent("wiredpart-export-\(table)-\(dateStr).\(ext)")
-
-                if selectedFormat == "json" {
-                    let data = try JSONSerialization.data(withJSONObject: rows, options: [.prettyPrinted, .sortedKeys])
-                    try data.write(to: fileURL)
-                } else {
-                    // CSV
-                    guard let firstRow = rows.first as? [String: Any] else { continue }
-                    let headers = firstRow.keys.sorted()
-                    var csv = headers.joined(separator: ",") + "\n"
-                    for row in rows {
-                        guard let dict = row as? [String: Any] else { continue }
-                        let values = headers.map { key -> String in
-                            let val = dict[key] ?? ""
-                            let str = "\(val)"
-                            if str.contains(",") || str.contains("\"") || str.contains("\n") {
-                                return "\"\(str.replacingOccurrences(of: "\"", with: "\"\""))\""
-                            }
-                            return str
-                        }
-                        csv += values.joined(separator: ",") + "\n"
+        Task.detached(priority: .userInitiated) {
+            do {
+                let urls = try IOSTableExportWriter.writeExports(
+                    tables: tables,
+                    format: format,
+                    settingsService: settingsService
+                )
+                await MainActor.run {
+                    if urls.isEmpty {
+                        exportSuccess = false
+                        errorMessage = "No rows were exported from the selected tables. Choose tables with data or export the full database."
+                    } else {
+                        exportSuccess = true
+                        activeSheet = .share(urls)
                     }
-                    try csv.write(to: fileURL, atomically: true, encoding: .utf8)
+                    isExporting = false
                 }
-                urls.append(fileURL)
+            } catch {
+                await MainActor.run {
+                    errorMessage = userFriendlyError(error, context: "export data")
+                    isExporting = false
+                }
             }
-
-            guard !urls.isEmpty else {
-                exportSuccess = false
-                errorMessage = "No rows were exported from the selected tables. Choose tables with data or export the full database."
-                isExporting = false
-                return
-            }
-
-            exportSuccess = true
-            isExporting = false
-            activeSheet = .share(urls)
-        } catch {
-            errorMessage = userFriendlyError(error, context: "export data")
-            isExporting = false
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
@@ -234,16 +234,21 @@ struct QRScanSheet: View {
                     case .detected(let payload, _):
                         await processPayload(payload)
                     case .error(let msg):
-                        scanError = msg
+                        // SwiftUI @State must be mutated on the main actor (GH #711).
+                        await MainActor.run { scanError = msg }
                     case .permissionDenied:
-                        scanError = "Camera permission required. Enable in Settings."
-                        isScanning = false
+                        await MainActor.run {
+                            scanError = "Camera permission required. Enable in Settings."
+                            isScanning = false
+                        }
                         return
                     }
                 }
             } catch {
-                scanError = userFriendlyError(error, context: "scan item")
-                isScanning = false
+                await MainActor.run {
+                    scanError = userFriendlyError(error, context: "scan item")
+                    isScanning = false
+                }
             }
         }
     }
@@ -259,7 +264,7 @@ struct QRScanSheet: View {
 
     private func processPayload(_ payload: String) async {
         guard let db = appCore.db else {
-            scanError = "Database not available"
+            await MainActor.run { scanError = "Database not available" }
             return
         }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/CategoriesSKURegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/CategoriesSKURegressionTests.swift
@@ -13,8 +13,8 @@ final class CategoriesSKURegressionTests: XCTestCase {
             "Tapping a SKU row should select that SKU for the right-side editor panel."
         )
         XCTAssertTrue(
-            source.contains("ContentUnavailableView") && source.contains("No SKU Rows Yet"),
-            "Expanded type/brand nodes with zero SKU rows should show a ContentUnavailableView empty state."
+            source.contains("EmptyStateView(") && source.contains("No SKU Rows Yet"),
+            "Expanded type/brand nodes with zero SKU rows should show the standard EmptyStateView empty state."
         )
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/DataExportShareRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/DataExportShareRegressionTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+
+/// Source-level guards for the Data Export share-sheet polish (GH #1314).
+///
+/// Covers the three Copilot follow-up findings from PR #1313:
+/// 1. Help/info copy must describe the temp-file + immediate share-sheet
+///    handoff instead of claiming exports are saved to Documents.
+/// 2. The `.share` active-sheet identity must be stable and must not embed
+///    file paths.
+/// 3. Selected-table export work must run off the main actor.
+final class DataExportShareRegressionTests: XCTestCase {
+    func testHelpCopyDescribesShareSheetHandoffNotDocumentsStorage() throws {
+        let source = try Self.readSettingsSource(named: "IOSDataExportPage.swift")
+
+        XCTAssertFalse(
+            source.contains("saved to the app's Documents folder"),
+            "Help copy must not claim exports are saved to the Documents folder — they are temp files handed to the share sheet."
+        )
+        XCTAssertFalse(
+            source.contains("saved to this app's Documents folder"),
+            "Info copy must not claim exports are saved to the Documents folder — they are temp files handed to the share sheet."
+        )
+        XCTAssertTrue(
+            source.contains("The share sheet opens as soon as the export is ready"),
+            "Help copy should explain the immediate share-sheet handoff."
+        )
+        XCTAssertTrue(
+            source.contains("they are not stored inside the app"),
+            "Info copy should explain that export files are temporary, not stored in the app."
+        )
+    }
+
+    func testShareSheetIdentityIsStableAndPathFree() throws {
+        let source = try Self.readSettingsSource(named: "IOSDataExportPage.swift")
+
+        XCTAssertTrue(
+            source.contains("case .share:") && source.contains("return \"share\""),
+            "The .share active-sheet case should use a stable constant ID."
+        )
+        XCTAssertFalse(
+            source.contains("urls.map(\\.path)"),
+            "SwiftUI sheet identity must not embed export file paths."
+        )
+    }
+
+    func testSelectedTableExportRunsOffMainActor() throws {
+        let source = try Self.readSettingsSource(named: "IOSDataExportPage.swift")
+
+        XCTAssertTrue(
+            source.contains("enum IOSTableExportWriter") &&
+            source.contains("nonisolated static func writeExports("),
+            "Selected-table export serialization should live in a nonisolated writer helper."
+        )
+        XCTAssertTrue(
+            source.contains("try IOSTableExportWriter.writeExports("),
+            "performExport should route file work through the off-main writer helper."
+        )
+        XCTAssertTrue(
+            source.contains("Task.detached(priority: .userInitiated)"),
+            "Export work should be detached from the main actor so large exports cannot freeze Settings."
+        )
+    }
+
+    private static func readSettingsSource(named filename: String, file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Settings")
+            .appendingPathComponent(filename)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/core/Tests/WiredPartCoreTests/E2EWarehouseTests.swift
+++ b/core/Tests/WiredPartCoreTests/E2EWarehouseTests.swift
@@ -208,7 +208,6 @@ struct E2EWarehouseTests {
                            arguments: [env.adminUserId])
         }
         let activity = try env.warehouse.getRecentActivity()
-        let entry = activity.first(where: { $0.description.contains("RA_Part") == false })
         let anyEntry = activity.first
         #expect(anyEntry != nil)
         #expect(anyEntry?.performedByName == "Unknown")


### PR DESCRIPTION
Batch P (hardening trivia) from `docs/plans/beta-readiness-issue-resolution-2026-07.md` — five small hardening items in one PR, plus a drive-by fix for a pre-existing main build break found during verification.

## Per-item changes

- **#711 — QRScanSheet off-main state mutations.** The scanner stream's `.error`, `.permissionDenied`, and start-catch paths mutated `scanError`/`isScanning` directly from the unannotated `Task`. All three now hop via `await MainActor.run { }`, matching the `processPayload(_:)` idiom already in the file. The `processPayload` "Database not available" early-return got the same treatment. Auto-dismiss behavior untouched.
- **#712 — unused test binding.** Removed the never-used `let entry = activity.first(where:)` in `core/Tests/WiredPartCoreTests/E2EWarehouseTests.swift`; `swift test` is back to zero warnings.
- **#1314 — Data Export share-sheet polish (all 3 Copilot follow-ups from PR #1313).**
  1. Help sheet, info section, and the page doc comment now describe the temp-file + immediate share-sheet handoff instead of claiming exports are saved to the Documents folder.
  2. `ActiveSheet.id` for `.share` is a stable `"share"` constant — file paths no longer leak into SwiftUI view identity.
  3. Selected-table export (row fetch + CSV/JSON serialization + file I/O) moved into a `nonisolated` `IOSTableExportWriter.writeExports(...)` helper running in `Task.detached`, with UI state updates hopping back to `MainActor` — mirroring the existing `exportFullDatabase()` pattern. `SettingsService` is `Sendable`, so the capture is safe.
  4. Source-level guard added: `Weird Parts IOSTests/DataExportShareRegressionTests.swift` (3 tests covering copy, sheet identity, and off-main export).
- **#43 remainder — last two raw `ContentUnavailableView` files.** `IOSTeamsPage` (search/filter empty state) and `CategoriesTreeView` (search empty state + inline "No SKU Rows Yet" state) converted to the standard `EmptyStateView` component used by 118 other files, with Clear Search/Clear Filters actions on the search states. `CategoriesSKURegressionTests` updated to assert the `EmptyStateView` idiom. Remaining raw usages (`WiredPartIOSApp` restore fallback, `UserMenuSheet` nav search, unused `SearchableList` helper) are outside the audited page scope per the beta-readiness plan.
- **#279 follow-up — 3 residual Fleet `isLoading` double-duty pages.** `IOSTelematicsPage`, `IOSTrailerLocationsPage`, `IOSTruckToolsPage` now use the same `isInitialLoading` / `isRefreshing` / `hasLoadedOnce` loaded-flag pattern PR #630 applied to the other six Fleet pages, including the top linear refreshing overlay with accessibility labels. Refreshes now show feedback, and fast empty loads no longer flicker the loader.
- **#1355 — pre-existing main build break (drive-by, required for CI).** `origin/main` (7131932dd) fails the iOS build: `IOSWishlistPage.swift:801` called main-actor-isolated `userFriendlyError` inside `Task.detached`. The raw error is now captured off-main and mapped inside the existing `MainActor.run` blocks. Verified broken on a pristine main worktree before touching it — see #1355 for evidence.

## Testing

- `xcrun swiftc -parse` clean on all 10 edited/added Swift files.
- `cd core && swift build` — `Build complete!` (30s).
- `cd core && swift test --filter E2EWarehouseTests` — 27/27 passed, the `E2EWarehouseTests.swift:211` warning is gone.
- Full iOS build on the local Mac runner path: `xcodebuild -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` — **BUILD SUCCEEDED**, no new warnings in any touched file (pristine main fails this same command with the #1355 error).
- `rg "isLoading"` over the three Fleet pages returns only `isInitialLoading` — no residual double-duty flag.

## CI routing

Hybrid runners per repo policy: ubuntu-latest cloud gates (Artifact Guard, CodeQL compat, PR-level Analyze (swift), Merge Maintenance) run in parallel; Xcode-dependent verification was performed locally on the Mac runner path (`docs/runbooks/local-mac-actions-runner.md`), matching what the self-hosted Mac executes.

Closes #711
Closes #712
Closes #1314
Closes #43
Closes #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)