### PR TITLE
fix: surface chat attachment write failures + fail closed on missing AI user session (#1101, #724)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
+++ b/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
@@ -985,7 +985,9 @@ struct IOSAIAssistantPanel: View {
                 query: queryText,
                 db: db,
                 permissions: appCore.permissions,
-                userId: appCore.currentUser?.id ?? 0,
+                // Fail closed: pass nil when no user session exists so user-specific
+                // tools return a not-signed-in error instead of running as user 0 (#724).
+                userId: appCore.currentUser?.id,
                 navigationContext: navContext,
                 conversationId: conversationId
             )

--- a/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSMessageThreadView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSMessageThreadView.swift
@@ -24,6 +24,7 @@ struct IOSMessageThreadView: View {
     @State private var isSending = false
     @State private var loadError: String?
     @State private var actionError: String?
+    @State private var attachmentError: String?
 
     // Thread info panel
     @State private var showInfoPanel = false
@@ -116,6 +117,11 @@ struct IOSMessageThreadView: View {
             Button("OK") { actionError = nil }
         } message: {
             Text(actionError ?? "")
+        }
+        .alert("Attachment Failed", isPresented: Binding(get: { attachmentError != nil }, set: { if !$0 { attachmentError = nil } })) {
+            Button("OK") { attachmentError = nil }
+        } message: {
+            Text(attachmentError ?? "")
         }
         .overlay(alignment: .bottom) {
             if showComingSoon {
@@ -232,20 +238,40 @@ struct IOSMessageThreadView: View {
             .accessibilityLabel("Attach photo")
             .onChange(of: selectedPhotoItems) {
                 Task {
+                    // Only queue an attachment after the temp-file write succeeds —
+                    // a swallowed failure here queues a path that doesn't exist and
+                    // silently drops the photo at send time (issue #1101).
+                    var failedCount = 0
                     for item in selectedPhotoItems {
-                        if let data = try? await item.loadTransferable(type: Data.self) {
+                        do {
+                            guard let data = try await item.loadTransferable(type: Data.self) else {
+                                failedCount += 1
+                                logger.error("Photo attachment import failed: no data returned for selected item")
+                                continue
+                            }
                             let tmpURL = FileManager.default.temporaryDirectory
                                 .appendingPathComponent(UUID().uuidString + ".jpg")
-                            try? data.write(to: tmpURL)
+                            try data.write(to: tmpURL)
                             let att = ChatService.PendingAttachment(
                                 type: "photo",
                                 filePath: tmpURL.path,
                                 fileName: tmpURL.lastPathComponent
                             )
                             await MainActor.run { pendingAttachments.append(att) }
+                        } catch {
+                            failedCount += 1
+                            logger.error("Photo attachment import failed: \(error.localizedDescription)")
                         }
                     }
-                    await MainActor.run { selectedPhotoItems = [] }
+                    let failures = failedCount
+                    await MainActor.run {
+                        selectedPhotoItems = []
+                        if failures > 0 {
+                            attachmentError = failures == 1
+                                ? "Couldn't attach the photo. Check available storage and try again."
+                                : "Couldn't attach \(failures) photos. Check available storage and try again."
+                        }
+                    }
                 }
             }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/AIAssistantPanelSessionRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/AIAssistantPanelSessionRegressionTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+/// Regression coverage for issue #724: the AI assistant panel must never
+/// substitute user id 0 for a missing session when invoking tool-backed chat.
+/// With a nil user id, the core companion-poll and voting tools fail closed
+/// with an explicit not-signed-in message instead of querying as user 0.
+final class AIAssistantPanelSessionRegressionTests: XCTestCase {
+    func testAssistantPanelDoesNotFallBackToSyntheticUserZero() throws {
+        let source = try Self.readAssistantPanelSource()
+
+        XCTAssertFalse(
+            source.contains("appCore.currentUser?.id ?? 0"),
+            "IOSAIAssistantPanel must not substitute user id 0 for a missing session — companion poll/voting tools would compute answers for user 0."
+        )
+        XCTAssertTrue(
+            source.contains("userId: appCore.currentUser?.id,"),
+            "IOSAIAssistantPanel should pass the optional current user id through to chatWithTools so core tools can fail closed when it is nil."
+        )
+    }
+
+    private static func readAssistantPanelSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("AI")
+            .appendingPathComponent("IOSAIAssistantPanel.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/MessageThreadAttachmentImportRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/MessageThreadAttachmentImportRegressionTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+/// Regression coverage for issue #1101: chat photo attachments must never be
+/// queued after a failed temp-file write. The import path has to use explicit
+/// do/catch, append the pending attachment only after `data.write(to:)`
+/// succeeds, and surface failures to the user.
+final class MessageThreadAttachmentImportRegressionTests: XCTestCase {
+    func testPhotoImportDoesNotSwallowTempFileWriteFailures() throws {
+        let source = try Self.readMessageThreadViewSource()
+
+        XCTAssertFalse(
+            source.contains("try? data.write("),
+            "Attachment import must not swallow temp-file write failures with try? — a failed write queues a path that doesn't exist and silently drops the photo at send time."
+        )
+        XCTAssertFalse(
+            source.contains("try? await item.loadTransferable"),
+            "Attachment import must not swallow photo-load failures with try? — failures should be counted and surfaced to the user."
+        )
+        XCTAssertTrue(
+            source.contains("try data.write(to: tmpURL)"),
+            "Attachment import should write the temp file with explicit error propagation inside do/catch."
+        )
+        XCTAssertTrue(
+            source.contains("attachmentError ="),
+            "Attachment import failures should set a user-visible attachmentError instead of failing silently."
+        )
+        XCTAssertTrue(
+            source.contains(".alert(\"Attachment Failed\""),
+            "The thread view should present an alert when photo attachment import fails."
+        )
+    }
+
+    func testPendingAttachmentAppendedOnlyAfterSuccessfulWrite() throws {
+        let source = try Self.readMessageThreadViewSource()
+
+        guard let writeRange = source.range(of: "try data.write(to: tmpURL)"),
+              let appendRange = source.range(of: "ChatService.PendingAttachment(\n                                type: \"photo\"") else {
+            XCTFail("Expected the explicit write and the photo PendingAttachment construction to both exist in the import path.")
+            return
+        }
+        XCTAssertTrue(
+            writeRange.lowerBound < appendRange.lowerBound,
+            "The temp-file write must happen (and succeed) before the photo attachment is constructed and queued."
+        )
+    }
+
+    private static func readMessageThreadViewSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Chat")
+            .appendingPathComponent("IOSMessageThreadView.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/core/Sources/WiredPartCore/AI/AITools.swift
+++ b/core/Sources/WiredPartCore/AI/AITools.swift
@@ -14,6 +14,30 @@ import FoundationModels
 /// These tools are only available on macOS 26+ / iOS 26+ where the
 /// FoundationModels framework exists.
 
+// MARK: - User Session Guard
+
+/// Fail-closed session guard for AI tools that answer user-specific questions.
+///
+/// Companion-poll and voting tools must never run as a default or sentinel user:
+/// substituting user id 0 for a missing session turns an auth-loss state into a
+/// plausible-but-wrong answer (issue #724). `nil` (no signed-in user) and the
+/// legacy `0` sentinel both fail validation.
+///
+/// Defined outside the `canImport(FoundationModels)` gate so the fail-closed
+/// rule is unit-testable on every platform.
+public enum AIToolUserSession {
+    /// Message returned by user-specific tools when no authenticated user exists.
+    public static let notSignedInMessage =
+        "No signed-in user session — user-specific poll and voting data is unavailable. Ask the user to sign in again."
+
+    /// Returns the validated real user id, or `nil` when the session has no
+    /// authenticated user (including the legacy sentinel id `0` and negatives).
+    public static func validatedUserId(_ userId: Int64?) -> Int64? {
+        guard let userId, userId > 0 else { return nil }
+        return userId
+    }
+}
+
 #if canImport(FoundationModels)
 
 // MARK: - Search Parts Tool
@@ -221,9 +245,9 @@ public struct GetActiveCompanionPollsTool: FoundationModels.Tool {
 
     private let db: AppDatabase
     private let permissions: [String]
-    private let userId: Int64
+    private let userId: Int64?
 
-    public init(db: AppDatabase, permissions: [String], userId: Int64) {
+    public init(db: AppDatabase, permissions: [String], userId: Int64?) {
         self.db = db
         self.permissions = permissions
         self.userId = userId
@@ -232,6 +256,10 @@ public struct GetActiveCompanionPollsTool: FoundationModels.Tool {
     public func call(arguments: Arguments) async throws -> String {
         guard permissions.contains("view_parts_catalog") else {
             return "You don't have permission to view companion polls."
+        }
+        // Fail closed: never query user-specific vote state as a sentinel user (#724).
+        guard let userId = AIToolUserSession.validatedUserId(userId) else {
+            return AIToolUserSession.notSignedInMessage
         }
         let service = PartsService(db: db, auth: AuthService(db: db))
         let polls = try service.getActivePolls(userId: userId, isAdmin: false)
@@ -327,9 +355,9 @@ public struct GetVotingSummaryTool: FoundationModels.Tool {
 
     private let db: AppDatabase
     private let permissions: [String]
-    private let userId: Int64
+    private let userId: Int64?
 
-    public init(db: AppDatabase, permissions: [String], userId: Int64) {
+    public init(db: AppDatabase, permissions: [String], userId: Int64?) {
         self.db = db
         self.permissions = permissions
         self.userId = userId
@@ -338,6 +366,10 @@ public struct GetVotingSummaryTool: FoundationModels.Tool {
     public func call(arguments: Arguments) async throws -> String {
         guard permissions.contains("view_parts_catalog") else {
             return "You don't have permission to view voting data."
+        }
+        // Fail closed: never compute voting summaries as a sentinel user (#724).
+        guard let userId = AIToolUserSession.validatedUserId(userId) else {
+            return AIToolUserSession.notSignedInMessage
         }
         let service = PartsService(db: db, auth: AuthService(db: db))
         let results = try service.getLastWeekResults(userId: userId)

--- a/core/Sources/WiredPartCore/AI/FoundationModelsService.swift
+++ b/core/Sources/WiredPartCore/AI/FoundationModelsService.swift
@@ -103,7 +103,7 @@ public enum AIConversationPersistenceError: LocalizedError, Sendable, Equatable 
 struct AIChatSessionIdentity: Equatable, Sendable {
     let conversationId: String
     let databaseIdentity: String
-    let userId: Int64
+    let userId: Int64?
     let permissionKeys: [String]
     let navigationContext: String
 
@@ -111,7 +111,7 @@ struct AIChatSessionIdentity: Equatable, Sendable {
         conversationId: String,
         db: AppDatabase,
         permissions: [String],
-        userId: Int64,
+        userId: Int64?,
         navigationContext: String
     ) {
         self.conversationId = conversationId
@@ -399,6 +399,9 @@ public actor FoundationModelsService {
     ///   - query: The user's question.
     ///   - db: The app database for tool queries.
     ///   - permissions: The current user's permission keys.
+    ///   - userId: The signed-in user's id, or `nil` when no user session exists.
+    ///     When `nil` (or the legacy `0` sentinel), user-specific tools fail closed
+    ///     with a not-signed-in message instead of querying as user 0 (#724).
     ///   - navigationContext: A string describing the app's module/tab layout with access annotations.
     ///   - conversationId: Identifier for this conversation thread. Defaults to `"default"`.
     /// - Returns: An `AIResult` containing the assistant's response.
@@ -406,7 +409,7 @@ public actor FoundationModelsService {
         query: String,
         db: AppDatabase,
         permissions: [String],
-        userId: Int64 = 0,
+        userId: Int64? = nil,
         navigationContext: String,
         conversationId: String = "default"
     ) async -> AIResult {

--- a/core/Tests/WiredPartCoreTests/AIToolUserSessionTests.swift
+++ b/core/Tests/WiredPartCoreTests/AIToolUserSessionTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+@testable import WiredPartCore
+
+/// Regression coverage for issue #724: AI assistant companion-poll tools must
+/// fail closed when no authenticated user exists, never defaulting to user 0.
+@Suite("AIToolUserSession Tests")
+struct AIToolUserSessionTests {
+
+    // MARK: - validatedUserId (fail-closed rule, platform-independent)
+
+    @Test("validatedUserId returns nil when no user session exists")
+    func testValidatedUserId_nilSession() {
+        #expect(AIToolUserSession.validatedUserId(nil) == nil)
+    }
+
+    @Test("validatedUserId rejects the legacy user-0 sentinel")
+    func testValidatedUserId_zeroSentinel() {
+        #expect(AIToolUserSession.validatedUserId(0) == nil)
+    }
+
+    @Test("validatedUserId rejects negative ids")
+    func testValidatedUserId_negativeId() {
+        #expect(AIToolUserSession.validatedUserId(-3) == nil)
+    }
+
+    @Test("validatedUserId passes through a real user id")
+    func testValidatedUserId_realUser() {
+        #expect(AIToolUserSession.validatedUserId(42) == 42)
+    }
+
+    @Test("notSignedInMessage tells the user to sign in again")
+    func testNotSignedInMessage_isActionable() {
+        #expect(AIToolUserSession.notSignedInMessage.lowercased().contains("sign in"))
+    }
+
+    // MARK: - Tool behavior (requires FoundationModels tool types)
+
+    #if canImport(FoundationModels)
+    @Test("GetActiveCompanionPollsTool fails closed when no user is signed in")
+    func testActivePollsTool_failsClosedWithoutUser() async throws {
+        guard #available(macOS 26.0, iOS 26.0, *) else { return }
+        let env = try E2ETestHelpers.setUp()
+        let tool = GetActiveCompanionPollsTool(
+            db: env.db,
+            permissions: ["view_parts_catalog"],
+            userId: nil
+        )
+        let result = try await tool.call(arguments: .init())
+        #expect(result == AIToolUserSession.notSignedInMessage)
+    }
+
+    @Test("GetActiveCompanionPollsTool fails closed for the user-0 sentinel")
+    func testActivePollsTool_failsClosedForUserZero() async throws {
+        guard #available(macOS 26.0, iOS 26.0, *) else { return }
+        let env = try E2ETestHelpers.setUp()
+        let tool = GetActiveCompanionPollsTool(
+            db: env.db,
+            permissions: ["view_parts_catalog"],
+            userId: 0
+        )
+        let result = try await tool.call(arguments: .init())
+        #expect(result == AIToolUserSession.notSignedInMessage)
+    }
+
+    @Test("GetActiveCompanionPollsTool still runs for a real signed-in user")
+    func testActivePollsTool_runsForRealUser() async throws {
+        guard #available(macOS 26.0, iOS 26.0, *) else { return }
+        let env = try E2ETestHelpers.setUp()
+        let tool = GetActiveCompanionPollsTool(
+            db: env.db,
+            permissions: ["view_parts_catalog"],
+            userId: 1
+        )
+        let result = try await tool.call(arguments: .init())
+        #expect(result != AIToolUserSession.notSignedInMessage)
+    }
+
+    @Test("GetVotingSummaryTool fails closed when no user is signed in")
+    func testVotingSummaryTool_failsClosedWithoutUser() async throws {
+        guard #available(macOS 26.0, iOS 26.0, *) else { return }
+        let env = try E2ETestHelpers.setUp()
+        let tool = GetVotingSummaryTool(
+            db: env.db,
+            permissions: ["view_parts_catalog"],
+            userId: nil
+        )
+        let result = try await tool.call(arguments: .init())
+        #expect(result == AIToolUserSession.notSignedInMessage)
+    }
+
+    @Test("GetVotingSummaryTool fails closed for the user-0 sentinel")
+    func testVotingSummaryTool_failsClosedForUserZero() async throws {
+        guard #available(macOS 26.0, iOS 26.0, *) else { return }
+        let env = try E2ETestHelpers.setUp()
+        let tool = GetVotingSummaryTool(
+            db: env.db,
+            permissions: ["view_parts_catalog"],
+            userId: 0
+        )
+        let result = try await tool.call(arguments: .init())
+        #expect(result == AIToolUserSession.notSignedInMessage)
+    }
+
+    @Test("GetVotingSummaryTool still runs for a real signed-in user")
+    func testVotingSummaryTool_runsForRealUser() async throws {
+        guard #available(macOS 26.0, iOS 26.0, *) else { return }
+        let env = try E2ETestHelpers.setUp()
+        let tool = GetVotingSummaryTool(
+            db: env.db,
+            permissions: ["view_parts_catalog"],
+            userId: 1
+        )
+        let result = try await tool.call(arguments: .init())
+        #expect(result != AIToolUserSession.notSignedInMessage)
+    }
+
+    @Test("permission check still precedes the session guard")
+    func testTools_permissionDeniedBeforeSessionGuard() async throws {
+        guard #available(macOS 26.0, iOS 26.0, *) else { return }
+        let env = try E2ETestHelpers.setUp()
+        let polls = GetActiveCompanionPollsTool(db: env.db, permissions: [], userId: nil)
+        let voting = GetVotingSummaryTool(db: env.db, permissions: [], userId: nil)
+        let pollsResult = try await polls.call(arguments: .init())
+        let votingResult = try await voting.call(arguments: .init())
+        #expect(pollsResult == "You don't have permission to view companion polls.")
+        #expect(votingResult == "You don't have permission to view voting data.")
+    }
+    #endif
+}


### PR DESCRIPTION
Closes #1101
Closes #724

Plan citation: docs/plans/beta-readiness-issue-resolution-2026-07.md §3 Batch L (silent-error surfacing wave 2 — attachment temp-write do/catch + AI panel fail-closed slice).

## What changed

**#1101 — chat photo attachments queued after failed temp-file writes (data-loss class)**
- `Weird Parts IOS/Weird Parts IOS/Features/Chat/IOSMessageThreadView.swift`: photo import now uses explicit `do/catch` for both `loadTransferable` and `data.write(to:)`. The `PendingAttachment` is constructed and appended **only after the temp-file write succeeds**, so the composer can never queue a path that doesn't exist.
- Failures are counted per selected item and surfaced to the user via a new `attachmentError` state + "Attachment Failed" alert (mirrors the existing `actionError`/"Send Failed" pattern in this view), with an `OSLog` error entry per failure.
- New source-level regression test `MessageThreadAttachmentImportRegressionTests` fails if `try? data.write(` or `try? await item.loadTransferable` reappears in the import path, and asserts the write precedes the append.

**#724 — AI assistant companion-poll tools ran as user 0 when currentUser was unavailable**
- `Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift`: removed the `userId: appCore.currentUser?.id ?? 0` fail-open fallback; the optional id is passed through unchanged.
- `core/Sources/WiredPartCore/AI/FoundationModelsService.swift`: `chatWithTools(userId:)` is now `Int64? = nil` (was `Int64 = 0`); `AIChatSessionIdentity.userId` is optional so session caching stays correct across sign-in/sign-out.
- `core/Sources/WiredPartCore/AI/AITools.swift`: new `AIToolUserSession` fail-closed guard (defined outside the `canImport(FoundationModels)` gate so it is testable everywhere). `GetActiveCompanionPollsTool` and `GetVotingSummaryTool` now return an explicit not-signed-in message when the user id is `nil` or the legacy `0`/negative sentinel — they never query `companion_votes` as user 0. Permission checks still run first.
- New core suite `AIToolUserSessionTests` (12 tests): guard validation (nil/0/negative/real), both tools fail closed for nil and user-0, both tools still run for a real user, and permission-denied ordering. New iOS source-level regression test `AIAssistantPanelSessionRegressionTests` fails if the `?? 0` fallback reappears in the panel.

## Test evidence
- `cd core && swift build` → Build complete! (27.44s)
- `cd core && swift test --filter "AIToolUserSession"` → 12 tests in 1 suite passed
- `cd core && swift test --filter "FoundationModelsService"` → 28 tests in 1 suite passed
- `cd core && swift test` (full suite) → **2270 tests in 69 suites passed** (82.9s; 2258 pre-existing + 12 new, exit 0)
- `xcrun swiftc -parse` on all four touched/added iOS app-target files → exit 0
- Scripted assertion check confirming every string pattern the two new source-level regression tests assert (including the multiline write-before-append ordering match) holds against the edited sources → 9/9 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)