### PR TITLE
feat(orders): JPO General/Specific brand toggle + resolved-brand PO wiring (#242, #243)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOCreationPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPOCreationPage.swift
@@ -90,11 +90,29 @@ struct IOSJPOCreationPage: View {
         let unitPrice: Double?
         let shopStock: Int
         let stockStatus: StockStatus
+        var brandSelectionMode: BrandSelectionMode = .specific
 
         enum StockStatus: String {
             case inStock
             case lowStock
             case outOfStock
+        }
+
+        /// Per-line brand mode (#242): 'Specific brand' keeps the part's brand;
+        /// 'General' defers the brand choice to PO creation, where it is resolved
+        /// against the selected supplier.
+        enum BrandSelectionMode: String, CaseIterable, Identifiable {
+            case specific
+            case general
+
+            var id: String { rawValue }
+
+            var title: String {
+                switch self {
+                case .specific: "Specific brand"
+                case .general: "General"
+                }
+            }
         }
     }
 
@@ -602,7 +620,19 @@ struct IOSJPOCreationPage: View {
                     Text("\(item.shopStock) in stock")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
+                    if item.brandSelectionMode == .general {
+                        generalModeBadge
+                    }
                 }
+                Picker("Brand mode", selection: $cartItems[index].brandSelectionMode) {
+                    ForEach(CartItem.BrandSelectionMode.allCases) { mode in
+                        Text(mode.title).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .controlSize(.mini)
+                .frame(maxWidth: 220)
+                .accessibilityLabel("Brand selection mode for \(item.partName)")
             }
 
             Spacer()
@@ -660,6 +690,13 @@ struct IOSJPOCreationPage: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    private var generalModeBadge: some View {
+        Label("General", systemImage: "circle.dashed")
+            .font(.caption2)
+            .foregroundStyle(.teal)
+            .labelStyle(.titleAndIcon)
     }
 
     private func stockStatusBadge(_ status: CartItem.StockStatus) -> some View {
@@ -1136,13 +1173,15 @@ struct IOSJPOCreationPage: View {
                 throw OrdersService.OrdersError.invalidQuantity(invalidLine.quantity)
             }
             let lines = cartItems.map { (partId: $0.partId, quantity: $0.quantity) }
+            let brandSelectionModes = cartItems.map(\.brandSelectionMode.rawValue)
             let jpoId = try service.createJPOWithLines(
                 jobId: jobId,
                 requestedBy: userId,
                 priority: priority,
                 deliveryOption: deliveryOption,
                 notes: notes.isEmpty ? nil : notes,
-                lines: lines
+                lines: lines,
+                brandSelectionModes: brandSelectionModes
             )
 
             appCore.onboardingManager?.markCompleted("jpo-create")

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSJPODetailPage.swift
@@ -401,9 +401,17 @@ struct IOSJPODetailPage: View {
                     Text(line.partName ?? "Unknown Part")
                         .font(.subheadline)
                         .fontWeight(.medium)
-                    Text("Qty: \(line.quantity)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    HStack(spacing: 6) {
+                        Text("Qty: \(line.quantity)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        if line.brandSelectionMode == "general" {
+                            // Brand deferred to PO creation (#242)
+                            Label("General", systemImage: "circle.dashed")
+                                .font(.caption2)
+                                .foregroundStyle(.teal)
+                        }
+                    }
                 }
 
                 Spacer()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPODetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSPODetailPage.swift
@@ -1410,6 +1410,24 @@ struct IOSPODetailPage: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
 
+                    // Resolved-brand pill: this line was ordered in General mode and
+                    // the brand was auto-resolved against the supplier at PO creation. (#243)
+                    if line.brandSelectionMode == "general", let brandName = line.brandName {
+                        HStack(spacing: 4) {
+                            Image(systemName: "info.circle.fill")
+                                .font(.caption2)
+                                .accessibilityHidden(true)
+                            Text("Resolved: \(brandName)")
+                                .font(.caption2)
+                                .fontWeight(.medium)
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(Color.teal.opacity(0.15)))
+                        .foregroundStyle(.teal)
+                        .accessibilityLabel("Brand auto-resolved to \(brandName)")
+                    }
+
                     // Stale price warning
                     if let partId = line.partId,
                        let service = appCore.partsService,

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSProcurementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSProcurementPage.swift
@@ -54,6 +54,13 @@ struct IOSProcurementPage: View {
     // General-mode brand resolution per part against the selected supplier (#243).
     // Recomputed alongside cachedReadyToGenerate; keyed by ProcurementItem.id.
     @State private var brandResolutions: [Int64: GeneralBrandResolution] = [:]
+    // True while a background brand-resolution pass is running; generation stays
+    // blocked (see hasUnresolvedGeneralBrand) so a stale/incomplete result can't
+    // slip a mis-branded line through while DB reads are still in flight.
+    @State private var isResolvingBrands = false
+    // Monotonically increasing token so a slow, superseded resolution pass can't
+    // clobber brandResolutions after a newer pass has already completed.
+    @State private var brandResolutionToken: Int = 0
 
     /// Outcome of resolving a part's general-mode JPO lines against the selected supplier.
     private enum GeneralBrandResolution: Equatable {
@@ -355,11 +362,50 @@ struct IOSProcurementPage: View {
     /// Resolve general-mode JPO lines against each part's selected supplier (#243).
     /// `.resolved` drives the teal pill; `.unresolved` shows the red warning and
     /// blocks generation (the service also rejects unresolved lines as a backstop).
+    ///
+    /// The actual DB reads run off the main thread — with preferred suppliers
+    /// auto-selected for many rows, this loop can issue several SQLite reads per
+    /// checked part, and doing that synchronously on every checkbox/supplier
+    /// `onChange` could stall the UI on larger procurement lists. `isResolvingBrands`
+    /// keeps generation blocked (fail closed) while a pass is in flight, and
+    /// `brandResolutionToken` discards results from a superseded pass.
     private func updateBrandResolutions() {
         guard let service = appCore.ordersService else {
             brandResolutions = [:]
+            isResolvingBrands = false
             return
         }
+        let snapshotItems = items
+        let snapshotSuppliers = selectedSupplier
+        let partsService = appCore.partsService
+
+        brandResolutionToken += 1
+        let token = brandResolutionToken
+        isResolvingBrands = true
+
+        Task {
+            let resolutions = await Self.resolveBrands(
+                items: snapshotItems,
+                selectedSupplier: snapshotSuppliers,
+                ordersService: service,
+                partsService: partsService
+            )
+            await MainActor.run {
+                guard token == brandResolutionToken else { return }
+                brandResolutions = resolutions
+                isResolvingBrands = false
+            }
+        }
+    }
+
+    /// Off-main-thread core of `updateBrandResolutions`. Static + explicit params
+    /// so it can't accidentally touch `@State` from a background context.
+    private static func resolveBrands(
+        items: [OrdersService.ProcurementItem],
+        selectedSupplier: [Int64: Int64],
+        ordersService: OrdersService,
+        partsService: PartsService?
+    ) async -> [Int64: GeneralBrandResolution] {
         var resolutions: [Int64: GeneralBrandResolution] = [:]
         for item in items {
             guard let supplierId = selectedSupplier[item.id] else { continue }
@@ -370,7 +416,7 @@ struct IOSProcurementPage: View {
             var hasUnresolved = false
             for lineId in jpoLineIds {
                 do {
-                    switch try service.resolveGeneralLineItem(jpoLineId: lineId, supplierId: supplierId) {
+                    switch try ordersService.resolveGeneralLineItem(jpoLineId: lineId, supplierId: supplierId) {
                     case .alreadySpecific:
                         continue
                     case .resolved(let brandId, _):
@@ -387,14 +433,14 @@ struct IOSProcurementPage: View {
             if hasUnresolved {
                 resolutions[item.id] = .unresolved
             } else if let brandId = resolvedBrandId {
-                resolutions[item.id] = .resolved(brandName: brandName(for: brandId))
+                resolutions[item.id] = .resolved(brandName: brandName(for: brandId, partsService: partsService))
             }
         }
-        brandResolutions = resolutions
+        return resolutions
     }
 
-    private func brandName(for brandId: Int64) -> String {
-        guard let parts = appCore.partsService else { return "Brand #\(brandId)" }
+    private static func brandName(for brandId: Int64, partsService: PartsService?) -> String {
+        guard let parts = partsService else { return "Brand #\(brandId)" }
         do {
             return try parts.getBrand(id: brandId).name
         } catch {
@@ -404,8 +450,10 @@ struct IOSProcurementPage: View {
 
     /// True when any checked, supplier-selected part still has an unresolved
     /// general-mode line — generation is blocked until the supplier changes.
+    /// Also true while a resolution pass is in flight: fail closed rather than
+    /// letting generation proceed on a stale/incomplete brandResolutions snapshot.
     private var hasUnresolvedGeneralBrand: Bool {
-        cachedReadyToGenerate.contains { brandResolutions[$0.id] == .unresolved }
+        isResolvingBrands || cachedReadyToGenerate.contains { brandResolutions[$0.id] == .unresolved }
     }
 
     /// The effective order quantity for a part, accounting for any pull decision.

--- a/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSProcurementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Orders/IOSProcurementPage.swift
@@ -51,6 +51,16 @@ struct IOSProcurementPage: View {
     @State private var sourceCounts: [String: Int] = [:]
     @State private var cachedReadyToGenerate: [OrdersService.ProcurementItem] = []
 
+    // General-mode brand resolution per part against the selected supplier (#243).
+    // Recomputed alongside cachedReadyToGenerate; keyed by ProcurementItem.id.
+    @State private var brandResolutions: [Int64: GeneralBrandResolution] = [:]
+
+    /// Outcome of resolving a part's general-mode JPO lines against the selected supplier.
+    private enum GeneralBrandResolution: Equatable {
+        case resolved(brandName: String)
+        case unresolved
+    }
+
     private enum ActiveSheet: Identifiable {
         case help
         var id: String { "help" }
@@ -339,6 +349,63 @@ struct IOSProcurementPage: View {
             selectedSupplier[item.id] != nil &&
             effectiveOrderQty(for: item) > 0
         }
+        updateBrandResolutions()
+    }
+
+    /// Resolve general-mode JPO lines against each part's selected supplier (#243).
+    /// `.resolved` drives the teal pill; `.unresolved` shows the red warning and
+    /// blocks generation (the service also rejects unresolved lines as a backstop).
+    private func updateBrandResolutions() {
+        guard let service = appCore.ordersService else {
+            brandResolutions = [:]
+            return
+        }
+        var resolutions: [Int64: GeneralBrandResolution] = [:]
+        for item in items {
+            guard let supplierId = selectedSupplier[item.id] else { continue }
+            let jpoLineIds = item.sources.filter { $0.sourceType == "jpo" }.flatMap(\.lineIds)
+            guard !jpoLineIds.isEmpty else { continue }
+
+            var resolvedBrandId: Int64?
+            var hasUnresolved = false
+            for lineId in jpoLineIds {
+                do {
+                    switch try service.resolveGeneralLineItem(jpoLineId: lineId, supplierId: supplierId) {
+                    case .alreadySpecific:
+                        continue
+                    case .resolved(let brandId, _):
+                        resolvedBrandId = brandId
+                    case .noMatch:
+                        hasUnresolved = true
+                    }
+                } catch {
+                    // Fail closed: if resolution cannot be confirmed, treat the line
+                    // as unresolved so generation is blocked instead of mis-branded.
+                    hasUnresolved = true
+                }
+            }
+            if hasUnresolved {
+                resolutions[item.id] = .unresolved
+            } else if let brandId = resolvedBrandId {
+                resolutions[item.id] = .resolved(brandName: brandName(for: brandId))
+            }
+        }
+        brandResolutions = resolutions
+    }
+
+    private func brandName(for brandId: Int64) -> String {
+        guard let parts = appCore.partsService else { return "Brand #\(brandId)" }
+        do {
+            return try parts.getBrand(id: brandId).name
+        } catch {
+            return "Brand #\(brandId)"
+        }
+    }
+
+    /// True when any checked, supplier-selected part still has an unresolved
+    /// general-mode line — generation is blocked until the supplier changes.
+    private var hasUnresolvedGeneralBrand: Bool {
+        cachedReadyToGenerate.contains { brandResolutions[$0.id] == .unresolved }
     }
 
     /// The effective order quantity for a part, accounting for any pull decision.
@@ -573,6 +640,18 @@ struct IOSProcurementPage: View {
                     .padding(.vertical, 2)
                 }
 
+                // Unresolved general-mode brands block generation (#243)
+                if hasUnresolvedGeneralBrand {
+                    HStack(spacing: 4) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.caption2)
+                            .accessibilityHidden(true)
+                        Text("A selected supplier doesn't carry a brand for a General-mode part. Pick another supplier to continue.")
+                            .font(.caption2)
+                    }
+                    .foregroundStyle(.red)
+                }
+
                 // Action buttons
                 HStack(spacing: 12) {
                     Button {
@@ -587,7 +666,7 @@ struct IOSProcurementPage: View {
                         .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.borderedProminent)
-                    .disabled(isGenerating)
+                    .disabled(isGenerating || hasUnresolvedGeneralBrand)
 
                     Button {
                         withAnimation { showSavedToast = true }
@@ -779,6 +858,41 @@ struct IOSProcurementPage: View {
                         }
                 }
             }
+
+            // General-mode brand resolution against the selected supplier (#243)
+            brandResolutionView(item)
+        }
+    }
+
+    /// Teal 'Resolved: Brand' pill or red blocking warning for general-mode lines. (#243)
+    @ViewBuilder
+    private func brandResolutionView(_ item: OrdersService.ProcurementItem) -> some View {
+        switch brandResolutions[item.id] {
+        case .resolved(let brandName):
+            HStack(spacing: 4) {
+                Image(systemName: "info.circle.fill")
+                    .font(.caption2)
+                    .accessibilityHidden(true)
+                Text("Resolved: \(brandName)")
+                    .font(.caption2)
+                    .fontWeight(.medium)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(Color.teal.opacity(0.15)))
+            .foregroundStyle(.teal)
+            .accessibilityLabel("General mode brand resolved to \(brandName)")
+        case .unresolved:
+            HStack(spacing: 4) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.caption2)
+                    .accessibilityHidden(true)
+                Text("Supplier doesn't carry this brand — pick another supplier")
+                    .font(.caption2)
+            }
+            .foregroundStyle(.red)
+        case nil:
+            EmptyView()
         }
     }
 

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -145,6 +145,7 @@ extension AppDatabase {
         registerMigration103TimesheetCorrectionAudit(&migrator)
         registerMigration104AuthTokenSessionDeviceId(&migrator)
         registerMigration105JobRecordsLocalFirst(&migrator)
+        registerMigration106POLineItemsBrandId(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -5858,6 +5859,23 @@ extension AppDatabase {
                           on: "auth_token_sessions",
                           columns: ["parent_refresh_id"],
                           ifNotExists: true)
+        }
+    }
+
+    private static func registerMigration106POLineItemsBrandId(_ migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("106_po_line_items_brand_id") { db in
+            // PE-COLORS Phase 3 (#243) — persist the brand resolved at PO-creation time.
+            // General-mode JPO lines (brand_selection_mode = 'general') carry no brand;
+            // the brand chosen via resolveGeneralLineItem against the selected supplier
+            // is written here so the PO shows it and future audits can see the
+            // auto-resolution (brand_selection_mode stays 'general' on the PO line).
+            try addColumnIfMissing(db, table: "po_line_items", column: "brand_id", type: .integer)
+            try db.create(
+                index: "idx_po_lines_brand",
+                on: "po_line_items",
+                columns: ["brand_id"],
+                ifNotExists: true
+            )
         }
     }
 

--- a/core/Sources/WiredPartCore/Services/OrdersService.swift
+++ b/core/Sources/WiredPartCore/Services/OrdersService.swift
@@ -80,8 +80,8 @@ public final class OrdersService: Sendable {
                 let attemptedText = attemptedSupplierName.map { "\($0) (#\(attemptedSupplierId))" } ?? "#\(attemptedSupplierId)"
                 return "Generic part \(partText) for job \(jobText) is locked to supplier \(lockedText), not supplier \(attemptedText)"
             case .generalBrandUnresolved(let partId, let partName, let supplierId, let supplierName):
-                let partText = partName ?? "part #\(partId)"
-                let supplierText = supplierName ?? "Supplier #\(supplierId)"
+                let partText = partName.map { "\($0) (#\(partId))" } ?? "part #\(partId)"
+                let supplierText = supplierName.map { "\($0) (#\(supplierId))" } ?? "Supplier #\(supplierId)"
                 return "\(supplierText) doesn't carry a brand for \(partText) — pick another supplier"
             case .insufficientStock(let partId, let available, let requested):
                 return "Part #\(partId) has \(available) available on warehouse shelves, but \(requested) was requested"

--- a/core/Sources/WiredPartCore/Services/OrdersService.swift
+++ b/core/Sources/WiredPartCore/Services/OrdersService.swift
@@ -3016,6 +3016,12 @@ public final class OrdersService: Sendable {
 
     /// Generate a Purchase Order from an approved JPO. Creates a new PO and links its
     /// line items to the JPO line items, then marks the JPO as "ordered".
+    ///
+    /// General-mode lines (`brand_selection_mode = 'general'`) are resolved to a concrete
+    /// brand for the chosen supplier via the same core as `generatePOsFromProcurement`;
+    /// the resolved `brand_id` is persisted and the mode is kept as `'general'` for
+    /// auditability. Throws `OrdersError.generalBrandUnresolved` (rolling back the whole
+    /// transaction) when the supplier carries no matching brand. (#243)
     @discardableResult
     public func generatePOFromJPO(jpoId: Int64, supplierId: Int64) throws -> Int64 {
         try db.writer.write { dbConn in
@@ -3034,11 +3040,12 @@ public final class OrdersService: Sendable {
             }
 
             // Guard: supplier must exist and not be tombstoned — a PO against a deleted
-            // supplier won't surface in supplier-filtered list views.
-            let supplierExists = (try Int.fetchOne(dbConn, sql: """
-                SELECT COUNT(*) FROM suppliers WHERE id = ? AND deleted_at IS NULL
-                """, arguments: [supplierId]) ?? 0) > 0
-            guard supplierExists else { throw OrdersError.supplierNotFound(supplierId) }
+            // supplier won't surface in supplier-filtered list views. Fetching the name
+            // (rather than COUNT) also feeds the generalBrandUnresolved error below.
+            guard let supplierName = try String.fetchOne(dbConn, sql: """
+                SELECT name FROM suppliers WHERE id = ? AND deleted_at IS NULL
+                """, arguments: [supplierId])
+            else { throw OrdersError.supplierNotFound(supplierId) }
 
             // Generate PO number (MAX-based to prevent duplicates after deletions)
             let maxNum = try Int.fetchOne(
@@ -3062,9 +3069,11 @@ public final class OrdersService: Sendable {
             let lines = try Row.fetchAll(
                 dbConn,
                 sql: """
-                    SELECT id, part_id, qty_requested
-                    FROM jpo_line_items
-                    WHERE jpo_id = ? AND deleted_at IS NULL
+                    SELECT jl.id, jl.part_id, jl.qty_requested, jl.brand_selection_mode,
+                           p.name AS part_name
+                    FROM jpo_line_items jl
+                    LEFT JOIN parts p ON p.id = jl.part_id AND p.deleted_at IS NULL
+                    WHERE jl.jpo_id = ? AND jl.deleted_at IS NULL
                     """,
                 arguments: [jpoId]
             )
@@ -3072,13 +3081,40 @@ public final class OrdersService: Sendable {
                 let partId: Int64 = line["part_id"] ?? 0
                 let qty: Int = line["qty_requested"] ?? 1
                 let jpoLineId: Int64 = line["id"] ?? 0
+
+                // General-mode lines carry no brand — resolve one against the chosen
+                // supplier and persist it on the PO line. The mode stays 'general' so
+                // audits can see this was an auto-resolution. Mirrors
+                // generatePOsFromProcurement — both JPO-to-PO paths share one invariant. (#243)
+                let brandSelectionMode: String = line["brand_selection_mode"] ?? "specific"
+                var resolvedBrandId: Int64? = nil
+                if brandSelectionMode == "general" {
+                    switch try Self.resolveGeneralLineItem(
+                        jpoLineId: jpoLineId, supplierId: supplierId, dbConn: dbConn
+                    ) {
+                    case .resolved(let brandId, _):
+                        resolvedBrandId = brandId
+                    case .noMatch:
+                        throw OrdersError.generalBrandUnresolved(
+                            partId: partId,
+                            partName: line["part_name"] as String?,
+                            supplierId: supplierId,
+                            supplierName: supplierName
+                        )
+                    case .alreadySpecific:
+                        break
+                    }
+                }
+
                 try dbConn.execute(
                     sql: """
                         INSERT INTO po_line_items
-                        (po_id, jpo_line_id, part_id, qty_ordered, created_at)
-                        VALUES (?, ?, ?, ?, datetime('now'))
+                        (po_id, jpo_line_id, part_id, qty_ordered,
+                         brand_id, brand_selection_mode, created_at)
+                        VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
                         """,
-                    arguments: [poId, jpoLineId, partId, qty]
+                    arguments: [poId, jpoLineId, partId, qty,
+                                resolvedBrandId, brandSelectionMode]
                 )
                 let poLineId = dbConn.lastInsertedRowID
                 try dbConn.execute(
@@ -4107,8 +4143,9 @@ public final class OrdersService: Sendable {
         }
     }
 
-    /// Connection-scoped resolution core — shared by the public read-only API and
-    /// `generatePOsFromProcurement`, which runs inside a write transaction. (#243)
+    /// Connection-scoped resolution core — shared by the public read-only API and the
+    /// two JPO-to-PO conversion paths (`generatePOsFromProcurement` and
+    /// `generatePOFromJPO`), which run inside write transactions. (#243)
     private static func resolveGeneralLineItem(
         jpoLineId: Int64,
         supplierId: Int64,

--- a/core/Sources/WiredPartCore/Services/OrdersService.swift
+++ b/core/Sources/WiredPartCore/Services/OrdersService.swift
@@ -41,6 +41,12 @@ public final class OrdersService: Sendable {
             attemptedSupplierId: Int64,
             attemptedSupplierName: String?
         )
+        case generalBrandUnresolved(
+            partId: Int64,
+            partName: String?,
+            supplierId: Int64,
+            supplierName: String?
+        )
         case insufficientStock(partId: Int64, available: Int, requested: Int)
         case overMaxPullRequired(partId: Int64, overage: Int)
         case invalidQuantity(Int)
@@ -73,6 +79,10 @@ public final class OrdersService: Sendable {
                 let lockedText = lockedSupplierName.map { "\($0) (#\(lockedSupplierId))" } ?? "#\(lockedSupplierId)"
                 let attemptedText = attemptedSupplierName.map { "\($0) (#\(attemptedSupplierId))" } ?? "#\(attemptedSupplierId)"
                 return "Generic part \(partText) for job \(jobText) is locked to supplier \(lockedText), not supplier \(attemptedText)"
+            case .generalBrandUnresolved(let partId, let partName, let supplierId, let supplierName):
+                let partText = partName ?? "part #\(partId)"
+                let supplierText = supplierName ?? "Supplier #\(supplierId)"
+                return "\(supplierText) doesn't carry a brand for \(partText) — pick another supplier"
             case .insufficientStock(let partId, let available, let requested):
                 return "Part #\(partId) has \(available) available on warehouse shelves, but \(requested) was requested"
             case .overMaxPullRequired(let partId, let overage):
@@ -375,6 +385,8 @@ public final class OrdersService: Sendable {
         public let chatThreadId: Int64?
         public let poLineId: Int64?
         public let transferId: Int64?
+        /// 'specific' (default) or 'general' — brand deferred to PO creation. (PE-COLORS Phase 3, #242)
+        public let brandSelectionMode: String
         public let createdAt: String?
 
         public init(
@@ -383,7 +395,8 @@ public final class OrdersService: Sendable {
             notes: String?, priority: String, createdAt: String?,
             lineStatus: String = "pending", holdReason: String? = nil,
             rejectReason: String? = nil, chatThreadId: Int64? = nil,
-            poLineId: Int64? = nil, transferId: Int64? = nil
+            poLineId: Int64? = nil, transferId: Int64? = nil,
+            brandSelectionMode: String = "specific"
         ) {
             self.id = id
             self.jpoId = jpoId
@@ -400,6 +413,7 @@ public final class OrdersService: Sendable {
             self.chatThreadId = chatThreadId
             self.poLineId = poLineId
             self.transferId = transferId
+            self.brandSelectionMode = brandSelectionMode
             self.createdAt = createdAt
         }
     }
@@ -523,6 +537,12 @@ public final class OrdersService: Sendable {
         public let jobId: Int64?
         public let jobName: String?
         public let source: String?  // "job", "forecast", "wishlist", "general"
+        /// Brand persisted on the PO line at creation time. Set when a general-mode
+        /// JPO line was auto-resolved against the supplier. (PE-COLORS Phase 3, #243)
+        public let brandId: Int64?
+        public let brandName: String?
+        /// 'specific' (default) or 'general' — kept for auditability of auto-resolutions.
+        public let brandSelectionMode: String
 
         // Computed line-level status for display
         public var lineStatus: String { status }
@@ -532,7 +552,9 @@ public final class OrdersService: Sendable {
             partName: String?, description: String?,
             quantityOrdered: Int, quantityReceived: Int, unitPrice: Double?,
             status: String, notes: String?, createdAt: String?,
-            jobId: Int64? = nil, jobName: String? = nil, source: String? = nil
+            jobId: Int64? = nil, jobName: String? = nil, source: String? = nil,
+            brandId: Int64? = nil, brandName: String? = nil,
+            brandSelectionMode: String = "specific"
         ) {
             self.id = id
             self.poId = poId
@@ -549,6 +571,9 @@ public final class OrdersService: Sendable {
             self.jobId = jobId
             self.jobName = jobName
             self.source = source
+            self.brandId = brandId
+            self.brandName = brandName
+            self.brandSelectionMode = brandSelectionMode
         }
     }
 
@@ -756,7 +781,8 @@ public final class OrdersService: Sendable {
                     rejectReason: lr["reject_reason"] as String?,
                     chatThreadId: lr["chat_thread_id"] as Int64?,
                     poLineId: lr["po_line_id"] as Int64?,
-                    transferId: lr["transfer_id"] as Int64?
+                    transferId: lr["transfer_id"] as Int64?,
+                    brandSelectionMode: lr["brand_selection_mode"] ?? "specific"
                 )
             }
 
@@ -1287,7 +1313,8 @@ public final class OrdersService: Sendable {
         deliveryOption: String,
         notes: String?,
         lines: [(partId: Int64, quantity: Int)],
-        lineNotes: [String?]? = nil
+        lineNotes: [String?]? = nil,
+        brandSelectionModes: [String]? = nil
     ) throws -> Int64 {
         try db.writer.write { dbConn in
             // Guard: job and requesting user must exist and not be tombstoned (mirrors createJPO).
@@ -1307,9 +1334,19 @@ public final class OrdersService: Sendable {
                 }
             }
 
-            // Guard: every line must have qty > 0 and a live part.
-            for line in lines {
+            if let brandSelectionModes {
+                guard brandSelectionModes.count == lines.count else {
+                    throw OrdersError.invalidStatus("Brand selection mode count must match JPO line count (expected \(lines.count), got \(brandSelectionModes.count))")
+                }
+            }
+
+            // Guard: every line must have qty > 0, a live part, and a valid brand mode.
+            for (index, line) in lines.enumerated() {
                 guard line.quantity > 0 else { throw OrdersError.invalidQuantity(line.quantity) }
+                let brandSelectionMode = brandSelectionModes?[index] ?? "specific"
+                guard brandSelectionMode == "specific" || brandSelectionMode == "general" else {
+                    throw OrdersError.invalidStatus("Invalid brand selection mode: \(brandSelectionMode)")
+                }
                 let partExists = (try Int.fetchOne(dbConn, sql: """
                     SELECT COUNT(*) FROM parts WHERE id = ? AND deleted_at IS NULL
                     """, arguments: [line.partId]) ?? 0) > 0
@@ -1329,11 +1366,12 @@ public final class OrdersService: Sendable {
             // 2. Insert each line and smart-route
             for (index, line) in lines.enumerated() {
                 let note = lineNotes?[index]
+                let brandSelectionMode = brandSelectionModes?[index] ?? "specific"
                 try dbConn.execute(sql: """
                     INSERT INTO jpo_line_items
-                    (jpo_id, part_id, qty_requested, priority, notes, created_at)
-                    VALUES (?, ?, ?, ?, ?, datetime('now'))
-                    """, arguments: [jpoId, line.partId, line.quantity, priority, note])
+                    (jpo_id, part_id, qty_requested, priority, notes, brand_selection_mode, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+                    """, arguments: [jpoId, line.partId, line.quantity, priority, note, brandSelectionMode])
                 let lineId = dbConn.lastInsertedRowID
 
                 // Check shop stock for smart routing
@@ -2657,9 +2695,11 @@ public final class OrdersService: Sendable {
                     var remainingQty = item.quantity
                     for jpoLineId in item.jpoLineIds where remainingQty > 0 {
                         let lineRow = try Row.fetchOne(dbConn, sql: """
-                            SELECT part_id, qty_requested
-                            FROM jpo_line_items
-                            WHERE id = ? AND deleted_at IS NULL
+                            SELECT jl.part_id, jl.qty_requested, jl.brand_selection_mode,
+                                   p.name AS part_name
+                            FROM jpo_line_items jl
+                            LEFT JOIN parts p ON p.id = jl.part_id AND p.deleted_at IS NULL
+                            WHERE jl.id = ? AND jl.deleted_at IS NULL
                             """, arguments: [jpoLineId])
                         guard let lineRow else { throw OrdersError.invalidStatus("JPO line #\(jpoLineId) not found or has been deleted") }
                         let sourcePartId: Int64 = lineRow["part_id"] ?? item.partId
@@ -2669,13 +2709,38 @@ public final class OrdersService: Sendable {
                         guard lineQty > 0 else { continue }
                         remainingQty -= lineQty
 
+                        // General-mode lines carry no brand — resolve one against the
+                        // chosen supplier and persist it on the PO line. The mode stays
+                        // 'general' so audits can see this was an auto-resolution. (#243)
+                        let brandSelectionMode: String = lineRow["brand_selection_mode"] ?? "specific"
+                        var resolvedBrandId: Int64? = nil
+                        if brandSelectionMode == "general" {
+                            switch try Self.resolveGeneralLineItem(
+                                jpoLineId: jpoLineId, supplierId: supplierId, dbConn: dbConn
+                            ) {
+                            case .resolved(let brandId, _):
+                                resolvedBrandId = brandId
+                            case .noMatch:
+                                throw OrdersError.generalBrandUnresolved(
+                                    partId: item.partId,
+                                    partName: lineRow["part_name"] as String?,
+                                    supplierId: supplierId,
+                                    supplierName: try supplierName(for: supplierId)
+                                )
+                            case .alreadySpecific:
+                                break
+                            }
+                        }
+
                         try dbConn.execute(
                             sql: """
                                 INSERT INTO po_line_items
-                                (po_id, jpo_line_id, part_id, qty_ordered, unit_cost, created_at)
-                                VALUES (?, ?, ?, ?, ?, datetime('now'))
+                                (po_id, jpo_line_id, part_id, qty_ordered, unit_cost,
+                                 brand_id, brand_selection_mode, created_at)
+                                VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
                                 """,
-                            arguments: [poId, jpoLineId, item.partId, lineQty, item.unitCost]
+                            arguments: [poId, jpoLineId, item.partId, lineQty, item.unitCost,
+                                        resolvedBrandId, brandSelectionMode]
                         )
                         let poLineId = dbConn.lastInsertedRowID
                         totalLines += 1
@@ -3119,6 +3184,7 @@ public final class OrdersService: Sendable {
             let linesSql = """
                 SELECT pl.*,
                        p.name AS part_name,
+                       b.name AS resolved_brand_name,
                        j.id AS job_id,
                        COALESCE(j.job_name,
                            CASE WHEN pl.notes LIKE '%forecast%' THEN 'Forecast Restock'
@@ -3133,6 +3199,7 @@ public final class OrdersService: Sendable {
                        END AS source
                 FROM po_line_items pl
                 LEFT JOIN parts p ON p.id = pl.part_id AND p.deleted_at IS NULL
+                LEFT JOIN brands b ON b.id = pl.brand_id AND b.deleted_at IS NULL
                 LEFT JOIN jpo_line_items jli ON jli.id = pl.jpo_line_id
                 LEFT JOIN job_parts_orders jpo ON jpo.id = jli.jpo_id
                 LEFT JOIN jobs j ON j.id = jpo.job_id AND j.deleted_at IS NULL
@@ -3156,7 +3223,10 @@ public final class OrdersService: Sendable {
                     createdAt: lr["created_at"] as String?,
                     jobId: lr["job_id"] as Int64?,
                     jobName: lr["job_name"] as String?,
-                    source: lr["source"] as String?
+                    source: lr["source"] as String?,
+                    brandId: lr["brand_id"] as Int64?,
+                    brandName: lr["resolved_brand_name"] as String?,
+                    brandSelectionMode: lr["brand_selection_mode"] ?? "specific"
                 )
             }
 
@@ -4029,78 +4099,88 @@ public final class OrdersService: Sendable {
     public func resolveGeneralLineItem(jpoLineId: Int64, supplierId: Int64) throws -> BrandResolutionResult {
         do {
             return try db.writer.read { dbConn in
-                // 1. Load the line item and its associated part
-                guard let lineRow = try Row.fetchOne(dbConn, sql: """
-                    SELECT jli.brand_selection_mode, p.color_id, p.type_id
-                    FROM jpo_line_items jli
-                    JOIN parts p ON p.id = jli.part_id AND p.deleted_at IS NULL
-                    WHERE jli.id = ? AND jli.deleted_at IS NULL
-                    """, arguments: [jpoLineId])
-                else { return .noMatch }
-
-                let mode: String = lineRow["brand_selection_mode"] ?? "specific"
-                guard mode == "general" else { return .alreadySpecific }
-
-                let colorId: Int64? = lineRow["color_id"]
-                let typeId: Int64? = lineRow["type_id"]
-                guard let colorId, let typeId else { return .noMatch }
-
-                // 2. Find brands the supplier carries that have a SKU for (color, type)
-                let candidateRows = try Row.fetchAll(dbConn, sql: """
-                    SELECT b.id AS brand_id, b.name AS brand_name
-                    FROM brand_supplier_links bsl
-                    JOIN brands b ON b.id = bsl.brand_id AND b.deleted_at IS NULL
-                    JOIN color_brand_skus cbs
-                        ON cbs.brand_id = b.id
-                       AND cbs.color_id = ?
-                       AND cbs.type_id  = ?
-                       AND cbs.deleted_at IS NULL
-                       AND cbs.is_active = 1
-                    WHERE bsl.supplier_id = ?
-                      AND bsl.deleted_at IS NULL
-                      AND bsl.is_active = 1
-                    ORDER BY b.name ASC
-                    """, arguments: [colorId, typeId, supplierId])
-
-                switch candidateRows.count {
-                case 0:
-                    return .noMatch
-                case 1:
-                    let brandId: Int64 = candidateRows[0]["brand_id"]
-                    return .resolved(brandId: brandId, confidence: .exclusive)
-                default:
-                    // 3. History tiebreak — most recently received brand for this supplier
-                    let candidateBrandIds = candidateRows.map { $0["brand_id"] as Int64 }
-                    let placeholders = candidateBrandIds.map { _ in "?" }.joined(separator: ", ")
-                    var histArgs: [DatabaseValueConvertible] = [supplierId, colorId, typeId]
-                    histArgs.append(contentsOf: candidateBrandIds)
-
-                    if let histRow = try Row.fetchOne(dbConn, sql: """
-                        SELECT p.brand_id
-                        FROM po_line_items poli
-                        JOIN purchase_orders po ON po.id = poli.po_id
-                        JOIN parts p ON p.id = poli.part_id AND p.deleted_at IS NULL
-                        WHERE po.supplier_id = ?
-                          AND p.color_id = ?
-                          AND p.type_id  = ?
-                          AND p.brand_id IN (\(placeholders))
-                          AND po.deleted_at IS NULL
-                          AND poli.deleted_at IS NULL
-                        ORDER BY po.order_date DESC
-                        LIMIT 1
-                        """, arguments: StatementArguments(histArgs)) {
-                        let brandId: Int64 = histRow["brand_id"]
-                        return .resolved(brandId: brandId, confidence: .byHistory)
-                    }
-
-                    // No history — pick first alphabetically (already sorted)
-                    let brandId: Int64 = candidateRows[0]["brand_id"]
-                    return .resolved(brandId: brandId, confidence: .arbitrary)
-                }
+                try Self.resolveGeneralLineItem(jpoLineId: jpoLineId, supplierId: supplierId, dbConn: dbConn)
             }
         } catch {
             if isTableNotFoundError(error) { return .noMatch }
             throw error
+        }
+    }
+
+    /// Connection-scoped resolution core — shared by the public read-only API and
+    /// `generatePOsFromProcurement`, which runs inside a write transaction. (#243)
+    private static func resolveGeneralLineItem(
+        jpoLineId: Int64,
+        supplierId: Int64,
+        dbConn: Database
+    ) throws -> BrandResolutionResult {
+        // 1. Load the line item and its associated part
+        guard let lineRow = try Row.fetchOne(dbConn, sql: """
+            SELECT jli.brand_selection_mode, p.color_id, p.type_id
+            FROM jpo_line_items jli
+            JOIN parts p ON p.id = jli.part_id AND p.deleted_at IS NULL
+            WHERE jli.id = ? AND jli.deleted_at IS NULL
+            """, arguments: [jpoLineId])
+        else { return .noMatch }
+
+        let mode: String = lineRow["brand_selection_mode"] ?? "specific"
+        guard mode == "general" else { return .alreadySpecific }
+
+        let colorId: Int64? = lineRow["color_id"]
+        let typeId: Int64? = lineRow["type_id"]
+        guard let colorId, let typeId else { return .noMatch }
+
+        // 2. Find brands the supplier carries that have a SKU for (color, type)
+        let candidateRows = try Row.fetchAll(dbConn, sql: """
+            SELECT b.id AS brand_id, b.name AS brand_name
+            FROM brand_supplier_links bsl
+            JOIN brands b ON b.id = bsl.brand_id AND b.deleted_at IS NULL
+            JOIN color_brand_skus cbs
+                ON cbs.brand_id = b.id
+               AND cbs.color_id = ?
+               AND cbs.type_id  = ?
+               AND cbs.deleted_at IS NULL
+               AND cbs.is_active = 1
+            WHERE bsl.supplier_id = ?
+              AND bsl.deleted_at IS NULL
+              AND bsl.is_active = 1
+            ORDER BY b.name ASC
+            """, arguments: [colorId, typeId, supplierId])
+
+        switch candidateRows.count {
+        case 0:
+            return .noMatch
+        case 1:
+            let brandId: Int64 = candidateRows[0]["brand_id"]
+            return .resolved(brandId: brandId, confidence: .exclusive)
+        default:
+            // 3. History tiebreak — most recently received brand for this supplier
+            let candidateBrandIds = candidateRows.map { $0["brand_id"] as Int64 }
+            let placeholders = candidateBrandIds.map { _ in "?" }.joined(separator: ", ")
+            var histArgs: [DatabaseValueConvertible] = [supplierId, colorId, typeId]
+            histArgs.append(contentsOf: candidateBrandIds)
+
+            if let histRow = try Row.fetchOne(dbConn, sql: """
+                SELECT p.brand_id
+                FROM po_line_items poli
+                JOIN purchase_orders po ON po.id = poli.po_id
+                JOIN parts p ON p.id = poli.part_id AND p.deleted_at IS NULL
+                WHERE po.supplier_id = ?
+                  AND p.color_id = ?
+                  AND p.type_id  = ?
+                  AND p.brand_id IN (\(placeholders))
+                  AND po.deleted_at IS NULL
+                  AND poli.deleted_at IS NULL
+                ORDER BY po.order_date DESC
+                LIMIT 1
+                """, arguments: StatementArguments(histArgs)) {
+                let brandId: Int64 = histRow["brand_id"]
+                return .resolved(brandId: brandId, confidence: .byHistory)
+            }
+
+            // No history — pick first alphabetically (already sorted)
+            let brandId: Int64 = candidateRows[0]["brand_id"]
+            return .resolved(brandId: brandId, confidence: .arbitrary)
         }
     }
 

--- a/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
@@ -2299,6 +2299,99 @@ struct OrdersServiceTests {
         #expect(poLineCount == 0)
     }
 
+    @Test("generatePOFromJPO persists resolved brand on general-mode PO lines")
+    func testGeneratePOFromJPOPersistsResolvedBrand() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let (_, _, typeId) = try E2ETestHelpers.seedPartHierarchy(env, type: "GenJPOType")
+        let catId = try E2ETestHelpers.seedCategory(env, name: "GenJPOCat")
+        let colorId = try env.parts.createColor(name: "GenJPOColor", hexCode: "#1A2B3C")
+        let brandId = try E2ETestHelpers.seedBrand(env, name: "GenJPOBrand")
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "GenJPOSupplier")
+
+        // Supplier carries the brand, and the (color, brand, type) SKU exists.
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT OR IGNORE INTO brand_supplier_links (brand_id, supplier_id, is_active)
+                VALUES (?, ?, 1)
+                """, arguments: [brandId, supplierId])
+        }
+        _ = try env.parts.upsertColorBrandSKU(colorId: colorId, brandId: brandId, typeId: typeId)
+
+        let partId = try env.parts.createPart(
+            categoryId: catId, name: "GenJPO Part",
+            typeId: typeId, colorId: colorId, brandId: brandId
+        )
+        let jpoId = try env.orders.createJPO(jobId: jobId, requestedBy: env.adminUserId)
+        let lineId = try env.orders.addJPOLineItem(
+            jpoId: jpoId, partId: partId, quantity: 3, brandSelectionMode: "general"
+        )
+        try env.orders.updateJPOStatus(id: jpoId, status: "pending")
+        try env.orders.updateJPOStatus(id: jpoId, status: "approved")
+
+        let poId = try env.orders.generatePOFromJPO(jpoId: jpoId, supplierId: supplierId)
+
+        // The PO line persists the resolved brand and keeps mode 'general' for audits —
+        // same invariant as the procurement path (#243).
+        let row = try env.db.writer.read { db in
+            try Row.fetchOne(db, sql: """
+                SELECT brand_id, brand_selection_mode FROM po_line_items
+                WHERE jpo_line_id = ? AND deleted_at IS NULL
+                """, arguments: [lineId])
+        }
+        #expect(row?["brand_id"] as Int64? == brandId)
+        #expect(row?["brand_selection_mode"] as String? == "general")
+
+        let detail = try env.orders.getPODetail(id: poId)
+        let line = try #require(detail.lines.first(where: { $0.jpoLineId == lineId }))
+        #expect(line.brandId == brandId)
+        #expect(line.brandName == "GenJPOBrand")
+        #expect(line.brandSelectionMode == "general")
+    }
+
+    @Test("generatePOFromJPO blocks unresolved general-mode lines and rolls back")
+    func testGeneratePOFromJPOBlocksUnresolvedGeneralBrand() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let (_, _, typeId) = try E2ETestHelpers.seedPartHierarchy(env, type: "BlockJPOType")
+        let catId = try E2ETestHelpers.seedCategory(env, name: "BlockJPOCat")
+        let colorId = try env.parts.createColor(name: "BlockJPOColor", hexCode: "#3C2B1A")
+        let brandId = try E2ETestHelpers.seedBrand(env, name: "BlockJPOBrand")
+        // Supplier does NOT carry any brand for this (color, type) — no links, no SKUs.
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "BlockJPOSupplier")
+
+        let partId = try env.parts.createPart(
+            categoryId: catId, name: "BlockJPO Part",
+            typeId: typeId, colorId: colorId, brandId: brandId
+        )
+        let jpoId = try env.orders.createJPO(jobId: jobId, requestedBy: env.adminUserId)
+        let lineId = try env.orders.addJPOLineItem(
+            jpoId: jpoId, partId: partId, quantity: 2, brandSelectionMode: "general"
+        )
+        try env.orders.updateJPOStatus(id: jpoId, status: "pending")
+        try env.orders.updateJPOStatus(id: jpoId, status: "approved")
+
+        #expect(throws: OrdersService.OrdersError.generalBrandUnresolved(
+            partId: partId, partName: "BlockJPO Part",
+            supplierId: supplierId, supplierName: "BlockJPOSupplier"
+        )) {
+            _ = try env.orders.generatePOFromJPO(jpoId: jpoId, supplierId: supplierId)
+        }
+
+        // Nothing persisted — generation is transactional: no PO line, JPO still approved.
+        let poLineCount = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM po_line_items WHERE jpo_line_id = ?
+                """, arguments: [lineId]) ?? 0
+        }
+        #expect(poLineCount == 0)
+        let jpoStatus = try env.db.writer.read { db in
+            try String.fetchOne(db, sql: "SELECT status FROM job_parts_orders WHERE id = ?",
+                                arguments: [jpoId])
+        }
+        #expect(jpoStatus == "approved")
+    }
+
     @Test("listJPOs shows Unknown for soft-deleted job and user")
     func testListJPOsHidesDeletedJobAndUser() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/OrdersServiceTests.swift
@@ -92,6 +92,55 @@ struct OrdersServiceTests {
         #expect(detail.lines.count == 1)
     }
 
+    @Test("Create JPO with lines persists mixed brand selection modes")
+    func testCreateJPOWithLinesPersistsMixedBrandSelectionModes() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let specificPartId = try E2ETestHelpers.seedPart(env, name: "Specific Wire", categoryId: catId)
+        let generalPartId = try E2ETestHelpers.seedPart(env, name: "General Wire", categoryId: catId)
+
+        let jpoId = try env.orders.createJPOWithLines(
+            jobId: jobId,
+            requestedBy: env.adminUserId,
+            priority: "normal",
+            deliveryOption: "partial",
+            notes: nil,
+            lines: [
+                (partId: specificPartId, quantity: 2),
+                (partId: generalPartId, quantity: 3)
+            ],
+            brandSelectionModes: ["specific", "general"]
+        )
+
+        let detail = try env.orders.getJPODetail(id: jpoId)
+        let modesByPartId = Dictionary(uniqueKeysWithValues: detail.lines.compactMap { line in
+            line.partId.map { ($0, line.brandSelectionMode) }
+        })
+        #expect(modesByPartId[specificPartId] == "specific")
+        #expect(modesByPartId[generalPartId] == "general")
+    }
+
+    @Test("Create JPO with lines rejects mismatched brand selection modes")
+    func testCreateJPOWithLinesRejectsMismatchedBrandSelectionModes() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let catId = try E2ETestHelpers.seedCategory(env)
+        let partId = try E2ETestHelpers.seedPart(env, categoryId: catId)
+
+        #expect(throws: OrdersService.OrdersError.self) {
+            _ = try env.orders.createJPOWithLines(
+                jobId: jobId,
+                requestedBy: env.adminUserId,
+                priority: "normal",
+                deliveryOption: "partial",
+                notes: nil,
+                lines: [(partId: partId, quantity: 1)],
+                brandSelectionModes: ["specific", "general"]
+            )
+        }
+    }
+
     @Test("Create JPO with lines persists line notes")
     func testCreateJPOWithLinesPersistsLineNotes() throws {
         let env = try E2ETestHelpers.setUp()
@@ -2152,6 +2201,102 @@ struct OrdersServiceTests {
             #expect(Bool(false),
                     "Expected .noMatch — soft-deleted part must not yield a resolvable brand even with an active line")
         }
+    }
+
+    // MARK: - generatePOsFromProcurement resolved-brand persistence (#243)
+
+    @Test("generatePOsFromProcurement persists resolved brand on general-mode PO lines")
+    func testGeneratePOsFromProcurementPersistsResolvedBrand() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let (_, _, typeId) = try E2ETestHelpers.seedPartHierarchy(env, type: "GenPOType")
+        let catId = try E2ETestHelpers.seedCategory(env, name: "GenPOCat")
+        let colorId = try env.parts.createColor(name: "GenPOColor", hexCode: "#0F0F0F")
+        let brandId = try E2ETestHelpers.seedBrand(env, name: "GenPOBrand")
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "GenPOSupplier")
+
+        // Supplier carries the brand, and the (color, brand, type) SKU exists.
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT OR IGNORE INTO brand_supplier_links (brand_id, supplier_id, is_active)
+                VALUES (?, ?, 1)
+                """, arguments: [brandId, supplierId])
+        }
+        _ = try env.parts.upsertColorBrandSKU(colorId: colorId, brandId: brandId, typeId: typeId)
+
+        let partId = try env.parts.createPart(
+            categoryId: catId, name: "GenPO Part",
+            typeId: typeId, colorId: colorId, brandId: brandId
+        )
+        let jpoId = try env.orders.createJPO(jobId: jobId, requestedBy: env.adminUserId)
+        let lineId = try env.orders.addJPOLineItem(
+            jpoId: jpoId, partId: partId, quantity: 4, brandSelectionMode: "general"
+        )
+
+        let result = try env.orders.generatePOsFromProcurement(items: [
+            OrdersService.ProcurementGenerateItem(
+                partId: partId, supplierId: supplierId, quantity: 4, jpoLineIds: [lineId]
+            )
+        ])
+        #expect(result.createdPOs.count == 1)
+
+        // The PO line persists the resolved brand and keeps mode 'general' for audits.
+        let row = try env.db.writer.read { db in
+            try Row.fetchOne(db, sql: """
+                SELECT brand_id, brand_selection_mode FROM po_line_items
+                WHERE jpo_line_id = ? AND deleted_at IS NULL
+                """, arguments: [lineId])
+        }
+        #expect(row?["brand_id"] as Int64? == brandId)
+        #expect(row?["brand_selection_mode"] as String? == "general")
+
+        // getPODetail exposes the resolved brand for the pill UI.
+        let poId = try #require(result.createdPOs.first?.poId)
+        let detail = try env.orders.getPODetail(id: poId)
+        let line = try #require(detail.lines.first(where: { $0.jpoLineId == lineId }))
+        #expect(line.brandId == brandId)
+        #expect(line.brandName == "GenPOBrand")
+        #expect(line.brandSelectionMode == "general")
+    }
+
+    @Test("generatePOsFromProcurement blocks unresolved general-mode lines")
+    func testGeneratePOsFromProcurementBlocksUnresolvedGeneralBrand() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+        let (_, _, typeId) = try E2ETestHelpers.seedPartHierarchy(env, type: "BlockType")
+        let catId = try E2ETestHelpers.seedCategory(env, name: "BlockCat")
+        let colorId = try env.parts.createColor(name: "BlockColor", hexCode: "#F0F0F0")
+        let brandId = try E2ETestHelpers.seedBrand(env, name: "BlockBrand")
+        // Supplier does NOT carry any brand for this (color, type) — no links, no SKUs.
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "BlockSupplier")
+
+        let partId = try env.parts.createPart(
+            categoryId: catId, name: "Block Part",
+            typeId: typeId, colorId: colorId, brandId: brandId
+        )
+        let jpoId = try env.orders.createJPO(jobId: jobId, requestedBy: env.adminUserId)
+        let lineId = try env.orders.addJPOLineItem(
+            jpoId: jpoId, partId: partId, quantity: 2, brandSelectionMode: "general"
+        )
+
+        #expect(throws: OrdersService.OrdersError.generalBrandUnresolved(
+            partId: partId, partName: "Block Part",
+            supplierId: supplierId, supplierName: "BlockSupplier"
+        )) {
+            _ = try env.orders.generatePOsFromProcurement(items: [
+                OrdersService.ProcurementGenerateItem(
+                    partId: partId, supplierId: supplierId, quantity: 2, jpoLineIds: [lineId]
+                )
+            ])
+        }
+
+        // Nothing persisted — generation is transactional.
+        let poLineCount = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM po_line_items WHERE jpo_line_id = ?
+                """, arguments: [lineId]) ?? 0
+        }
+        #expect(poLineCount == 0)
     }
 
     @Test("listJPOs shows Unknown for soft-deleted job and user")


### PR DESCRIPTION
Closes #242
Closes #243
Closes #98

**Plan:** docs/plans/beta-readiness-issue-resolution-2026-07.md §3 Batch C (Colors/SKU Phase 3 order-flow wiring); design per docs/plans/colors-parts-redesign.md Concept 3 (General Mode). Re-lands the never-merged local work (#242's commit 7790928d adapted to current main; #243 rebuilt on the landed resolveGeneralLineItem service).

## What changed

**#242 — JPO General/Specific toggle UI**
- `IOSJPOCreationPage`: each cart line gets a mini segmented control `Specific brand | General`; General lines show a teal `General` badge; save passes per-line modes.
- `OrdersService.createJPOWithLines` gains optional `brandSelectionModes` (validates count matches lines and values are `specific|general`), persists `jpo_line_items.brand_selection_mode`.
- `JPOLineRow.brandSelectionMode` exposed via `getJPODetail`; `IOSJPODetailPage` shows the `General` badge on reopened lines, so toggle state survives round-trip.

**#243 — resolved-brand pill + PO persistence**
- New migration `106_po_line_items_brand_id`: adds `po_line_items.brand_id` + `idx_po_lines_brand` (next number after 105 in core's sequence).
- `generatePOsFromProcurement`: general-mode JPO lines are resolved against the chosen supplier via a connection-scoped `resolveGeneralLineItem` core (shared with the public read-only API); the resolved `brand_id` is persisted and `brand_selection_mode='general'` is kept on the PO line for auditability. Unresolvable lines throw the new `OrdersError.generalBrandUnresolved` (transaction rolls back — nothing partial is written).
- `IOSProcurementPage`: after supplier selection, general-mode parts show a teal `Resolved: [Brand]` pill or a red "Supplier doesn't carry this brand — pick another supplier" warning; the Generate button is disabled while any checked part is unresolved (service throw remains the backstop).
- `getPODetail` exposes `brandId`/`brandName`/`brandSelectionMode` on PO lines; `IOSPODetailPage` shows the resolved-brand pill after save.

**Review fixup (commit 33ee31af2) — `generatePOFromJPO` second-path wiring**
- Review finding: `generatePOFromJPO` was a second JPO-to-PO conversion path that bypassed the #243 wiring — general-mode lines got `brand_id` NULL and the column default rewrote `brand_selection_mode` to `'specific'`, erasing the 'general' audit trail. Its only caller (`SupplierPickerSheet`) is currently unreferenced dead code, but the public service API now upholds the same invariant so any future rewiring of that sheet is safe.
- `generatePOFromJPO` now resolves general-mode lines via the shared static `resolveGeneralLineItem` core, persists the resolved `brand_id`, keeps `brand_selection_mode='general'` on the PO line, and throws `generalBrandUnresolved` (full rollback, JPO stays `approved`) when the supplier carries no matching brand.
- 2 new tests: `testGeneratePOFromJPOPersistsResolvedBrand`, `testGeneratePOFromJPOBlocksUnresolvedGeneralBrand`.

**Acceptance-criteria mapping**
- Toggle persists per line, mixed-mode save writes correct values, reopen restores state (#242) — covered by UI wiring + `testCreateJPOWithLinesPersistsMixedBrandSelectionModes`.
- Single-brand supplier auto-resolves; multi-brand resolves by most-recent order history (existing `resolveGeneralLineItem` tests on main); no-match shows warning and blocks save; saved PO shows resolved brand (#243) — new tests below.
- #107 reframing (from #242 acceptance criteria): 'General as a default brand' is subsumed by this mode flag; the 'confirmation on brand removal' part of #107 is independent and stays open. **Owner follow-up:** post the reframing note on #107 at merge time — the automation session was not permitted to comment on issues outside the batch.

## Test evidence
- `cd core && swift build` — Build complete.
- `cd core && swift test --filter OrdersServiceTests` — 127 tests passed (includes 6 new: mixed-mode persistence, mode-count mismatch rejection, `testGeneratePOsFromProcurementPersistsResolvedBrand`, `testGeneratePOsFromProcurementBlocksUnresolvedGeneralBrand`, `testGeneratePOFromJPOPersistsResolvedBrand`, `testGeneratePOFromJPOBlocksUnresolvedGeneralBrand`).
- `cd core && swift test` (full suite, re-run after review fixup) — **2264 tests in 68 suites passed** (was 2258 on main; +6 new, none broken).
- `xcrun swiftc -parse` on all four touched app-target files — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
