### PR TITLE
fix: accessibility pass — icon-button labels, 44pt targets, AX5 walkthrough (Batch M)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Auth/OnboardingWalkthroughView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/OnboardingWalkthroughView.swift
@@ -249,6 +249,7 @@ let onboardingModules: [OnboardingModule] = [
 /// Walks through every app module filtered by the user's hat permissions.
 struct OnboardingWalkthroughView: View {
     @EnvironmentObject private var appCore: AppCore
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @State private var currentStep = 0
     @State private var showWelcome = true
@@ -288,62 +289,81 @@ struct OnboardingWalkthroughView: View {
 
     // MARK: - Welcome Screen
 
+    // Scrolls and drops centering spacers at accessibility Dynamic Type sizes
+    // so the welcome copy and both action buttons stay reachable (issue #1311).
     private var welcomeScreen: some View {
-        VStack(spacing: 32) {
-            Spacer()
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(spacing: dynamicTypeSize.isAccessibilitySize ? 24 : 32) {
+                    if !dynamicTypeSize.isAccessibilitySize {
+                        Spacer(minLength: 24)
+                    }
 
-            Image(systemName: "wrench.and.screwdriver.fill")
-                .decorativeIconFont(72)
-                .foregroundStyle(.blue)
+                    Image(systemName: "wrench.and.screwdriver.fill")
+                        .decorativeIconFont(dynamicTypeSize.isAccessibilitySize ? 56 : 72)
+                        .foregroundStyle(.blue)
+                        .accessibilityHidden(true)
+                        .padding(.top, dynamicTypeSize.isAccessibilitySize ? 24 : 0)
 
-            VStack(spacing: 8) {
-                Text("Welcome to WiredPart")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
+                    VStack(spacing: 8) {
+                        Text("Welcome to WiredPart")
+                            .font(.largeTitle)
+                            .fontWeight(.bold)
+                            .multilineTextAlignment(.center)
+                            .fixedSize(horizontal: false, vertical: true)
 
-                if let user = appCore.currentUser {
-                    Text("Hi \(user.displayName)!")
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
-                }
+                        if let user = appCore.currentUser {
+                            Text("Hi \(user.displayName)!")
+                                .font(.title3)
+                                .foregroundStyle(.secondary)
+                                .multilineTextAlignment(.center)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
 
-                Text("Let's walk through the app together so you know where everything is. This takes about 5 minutes.")
+                        Text("Let's walk through the app together so you know where everything is. This takes about 5 minutes.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.horizontal, dynamicTypeSize.isAccessibilitySize ? 24 : 40)
+                    }
+
+                    VStack(spacing: 4) {
+                        Text("\(availableModules.count) modules")
+                            .font(.headline)
+                        Text("based on your permissions")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                    .padding()
+                    .background(Color.blue.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+
+                    if !dynamicTypeSize.isAccessibilitySize {
+                        Spacer(minLength: 24)
+                    }
+
+                    Button {
+                        withAnimation { showWelcome = false }
+                    } label: {
+                        Text("Let's Get Started")
+                            .fontWeight(.semibold)
+                            .frame(maxWidth: 280)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+
+                    Button("Skip Onboarding") {
+                        finishOnboarding()
+                    }
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 40)
+                    .dsMinTapTarget()
+                    .padding(.bottom, 40)
+                }
+                .frame(maxWidth: .infinity)
+                .frame(minHeight: proxy.size.height)
             }
-
-            VStack(spacing: 4) {
-                Text("\(availableModules.count) modules")
-                    .font(.headline)
-                Text("based on your permissions")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-            }
-            .padding()
-            .background(Color.blue.opacity(0.1))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-
-            Spacer()
-
-            Button {
-                withAnimation { showWelcome = false }
-            } label: {
-                Text("Let's Get Started")
-                    .fontWeight(.semibold)
-                    .frame(maxWidth: 280)
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-
-            Button("Skip Onboarding") {
-                finishOnboarding()
-            }
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
-
-            Spacer().frame(height: 40)
         }
     }
 
@@ -379,6 +399,7 @@ struct OnboardingWalkthroughView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                                 .multilineTextAlignment(.center)
+                                .fixedSize(horizontal: false, vertical: true)
                                 .padding(.horizontal, 24)
                         }
 
@@ -389,18 +410,21 @@ struct OnboardingWalkthroughView: View {
                                 .padding(.horizontal)
 
                             ForEach(module.keyFeatures, id: \.label) { feature in
-                                HStack(spacing: 12) {
+                                HStack(alignment: dynamicTypeSize.isAccessibilitySize ? .top : .center, spacing: 12) {
                                     Image(systemName: feature.icon)
                                         .font(.title3)
                                         .foregroundStyle(module.iconColor)
                                         .frame(width: 32)
+                                        .accessibilityHidden(true)
                                     VStack(alignment: .leading, spacing: 2) {
                                         Text(feature.label)
                                             .font(.subheadline)
                                             .fontWeight(.semibold)
+                                            .fixedSize(horizontal: false, vertical: true)
                                         Text(feature.detail)
                                             .font(.caption)
                                             .foregroundStyle(.secondary)
+                                            .fixedSize(horizontal: false, vertical: true)
                                     }
                                     Spacer()
                                 }
@@ -422,11 +446,13 @@ struct OnboardingWalkthroughView: View {
                             Text(module.requiredAction)
                                 .font(.subheadline)
                                 .multilineTextAlignment(.center)
+                                .fixedSize(horizontal: false, vertical: true)
 
                             Text(module.actionHint)
                                 .font(.caption)
                                 .foregroundStyle(.tertiary)
                                 .italic()
+                                .fixedSize(horizontal: false, vertical: true)
                         }
                         .padding()
                         .background(
@@ -440,7 +466,9 @@ struct OnboardingWalkthroughView: View {
                     .padding(.bottom, 24)
                 }
 
-                // Action buttons
+                // Action buttons — stack vertically at accessibility Dynamic
+                // Type sizes so wrapped titles keep every control reachable
+                // (issue #1311).
                 VStack(spacing: 12) {
                     if !completedModules.contains(module.id) {
                         Button {
@@ -455,39 +483,65 @@ struct OnboardingWalkthroughView: View {
                         .controlSize(.large)
                     }
 
-                    HStack(spacing: 16) {
-                        if currentStep > 0 {
-                            Button {
-                                withAnimation { currentStep -= 1 }
-                            } label: {
-                                Label("Back", systemImage: "chevron.left")
-                            }
-                            .buttonStyle(.bordered)
+                    if dynamicTypeSize.isAccessibilitySize {
+                        VStack(spacing: 12) {
+                            navigationFooterButtons(module: module, fullWidth: true)
                         }
-
-                        Spacer()
-
-                        if !completedModules.contains(module.id) {
-                            Button("Skip") {
-                                skippedModules.insert(module.id)
-                                saveProgress()
-                                advanceStep()
-                            }
-                            .foregroundStyle(.secondary)
+                    } else {
+                        HStack(spacing: 16) {
+                            backButtonIfNeeded(fullWidth: false)
+                            Spacer()
+                            skipAndNextButtons(module: module, fullWidth: false)
                         }
-
-                        Button {
-                            advanceStep()
-                        } label: {
-                            Label("Next", systemImage: "chevron.right")
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .disabled(!completedModules.contains(module.id) && !skippedModules.contains(module.id))
                     }
                 }
                 .padding()
             }
         }
+    }
+
+    // MARK: - Step Footer Buttons
+
+    @ViewBuilder
+    private func navigationFooterButtons(module: OnboardingModule, fullWidth: Bool) -> some View {
+        backButtonIfNeeded(fullWidth: fullWidth)
+        skipAndNextButtons(module: module, fullWidth: fullWidth)
+    }
+
+    @ViewBuilder
+    private func backButtonIfNeeded(fullWidth: Bool) -> some View {
+        if currentStep > 0 {
+            Button {
+                withAnimation { currentStep -= 1 }
+            } label: {
+                Label("Back", systemImage: "chevron.left")
+                    .frame(maxWidth: fullWidth ? .infinity : nil)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    @ViewBuilder
+    private func skipAndNextButtons(module: OnboardingModule, fullWidth: Bool) -> some View {
+        if !completedModules.contains(module.id) {
+            Button("Skip") {
+                skippedModules.insert(module.id)
+                saveProgress()
+                advanceStep()
+            }
+            .foregroundStyle(.secondary)
+            .dsMinTapTarget()
+            .frame(maxWidth: fullWidth ? .infinity : nil)
+        }
+
+        Button {
+            advanceStep()
+        } label: {
+            Label("Next", systemImage: "chevron.right")
+                .frame(maxWidth: fullWidth ? .infinity : nil)
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(!completedModules.contains(module.id) && !skippedModules.contains(module.id))
     }
 
     // MARK: - Completion Screen
@@ -508,6 +562,8 @@ struct OnboardingWalkthroughView: View {
                 Text("You've completed the WiredPart walkthrough.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 // Summary
                 VStack(alignment: .leading, spacing: 12) {
@@ -538,6 +594,7 @@ struct OnboardingWalkthroughView: View {
                         Text("Tap the ? button on any page for help when you visit these later.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
 
                         ForEach(availableModules.filter { skippedModules.contains($0.id) }) { module in
                             HStack(spacing: 8) {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPartsOrderManagementPage.swift
@@ -385,6 +385,8 @@ struct IOSPartsOrderManagementPage: View {
         .frame(minHeight: 50)
     }
 
+    // The icon is the only channel conveying line status in the row, so it
+    // must stay visible to VoiceOver with a semantic label (issue #1184).
     @ViewBuilder
     private func statusIcon(_ status: String) -> some View {
         switch status {
@@ -392,22 +394,22 @@ struct IOSPartsOrderManagementPage: View {
             Image(systemName: "checkmark.circle.fill")
                 .foregroundStyle(.green)
                 .font(.caption)
-                .accessibilityHidden(true)
+                .accessibilityLabel("Status: Received")
         case "backorder":
             Image(systemName: "clock.badge.exclamationmark")
                 .foregroundStyle(.red)
                 .font(.caption)
-                .accessibilityHidden(true)
+                .accessibilityLabel("Status: On backorder")
         case "pending":
             Image(systemName: "hourglass")
                 .foregroundStyle(.blue)
                 .font(.caption)
-                .accessibilityHidden(true)
+                .accessibilityLabel("Status: Pending")
         default:
             Image(systemName: "circle")
                 .foregroundStyle(.secondary)
                 .font(.caption)
-                .accessibilityHidden(true)
+                .accessibilityLabel("Status: \(status.capitalized)")
         }
     }
 
@@ -426,17 +428,20 @@ struct IOSPartsOrderManagementPage: View {
                 }
                 .font(.caption)
                 .buttonStyle(.bordered)
+                .accessibilityIdentifier("partsManagementMoveToPOButton")
                 Button("Change Qty") {
                     withAnimation { showComingSoon = true }
                 }
                 .font(.caption)
                 .buttonStyle(.bordered)
+                .accessibilityIdentifier("partsManagementChangeQtyButton")
                 Button("Remove + Hold") {
                     withAnimation { showComingSoon = true }
                 }
                 .font(.caption)
                 .buttonStyle(.bordered)
                 .tint(.red)
+                .accessibilityIdentifier("partsManagementRemoveHoldButton")
             }
             .padding(.horizontal)
             .padding(.vertical, 10)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPurchaseOrdersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPurchaseOrdersPage.swift
@@ -80,8 +80,10 @@ struct IOSPurchaseOrdersPage: View {
             ToolbarItemGroup(placement: .primaryAction) {
                 Button { activeSheet = .qrScanner } label: { Image(systemName: "qrcode.viewfinder") }
                     .accessibilityLabel("Scan QR code")
+                    .accessibilityIdentifier("poScanQRButton")
                 Button { activeSheet = .createPO } label: { Image(systemName: "plus") }
                     .accessibilityLabel("Create purchase order")
+                    .accessibilityIdentifier("poCreateButton")
             }
             ToolbarItem(placement: .secondaryAction) {
                 Menu {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSReceiveShipmentPage.swift
@@ -570,6 +570,7 @@ struct IOSReceiveShipmentPage: View {
                     }
                     .frame(minHeight: 44)
                     .disabled(isCompleting)
+                    .accessibilityIdentifier("completeReceivingButton")
                 }
 
                 if let error = actionError {
@@ -636,6 +637,7 @@ struct IOSReceiveShipmentPage: View {
                     Image(systemName: "barcode.viewfinder")
                 }
                 .accessibilityLabel("Scan barcode")
+                .accessibilityIdentifier("receiveShipmentScanBarcodeButton")
             }
         }
         .alert("Barcode Not Found", isPresented: Binding(
@@ -754,6 +756,7 @@ struct IOSReceiveShipmentPage: View {
                             .font(.title3)
                     }
                     .buttonStyle(.plain)
+                    .dsMinTapTarget()
                     .accessibilityLabel("Decrease quantity")
 
                     Text("\(receivedQtys[item.id] ?? item.expectedQty)")
@@ -782,6 +785,7 @@ struct IOSReceiveShipmentPage: View {
                             .font(.title3)
                     }
                     .buttonStyle(.plain)
+                    .dsMinTapTarget()
                     .accessibilityLabel("Increase quantity")
 
                     // Quick-fill to expected qty (shown when quantity differs)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/POSendToSupplierSheet.swift
@@ -385,6 +385,10 @@ struct POSendToSupplierSheet: View {
                         .font(.title3)
                 }
                 .buttonStyle(.plain)
+                .dsMinTapTarget()
+                .accessibilityLabel(isIncluded
+                                    ? "Exclude \(poNumber) from this send"
+                                    : "Include \(poNumber) in this send")
             }
 
             VStack(alignment: .leading, spacing: 2) {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/CompanionSandboxSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/CompanionSandboxSheet.swift
@@ -138,6 +138,7 @@ struct CompanionSandboxSheet: View {
                                 Image(systemName: "xmark.circle.fill")
                                     .font(.caption2)
                             }
+                            .accessibilityLabel("Remove \(cat.categoryName)")
                         }
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
@@ -172,6 +172,7 @@ struct PartsCatalogPage: View {
                     Image(systemName: "plus")
                 }
                 .accessibilityLabel("Add new part")
+                .accessibilityIdentifier("catalogAddPartButton")
             }
         }
         .onChange(of: showPricing) {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
@@ -1013,6 +1013,7 @@ private struct SupplierDetailSheet: View {
                     } label: {
                         Image(systemName: "pencil")
                     }
+                    .accessibilityLabel("Edit supplier")
                 }
             }
             .task { await loadAllDetails() }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSDispatchPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSDispatchPage.swift
@@ -342,6 +342,10 @@ struct IOSDispatchPage: View {
                                 .font(.caption2)
                                 .foregroundStyle(.gray)
                         }
+                        // Keep the compact 24pt visual, but give touch a
+                        // 44pt hit area per HIG / issue #1184.
+                        .frame(minHeight: 44)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Assign worker")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSDispatchPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSDispatchPage.swift
@@ -66,6 +66,31 @@ struct IOSDispatchPage: View {
 
     private let calendar = Calendar.current
 
+    // MARK: - Grid Metrics
+
+    /// Fixed width of the leading job-name column.
+    private let jobColumnWidth: CGFloat = 100
+    /// Spacing between grid columns (must match the `HStack(spacing:)` used by
+    /// the day header row and the job rows).
+    private let gridColumnSpacing: CGFloat = 1
+    /// Horizontal padding applied to the day header row and each job row.
+    private let gridRowHorizontalPadding: CGFloat = 8
+    /// Minimum width of a day column: HIG 44pt touch target (issue #1184).
+    private let minDayColumnWidth: CGFloat = 44
+
+    /// Width of each of the 7 day columns. The columns share the viewport
+    /// width when there is room (iPad / landscape), but never shrink below
+    /// 44pt — on narrow phones the grid scrolls horizontally instead, so the
+    /// empty-cell "Assign worker" buttons keep a full 44x44pt tap target
+    /// (issue #1184, acceptance criterion 2).
+    private func dayColumnWidth(forAvailableWidth availableWidth: CGFloat) -> CGFloat {
+        let fixedWidth = jobColumnWidth
+            + 7 * gridColumnSpacing
+            + 2 * gridRowHorizontalPadding
+        let flexibleWidth = (availableWidth - fixedWidth) / 7
+        return max(minDayColumnWidth, flexibleWidth)
+    }
+
     private var weekStart: Date {
         calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: weekStartDate)) ?? weekStartDate
     }
@@ -200,37 +225,50 @@ struct IOSDispatchPage: View {
         } else if let error = loadError {
             ErrorStateView(message: error) { loadData() }
         } else {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    // Day headers
-                    dayHeaderRow
+            GeometryReader { proxy in
+                let dayWidth = dayColumnWidth(forAvailableWidth: proxy.size.width)
 
-                    if jobRows.isEmpty {
-                        EmptyStateView(
-                            icon: "wrench.and.screwdriver",
-                            title: "No Active Jobs",
-                            message: "No jobs available for dispatch this week."
-                        )
-                        .padding()
-                    } else {
-                        // Job rows
-                        ForEach(jobRows, id: \.id) { row in
-                            jobRowView(row)
-                            Divider()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        // Day headers + job rows share one horizontal
+                        // scroller so the 7 day columns keep a >=44pt tap
+                        // width on narrow phones without losing column
+                        // alignment (issue #1184). On wider screens the
+                        // columns fill the viewport and nothing scrolls.
+                        ScrollView(.horizontal) {
+                            VStack(alignment: .leading, spacing: 0) {
+                                dayHeaderRow(dayWidth: dayWidth)
+
+                                // Job rows
+                                ForEach(jobRows, id: \.id) { row in
+                                    jobRowView(row, dayWidth: dayWidth)
+                                    Divider()
+                                }
+                            }
                         }
-                    }
 
-                    // Unassigned workers section
-                    if !unassignedWorkers.isEmpty {
-                        unassignedSection
-                    }
-
-                    // Action error
-                    if let error = actionError {
-                        Text(error)
-                            .font(.caption)
-                            .foregroundStyle(.red)
+                        if jobRows.isEmpty {
+                            EmptyStateView(
+                                icon: "wrench.and.screwdriver",
+                                title: "No Active Jobs",
+                                message: "No jobs available for dispatch this week."
+                            )
                             .padding()
+                            .frame(maxWidth: .infinity)
+                        }
+
+                        // Unassigned workers section
+                        if !unassignedWorkers.isEmpty {
+                            unassignedSection
+                        }
+
+                        // Action error
+                        if let error = actionError {
+                            Text(error)
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                                .padding()
+                        }
                     }
                 }
             }
@@ -239,10 +277,10 @@ struct IOSDispatchPage: View {
 
     // MARK: - Day Header Row
 
-    private var dayHeaderRow: some View {
-        HStack(spacing: 1) {
+    private func dayHeaderRow(dayWidth: CGFloat) -> some View {
+        HStack(spacing: gridColumnSpacing) {
             Text("Job")
-                .frame(width: 100, alignment: .leading)
+                .frame(width: jobColumnWidth, alignment: .leading)
                 .font(.caption)
                 .fontWeight(.bold)
 
@@ -254,7 +292,7 @@ struct IOSDispatchPage: View {
                         .font(.caption)
                         .fontWeight(.bold)
                 }
-                .frame(maxWidth: .infinity)
+                .frame(width: dayWidth)
                 .padding(.vertical, 4)
                 .background(
                     calendar.isDateInToday(day)
@@ -263,17 +301,17 @@ struct IOSDispatchPage: View {
                 )
             }
         }
-        .padding(.horizontal, 8)
+        .padding(.horizontal, gridRowHorizontalPadding)
         .padding(.vertical, 6)
         .background(Color(.systemGray6))
     }
 
     // MARK: - Job Row
 
-    private func jobRowView(_ row: SchedulingService.DispatchJobRow) -> some View {
+    private func jobRowView(_ row: SchedulingService.DispatchJobRow, dayWidth: CGFloat) -> some View {
         let isDropTarget = dropTargetJobId == row.id
 
-        return HStack(spacing: 1) {
+        return HStack(spacing: gridColumnSpacing) {
             // Job name column
             VStack(alignment: .leading, spacing: 2) {
                 Text(row.jobName)
@@ -287,7 +325,7 @@ struct IOSDispatchPage: View {
                         .lineLimit(1)
                 }
             }
-            .frame(width: 100, alignment: .leading)
+            .frame(width: jobColumnWidth, alignment: .leading)
             .contextMenu {
                 Text(row.jobName)
                 if let stage = row.stageName {
@@ -299,10 +337,10 @@ struct IOSDispatchPage: View {
 
             // Day cells
             ForEach(weekDays, id: \.self) { day in
-                dayCellForJob(row: row, day: day)
+                dayCellForJob(row: row, day: day, width: dayWidth)
             }
         }
-        .padding(.horizontal, 8)
+        .padding(.horizontal, gridRowHorizontalPadding)
         .padding(.vertical, 4)
         .background(
             RoundedRectangle(cornerRadius: 6)
@@ -321,7 +359,7 @@ struct IOSDispatchPage: View {
         }
     }
 
-    private func dayCellForJob(row: SchedulingService.DispatchJobRow, day: Date) -> some View {
+    private func dayCellForJob(row: SchedulingService.DispatchJobRow, day: Date, width: CGFloat) -> some View {
         let dayStr = dateString(day)
         let workers = assignments.filter { $0.jobId == row.id && $0.date == dayStr }
 
@@ -343,8 +381,11 @@ struct IOSDispatchPage: View {
                                 .foregroundStyle(.gray)
                         }
                         // Keep the compact 24pt visual, but give touch a
-                        // 44pt hit area per HIG / issue #1184.
-                        .frame(minHeight: 44)
+                        // 44pt hit area per HIG / issue #1184. The 44pt
+                        // width comes from the enclosing day column, which
+                        // dayColumnWidth(forAvailableWidth:) never lets
+                        // drop below minDayColumnWidth (44pt).
+                        .frame(minWidth: minDayColumnWidth, minHeight: 44)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
@@ -368,7 +409,7 @@ struct IOSDispatchPage: View {
                 }
             }
         }
-        .frame(maxWidth: .infinity, minHeight: 24)
+        .frame(minWidth: width, maxWidth: width, minHeight: 24)
         .dropDestination(for: DraggableWorker.self) { workers, _ in
             guard let worker = workers.first else { return false }
             createAssignment(jobId: row.id, userId: worker.id, date: dayStr, timeSlot: "full")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ZoneGridCanvas.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ZoneGridCanvas.swift
@@ -184,8 +184,6 @@ struct ZoneGridCanvas: View {
         }
             .buttonStyle(.plain)
             .contentShape(Rectangle())
-            .accessibilityLabel("Resize \(zone.label ?? zone.zoneType) zone")
-            .accessibilityHint("Double tap to grow the zone by one row and one column.")
             .highPriorityGesture(
                 DragGesture(minimumDistance: 6)
                     .onEnded { value in

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ZoneGridCanvas.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ZoneGridCanvas.swift
@@ -184,6 +184,8 @@ struct ZoneGridCanvas: View {
         }
             .buttonStyle(.plain)
             .contentShape(Rectangle())
+            .accessibilityLabel("Resize \(zone.label ?? zone.zoneType) zone")
+            .accessibilityHint("Double tap to grow the zone by one row and one column.")
             .highPriorityGesture(
                 DragGesture(minimumDistance: 6)
                     .onEnded { value in

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
@@ -325,6 +325,8 @@ struct IOSMainView: View {
                     } label: {
                         Image(systemName: "person.circle")
                     }
+                    .accessibilityLabel("Account and settings")
+                    .accessibilityIdentifier("userMenuButton")
                 }
             }
         }
@@ -645,6 +647,7 @@ struct IOSMainView: View {
                 .shadow(color: .black.opacity(0.2), radius: 4, y: 2)
         }
         .dsMinTapTarget()
+        .accessibilityLabel("AI Assistant")
         .accessibilityIdentifier("aiAssistantButton")
         .padding(.trailing, DS.Space.lg)
         .padding(.bottom, bottomPadding)
@@ -764,6 +767,8 @@ struct ModuleHostView: View {
                 } label: {
                     Image(systemName: "person.circle")
                 }
+                .accessibilityLabel("Account and settings")
+                .accessibilityIdentifier("userMenuButton")
             }
         }
         .sheet(isPresented: $showUserMenu) {

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/TabBarEditorView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/TabBarEditorView.swift
@@ -198,6 +198,10 @@ struct TabBarEditorView: View {
                     .foregroundStyle(section == .bottom ? .orange : .green)
             }
             .buttonStyle(.plain)
+            .dsMinTapTarget()
+            .accessibilityLabel(section == .bottom
+                                ? "Move \(module.label) to More menu"
+                                : "Move \(module.label) to tab bar")
         }
         .padding(.vertical, 2)
     }

--- a/Weird Parts IOS/Weird Parts IOS/Scanning/IOSAutoFillBanner.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Scanning/IOSAutoFillBanner.swift
@@ -43,6 +43,7 @@ struct IOSAutoFillBanner: View {
                         .font(.title3)
                         .foregroundStyle(.secondary)
                 }
+                .buttonStyle(.dsIcon)
                 .accessibilityLabel("Dismiss")
             }
 
@@ -64,6 +65,10 @@ struct IOSAutoFillBanner: View {
                                              ? .blue : .secondary)
                     }
                     .buttonStyle(.plain)
+                    .dsMinTapTarget()
+                    .accessibilityLabel(selectedFields.contains(field.id)
+                                        ? "Deselect \(field.label)"
+                                        : "Select \(field.label)")
 
                     // Confidence dot
                     IOSConfidenceIndicator(confidence: field.confidence)
@@ -183,6 +188,8 @@ struct IOSQRAutoFillBanner: View {
                     .font(.title3)
                     .foregroundStyle(.secondary)
             }
+            .buttonStyle(.dsIcon)
+            .accessibilityLabel("Dismiss")
         }
         .padding()
         .background(.ultraThinMaterial)

--- a/Weird Parts IOS/Weird Parts IOS/Scanning/QRLabelPrintSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Scanning/QRLabelPrintSheet.swift
@@ -48,7 +48,10 @@ struct UsedStickerPicker: View {
                         }
                     }
                     .buttonStyle(.plain)
-                    .frame(minHeight: 30)
+                    // 44pt minimum touch target per Apple HIG / issue #1199 —
+                    // dense sticker sheets (e.g. Avery 5167) must stay tappable.
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Rectangle())
                     .disabled(!usedPositions.contains(position) && availablePositionCount <= 1)
                     .accessibilityLabel(usedPositions.contains(position) ? "Position \(position + 1): Used" : "Position \(position + 1): Available")
                     .accessibilityHint(!usedPositions.contains(position) && availablePositionCount <= 1 ? "At least one blank sticker position must remain available to print." : "Double tap to toggle whether this sticker position is already used.")

--- a/Weird Parts IOS/Weird Parts IOS/Shared/FirstVisitHint.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/FirstVisitHint.swift
@@ -25,6 +25,8 @@ struct FirstVisitHint: View {
                     Image(systemName: "xmark")
                         .font(.caption2)
                 }
+                .dsMinTapTarget()
+                .accessibilityLabel("Dismiss hint")
             }
             .padding(10)
             .background(Color.blue.opacity(0.1))

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
@@ -36,6 +36,7 @@ struct IOSPeerBrowser: View {
                         Image(systemName: "arrow.clockwise")
                     }
                     .disabled(syncManager.isScanning)
+                    .accessibilityLabel("Scan again for nearby devices")
                 }
             }
             .onAppear {

--- a/Weird Parts IOS/Weird Parts IOSTests/IconButtonAccessibilityRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/IconButtonAccessibilityRegressionTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+
+/// Regression coverage for GitHub #1184 and #1199.
+///
+/// Icon-only buttons must carry a semantic `.accessibilityLabel` and provide a
+/// 44x44pt minimum touch target. This suite statically scans the files fixed in
+/// the 2026-07 accessibility pass so the specific controls cannot silently lose
+/// their labels or tap targets again.
+final class IconButtonAccessibilityRegressionTests: XCTestCase {
+
+    /// Files audited and fixed under issue #1184. Any icon-only button in these
+    /// files must have an `.accessibilityLabel` within its modifier chain.
+    private static let auditedFiles = [
+        "Navigation/IOSMainView.swift",
+        "Navigation/TabBarEditorView.swift",
+        "Sync/IOSPeerBrowser.swift",
+        "Shared/FirstVisitHint.swift",
+        "Scanning/IOSAutoFillBanner.swift",
+        "Scanning/QRLabelPrintSheet.swift",
+        "Features/Scheduling/IOSDispatchPage.swift",
+        "Features/Orders/IOSReceiveShipmentPage.swift",
+        "Features/Orders/POSendToSupplierSheet.swift",
+        "Features/Parts/PartsSuppliersPage.swift",
+        "Features/Parts/CompanionSandboxSheet.swift",
+        "Features/Warehouse/ZoneGridCanvas.swift",
+    ]
+
+    /// Port of the scanner from issue #1184: a `Button` whose nearby label block
+    /// contains only `Image(systemName:)` (no visible `Text`/`Label`) must have
+    /// an `.accessibilityLabel` in the surrounding window.
+    func testAuditedFilesHaveNoUnlabeledIconOnlyButtons() throws {
+        for relativePath in Self.auditedFiles {
+            let source = try Self.readSource(relativePath)
+            let lines = source.components(separatedBy: "\n")
+            for (index, line) in lines.enumerated() {
+                let isButtonStart = line.range(of: #"Button\s*\{"#, options: .regularExpression) != nil
+                    || line.contains("Button(action:")
+                guard isButtonStart else { continue }
+                let window = lines[index..<min(index + 40, lines.count)].joined(separator: "\n")
+                let looksIconOnly = window.contains("label:")
+                    && window.contains("Image(systemName:")
+                    && !window.contains("Text(")
+                    && !window.contains("Label(")
+                if looksIconOnly {
+                    XCTAssertTrue(
+                        window.contains(".accessibilityLabel"),
+                        "\(relativePath):\(index + 1) — icon-only button without .accessibilityLabel. Add a semantic label (issue #1184)."
+                    )
+                }
+            }
+        }
+    }
+
+    func testUsedStickerPickerKeepsFortyFourPointTouchTargets() throws {
+        let source = try Self.readSource("Scanning/QRLabelPrintSheet.swift")
+
+        XCTAssertTrue(
+            source.contains(".frame(minWidth: 44, minHeight: 44)"),
+            "Used-position sticker buttons must keep a 44x44pt minimum touch target (issue #1199)."
+        )
+        XCTAssertFalse(
+            source.contains(".frame(minHeight: 30)"),
+            "The used-position picker must not regress to sub-44pt touch targets (issue #1199)."
+        )
+        XCTAssertTrue(
+            source.contains(".contentShape(Rectangle())"),
+            "Used-position buttons must hit-test their full 44pt frame, not just the drawn sticker shape."
+        )
+    }
+
+    func testDispatchGridEmptyCellKeepsAccessibleAssignTarget() throws {
+        let source = try Self.readSource("Features/Scheduling/IOSDispatchPage.swift")
+
+        XCTAssertTrue(
+            source.contains(".accessibilityLabel(\"Assign worker\")"),
+            "The dispatch-grid empty day cell must announce itself as an assign action."
+        )
+        XCTAssertTrue(
+            source.contains(".frame(minHeight: 44)"),
+            "The dispatch-grid empty day cell must provide a 44pt hit area (issue #1184)."
+        )
+    }
+
+    func testReceiveShipmentSteppersKeepLabelsAndTapTargets() throws {
+        let source = try Self.readSource("Features/Orders/IOSReceiveShipmentPage.swift")
+
+        XCTAssertTrue(source.contains(".accessibilityLabel(\"Decrease quantity\")"))
+        XCTAssertTrue(source.contains(".accessibilityLabel(\"Increase quantity\")"))
+        XCTAssertGreaterThanOrEqual(
+            source.components(separatedBy: ".dsMinTapTarget()").count - 1, 2,
+            "The received-quantity plus/minus steppers must keep 44pt tap targets (issue #1184)."
+        )
+    }
+
+    func testPartsManagementLineStatusIsVisibleToVoiceOver() throws {
+        let source = try Self.readSource("Features/Orders/IOSPartsOrderManagementPage.swift")
+        let section = try XCTUnwrap(
+            source.range(of: "private func statusIcon").map { String(source[$0.lowerBound...].prefix(1200)) },
+            "statusIcon helper should exist in IOSPartsOrderManagementPage."
+        )
+
+        XCTAssertFalse(
+            section.contains(".accessibilityHidden(true)"),
+            "Line-status icons are the only channel conveying status — they must not be hidden from VoiceOver (issue #1184)."
+        )
+        XCTAssertTrue(section.contains(".accessibilityLabel(\"Status: Received\")"))
+        XCTAssertTrue(section.contains(".accessibilityLabel(\"Status: On backorder\")"))
+        XCTAssertTrue(section.contains(".accessibilityLabel(\"Status: Pending\")"))
+    }
+
+    func testMainViewUserMenuAndAssistantButtonsAreLabeled() throws {
+        let source = try Self.readSource("Navigation/IOSMainView.swift")
+
+        XCTAssertGreaterThanOrEqual(
+            source.components(separatedBy: ".accessibilityLabel(\"Account and settings\")").count - 1, 2,
+            "Both user-menu toolbar buttons (sidebar and tab layouts) must be labeled."
+        )
+        XCTAssertTrue(source.contains(".accessibilityLabel(\"AI Assistant\")"))
+    }
+
+    private static func readSource(_ relativePath: String, file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent(relativePath)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/IconButtonAccessibilityRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/IconButtonAccessibilityRegressionTests.swift
@@ -75,9 +75,31 @@ final class IconButtonAccessibilityRegressionTests: XCTestCase {
             source.contains(".accessibilityLabel(\"Assign worker\")"),
             "The dispatch-grid empty day cell must announce itself as an assign action."
         )
+        // Height: the empty-cell button keeps a 44pt-tall hit area.
         XCTAssertTrue(
-            source.contains(".frame(minHeight: 44)"),
-            "The dispatch-grid empty day cell must provide a 44pt hit area (issue #1184)."
+            source.contains(".frame(minWidth: minDayColumnWidth, minHeight: 44)"),
+            "The dispatch-grid empty day cell must provide a 44x44pt hit area (issue #1184)."
+        )
+        // Width: day columns must never shrink below the 44pt HIG minimum —
+        // dayColumnWidth(forAvailableWidth:) clamps to minDayColumnWidth and
+        // the grid overflows into a horizontal scroller on narrow phones.
+        // Without this, a 390pt iPhone squeezes the 7 shared columns to
+        // ~38pt, silently breaking acceptance criterion 2 of issue #1184.
+        XCTAssertTrue(
+            source.contains("private let minDayColumnWidth: CGFloat = 44"),
+            "The dispatch grid must declare a 44pt minimum day-column width (issue #1184)."
+        )
+        XCTAssertTrue(
+            source.contains("max(minDayColumnWidth, flexibleWidth)"),
+            "dayColumnWidth(forAvailableWidth:) must clamp day columns to the 44pt minimum (issue #1184)."
+        )
+        XCTAssertTrue(
+            source.contains("ScrollView(.horizontal)"),
+            "The dispatch grid must scroll horizontally when 44pt-wide day columns overflow narrow screens (issue #1184)."
+        )
+        XCTAssertFalse(
+            source.contains(".frame(maxWidth: .infinity, minHeight: 24)"),
+            "Day cells must use the clamped fixed column width, not an unconstrained flexible width that can compress below 44pt (issue #1184)."
         )
     }
 

--- a/Weird Parts IOS/Weird Parts IOSTests/OnboardingAX5LayoutRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/OnboardingAX5LayoutRegressionTests.swift
@@ -92,18 +92,26 @@ final class OnboardingAX5LayoutRegressionTests: XCTestCase {
             source.contains("@Environment(\\.dynamicTypeSize) private var dynamicTypeSize"),
             "The post-login walkthrough should read Dynamic Type so it can adapt at AX sizes (issue #1311)."
         )
+
+        let welcomeScreen = try Self.extractSection(
+            from: source,
+            startingAt: "private var welcomeScreen: some View {",
+            upTo: "// MARK: - Step View"
+        )
+
         XCTAssertTrue(
-            source.contains("ScrollView {"),
-            "The walkthrough welcome screen should scroll at AX5 instead of clipping copy and buttons."
+            welcomeScreen.contains("ScrollView {"),
+            "The walkthrough welcome screen should scroll at AX5 instead of clipping copy and buttons (issue #1311)."
         )
         XCTAssertTrue(
-            source.contains(".frame(minHeight: proxy.size.height)"),
+            welcomeScreen.contains(".frame(minHeight: proxy.size.height)"),
             "The welcome screen should keep its centered layout at regular sizes while remaining scrollable."
         )
         XCTAssertTrue(
-            source.contains("if !dynamicTypeSize.isAccessibilitySize {"),
-            "The walkthrough should not spend scarce AX5 vertical space on centering spacers."
+            welcomeScreen.contains("if !dynamicTypeSize.isAccessibilitySize {"),
+            "The welcome screen should not spend scarce AX5 vertical space on centering spacers."
         )
+
         XCTAssertTrue(
             source.contains("HStack(alignment: dynamicTypeSize.isAccessibilitySize ? .top : .center, spacing: 12)"),
             "Key-feature rows should top-align when text wraps at accessibility sizes."
@@ -140,5 +148,28 @@ final class OnboardingAX5LayoutRegressionTests: XCTestCase {
             .appendingPathComponent("Weird Parts IOS")
             .appendingPathComponent(relativePath)
         return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    /// Slices `source` to the substring between `start` (inclusive) and the
+    /// next occurrence of `end` after it, so assertions about a specific
+    /// view/property can't be satisfied by unrelated code elsewhere in the
+    /// file that happens to contain the same snippet.
+    private static func extractSection(
+        from source: String,
+        startingAt start: String,
+        upTo end: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> String {
+        guard let startRange = source.range(of: start) else {
+            XCTFail("Could not locate section start marker '\(start)'", file: file, line: line)
+            return ""
+        }
+        let remainder = source[startRange.upperBound...]
+        guard let endRange = remainder.range(of: end) else {
+            XCTFail("Could not locate section end marker '\(end)' after '\(start)'", file: file, line: line)
+            return ""
+        }
+        return String(remainder[..<endRange.lowerBound])
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/OnboardingAX5LayoutRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/OnboardingAX5LayoutRegressionTests.swift
@@ -85,6 +85,39 @@ final class OnboardingAX5LayoutRegressionTests: XCTestCase {
         )
     }
 
+    func testPostLoginWalkthroughAdaptsToAccessibilityDynamicType() throws {
+        let source = try Self.readSource("Auth/OnboardingWalkthroughView.swift")
+
+        XCTAssertTrue(
+            source.contains("@Environment(\\.dynamicTypeSize) private var dynamicTypeSize"),
+            "The post-login walkthrough should read Dynamic Type so it can adapt at AX sizes (issue #1311)."
+        )
+        XCTAssertTrue(
+            source.contains("ScrollView {"),
+            "The walkthrough welcome screen should scroll at AX5 instead of clipping copy and buttons."
+        )
+        XCTAssertTrue(
+            source.contains(".frame(minHeight: proxy.size.height)"),
+            "The welcome screen should keep its centered layout at regular sizes while remaining scrollable."
+        )
+        XCTAssertTrue(
+            source.contains("if !dynamicTypeSize.isAccessibilitySize {"),
+            "The walkthrough should not spend scarce AX5 vertical space on centering spacers."
+        )
+        XCTAssertTrue(
+            source.contains("HStack(alignment: dynamicTypeSize.isAccessibilitySize ? .top : .center, spacing: 12)"),
+            "Key-feature rows should top-align when text wraps at accessibility sizes."
+        )
+        XCTAssertTrue(
+            source.contains(".fixedSize(horizontal: false, vertical: true)"),
+            "Wrapped walkthrough copy should keep its full vertical height instead of compressing."
+        )
+        XCTAssertTrue(
+            source.contains("navigationFooterButtons(module: module, fullWidth: true)"),
+            "Back/Skip/Next should stack vertically at accessibility sizes so every control stays reachable."
+        )
+    }
+
     func testNotStartedFixtureSuppressesModuleTourForChecklistEvidence() throws {
         let source = try Self.readSource("App/AppCore.swift")
 


### PR DESCRIPTION
Closes #1184
Closes #1199
Closes #1311

Plan: docs/plans/beta-readiness-issue-resolution-2026-07.md §3 Batch M — Accessibility pass.

## What changed

**#1184 — icon-only controls lack labels / 44pt targets (umbrella):**
- `.accessibilityLabel` added to every genuine hit of the issue's scanner: user-menu toolbar buttons (both sidebar and tab layouts) + AI assistant FAB in `IOSMainView`, rescan button in `IOSPeerBrowser`, dismiss button in `FirstVisitHint`, move-section buttons in `TabBarEditorView`, field toggles and both dismiss buttons in `IOSAutoFillBanner`, include-PO toggle in `POSendToSupplierSheet`, edit-supplier toolbar button in `PartsSuppliersPage`, remove-category chips in `CompanionSandboxSheet`, zone resize handle in `ZoneGridCanvas`.
- 44pt touch targets (via `dsMinTapTarget()` / `DSIconButtonStyle` / min frames + `contentShape`) on the FirstVisitHint dismiss, AutoFillBanner controls, receive-shipment quantity steppers, dispatch-grid empty day cells (visual stays 24pt tall, hit area 44pt tall; per review finding, day columns now also clamp to a 44pt minimum WIDTH — the grid header + rows share a horizontal ScrollView that overflows sideways on narrow phones instead of compressing the 7 columns to ~38pt, while iPad/landscape still fills the viewport exactly as before), and tab-bar move buttons. Toolbar-placed buttons rely on the system toolbar target.
- **Thread addition 1 (medium):** `IOSPartsOrderManagementPage` line-status icons no longer `.accessibilityHidden(true)` — they now carry semantic labels ("Status: Received" / "Status: On backorder" / "Status: Pending" / fallback), since they are the sole status channel in the row.
- **Thread addition 2 (low):** `accessibilityIdentifier`s added to primary actions on PO/Orders pages and Parts Catalog (`poCreateButton`, `poScanQRButton`, `userMenuButton`, `completeReceivingButton`, `receiveShipmentScanBarcodeButton`, `partsManagementMoveToPOButton`/`ChangeQty`/`RemoveHold`, `catalogAddPartButton`).
- Regression coverage: new `IconButtonAccessibilityRegressionTests` ports the issue's scanner (40-line window) over the audited files and adds exact static assertions for the fixed controls.

**#1199 — QR label used-position picker sub-44pt targets:**
- `QRLabelPrintSheet` used-position buttons: `.frame(minHeight: 30)` → `.frame(minWidth: 44, minHeight: 44)` + `.contentShape(Rectangle())` so the full frame hit-tests. Grid stays horizontally contained (flexible columns, max 4 columns for Avery 5167). Static regression test asserts the 44pt frame and forbids `minHeight: 30`.

**#1311 — post-login walkthrough ignores Accessibility Dynamic Type:**
- `OnboardingWalkthroughView` now reads `@Environment(\.dynamicTypeSize)`, mirroring the AX5 patterns of `OnboardingWelcomeView`/`ModuleTourView`:
  - welcome screen wrapped in `GeometryReader` + `ScrollView` with `minHeight: proxy.size.height` (keeps regular-size centered layout, scrolls at AX5);
  - centering spacers dropped and decorative icon shrunk at accessibility sizes; wrapped copy gets `.fixedSize(horizontal: false, vertical: true)`;
  - key-feature rows top-align at AX sizes;
  - step footer Back/Skip/Next stack vertically full-width at AX sizes so every control stays reachable; Skip gets a 44pt target.
- Regression test added to `OnboardingAX5LayoutRegressionTests` (`testPostLoginWalkthroughAdaptsToAccessibilityDynamicType`).

## Test evidence
- Review-finding fixup (`558f8d4`): `xcrun swiftc -parse` re-run on `IOSDispatchPage.swift` and `IconButtonAccessibilityRegressionTests.swift` (both pass); the strengthened `testDispatchGridEmptyCellKeepsAccessibleAssignTarget` assertions (44pt column-width clamp, horizontal-overflow strategy, 44x44 button frame, no unconstrained flexible cell width) verified byte-identical against the source via Python, plus the #1184 scanner re-run on the file (0 hits).
- `xcrun swiftc -parse` on all 18 touched Swift files (16 app files + 2 test files): all pass with no diagnostics.
- Issue #1184's original scanner re-run over `Weird Parts IOS/Weird Parts IOS` after the fix: every remaining hit is a verified false positive — either visible `Text` inside the button label (`CategoriesFormSheets:495`, `IOSReceivingPage:181`, `WarehouseMovementsPage:303`, `IOSMainView:601` sidebar row), a doc-comment example (`ButtonStyles.swift:64`), or an `.accessibilityLabel` just beyond the scanner's 16-line window (dispatch/stepper/QR-picker/tab-editor buttons — confirmed present at a 45-line window).
- New/updated XCTest assertions were verified by running byte-identical string checks against the modified sources via Python (all pass, scanner reports 0 failures over the audited file list).
- Not run: full `xcodebuild test` simulator pass for the app test target (fresh worktree, heavy build). `core/` untouched, so the core swift test suite is unaffected.

## Manual verification steps for #1311 (for reviewer/owner)
1. Reset defaults so `hasCompletedOnboarding == false`; log in.
2. Settings → Accessibility → Display & Text Size → Larger Text → AX5.
3. Welcome screen: all copy plus "Let's Get Started" and "Skip Onboarding" reachable by scrolling.
4. Any module step: description/features wrap without truncation; Back/Skip/Next appear stacked full-width and reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
