### PR TITLE
fix: burn down all 33 iOS app-target build warnings (#1139)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -777,7 +777,9 @@ final class AppCore: ObservableObject {
     func changePin(userId: Int64, oldPin: String, newPin: String) async -> String? {
         guard let authService else { return "App not ready. Please wait." }
         do {
-            try await Task.detached(priority: .userInitiated) {
+            // changePin returns Bool; success is signaled by not throwing, so the
+            // returned value is intentionally discarded.
+            _ = try await Task.detached(priority: .userInitiated) {
                 try authService.changePin(userId: userId, oldPin: oldPin, newPin: newPin)
             }.value
             return nil

--- a/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/DashboardDailyReportPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Dashboard/DashboardDailyReportPage.swift
@@ -515,7 +515,7 @@ struct DashboardDailyReportPage: View {
                 }
             }
         } catch {
-            await setFastActionError(error, context: "update lunch")
+            setFastActionError(error, context: "update lunch")
         }
 
         await loadData()
@@ -564,7 +564,7 @@ struct DashboardDailyReportPage: View {
                 }
             }
         } catch {
-            await setFastActionError(error, context: "update break")
+            setFastActionError(error, context: "update break")
         }
 
         await loadData()
@@ -595,7 +595,7 @@ struct DashboardDailyReportPage: View {
                     : (.info, "Supply run ended", "The run marker was closed on this labor entry.")
             }
         } catch {
-            await setFastActionError(error, context: "toggle supply run")
+            setFastActionError(error, context: "toggle supply run")
         }
 
         await loadData()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/JobsListPage.swift
@@ -183,7 +183,7 @@ struct JobsListPage: View {
             }
         } message: {
             if let target = quickStatusTarget {
-                Text("Job: \(target.job.jobName ?? target.job.jobNumber)"  )
+                Text("Job: \(target.job.jobName)")
             }
         }
         .onChange(of: searchText) { loadJobs() }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPODetailPage.swift
