### PR TITLE
fix(warehouse): Batch G data integrity — dimension validation, verification guards, canonical onboarding stock, quick-audit prompt

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/IOSDashboardQRScannerPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/IOSDashboardQRScannerPage.swift
@@ -33,6 +33,11 @@ struct IOSDashboardQRScannerPage: View {
     @State private var directionResult: WarehouseService.DirectionResult?
     @State private var userPositionAreaId: Int64?
 
+    // "While You're Here" quick audit (#75): low-confidence parts at the
+    // scanned area, offered as an opportunistic ~10-second count.
+    @State private var quickAuditCandidates: [WarehouseService.QuickAuditCandidate] = []
+    @State private var showQuickAuditPrompt = false
+
     // Manual entry
     @State private var manualCode = ""
     @State private var activeSheet: ActiveSheet?
@@ -40,10 +45,12 @@ struct IOSDashboardQRScannerPage: View {
     private enum ActiveSheet: Identifiable {
         case help
         case scannedDetail
+        case quickAudit
         var id: String {
             switch self {
             case .help: return "help"
             case .scannedDetail: return "scannedDetail"
+            case .quickAudit: return "quickAudit"
             }
         }
     }
@@ -130,6 +137,15 @@ struct IOSDashboardQRScannerPage: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+            case .quickAudit:
+                QuickAuditCountSheet(
+                    candidates: quickAuditCandidates,
+                    locationCode: currentLocationInfo?.fullLocationCode ?? ""
+                ) {
+                    quickAuditCandidates = []
+                }
+                .environmentObject(appCore)
+                .presentationDetents([.medium, .large])
             }
         }
         .onAppear {
@@ -264,6 +280,11 @@ struct IOSDashboardQRScannerPage: View {
                 // Location contents (warehouse locations)
                 if result.isLocation, let locInfo = currentLocationInfo {
                     locationContentsSection(locInfo)
+                }
+
+                // "While You're Here" quick audit prompt (#75)
+                if result.isLocation, showQuickAuditPrompt, !quickAuditCandidates.isEmpty {
+                    quickAuditPromptRow
                 }
 
                 // Direction guidance
@@ -600,6 +621,21 @@ struct IOSDashboardQRScannerPage: View {
                     }
                 }
 
+                // "While You're Here" quick audit (#75): being at this area is
+                // the trigger — offer a quick count of its low-confidence
+                // (≤85%) parts, at most once per area per day.
+                var auditCandidates: [WarehouseService.QuickAuditCandidate] = []
+                if let service = appCore.warehouseService,
+                   QuickAuditPromptStore.shouldPrompt(areaId: locationInfo.areaId, userId: appCore.currentUser?.id) {
+                    do {
+                        auditCandidates = try service.getQuickAuditCandidates(areaId: locationInfo.areaId)
+                    } catch {
+                        // Non-critical: the scan result still shows; log so the
+                        // failure is visible instead of silently swallowed.
+                        qrScannerLog.error("getQuickAuditCandidates failed (non-critical): \(error.localizedDescription, privacy: .public)")
+                    }
+                }
+
                 await MainActor.run {
                     currentLocationInfo = locationInfo
                     directionResult = directions
@@ -608,6 +644,18 @@ struct IOSDashboardQRScannerPage: View {
                     lastResult = scanData
                     isProcessing = false
                     if autoLock { isLocked = true }
+                    if !auditCandidates.isEmpty {
+                        quickAuditCandidates = auditCandidates
+                        showQuickAuditPrompt = true
+                        // Mark at display time: "only asks once per area per day".
+                        QuickAuditPromptStore.markPrompted(
+                            areaId: locationInfo.areaId,
+                            userId: appCore.currentUser?.id
+                        )
+                    } else {
+                        quickAuditCandidates = []
+                        showQuickAuditPrompt = false
+                    }
                 }
                 return
             }
@@ -637,6 +685,8 @@ struct IOSDashboardQRScannerPage: View {
             await MainActor.run {
                 currentLocationInfo = nil
                 directionResult = nil
+                quickAuditCandidates = []
+                showQuickAuditPrompt = false
                 currentResult = scanData
                 lastResult = scanData // Remember it
                 isProcessing = false
@@ -786,6 +836,53 @@ struct IOSDashboardQRScannerPage: View {
         }
     }
 
+    // MARK: - "While You're Here" Quick Audit (#75)
+
+    /// Opportunistic quick-count offer shown after scanning a location whose
+    /// parts include low-confidence (≤85%) entries. Asked at most once per
+    /// area per day (gated by `QuickAuditPromptStore`).
+    @ViewBuilder
+    private var quickAuditPromptRow: some View {
+        HStack(spacing: DS.Space.sm) {
+            Image(systemName: "checklist")
+                .foregroundStyle(.orange)
+                .accessibilityHidden(true)
+
+            Text("\(quickAuditCandidates.count) part\(quickAuditCandidates.count == 1 ? "" : "s") here need\(quickAuditCandidates.count == 1 ? "s" : "") a quick count.")
+                .font(.caption)
+                .fontWeight(.medium)
+
+            Spacer()
+
+            Button("Count Now") {
+                showQuickAuditPrompt = false
+                isLocked = true
+                activeSheet = .quickAudit
+            }
+            .font(.caption)
+            .fontWeight(.semibold)
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .tint(.orange)
+            .frame(minHeight: 44)
+
+            Button("Not Now") {
+                showQuickAuditPrompt = false
+                quickAuditCandidates = []
+            }
+            .font(.caption)
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .frame(minHeight: 44)
+        }
+        .padding(.horizontal, DS.Space.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("quick-audit-prompt")
+    }
+
     // MARK: - Direction Guidance
 
     @ViewBuilder
@@ -873,4 +970,178 @@ private struct StockLocation {
 private struct DetailField {
     let key: String
     let value: String
+}
+
+// MARK: - "While You're Here" Quick Audit (#75)
+
+/// Once-per-area-per-day gate for the "While You're Here" quick-audit prompt
+/// (issue #75). Stored in UserDefaults keyed per user so switching operators
+/// on a shared device does not suppress each other's prompts.
+enum QuickAuditPromptStore {
+    static func storageKey(userId: Int64?) -> String {
+        guard let userId else { return "quickAuditPrompts_anonymous" }
+        return "quickAuditPrompts_user_\(userId)"
+    }
+
+    private static func todayString() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date())
+    }
+
+    /// True when the prompt has not been shown for this area today.
+    static func shouldPrompt(areaId: Int64, userId: Int64?) -> Bool {
+        let saved = (UserDefaults.standard.dictionary(forKey: storageKey(userId: userId)) as? [String: String]) ?? [:]
+        return saved["\(areaId)"] != todayString()
+    }
+
+    /// Record that the prompt was shown for this area today. Stale entries
+    /// from previous days are dropped so the dictionary stays small.
+    static func markPrompted(areaId: Int64, userId: Int64?) {
+        let today = todayString()
+        var saved = (UserDefaults.standard.dictionary(forKey: storageKey(userId: userId)) as? [String: String]) ?? [:]
+        saved = saved.filter { $0.value == today }
+        saved["\(areaId)"] = today
+        UserDefaults.standard.set(saved, forKey: storageKey(userId: userId))
+    }
+}
+
+/// Quick-count entry sheet for the "While You're Here" audit (#75).
+///
+/// Lists the low-confidence parts at the scanned area with a count field
+/// each. System counts stay hidden while counting (audit rule). Submitting
+/// records each entered count via `recordQuickVerificationCount`, which
+/// resets confidence to 100% and clears the movement decay factor.
+private struct QuickAuditCountSheet: View {
+    @EnvironmentObject private var appCore: AppCore
+    @Environment(\.dismiss) private var dismiss
+
+    let candidates: [WarehouseService.QuickAuditCandidate]
+    let locationCode: String
+    let onFinished: () -> Void
+
+    @State private var countsText: [Int64: String] = [:]
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    private var enteredCounts: [(candidate: WarehouseService.QuickAuditCandidate, qty: Int)] {
+        candidates.compactMap { candidate in
+            guard let text = countsText[candidate.partId]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !text.isEmpty, let qty = Int(text), qty >= 0 else { return nil }
+            return (candidate, qty)
+        }
+    }
+
+    private var hasInvalidEntry: Bool {
+        candidates.contains { candidate in
+            guard let text = countsText[candidate.partId]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !text.isEmpty else { return false }
+            guard let qty = Int(text) else { return true }
+            return qty < 0
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Text("Count what you physically see for each part. Leave a part blank to skip it.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    if !locationCode.isEmpty {
+                        Text("Quick count at \(locationCode)")
+                    } else {
+                        Text("Quick count")
+                    }
+                }
+
+                Section("Parts") {
+                    ForEach(candidates) { candidate in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(candidate.partName)
+                                    .font(.subheadline)
+                                if let code = candidate.partCode, !code.isEmpty {
+                                    Text(code)
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            Spacer()
+                            // Audit rule: the system count stays hidden while
+                            // the user counts, so it is deliberately not shown.
+                            TextField("Count", text: Binding(
+                                get: { countsText[candidate.partId] ?? "" },
+                                set: { countsText[candidate.partId] = $0 }
+                            ))
+                            .keyboardType(.numberPad)
+                            .multilineTextAlignment(.trailing)
+                            .frame(width: 80, height: 44)
+                            .textFieldStyle(.roundedBorder)
+                            .accessibilityLabel("Count for \(candidate.partName)")
+                        }
+                    }
+                }
+
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Quick Audit")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Submit") { submit() }
+                            .fontWeight(.semibold)
+                            .disabled(enteredCounts.isEmpty || hasInvalidEntry)
+                    }
+                }
+            }
+            .interactiveDismissDisabled(isSaving)
+        }
+    }
+
+    private func submit() {
+        guard let service = appCore.warehouseService,
+              let userId = appCore.currentUser?.id else {
+            errorMessage = "Service or user unavailable."
+            return
+        }
+        guard hasInvalidEntry == false else {
+            errorMessage = "Counts must be whole numbers of zero or more."
+            return
+        }
+
+        isSaving = true
+        errorMessage = nil
+        do {
+            for entry in enteredCounts {
+                _ = try service.recordQuickVerificationCount(
+                    partId: entry.candidate.partId,
+                    areaId: entry.candidate.areaId,
+                    countedQuantity: entry.qty,
+                    verifiedBy: userId
+                )
+            }
+            isSaving = false
+            dismiss()
+            onFinished()
+        } catch {
+            isSaving = false
+            errorMessage = userFriendlyError(error, context: "save quick audit counts")
+        }
+    }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
@@ -160,6 +160,7 @@ struct IOSAuditPage: View {
                 loadData()
             }
             .environmentObject(appCore)
