### PR TITLE
fix: tracker-sync snapshot builds in jq — kills the bash rewrite hang

### DIFF
--- a/scripts/paperclip-github-tracker-sync.sh
+++ b/scripts/paperclip-github-tracker-sync.sh
@@ -171,8 +171,8 @@ printf '%s' "$AGENTS_JSON" > "$_agents_file"
 # forever once the active-issue payload grew large (run 28589871223 hung in
 # "building snapshot" for 10 minutes on a 560 KB issues payload).
 # The bullet list is also capped: GitHub issue comments max out at 65,536
-# characters, so beyond MAX_LISTED issues the snapshot lists the newest and
-# summarizes the rest.
+# characters, so beyond MAX_LISTED issues the snapshot lists the first
+# MAX_LISTED (sorted by identifier) and summarizes the rest.
 MAX_LISTED=300
 COMMENT_BODY="$(
   jq -nr \
@@ -190,6 +190,7 @@ COMMENT_BODY="$(
       $issues[0]
       | map({
           identifier,
+          id,
           title,
           status,
           priority,
@@ -209,10 +210,13 @@ COMMENT_BODY="$(
         | join(", "))
       end;
 
-    def render_id($id):
-      if $web == "" then $id
-      else "[" + $id + "](" + $web + "/" + ($id | split("-")[0]) + "/issues/" + $id + ")"
-      end;
+    def render_id($raw):
+      ($raw | tostring) as $id
+      # only WEI-123-style identifiers produce internal links; anything
+      # else (missing identifier, raw uuid id) renders as plain text
+      | if $web == "" or ($id | test("^[A-Za-z]+-[0-9]+$") | not) then $id
+        else "[" + $id + "](" + $web + "/" + ($id | split("-")[0]) + "/issues/" + $id + ")"
+        end;
 
     normalized as $all
     | ($all | length) as $total
@@ -226,7 +230,7 @@ COMMENT_BODY="$(
     "### Active Issues\n\n" +
     (
       ($listed | map(
-        "- " + render_id(.identifier // .id) +
+        "- " + render_id(.identifier // .id // "?") +
         " | **" + (.status // "unknown") + "**" +
         " | owner: `" + (agent_name(.assigneeAgentId)) + "`" +
         " | blockers: `" + blocker_summary(.) + "`" +

--- a/scripts/paperclip-github-tracker-sync.sh
+++ b/scripts/paperclip-github-tracker-sync.sh
@@ -162,25 +162,25 @@ AGENTS_JSON="$(curl "${CURL_OPTS[@]}" \
 # stage now reports so the next hang is attributable).
 echo "tracker-sync: fetched $(printf '%s' "$ISSUES_JSON" | wc -c | tr -d ' ') bytes issues, $(printf '%s' "$AGENTS_JSON" | wc -c | tr -d ' ') bytes agents; building snapshot" >&2
 
-render_link() {
-  local identifier="$1"
-  if [[ -n "$WEB_URL" ]]; then
-    local prefix="${identifier%%-*}"
-    printf "[%s](%s/%s/issues/%s)" "$identifier" "$WEB_URL" "$prefix" "$identifier"
-  else
-    printf "%s" "$identifier"
-  fi
-}
-
 _issues_file=$(mktemp); _agents_file=$(mktemp)
 printf '%s' "$ISSUES_JSON" > "$_issues_file"
 printf '%s' "$AGENTS_JSON" > "$_agents_file"
 
+# Links are rendered inside jq: the old post-hoc bash rewrite loop did an
+# O(body-length) substring replacement per issue line, which took effectively
+# forever once the active-issue payload grew large (run 28589871223 hung in
+# "building snapshot" for 10 minutes on a 560 KB issues payload).
+# The bullet list is also capped: GitHub issue comments max out at 65,536
+# characters, so beyond MAX_LISTED issues the snapshot lists the newest and
+# summarizes the rest.
+MAX_LISTED=300
 COMMENT_BODY="$(
   jq -nr \
     --slurpfile issues "$_issues_file" \
     --slurpfile agents "$_agents_file" \
-    --arg stamp "$STAMP" '
+    --arg stamp "$STAMP" \
+    --arg web "$WEB_URL" \
+    --argjson max "$MAX_LISTED" '
     def agent_name($id):
       ($agents[0] | map(select(.id == $id)) | .[0].name) // "unassigned";
 
@@ -202,25 +202,39 @@ COMMENT_BODY="$(
       | sort_by(issue_sort_key);
 
     def blocker_summary($issue):
+      # entries are scalar ids after normalization; tolerate objects too
       if (($issue.blockedByIssueIds // []) | length) == 0 then "none"
-      else (($issue.blockedByIssueIds // []) | map(.identifier // .id // tostring) | join(", "))
+      else (($issue.blockedByIssueIds // [])
+        | map(if type == "object" then (.identifier // .id // "?" | tostring) else tostring end)
+        | join(", "))
       end;
 
-    "# paperclip-tracker-sync:v1\n" +
+    def render_id($id):
+      if $web == "" then $id
+      else "[" + $id + "](" + $web + "/" + ($id | split("-")[0]) + "/issues/" + $id + ")"
+      end;
+
+    normalized as $all
+    | ($all | length) as $total
+    | ($all | .[0:$max]) as $listed
+    | "# paperclip-tracker-sync:v1\n" +
     "## Paperclip Active Issues Snapshot\n\n" +
     "- Synced at (UTC): `" + $stamp + "`\n" +
     "- Active statuses: `todo`, `in_progress`, `in_review`, `blocked`\n" +
-    "- Issue count: `" + ((normalized | length) | tostring) + "`\n\n" +
+    "- Issue count: `" + ($total | tostring) + "`" +
+    (if $total > $max then " (listing first " + ($max | tostring) + ")" else "" end) + "\n\n" +
     "### Active Issues\n\n" +
     (
-      (normalized | map(
-        "- " + (.identifier // .id) +
+      ($listed | map(
+        "- " + render_id(.identifier // .id) +
         " | **" + (.status // "unknown") + "**" +
         " | owner: `" + (agent_name(.assigneeAgentId)) + "`" +
         " | blockers: `" + blocker_summary(.) + "`" +
         " | " + (.title // "(untitled)")
       )) | join("\n")
-    ) + "\n"
+    ) +
+    (if $total > $max then "\n\n_…and " + (($total - $max) | tostring) + " more active issues not listed (comment size cap)._" else "" end) +
+    "\n"
   '
 )"
 
@@ -242,17 +256,6 @@ SYNC_FINGERPRINT="$(
     | sort_by(.identifier // .id // "")
   '
 )"
-
-# Convert bare identifiers in bullet lines to markdown links when WEB URL is present.
-if [[ -n "$WEB_URL" ]]; then
-  while IFS= read -r line; do
-    if [[ "$line" =~ ^-\ ([A-Z]+-[0-9]+)\ \| ]]; then
-      id="${BASH_REMATCH[1]}"
-      linked="$(render_link "$id")"
-      COMMENT_BODY="${COMMENT_BODY/- $id |/- $linked |}"
-    fi
-  done < <(printf "%s\n" "$COMMENT_BODY")
-fi
 
 echo "tracker-sync: snapshot built ($(printf '%s' "$COMMENT_BODY" | wc -c | tr -d ' ') bytes); hashing" >&2
 CONTENT_HASH="$(printf "%s" "$SYNC_FINGERPRINT" | hash_sha256)"


### PR DESCRIPTION
## Summary
Fourth and (evidence says) final tracker-sync fix. The instrumentation from #1358 pinpointed the hang precisely: fetches now take 0.2 s, and the job died in **building snapshot** — the bash loop that rewrote issue ids into markdown links with an O(body-length) substring replacement per line, unusable against today's 560 KB active-issue payload.

- Links render inside jq (single pass; 320-issue fixture renders in **7 ms**)
- Issue list capped at 300 with an "…and N more" summary — keeps the tracker comment under GitHub's 65,536-character limit (the uncapped body would have failed the PATCH anyway)
- Drive-by fix of a latent crash the fixture exposed: `blocker_summary` indexed scalar blocker ids as objects — any issue with blockers would have errored the render

## Testing
- `bash -n` clean; jq program run against a 320-issue fixture incl. blockers: correct links, cap text, 37 KB output, 7 ms
- Post-merge verification: `gh workflow run 'Paperclip Tracker Sync'` should now complete end-to-end and update tracker #372 (I'll dispatch and confirm)

Local Mac runner job; PR gates on ubuntu-latest per hybrid routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)