@@ -226,7 +226,7 @@ struct IOSPODetailPage: View {
                     po: po,
                     supplierContacts: supplierContacts
                 ) {
-                    Task { await loadData() }   // refresh PO status after confirmed send
+                    Task { loadData() }   // refresh PO status after confirmed send (loadData is synchronous)
                 }
                 .environmentObject(appCore)
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSWishlistPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSWishlistPage.swift
@@ -972,10 +972,10 @@ private struct AddWishlistItemSheet: View {
                 Section("Part Information") {
                     TextField("Part Name", text: $partName)
                         .textContentType(.none)
-                        .onChange(of: partName) { _ in isDirty = true }
+                        .onChange(of: partName) { isDirty = true }
 
                     Stepper("Quantity: \(qtySuggested)", value: $qtySuggested, in: 1...9999)
-                        .onChange(of: qtySuggested) { _ in isDirty = true }
+                        .onChange(of: qtySuggested) { isDirty = true }
                 }
 
                 Section("Priority") {
@@ -986,17 +986,17 @@ private struct AddWishlistItemSheet: View {
                         }
                     }
                     .pickerStyle(.segmented)
-                    .onChange(of: priority) { _ in isDirty = true }
+                    .onChange(of: priority) { isDirty = true }
                 }
 
                 Section("Details") {
                     TextField("Reason (optional)", text: $reason, axis: .vertical)
                         .lineLimit(2...4)
-                        .onChange(of: reason) { _ in isDirty = true }
+                        .onChange(of: reason) { isDirty = true }
 
                     TextField("Notes (optional)", text: $notes, axis: .vertical)
                         .lineLimit(2...4)
-                        .onChange(of: notes) { _ in isDirty = true }
+                        .onChange(of: notes) { isDirty = true }
                 }
 
                 if let error = saveError {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/ForecastSettingsSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/ForecastSettingsSheet.swift
@@ -100,7 +100,7 @@ struct ForecastSettingsSheet: View {
                 Text("Trailer").tag("trailer")
             }
             .pickerStyle(.segmented)
-            .onChange(of: selectedLocationType) { _ in
+            .onChange(of: selectedLocationType) {
                 populateFields()
                 isDirty = false
             }
@@ -137,7 +137,7 @@ struct ForecastSettingsSheet: View {
                         .multilineTextAlignment(.trailing)
                         .frame(maxWidth: 80)
                         .keyboardType(.numberPad)
-                        .onChange(of: aduLookbackDays) { _ in isDirty = true }
+                        .onChange(of: aduLookbackDays) { isDirty = true }
                     Text("days")
                 }
                 .frame(minHeight: 44)
@@ -149,7 +149,7 @@ struct ForecastSettingsSheet: View {
                         .multilineTextAlignment(.trailing)
                         .frame(maxWidth: 60)
                         .keyboardType(.numberPad)
-                        .onChange(of: windowWeeks) { _ in isDirty = true }
+                        .onChange(of: windowWeeks) { isDirty = true }
                     Text("weeks")
                 }
                 .frame(minHeight: 44)
@@ -162,7 +162,7 @@ struct ForecastSettingsSheet: View {
                     .multilineTextAlignment(.trailing)
                     .frame(maxWidth: 80)
                     .keyboardType(.numberPad)
-                    .onChange(of: minDataDays) { _ in isDirty = true }
+                    .onChange(of: minDataDays) { isDirty = true }
                 Text("days")
             }
             .frame(minHeight: 44)
@@ -200,7 +200,7 @@ struct ForecastSettingsSheet: View {
                 .multilineTextAlignment(.trailing)
                 .frame(maxWidth: 80)
                 .keyboardType(.decimalPad)
-                .onChange(of: value.wrappedValue) { _ in isDirty = true }
+                .onChange(of: value.wrappedValue) { isDirty = true }
             Text("x \(unitLabel)")
                 .foregroundStyle(.secondary)
         }
@@ -211,7 +211,7 @@ struct ForecastSettingsSheet: View {
         Section {
             Stepper("Suppress below: \(freeSpaceThreshold)", value: $freeSpaceThreshold, in: 1...10)
                 .frame(minHeight: 44)
-                .onChange(of: freeSpaceThreshold) { _ in isDirty = true }
+                .onChange(of: freeSpaceThreshold) { isDirty = true }
         } header: {
             Text("Free Space Threshold")
         } footer: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsBrandsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsBrandsPage.swift
@@ -238,7 +238,7 @@ struct PartsBrandsPage: View {
     @ViewBuilder
     private var emptyState: some View {
         let isSearching = !searchText.isEmpty
-        return VStack(spacing: 16) {
+        VStack(spacing: 16) {
             Image(systemName: isSearching ? "magnifyingglass" : "tag")
                 .decorativeIconFont(48)
                 .foregroundStyle(.secondary)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsForecastingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsForecastingPage.swift
@@ -461,7 +461,7 @@ struct PartsForecastingPage: View {
     @ViewBuilder
     private var emptyState: some View {
         let isFiltered = !searchText.isEmpty || filterUrgency != .all
-        return VStack(spacing: 16) {
+        VStack(spacing: 16) {
             Image(systemName: isFiltered ? "magnifyingglass" : "chart.line.uptrend.xyaxis")
                 .decorativeIconFont(48)
                 .foregroundStyle(.secondary)
@@ -911,13 +911,13 @@ private struct ForecastDetailSheet: View {
             LabeledContent("Name") {
                 TextField("Name", text: $editName)
                     .multilineTextAlignment(.trailing)
-                    .onChange(of: editName) { _ in isDirty = true }
+                    .onChange(of: editName) { isDirty = true }
             }
             LabeledContent("Code") {
                 TextField("Code", text: $editCode)
                     .multilineTextAlignment(.trailing)
                     .monospaced()
-                    .onChange(of: editCode) { _ in isDirty = true }
+                    .onChange(of: editCode) { isDirty = true }
             }
 
             LabeledContent("Min Stock (Global)") {
@@ -925,21 +925,21 @@ private struct ForecastDetailSheet: View {
                     .keyboardType(.numberPad)
                     .multilineTextAlignment(.trailing)
                     .frame(width: 60)
-                    .onChange(of: editMinStock) { _ in isDirty = true }
+                    .onChange(of: editMinStock) { isDirty = true }
             }
             LabeledContent("Target Stock (Global)") {
                 TextField("0", text: $editTargetStock)
                     .keyboardType(.numberPad)
                     .multilineTextAlignment(.trailing)
                     .frame(width: 60)
-                    .onChange(of: editTargetStock) { _ in isDirty = true }
+                    .onChange(of: editTargetStock) { isDirty = true }
             }
             LabeledContent("Max Stock (Global)") {
                 TextField("0", text: $editMaxStock)
                     .keyboardType(.numberPad)
                     .multilineTextAlignment(.trailing)
                     .frame(width: 60)
-                    .onChange(of: editMaxStock) { _ in isDirty = true }
+                    .onChange(of: editMaxStock) { isDirty = true }
             }
 
             LabeledContent("Total Stock (All Locations)", value: "\(row.currentStock)")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsPricingPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsPricingPage.swift
@@ -569,7 +569,7 @@ struct PartsPricingPage: View {
     @ViewBuilder
     private var emptyState: some View {
         let isFiltered = !searchText.isEmpty || showMissingPriceOnly
-        return VStack(spacing: 16) {
+        VStack(spacing: 16) {
             Image(systemName: isFiltered ? "magnifyingglass" : "dollarsign.circle")
                 .decorativeIconFont(48)
                 .foregroundStyle(.secondary)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
@@ -358,7 +358,7 @@ struct PartsSuppliersPage: View {
     @ViewBuilder
     private var emptyState: some View {
         let isSearching = !searchText.isEmpty
-        return VStack(spacing: 16) {
+        VStack(spacing: 16) {
             Image(systemName: isSearching ? "magnifyingglass" : "building.2")
                 .decorativeIconFont(48)
                 .foregroundStyle(.secondary)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/TypeBrandColorSection.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/TypeBrandColorSection.swift
@@ -88,7 +88,7 @@ struct TypeBrandColorSection: View {
             }
         }
         .task { await loadSKUData() }
-        .onChange(of: linkedBrandIds) { _ in
+        .onChange(of: linkedBrandIds) {
             normalizeSelectedBrand()
         }
         .sheet(item: $activeSheet) { sheet in

--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateScheduleEntrySheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/CreateScheduleEntrySheet.swift
@@ -116,8 +116,8 @@ struct CreateScheduleEntrySheet: View {
                 selectedJobId = initialJobId
                 loadAssignmentDetail()
             }
-            .onChange(of: entryDate) { _ in loadAssignmentDetail() }
-            .onChange(of: selectedJobId) { _ in loadAssignmentDetail() }
+            .onChange(of: entryDate) { loadAssignmentDetail() }
+            .onChange(of: selectedJobId) { loadAssignmentDetail() }
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseDashboardPage.swift
@@ -617,7 +617,16 @@ struct WarehouseDashboardPage: View {
 
     private var usesCompactQuickActionGrid: Bool {
         horizontalSizeClass == .compact &&
-            (dynamicTypeSize >= .accessibility1 || UIScreen.main.bounds.width < 360)
+            (dynamicTypeSize >= .accessibility1 || activeSceneScreenWidth < 360)
+    }
+
+    /// Screen width via the active window scene (UIScreen.main is deprecated in
+    /// iOS 26). Falls back to a standard iPhone width when no scene is attached
+    /// yet, which keeps the regular (non-compact) grid — same as most devices.
+    private var activeSceneScreenWidth: CGFloat {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+        return scene?.screen.bounds.width ?? 390
     }
 
     private var quickActions: [WarehouseQuickAction] {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepBins.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WizardStepBins.swift
@@ -116,7 +116,7 @@ struct WizardStepBins: View {
                                 .font(.subheadline)
                                 .monospaced()
                             Spacer()
-                            if let partId = bin.assignedPartId {
+                            if bin.assignedPartId != nil {
                                 Image(systemName: "shippingbox.fill")
                                     .foregroundStyle(.green)
                                     .font(.caption)

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -49,7 +49,9 @@ final class IOSSyncManager {
 
     private let logger = Logger(subsystem: "com.wiredpart.ios", category: "IOSSyncManager")
 
-    nonisolated(unsafe) private var syncTimer: Timer?
+    // @ObservationIgnored keeps this a plain stored property so nonisolated(unsafe)
+    // takes effect (deinit needs synchronous access); no view observes the timer.
+    @ObservationIgnored nonisolated(unsafe) private var syncTimer: Timer?
     private var syncIntervalSeconds: TimeInterval = 60
 
     private var db: AppDatabase?
@@ -987,7 +989,9 @@ final class IOSSyncManager {
     }
 
     /// Observer token returned by addObserver. Retained so deinit can remove it.
-    nonisolated(unsafe) private var foregroundObserver: NSObjectProtocol?
+    /// @ObservationIgnored keeps this a plain stored property so nonisolated(unsafe)
+    /// takes effect (deinit needs synchronous access); no view observes the token.
+    @ObservationIgnored nonisolated(unsafe) private var foregroundObserver: NSObjectProtocol?
 
     deinit {
         // Fix #215: invalidate timer and remove notification observer so logout /


### PR DESCRIPTION
Closes #1139

Plan: docs/plans/beta-readiness-issue-resolution-2026-07.md §3 Batch S — Build-warning burn-down.

## What changed

Burned down all 33 Swift compiler warnings in the iOS app target (**before: 33, after: 0**). No behavior changes — every fix is mechanical:

- **19× `onChange(of:perform:)` deprecated (iOS 17)** — converted single-parameter `{ _ in ... }` closures to the zero-parameter form in IOSWishlistPage, ForecastSettingsSheet, PartsForecastingPage, TypeBrandColorSection, CreateScheduleEntrySheet.
- **4× "application of result builder 'ViewBuilder' disabled by explicit 'return'"** — removed the explicit `return` in the `emptyState` views of PartsBrandsPage, PartsForecastingPage, PartsPricingPage, PartsSuppliersPage.
- **4× "no 'async' operations occur within 'await'"** — dropped the no-op `await` on the synchronous `setFastActionError` (DashboardDailyReportPage ×3) and synchronous `loadData` inside `Task {}` (IOSPODetailPage).
- **2× "'nonisolated(unsafe)' has no effect"** — `syncTimer` / `foregroundObserver` in IOSSyncManager were being rewritten into MainActor-isolated computed properties by the `@Observable` macro, which made `nonisolated(unsafe)` a no-op. Added `@ObservationIgnored` so they stay plain stored properties and the annotation (needed for `deinit` cleanup, fix #215) takes effect. Neither private property is observed by any view.
- **1× "expression of type 'Bool' is unused"** — explicitly discarded `changePin`'s Bool return in AppCore (success is signaled by not throwing); comment added.
- **1× dead `??` (left side non-optional)** — `Job.jobName` is non-optional `String`, so `?? target.job.jobNumber` in JobsListPage was dead code; removed (behavior identical).
- **1× unused value `partId`** — replaced `if let partId = bin.assignedPartId` with a boolean test in WizardStepBins.
- **1× `UIScreen.main` deprecated (iOS 26)** — WarehouseDashboardPage now reads the screen width from the active `UIWindowScene` (scene-based access per the deprecation guidance), falling back to a standard iPhone width (390, keeps the regular grid) if no scene is attached.

## Deliberately skipped (not code warnings / need design decisions)

- `appintentsmetadataprocessor ... Metadata extraction skipped. No AppIntents.framework dependency found.` — toolchain-level notice, not a Swift diagnostic; silencing it requires a build-settings decision (`LM_SKIP_METADATA_EXTRACTION`) or adopting AppIntents.
- Issue #1139's follow-up suggestion of a CI warning gate/allowlist — a process/design decision, left for a separate change.

## Test evidence

- Baseline: `xcodebuild -workspace "Weird Parts.xcworkspace" -scheme WiredPart-iOS -destination 'generic/platform=iOS Simulator' build` → `** BUILD SUCCEEDED **` with **33** unique Swift warnings (+1 toolchain notice).
- After fixes, same command → `** BUILD SUCCEEDED **` with **0** Swift warnings (only the toolchain AppIntents notice remains).
- `xcrun swiftc -parse` clean on all 15 touched files.
- No `core/` files touched, so the core test suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