+            .presentationDetents([.medium, .large])
         }
         .alert("Error", isPresented: Binding(
             get: { actionError != nil },

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/PartsFlowWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/PartsFlowWizard.swift
@@ -564,7 +564,8 @@ struct PartsFlowWizard: View {
         guard validateBeforeSaving() else { return }
         isSaving = true
 
-        guard let service = appCore.partsService else {
+        guard let service = appCore.partsService,
+              let warehouseService = appCore.warehouseService else {
             isSaving = false
             saveErrorMessage = "Parts service unavailable. Your draft is still saved on this device."
             return
@@ -581,22 +582,27 @@ struct PartsFlowWizard: View {
                 var failedParts: [String] = []
                 for item in snapshot {
                     guard let partId = item.part.id else { continue }
-                    var notesParts: [String] = []
-                    if let location = locations[partId]?.trimmingCharacters(in: .whitespacesAndNewlines),
-                       !location.isEmpty {
-                        notesParts.append("Location: \(location)")
-                    }
-                    if let qty = Self.validQuantity(from: counts[partId]) {
-                        notesParts.append("Initial count: \(qty)")
-                    }
-                    if !notesParts.isEmpty {
-                        let combined = notesParts.joined(separator: " | ")
-                        do {
-                            try service.updatePart(id: partId, notes: combined)
-                            savedEntries += 1
-                        } catch {
-                            failedParts.append(item.part.name)
+                    var didPersistEntry = false
+                    do {
+                        // Issue #91: persist to canonical records instead of
+                        // concatenating "Location: X | Initial count: N" into
+                        // the part's free-text notes field.
+                        if let location = locations[partId]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                           !location.isEmpty {
+                            try service.updatePart(id: partId, shelfLocation: location)
+                            didPersistEntry = true
                         }
+                        if let qty = Self.validQuantity(from: counts[partId]) {
+                            // Upserts the warehouse stock row and records a
+                            // traceable adjustment movement.
+                            _ = try warehouseService.recordPartsFirstSetupCount(
+                                partId: partId, countedQty: qty, performedBy: userId
+                            )
+                            didPersistEntry = true
+                        }
+                        if didPersistEntry { savedEntries += 1 }
+                    } catch {
+                        failedParts.append(item.part.name)
                     }
                 }
                 return (savedEntries: savedEntries, failedParts: failedParts)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/PartsFlowWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/PartsFlowWizard.swift
@@ -567,7 +567,12 @@ struct PartsFlowWizard: View {
         guard let service = appCore.partsService,
               let warehouseService = appCore.warehouseService else {
             isSaving = false
-            saveErrorMessage = "Parts service unavailable. Your draft is still saved on this device."
+            saveErrorMessage = "Parts or warehouse service unavailable. Your draft is still saved on this device."
+            return
+        }
+        guard let performedBy = userId else {
+            isSaving = false
+            saveErrorMessage = "Not logged in. Your draft is still saved on this device."
             return
         }
 
@@ -596,7 +601,7 @@ struct PartsFlowWizard: View {
                             // Upserts the warehouse stock row and records a
                             // traceable adjustment movement.
                             _ = try warehouseService.recordPartsFirstSetupCount(
-                                partId: partId, countedQty: qty, performedBy: userId
+                                partId: partId, countedQty: qty, performedBy: performedBy
                             )
                             didPersistEntry = true
                         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseLocationsPage.swift
@@ -1058,7 +1058,9 @@ private struct AddStorageUnitSheet: View {
             onCreated()
             dismiss()
         } catch {
-            self.error = userFriendlyError(error, context: "load locations")
+            // Issue #1165: surface service-layer dimension/placement
+            // rejections inline so the sheet stays open for correction.
+            self.error = userFriendlyError(error, context: "create storage unit")
         }
     }
 }
@@ -1187,7 +1189,8 @@ private struct EditStorageUnitSheet: View {
             onUpdated()
             dismiss()
         } catch {
-            self.error = userFriendlyError(error, context: "load locations")
+            // Issue #1165: surface service-layer placement rejections inline.
+            self.error = userFriendlyError(error, context: "update storage unit")
         }
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Shared/UserFriendlyError.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/UserFriendlyError.swift
@@ -23,13 +23,27 @@ func userFriendlyError(_ error: Error, context: String = "load data") -> String 
         return "A saved clock entry has an invalid timestamp. Ask an admin to review the timesheet before using today's hours."
     }
 
-    if let warehouseError = error as? WarehouseService.WarehouseError,
-       case .gridShrinkWouldOrphanItems(let features, let zones) = warehouseError {
-        // Fixed counts only — no row contents (see security note above).
-        var stranded: [String] = []
-        if features > 0 { stranded.append("\(features) feature\(features == 1 ? "" : "s")") }
-        if zones > 0 { stranded.append("\(zones) zone\(zones == 1 ? "" : "s")") }
-        return "Can't shrink the grid: \(stranded.joined(separator: " and ")) would fall outside the new size. Move or remove them first."
+    if let warehouseError = error as? WarehouseService.WarehouseError {
+        switch warehouseError {
+        case .gridShrinkWouldOrphanItems(let features, let zones):
+            // Fixed counts only — no row contents (see security note above).
+            var stranded: [String] = []
+            if features > 0 { stranded.append("\(features) feature\(features == 1 ? "" : "s")") }
+            if zones > 0 { stranded.append("\(zones) zone\(zones == 1 ? "" : "s")") }
+            return "Can't shrink the grid: \(stranded.joined(separator: " and ")) would fall outside the new size. Move or remove them first."
+        case .invalidDimension:
+            // Issue #1165: service-layer dimension/placement validation.
+            // Fixed string — no dimension values from the failed input.
+            return "Dimensions and grid placement must be positive and fit inside the floor-plan grid."
+        case .noEligibleVerificationCounters(let required, let available):
+            // Issue #494: fixed counts only — no user names or part data.
+            return "Not enough eligible counters: \(required) needed, \(available) available besides you. Add active users or lower the required count."
+        case .partAlreadyFlaggedForVerification:
+            // Issue #494: fixed string — no part identifiers (see security note).
+            return "This part is already out for verification. Wait for those counts to be resolved before sending it again."
+        default:
+            break
+        }
     }
 
     let raw = error.localizedDescription

--- a/Weird Parts IOS/Weird Parts IOS/Shared/UserFriendlyError.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/UserFriendlyError.swift
@@ -40,7 +40,9 @@ func userFriendlyError(_ error: Error, context: String = "load data") -> String 
             return "Not enough eligible counters: \(required) needed, \(available) available besides you. Add active users or lower the required count."
         case .partAlreadyFlaggedForVerification:
             // Issue #494: fixed string — no part identifiers (see security note).
-            return "This part is already out for verification. Wait for those counts to be resolved before sending it again."
+            // Only thrown while counts are still coming in or a consensus is
+            // waiting to be resolved — dead-end sets are superseded instead.
+            return "This part is already out for verification. Wait for the counts to come in, or resolve the submitted counts, before sending it again."
         default:
             break
         }

--- a/Weird Parts IOS/Weird Parts IOS/Shared/UserFriendlyError.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/UserFriendlyError.swift
@@ -34,7 +34,8 @@ func userFriendlyError(_ error: Error, context: String = "load data") -> String 
         case .invalidDimension:
             // Issue #1165: service-layer dimension/placement validation.
             // Fixed string — no dimension values from the failed input.
-            return "Dimensions and grid placement must be positive and fit inside the floor-plan grid."
+            // Width/height must be positive; grid X/Y must be non-negative (0 is valid).
+            return "Dimensions must be positive, and grid placement must be zero or greater, and fit inside the floor-plan grid."
         case .noEligibleVerificationCounters(let required, let available):
             // Issue #494: fixed counts only — no user names or part data.
             return "Not enough eligible counters: \(required) needed, \(available) available besides you. Add active users or lower the required count."

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -7100,9 +7100,13 @@ public final class WarehouseService: Sendable {
     ///   - requiredCounts: Number of independent counts needed (default 2, max 3).
     /// - Returns: The created assignments.
     /// - Throws: `WarehouseError.partAlreadyFlaggedForVerification` when the
-    ///   part already has unresolved assignments for this session, and
+    ///   part already has an assignment set for this session that is still
+    ///   collecting counts or can still reach consensus, and
     ///   `WarehouseError.noEligibleVerificationCounters` when fewer eligible
-    ///   active counters exist than requested (issue #494).
+    ///   active counters exist than requested (issue #494). Fully-counted
+    ///   sets whose counts cannot reach consensus — and session-less sets,
+    ///   which `resolveMultiUserAudit` can never touch — are marked
+    ///   `superseded` and re-flagged instead of blocking forever.
     @discardableResult
     public func flagForMultiUserAudit(
         partId: Int64,
@@ -7112,12 +7116,17 @@ public final class WarehouseService: Sendable {
         requiredCounts: Int = 2
     ) throws -> [MultiUserAuditAssignment] {
         try db.writer.write { dbConn in
-            // Issue #494: block duplicate flagging. An unresolved assignment
-            // set (pending or counted) for the same part/session means the
-            // part is already out for verification — inserting more rows
-            // would create duplicate work assignments.
+            // Issue #494: block duplicate flagging while verification is
+            // genuinely in flight — counters still pending, or submitted
+            // counts that can reach consensus and just await resolution.
+            //
+            // PR #1364 review: a fully-counted set whose counts disagree is
+            // a dead end — resolveMultiUserAudit returns nil and leaves the
+            // rows 'counted' — and session-less sets have no resolution path
+            // at all. Blocking those made the part permanently un-flaggable,
+            // so dead-end sets are superseded and the re-flag proceeds.
             var dupSql = """
-                SELECT COUNT(*) FROM multi_user_audit_assignments
+                SELECT * FROM multi_user_audit_assignments
                 WHERE part_id = ? AND status IN ('pending', 'counted')
                 """
             var dupArgs: [DatabaseValueConvertible?] = [partId]
@@ -7127,11 +7136,25 @@ public final class WarehouseService: Sendable {
             } else {
                 dupSql += " AND audit_session_id IS NULL"
             }
-            let unresolvedCount = try Int.fetchOne(
+            let unresolved = try MultiUserAuditAssignment.fetchAll(
                 dbConn, sql: dupSql, arguments: StatementArguments(dupArgs)
-            ) ?? 0
-            guard unresolvedCount == 0 else {
-                throw WarehouseError.partAlreadyFlaggedForVerification(partId: partId)
+            )
+            if !unresolved.isEmpty {
+                let stillCollecting = unresolved.contains { $0.status == "pending" }
+                // Session-less sets can never be resolved (resolution
+                // requires a session), so a fully-counted one is always a
+                // dead end regardless of whether the counts agree.
+                let resolvable = sessionId != nil && Self.consensusIsReachable(unresolved)
+                if stillCollecting || resolvable {
+                    throw WarehouseError.partAlreadyFlaggedForVerification(partId: partId)
+                }
+                // Dead end: every counter submitted but no consensus is
+                // possible. Supersede the stale rows (preserving them for
+                // history) so this retry can create a fresh assignment set.
+                for var assignment in unresolved {
+                    assignment.status = "superseded"
+                    try assignment.update(dbConn)
+                }
             }
 
             // Get part info
@@ -7251,7 +7274,9 @@ public final class WarehouseService: Sendable {
     public func getMultiUserAuditAssignments(sessionId: Int64? = nil) throws -> [MultiUserAuditPartSummary] {
         do {
             return try db.writer.read { dbConn -> [MultiUserAuditPartSummary] in
-                var whereClauses = ["1=1"]
+                // Superseded rows are dead assignment sets replaced by a
+                // re-flag — history only, never active work.
+                var whereClauses = ["status != 'superseded'"]
                 var args: [DatabaseValueConvertible?] = []
 
                 if let sessionId {
@@ -7350,9 +7375,12 @@ public final class WarehouseService: Sendable {
                 SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL AND is_active = 1
                 """, arguments: [resolvedBy]) ?? 0) > 0
             guard userExists else { throw WarehouseError.userNotFound(resolvedBy) }
-            // Get all assignments for this part in this session
+            // Get all assignments for this part in this session, skipping
+            // superseded rows (dead sets replaced by a re-flag) so an old
+            // failed set never pollutes the consensus of its replacement.
             let assignments = try MultiUserAuditAssignment
-                .filter(Column("part_id") == partId && Column("audit_session_id") == sessionId)
+                .filter(Column("part_id") == partId && Column("audit_session_id") == sessionId
+                    && Column("status") != "superseded")
                 .fetchAll(dbConn)
 
             let countedAssignments = assignments.filter { $0.status == "counted" }
@@ -7505,6 +7533,23 @@ public final class WarehouseService: Sendable {
     }
 
     // MARK: - Helpers (Audit)
+
+    /// Whether an unresolved assignment set's submitted counts can still
+    /// reach consensus under the same rules `resolveMultiUserAudit` applies:
+    /// at least 2 counts, 2 counters must agree exactly, 3+ need a count
+    /// with a majority (>= 2 votes). Pending assignments are the caller's
+    /// concern — this only judges the counted rows.
+    private static func consensusIsReachable(_ assignments: [MultiUserAuditAssignment]) -> Bool {
+        let counted = assignments.filter { $0.status == "counted" }
+        guard counted.count >= 2 else { return false }
+        let counts = counted.compactMap { $0.countedQuantity }
+        // A counted row missing its quantity makes consensus impossible
+        // (mirrors the resolveMultiUserAudit guard).
+        guard counts.count == counted.count else { return false }
+        if counts.count == 2 { return counts[0] == counts[1] }
+        let countFreq = counts.reduce(into: [Int: Int]()) { $0[$1, default: 0] += 1 }
+        return (countFreq.values.max() ?? 0) >= 2
+    }
 
     private static func clampedConfidence(_ percent: Double, counted: Bool) -> Double {
         let lowerBound = counted ? minimumCountedConfidencePercent : 0

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -2789,10 +2789,12 @@ public final class WarehouseService: Sendable {
     public func recordPartsFirstSetupCount(
         partId: Int64,
         countedQty: Int,
-        performedBy: Int64? = nil
+        performedBy: Int64
     ) throws -> Int {
         guard countedQty >= 0 else { throw WarehouseError.invalidQuantity }
         return try db.writer.write { dbConn in
+            try Self.requireActiveUser(performedBy, dbConn: dbConn)
+
             let partExists = (try Int.fetchOne(dbConn, sql: """
                 SELECT COUNT(*) FROM parts WHERE id = ? AND deleted_at IS NULL
                 """, arguments: [partId]) ?? 0) > 0

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -44,6 +44,14 @@ public final class WarehouseService: Sendable {
         /// A grid shrink would leave existing floor features/zones outside
         /// the new bounds (issue #1240). Counts identify how many of each.
         case gridShrinkWouldOrphanItems(features: Int, zones: Int)
+        /// Multi-user verification cannot proceed because there are not
+        /// enough eligible active counters after excluding the flagging
+        /// operator (issue #494).
+        case noEligibleVerificationCounters(required: Int, available: Int)
+        /// The part already has unresolved multi-user verification
+        /// assignments for this session (issue #494) — flagging it again
+        /// would create duplicate work assignments.
+        case partAlreadyFlaggedForVerification(partId: Int64)
     }
 
     // =========================================================================
@@ -2766,6 +2774,73 @@ public final class WarehouseService: Sendable {
         }
     }
 
+    /// Persist a parts-first (Parts Flow wizard) onboarding count to the
+    /// canonical stock records (issue #91).
+    ///
+    /// Unlike `adjustAuditCount`, this upserts the general warehouse stock
+    /// row (`location_type = 'warehouse'`, `location_id = 1`) because the
+    /// parts-first path runs before any floor plan or stock rows exist, and
+    /// it does not require audit permission — it is an onboarding count, not
+    /// an audit correction. A signed adjustment movement is recorded whenever
+    /// the quantity changes so the count is traceable in movement history.
+    ///
+    /// - Returns: The quantity delta applied to the stock record.
+    @discardableResult
+    public func recordPartsFirstSetupCount(
+        partId: Int64,
+        countedQty: Int,
+        performedBy: Int64? = nil
+    ) throws -> Int {
+        guard countedQty >= 0 else { throw WarehouseError.invalidQuantity }
+        return try db.writer.write { dbConn in
+            let partExists = (try Int.fetchOne(dbConn, sql: """
+                SELECT COUNT(*) FROM parts WHERE id = ? AND deleted_at IS NULL
+                """, arguments: [partId]) ?? 0) > 0
+            guard partExists else { throw WarehouseError.partNotFound(partId) }
+
+            let currentQty = try Int.fetchOne(dbConn, sql: """
+                SELECT qty FROM stock
+                WHERE part_id = ? AND location_type = 'warehouse' AND location_id = 1
+                  AND deleted_at IS NULL
+                """, arguments: [partId])
+
+            if currentQty != nil {
+                try dbConn.execute(sql: """
+                    UPDATE stock
+                    SET qty = ?, counted_qty = ?, last_counted = datetime('now'),
+                        updated_at = datetime('now')
+                    WHERE part_id = ? AND location_type = 'warehouse' AND location_id = 1
+                      AND deleted_at IS NULL
+                    """, arguments: [countedQty, countedQty, partId])
+            } else {
+                try dbConn.execute(sql: """
+                    INSERT INTO stock
+                        (part_id, location_type, location_id, qty, counted_qty, last_counted, updated_at)
+                    VALUES (?, 'warehouse', 1, ?, ?, datetime('now'), datetime('now'))
+                    """, arguments: [partId, countedQty, countedQty])
+            }
+
+            let delta = countedQty - (currentQty ?? 0)
+            guard delta != 0 else { return 0 }
+            let signedDelta = delta >= 0 ? "+\(delta)" : "\(delta)"
+            try dbConn.execute(sql: """
+                INSERT INTO stock_movements
+                    (part_id, qty, from_location_type, from_location_id,
+                     to_location_type, to_location_id, movement_type,
+                     reason, notes, performed_by, created_at)
+                VALUES (?, ?, 'warehouse', 1, 'warehouse', 1,
+                        '\(StockMovement.MovementType.adjustment.rawValue)', ?, ?, ?, datetime('now'))
+                """, arguments: [
+                    partId,
+                    delta,
+                    "Parts-first setup count",
+                    "Initial count: \(currentQty ?? 0) -> \(countedQty) (\(signedDelta))",
+                    performedBy,
+                ])
+            return delta
+        }
+    }
+
     /// Record an audit recount for a part at a specific location.
     public func recordAuditRecount(partId: Int64, locationType: String, locationId: Int64) throws {
         try db.writer.write { dbConn in
@@ -4903,7 +4978,28 @@ public final class WarehouseService: Sendable {
         guard !name.isBlankRequiredText else {
             throw WarehouseError.requiredFieldEmpty
         }
+        // Issue #1165: reject impossible physical/grid geometry at the service
+        // boundary, mirroring the zone/floor-feature validation approach.
+        if let widthInches, widthInches <= 0 { throw WarehouseError.invalidDimension }
+        if let depthInches, depthInches <= 0 { throw WarehouseError.invalidDimension }
+        if let heightInches, heightInches <= 0 { throw WarehouseError.invalidDimension }
+        if let gridX, gridX < 0 { throw WarehouseError.invalidDimension }
+        if let gridY, gridY < 0 { throw WarehouseError.invalidDimension }
+        if let gridWidth, gridWidth <= 0 { throw WarehouseError.invalidDimension }
+        if let gridHeight, gridHeight <= 0 { throw WarehouseError.invalidDimension }
         return try db.writer.write { dbConn in
+            // Issue #1165: when the unit is placed on the grid and the floor
+            // plan has saved grid bounds, the footprint must fit inside them.
+            if gridX != nil || gridY != nil || gridWidth != nil || gridHeight != nil {
+                let floorPlan = try WarehouseFloorPlan.fetchOne(dbConn, key: floorPlanId)
+                try validateFloorPlanGridPlacement(
+                    floorPlan: floorPlan,
+                    gridX: gridX ?? 0,
+                    gridY: gridY ?? 0,
+                    gridWidth: gridWidth ?? 1,
+                    gridHeight: gridHeight ?? 1
+                )
+            }
             var unit = WarehouseStorageUnit(
                 floorPlanId: floorPlanId,
                 name: name,
@@ -4950,10 +5046,28 @@ public final class WarehouseService: Sendable {
         if let name, name.isBlankRequiredText {
             throw WarehouseError.requiredFieldEmpty
         }
+        // Issue #1165: same grid-geometry guards as addStorageUnit.
+        if let gridX, gridX < 0 { throw WarehouseError.invalidDimension }
+        if let gridY, gridY < 0 { throw WarehouseError.invalidDimension }
+        if let gridWidth, gridWidth <= 0 { throw WarehouseError.invalidDimension }
+        if let gridHeight, gridHeight <= 0 { throw WarehouseError.invalidDimension }
 
         try db.writer.write { dbConn in
             guard var unit = try WarehouseStorageUnit.fetchOne(dbConn, key: id),
                   unit.deletedAt == nil else { return }
+            // Issue #1165: re-validate placement against the floor-plan grid
+            // bounds only when a placement field is actually changing, so
+            // unrelated updates (rename, configure) never trip on legacy rows.
+            if gridX != nil || gridY != nil || gridWidth != nil || gridHeight != nil {
+                let floorPlan = try WarehouseFloorPlan.fetchOne(dbConn, key: unit.floorPlanId)
+                try validateFloorPlanGridPlacement(
+                    floorPlan: floorPlan,
+                    gridX: gridX ?? unit.gridX ?? 0,
+                    gridY: gridY ?? unit.gridY ?? 0,
+                    gridWidth: gridWidth ?? unit.gridWidth ?? 1,
+                    gridHeight: gridHeight ?? unit.gridHeight ?? 1
+                )
+            }
             if let name = name { unit.name = name }
             if let unitType = unitType { unit.unitType = unitType }
             if let rowNumber = rowNumber { unit.rowNumber = rowNumber }
@@ -6100,6 +6214,66 @@ public final class WarehouseService: Sendable {
         return confidence.confidencePercent <= Self.quickVerificationTriggerConfidencePercent
     }
 
+    /// A part at an area that qualifies for a "While You're Here" quick audit
+    /// (issue #75): confidence at or below the quick-verification trigger.
+    public struct QuickAuditCandidate: Sendable, Identifiable {
+        public let partId: Int64
+        public let areaId: Int64
+        public let partName: String
+        public let partCode: String?
+        public let confidencePercent: Double
+        public let systemCount: Int
+
+        public var id: Int64 { partId }
+
+        public init(
+            partId: Int64, areaId: Int64, partName: String, partCode: String?,
+            confidencePercent: Double, systemCount: Int
+        ) {
+            self.partId = partId
+            self.areaId = areaId
+            self.partName = partName
+            self.partCode = partCode
+            self.confidencePercent = confidencePercent
+            self.systemCount = systemCount
+        }
+    }
+
+    /// "While You're Here" quick-audit candidates for an area (issue #75).
+    ///
+    /// Returns parts stored at `areaId` whose confidence is at or below the
+    /// quick-verification trigger (85%), lowest confidence first. Used to
+    /// offer an opportunistic ~10-second count when a user is physically at
+    /// an area for another task (e.g. after scanning its location QR).
+    public func getQuickAuditCandidates(areaId: Int64, limit: Int = 20) throws -> [QuickAuditCandidate] {
+        do {
+            return try db.writer.read { dbConn in
+                let rows = try Row.fetchAll(dbConn, sql: """
+                    SELECT pc.part_id, pc.area_id, pc.confidence_percent, pc.system_count,
+                           p.name AS part_name, p.code AS part_code
+                    FROM part_confidence pc
+                    JOIN parts p ON p.id = pc.part_id AND p.deleted_at IS NULL
+                    WHERE pc.area_id = ? AND pc.confidence_percent <= ?
+                    ORDER BY pc.confidence_percent ASC, p.name ASC
+                    LIMIT ?
+                    """, arguments: [areaId, Self.quickVerificationTriggerConfidencePercent, limit])
+                return rows.map { row in
+                    QuickAuditCandidate(
+                        partId: row["part_id"] as Int64,
+                        areaId: row["area_id"] as Int64,
+                        partName: (row["part_name"] as String?) ?? "Unknown Part",
+                        partCode: row["part_code"] as String?,
+                        confidencePercent: row["confidence_percent"] as Double,
+                        systemCount: (row["system_count"] as Int?) ?? 0
+                    )
+                }
+            }
+        } catch {
+            if isTableNotFoundError(error) { return [] }
+            throw error
+        }
+    }
+
     @discardableResult
     public func recordQuickVerificationCount(
         partId: Int64,
@@ -6925,6 +7099,10 @@ public final class WarehouseService: Sendable {
     ///   - flaggedBy: The user who flagged the discrepancy (excluded from assignments).
     ///   - requiredCounts: Number of independent counts needed (default 2, max 3).
     /// - Returns: The created assignments.
+    /// - Throws: `WarehouseError.partAlreadyFlaggedForVerification` when the
+    ///   part already has unresolved assignments for this session, and
+    ///   `WarehouseError.noEligibleVerificationCounters` when fewer eligible
+    ///   active counters exist than requested (issue #494).
     @discardableResult
     public func flagForMultiUserAudit(
         partId: Int64,
@@ -6934,6 +7112,28 @@ public final class WarehouseService: Sendable {
         requiredCounts: Int = 2
     ) throws -> [MultiUserAuditAssignment] {
         try db.writer.write { dbConn in
+            // Issue #494: block duplicate flagging. An unresolved assignment
+            // set (pending or counted) for the same part/session means the
+            // part is already out for verification — inserting more rows
+            // would create duplicate work assignments.
+            var dupSql = """
+                SELECT COUNT(*) FROM multi_user_audit_assignments
+                WHERE part_id = ? AND status IN ('pending', 'counted')
+                """
+            var dupArgs: [DatabaseValueConvertible?] = [partId]
+            if let sessionId {
+                dupSql += " AND audit_session_id = ?"
+                dupArgs.append(sessionId)
+            } else {
+                dupSql += " AND audit_session_id IS NULL"
+            }
+            let unresolvedCount = try Int.fetchOne(
+                dbConn, sql: dupSql, arguments: StatementArguments(dupArgs)
+            ) ?? 0
+            guard unresolvedCount == 0 else {
+                throw WarehouseError.partAlreadyFlaggedForVerification(partId: partId)
+            }
+
             // Get part info
             let partRow = try Row.fetchOne(dbConn, sql: """
                 SELECT p.name, COALESCE(wpa.area_id, 0) AS area_id,
@@ -6957,6 +7157,10 @@ public final class WarehouseService: Sendable {
                 userArgs.append(flaggedBy)
             }
 
+            // Multi-user consensus needs at least 2 independent counters and
+            // caps at 3 (issue #494).
+            let neededCounters = min(max(requiredCounts, 2), 3)
+
             let userRows = try Row.fetchAll(dbConn, sql: """
                 SELECT u.id, COALESCE(u.display_name, u.email, 'User') AS name,
                        COALESCE(uwr.accuracy_rating, 5.0) AS accuracy
@@ -6966,7 +7170,16 @@ public final class WarehouseService: Sendable {
                     \(excludeClause)
                 ORDER BY COALESCE(uwr.accuracy_rating, 5.0) DESC
                 LIMIT ?
-                """, arguments: StatementArguments(userArgs + [min(requiredCounts, 3)]))
+                """, arguments: StatementArguments(userArgs + [neededCounters]))
+
+            // Issue #494: fail loudly instead of silently creating fewer (or
+            // zero) assignments when not enough eligible counters exist.
+            guard userRows.count >= neededCounters else {
+                throw WarehouseError.noEligibleVerificationCounters(
+                    required: neededCounters,
+                    available: userRows.count
+                )
+            }
 
             var assignments: [MultiUserAuditAssignment] = []
 

--- a/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
@@ -1267,6 +1267,160 @@ struct WarehouseAuditTests {
         #expect(second.count == 2)
     }
 
+    @Test("flagForMultiUserAudit supersedes a dead-end set when counts disagree")
+    func testFlagForMultiUserAuditReflagAfterConsensusFailure() throws {
+        let env = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10)
+
+        let session = try env.warehouse.startAuditSession(startedBy: env.adminUserId)
+        let sessionId = session.id!
+        _ = try env.auth.createUser(displayName: "Counter Two", pin: "5678")
+
+        let first = try env.warehouse.flagForMultiUserAudit(
+            partId: partId, expectedQty: 10, sessionId: sessionId,
+            flaggedBy: nil, requiredCounts: 2
+        )
+        // Two counters disagree — consensus is impossible for this set.
+        try env.warehouse.submitMultiUserCount(
+            assignmentId: first[0].id!, quantity: 8, userId: first[0].assignedUserId
+        )
+        try env.warehouse.submitMultiUserCount(
+            assignmentId: first[1].id!, quantity: 12, userId: first[1].assignedUserId
+        )
+        let failed = try env.warehouse.resolveMultiUserAudit(
+            partId: partId, sessionId: sessionId, resolvedBy: env.adminUserId
+        )
+        #expect(failed == nil)
+
+        // PR #1364 review: this used to throw partAlreadyFlaggedForVerification
+        // forever. The dead-end set must be superseded and re-flag allowed.
+        let second = try env.warehouse.flagForMultiUserAudit(
+            partId: partId, expectedQty: 10, sessionId: sessionId,
+            flaggedBy: nil, requiredCounts: 2
+        )
+        #expect(second.count == 2)
+        #expect(second.allSatisfy { $0.status == "pending" })
+
+        // Old rows survive as history, marked superseded.
+        let superseded = try env.db.writer.read { dbConn in
+            try Int.fetchOne(dbConn, sql: """
+                SELECT COUNT(*) FROM multi_user_audit_assignments
+                WHERE part_id = ? AND status = 'superseded'
+                """, arguments: [partId]) ?? 0
+        }
+        #expect(superseded == 2)
+
+        // The summary only shows the fresh set.
+        let grouped = try env.warehouse.getMultiUserAuditAssignments(sessionId: sessionId)
+        #expect(grouped.count == 1)
+        #expect(grouped[0].assignments.count == 2)
+
+        // The replacement set resolves normally — superseded rows must not
+        // pollute its consensus.
+        try env.warehouse.submitMultiUserCount(
+            assignmentId: second[0].id!, quantity: 9, userId: second[0].assignedUserId
+        )
+        try env.warehouse.submitMultiUserCount(
+            assignmentId: second[1].id!, quantity: 9, userId: second[1].assignedUserId
+        )
+        let resolved = try env.warehouse.resolveMultiUserAudit(
+            partId: partId, sessionId: sessionId, resolvedBy: env.adminUserId
+        )
+        #expect(resolved == 9)
+    }
+
+    @Test("flagForMultiUserAudit still blocks while submitted counts can reach consensus")
+    func testFlagForMultiUserAuditBlocksWhileConsensusReachable() throws {
+        let env = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10)
+
+        let session = try env.warehouse.startAuditSession(startedBy: env.adminUserId)
+        let sessionId = session.id!
+        _ = try env.auth.createUser(displayName: "Counter Two", pin: "5678")
+
+        let assignments = try env.warehouse.flagForMultiUserAudit(
+            partId: partId, expectedQty: 10, sessionId: sessionId,
+            flaggedBy: nil, requiredCounts: 2
+        )
+        // One count in, one still pending — set is collecting, so block.
+        try env.warehouse.submitMultiUserCount(
+            assignmentId: assignments[0].id!, quantity: 10, userId: assignments[0].assignedUserId
+        )
+        #expect(throws: WarehouseService.WarehouseError.partAlreadyFlaggedForVerification(partId: partId)) {
+            _ = try env.warehouse.flagForMultiUserAudit(
+                partId: partId, expectedQty: 10, sessionId: sessionId,
+                flaggedBy: nil, requiredCounts: 2
+            )
+        }
+
+        // Both counts agree — consensus is reachable and just awaits
+        // resolution, so re-flagging must still be blocked.
+        try env.warehouse.submitMultiUserCount(
+            assignmentId: assignments[1].id!, quantity: 10, userId: assignments[1].assignedUserId
+        )
+        #expect(throws: WarehouseService.WarehouseError.partAlreadyFlaggedForVerification(partId: partId)) {
+            _ = try env.warehouse.flagForMultiUserAudit(
+                partId: partId, expectedQty: 10, sessionId: sessionId,
+                flaggedBy: nil, requiredCounts: 2
+            )
+        }
+        // No duplicate or superseded rows were created by the rejections.
+        let grouped = try env.warehouse.getMultiUserAuditAssignments(sessionId: sessionId)
+        #expect(grouped.count == 1)
+        #expect(grouped[0].assignments.count == 2)
+    }
+
+    @Test("flagForMultiUserAudit re-flags a fully counted session-less set")
+    func testFlagForMultiUserAuditNullSessionDeadEndReflag() throws {
+        let env = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10)
+        _ = try env.auth.createUser(displayName: "Counter Two", pin: "5678")
+
+        // Session-less flag (the QueueSendForVerificationSheet path when no
+        // audit session is active).
+        let first = try env.warehouse.flagForMultiUserAudit(
+            partId: partId, expectedQty: 10, sessionId: nil,
+            flaggedBy: nil, requiredCounts: 2
+        )
+        // Still collecting — blocked.
+        #expect(throws: WarehouseService.WarehouseError.partAlreadyFlaggedForVerification(partId: partId)) {
+            _ = try env.warehouse.flagForMultiUserAudit(
+                partId: partId, expectedQty: 10, sessionId: nil,
+                flaggedBy: nil, requiredCounts: 2
+            )
+        }
+
+        // Even agreeing counts are a dead end without a session:
+        // resolveMultiUserAudit requires a session id, so nothing can ever
+        // resolve this set. Re-flagging must supersede it, not throw.
+        try env.warehouse.submitMultiUserCount(
+            assignmentId: first[0].id!, quantity: 10, userId: first[0].assignedUserId
+        )
+        try env.warehouse.submitMultiUserCount(
+            assignmentId: first[1].id!, quantity: 10, userId: first[1].assignedUserId
+        )
+        let second = try env.warehouse.flagForMultiUserAudit(
+            partId: partId, expectedQty: 10, sessionId: nil,
+            flaggedBy: nil, requiredCounts: 2
+        )
+        #expect(second.count == 2)
+        #expect(second.allSatisfy { $0.status == "pending" })
+
+        let superseded = try env.db.writer.read { dbConn in
+            try Int.fetchOne(dbConn, sql: """
+                SELECT COUNT(*) FROM multi_user_audit_assignments
+                WHERE part_id = ? AND audit_session_id IS NULL AND status = 'superseded'
+                """, arguments: [partId]) ?? 0
+        }
+        #expect(superseded == 2)
+    }
+
     // MARK: - "While You're Here" Quick Audit Candidates (#75)
 
     @Test("getQuickAuditCandidates returns only low-confidence parts at the area")

--- a/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
@@ -1156,6 +1156,189 @@ struct WarehouseAuditTests {
         #expect(forSession2.isEmpty)
     }
 
+    // MARK: - Multi-User Verification Guards (#494)
+
+    @Test("flagForMultiUserAudit throws when no eligible counters exist")
+    func testFlagForMultiUserAuditNoEligibleCounters() throws {
+        let env = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10)
+
+        let session = try env.warehouse.startAuditSession(startedBy: env.adminUserId)
+
+        // Admin is the only active user; excluding them as the flagger leaves
+        // zero eligible counters.
+        #expect(throws: WarehouseService.WarehouseError.noEligibleVerificationCounters(required: 2, available: 0)) {
+            _ = try env.warehouse.flagForMultiUserAudit(
+                partId: partId,
+                expectedQty: 10,
+                sessionId: session.id!,
+                flaggedBy: env.adminUserId,
+                requiredCounts: 2
+            )
+        }
+        #expect(try env.warehouse.getMultiUserAuditAssignments(sessionId: session.id!).isEmpty)
+    }
+
+    @Test("flagForMultiUserAudit throws when fewer eligible counters than requested")
+    func testFlagForMultiUserAuditInsufficientEligibleCounters() throws {
+        let env = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10)
+
+        let session = try env.warehouse.startAuditSession(startedBy: env.adminUserId)
+        _ = try env.auth.createUser(displayName: "Counter Two", pin: "5678")
+
+        // Two active users, but excluding the flagging admin leaves one — not
+        // enough for a 2-counter consensus.
+        #expect(throws: WarehouseService.WarehouseError.noEligibleVerificationCounters(required: 2, available: 1)) {
+            _ = try env.warehouse.flagForMultiUserAudit(
+                partId: partId,
+                expectedQty: 10,
+                sessionId: session.id!,
+                flaggedBy: env.adminUserId,
+                requiredCounts: 2
+            )
+        }
+        #expect(try env.warehouse.getMultiUserAuditAssignments(sessionId: session.id!).isEmpty)
+    }
+
+    @Test("flagForMultiUserAudit throws when the part is already flagged in the session")
+    func testFlagForMultiUserAuditAlreadyFlaggedInSession() throws {
+        let env = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10)
+
+        let session = try env.warehouse.startAuditSession(startedBy: env.adminUserId)
+        let sessionId = session.id!
+        _ = try env.auth.createUser(displayName: "Counter Two", pin: "5678")
+
+        let first = try env.warehouse.flagForMultiUserAudit(
+            partId: partId, expectedQty: 10, sessionId: sessionId,
+            flaggedBy: nil, requiredCounts: 2
+        )
+        #expect(first.count == 2)
+
+        // Second flag for the same part/session must not create duplicates.
+        #expect(throws: WarehouseService.WarehouseError.partAlreadyFlaggedForVerification(partId: partId)) {
+            _ = try env.warehouse.flagForMultiUserAudit(
+                partId: partId, expectedQty: 10, sessionId: sessionId,
+                flaggedBy: nil, requiredCounts: 2
+            )
+        }
+        let grouped = try env.warehouse.getMultiUserAuditAssignments(sessionId: sessionId)
+        #expect(grouped.count == 1)
+        #expect(grouped[0].assignments.count == 2)
+    }
+
+    @Test("flagForMultiUserAudit allows re-flagging after assignments resolve")
+    func testFlagForMultiUserAuditAllowsReflagAfterResolution() throws {
+        let env = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10)
+
+        let session = try env.warehouse.startAuditSession(startedBy: env.adminUserId)
+        let sessionId = session.id!
+        _ = try env.auth.createUser(displayName: "Counter Two", pin: "5678")
+
+        let assignments = try env.warehouse.flagForMultiUserAudit(
+            partId: partId, expectedQty: 10, sessionId: sessionId,
+            flaggedBy: nil, requiredCounts: 2
+        )
+        try env.warehouse.submitMultiUserCount(
+            assignmentId: assignments[0].id!, quantity: 10, userId: assignments[0].assignedUserId
+        )
+        try env.warehouse.submitMultiUserCount(
+            assignmentId: assignments[1].id!, quantity: 10, userId: assignments[1].assignedUserId
+        )
+        _ = try env.warehouse.resolveMultiUserAudit(
+            partId: partId, sessionId: sessionId, resolvedBy: env.adminUserId
+        )
+
+        // Once resolved, the part can legitimately be flagged again.
+        let second = try env.warehouse.flagForMultiUserAudit(
+            partId: partId, expectedQty: 10, sessionId: sessionId,
+            flaggedBy: nil, requiredCounts: 2
+        )
+        #expect(second.count == 2)
+    }
+
+    // MARK: - "While You're Here" Quick Audit Candidates (#75)
+
+    @Test("getQuickAuditCandidates returns only low-confidence parts at the area")
+    func testGetQuickAuditCandidates() throws {
+        let env = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let lowPart = try E2ETestHelpers.seedPart(env, name: "Low Confidence", categoryId: catId)
+        let highPart = try E2ETestHelpers.seedPart(env, name: "High Confidence", categoryId: catId)
+        let fixture = try seedStorageAreas(env, count: 2)
+        let areaId = fixture.areas[0]
+        let otherAreaId = fixture.areas[1]
+
+        try env.warehouse.setPartConfidence(partId: lowPart, areaId: areaId, percent: 40)
+        try env.warehouse.setPartConfidence(partId: highPart, areaId: areaId, percent: 95)
+        // Low-confidence part at a different area must not leak in.
+        try env.warehouse.setPartConfidence(partId: highPart, areaId: otherAreaId, percent: 10)
+
+        let candidates = try env.warehouse.getQuickAuditCandidates(areaId: areaId)
+        #expect(candidates.count == 1)
+        #expect(candidates.first?.partId == lowPart)
+        #expect(candidates.first?.areaId == areaId)
+
+        // A quick count resets confidence, so the part drops out of the list.
+        _ = try env.warehouse.recordQuickVerificationCount(
+            partId: lowPart, areaId: areaId, countedQuantity: 3, verifiedBy: env.adminUserId
+        )
+        #expect(try env.warehouse.getQuickAuditCandidates(areaId: areaId).isEmpty)
+    }
+
+    // MARK: - Parts-First Setup Count (#91)
+
+    @Test("recordPartsFirstSetupCount upserts canonical stock and records an adjustment movement")
+    func testRecordPartsFirstSetupCount() throws {
+        let env = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+
+        // First count: no stock row exists yet → insert.
+        let firstDelta = try env.warehouse.recordPartsFirstSetupCount(
+            partId: partId, countedQty: 7, performedBy: env.adminUserId
+        )
+        #expect(firstDelta == 7)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 7)
+
+        // Re-count: existing row updates and the delta is signed.
+        let secondDelta = try env.warehouse.recordPartsFirstSetupCount(
+            partId: partId, countedQty: 5, performedBy: env.adminUserId
+        )
+        #expect(secondDelta == -2)
+        #expect(try env.warehouse.getStockQty(partId: partId, locationType: "warehouse", locationId: 1) == 5)
+
+        // Unchanged count applies no delta but still succeeds.
+        let thirdDelta = try env.warehouse.recordPartsFirstSetupCount(
+            partId: partId, countedQty: 5, performedBy: env.adminUserId
+        )
+        #expect(thirdDelta == 0)
+    }
+
+    @Test("recordPartsFirstSetupCount rejects negative counts and missing parts")
+    func testRecordPartsFirstSetupCountValidation() throws {
+        let env = try freshEnv()
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+
+        #expect(throws: WarehouseService.WarehouseError.invalidQuantity) {
+            _ = try env.warehouse.recordPartsFirstSetupCount(partId: partId, countedQty: -1)
+        }
+        #expect(throws: WarehouseService.WarehouseError.partNotFound(999_999)) {
+            _ = try env.warehouse.recordPartsFirstSetupCount(partId: 999_999, countedQty: 3)
+        }
+    }
+
     // MARK: - Low Confidence Verification
 
     @Test("getLowConfidencePartsForVerification returns parts below threshold")

--- a/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseAuditTests.swift
@@ -1486,10 +1486,14 @@ struct WarehouseAuditTests {
         let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
 
         #expect(throws: WarehouseService.WarehouseError.invalidQuantity) {
-            _ = try env.warehouse.recordPartsFirstSetupCount(partId: partId, countedQty: -1)
+            _ = try env.warehouse.recordPartsFirstSetupCount(
+                partId: partId, countedQty: -1, performedBy: env.adminUserId
+            )
         }
         #expect(throws: WarehouseService.WarehouseError.partNotFound(999_999)) {
-            _ = try env.warehouse.recordPartsFirstSetupCount(partId: 999_999, countedQty: 3)
+            _ = try env.warehouse.recordPartsFirstSetupCount(
+                partId: 999_999, countedQty: 3, performedBy: env.adminUserId
+            )
         }
     }
 

--- a/core/Tests/WiredPartCoreTests/WarehouseFloorPlanTests.swift
+++ b/core/Tests/WiredPartCoreTests/WarehouseFloorPlanTests.swift
@@ -261,6 +261,111 @@ struct WarehouseFloorPlanTests {
         #expect(units[0].name == "Original Name")
     }
 
+    // MARK: - Storage Unit Dimension Validation (#1165)
+
+    @Test("addStorageUnit rejects non-positive physical dimensions")
+    func testAddStorageUnitRejectsNonPositivePhysicalDimensions() throws {
+        let env = try freshEnv()
+        let plan = try env.warehouse.createFloorPlan(name: "WH", widthInches: 200, lengthInches: 200)
+
+        let invalidInputs: [(width: Int?, depth: Int?, height: Int?)] = [
+            (0, 24, 72), (-6, 24, 72),
+            (48, 0, 72), (48, -1, 72),
+            (48, 24, 0), (48, 24, -12),
+        ]
+        for input in invalidInputs {
+            #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+                _ = try env.warehouse.addStorageUnit(
+                    floorPlanId: plan.id!, name: "Invalid Unit", unitType: "rack",
+                    widthInches: input.width, depthInches: input.depth, heightInches: input.height
+                )
+            }
+        }
+        #expect(try env.warehouse.listStorageUnits(floorPlanId: plan.id!).isEmpty)
+    }
+
+    @Test("addStorageUnit rejects non-positive grid dimensions and negative coordinates")
+    func testAddStorageUnitRejectsInvalidGridGeometry() throws {
+        let env = try freshEnv()
+        let plan = try env.warehouse.createFloorPlan(name: "WH", widthInches: 200, lengthInches: 200)
+
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            _ = try env.warehouse.addStorageUnit(
+                floorPlanId: plan.id!, name: "Bad Grid", unitType: "rack",
+                gridWidth: 0, gridHeight: 1
+            )
+        }
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            _ = try env.warehouse.addStorageUnit(
+                floorPlanId: plan.id!, name: "Bad Grid", unitType: "rack",
+                gridWidth: 2, gridHeight: -1
+            )
+        }
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            _ = try env.warehouse.addStorageUnit(
+                floorPlanId: plan.id!, name: "Bad Coord", unitType: "rack",
+                gridX: -1, gridY: 0
+            )
+        }
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            _ = try env.warehouse.addStorageUnit(
+                floorPlanId: plan.id!, name: "Bad Coord", unitType: "rack",
+                gridX: 0, gridY: -3
+            )
+        }
+        #expect(try env.warehouse.listStorageUnits(floorPlanId: plan.id!).isEmpty)
+    }
+
+    @Test("addStorageUnit rejects placement outside saved floor-plan grid bounds")
+    func testAddStorageUnitRejectsOutOfBoundsPlacement() throws {
+        let env = try freshEnv()
+        let plan = try env.warehouse.createFloorPlan(name: "WH", widthInches: 200, lengthInches: 200)
+        try env.warehouse.updateFloorPlanGrid(floorPlanId: plan.id!, rows: 4, cols: 5)
+
+        // 2-wide unit starting at column 4 of a 5-column grid → off the edge.
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            _ = try env.warehouse.addStorageUnit(
+                floorPlanId: plan.id!, name: "Off Grid", unitType: "rack",
+                gridX: 4, gridY: 0, gridWidth: 2, gridHeight: 1
+            )
+        }
+
+        // Same footprint inside the bounds succeeds.
+        let unit = try env.warehouse.addStorageUnit(
+            floorPlanId: plan.id!, name: "On Grid", unitType: "rack",
+            widthInches: 48, depthInches: 24, heightInches: 72,
+            gridX: 3, gridY: 0, gridWidth: 2, gridHeight: 1
+        )
+        #expect(unit.gridX == 3)
+    }
+
+    @Test("updateStorageUnit rejects invalid grid geometry and out-of-bounds moves")
+    func testUpdateStorageUnitRejectsInvalidGridGeometry() throws {
+        let env = try freshEnv()
+        let plan = try env.warehouse.createFloorPlan(name: "WH", widthInches: 200, lengthInches: 200)
+        try env.warehouse.updateFloorPlanGrid(floorPlanId: plan.id!, rows: 4, cols: 5)
+        let unit = try env.warehouse.addStorageUnit(
+            floorPlanId: plan.id!, name: "Unit", unitType: "rack",
+            gridX: 0, gridY: 0, gridWidth: 2, gridHeight: 1
+        )
+
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            try env.warehouse.updateStorageUnit(id: unit.id!, gridWidth: 0)
+        }
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            try env.warehouse.updateStorageUnit(id: unit.id!, gridX: -2)
+        }
+        // Moving the 2-wide unit to column 4 of a 5-column grid → off the edge.
+        #expect(throws: WarehouseService.WarehouseError.invalidDimension) {
+            try env.warehouse.updateStorageUnit(id: unit.id!, gridX: 4)
+        }
+        // Non-placement updates still succeed.
+        try env.warehouse.updateStorageUnit(id: unit.id!, name: "Renamed")
+        let units = try env.warehouse.listStorageUnits(floorPlanId: plan.id!)
+        #expect(units[0].name == "Renamed")
+        #expect(units[0].gridX == 0)
+    }
+
     @Test("Delete cascades through storage hierarchy")
     func testDeleteStorageUnit() throws {
         let env = try freshEnv()


### PR DESCRIPTION
## Batch G — Warehouse data integrity

Plan: docs/plans/beta-readiness-issue-resolution-2026-07.md §3 Batch G

Closes #1165
Closes #494
Closes #91
Closes #75

### What changed

**#1165 — Storage-unit dimension/placement validation**
- `WarehouseService.addStorageUnit` now rejects non-positive `widthInches` / `depthInches` / `heightInches`, non-positive `gridWidth` / `gridHeight`, negative `gridX` / `gridY`, and placement outside saved floor-plan grid bounds (`WarehouseError.invalidDimension`), mirroring the zone/floor-feature validation approach.
- `updateStorageUnit` gets the same guards; the floor-plan bounds check only runs when a placement field is actually changing so unrelated updates (rename, configure) never trip on legacy rows.
- Add/Edit Storage Unit sheets surface the rejection inline with a specific message (new `invalidDimension` mapping in `userFriendlyError`), fixed wrong "load locations" error contexts.

**#494 — Send-for-verification guards**
- `flagForMultiUserAudit` now throws `partAlreadyFlaggedForVerification` when the part already has unresolved (pending/counted) assignments for the same session, and `noEligibleVerificationCounters(required:available:)` when fewer eligible active counters exist than requested (minimum 2 for consensus) — instead of silently creating zero or duplicate assignments.
- `QueueSendForVerificationSheet` surfaces both errors inline (distinct messages via `userFriendlyError`) and stays open; added `.presentationDetents` to the sheet per repo convention.

**#91 — PartsFlowWizard canonical persistence (last open slice per beta plan)**
- New `WarehouseService.recordPartsFirstSetupCount(partId:countedQty:performedBy:)` upserts the canonical warehouse `stock` row (`warehouse`/1) and records a signed adjustment `stock_movements` row when quantity changes.
- `PartsFlowWizard.saveAllProgress` now persists counts via that method and locations to the canonical `parts.shelf_location` field, replacing the old "Location: X | Initial count: N" notes-field concatenation (which also clobbered user notes).

**#75 — "While You're Here" quick-audit prompt (last open slice)**
- New `WarehouseService.getQuickAuditCandidates(areaId:limit:)` returns parts at an area with confidence ≤ 85% (the quick-verification trigger), lowest first.
- The dashboard QR scanner now offers the prompt after scanning a warehouse location whose parts include low-confidence entries: "N parts here need a quick count." with Count Now / Not Now, at most once per area per day (`QuickAuditPromptStore`, per-user in UserDefaults).
- New `QuickAuditCountSheet` records counts via the existing `recordQuickVerificationCount` (resets confidence to 100% and the movement decay factor). System counts stay hidden while counting, per the audit spec.

### Test evidence

- `cd core && swift build` → Build complete.
- `cd core && swift test --filter "WarehouseAuditTests|WarehouseFloorPlanTests"` → 116 tests in 2 suites passed (includes 11 new tests: dimension/placement validation, no-eligible + already-flagged + re-flag-after-resolution guards, quick-audit candidates, parts-first setup count).
- `cd core && swift test --filter "E2EWarehouseTests|WarehouseWalkingPathTests|WarehouseLocationTests|WarehouseServiceExtTests"` → 178 tests in 4 suites passed.
- `cd core && swift test` (full suite) → 2269 tests in 68 suites passed (139.97s), 0 failures.
- `xcodebuild -workspace "Weird Parts.xcworkspace" -scheme "WiredPart-iOS" -destination "generic/platform=iOS Simulator" build CODE_SIGNING_ALLOWED=NO` → succeeded (exit 0); only pre-existing warnings in untouched files.
- `xcrun swiftc -parse` on all 5 touched app-target files → clean.

### Notes
- #91 and #75 are umbrella trackers; per the beta plan (§3 Batch G) these were the last open slices, so both carry Closes lines. Earlier triage lanes (WEI-1090/1092 progress-persistence and zone-UX spec; #486 operator submission flow) were addressed or tracked separately per the plan.
- `updateFloorPlanGrid`'s shrink-orphan check (#1240) still only counts features/zones, not storage units — pre-existing scope, unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
