### PR TITLE
fix: supplier scores + traceability, part-level pricing target, catalog smart-card filters (Batch D+E)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
@@ -35,6 +35,9 @@ struct PartsCatalogPage: View {
     @State private var selectedBrandId: Int64?
     @State private var lowStockOnly = false
 
+    // Smart-card filter facet counts (GH#67)
+    @State private var filterCounts: PartsService.CatalogFilterCounts?
+
     // MARK: - Sorting
     @State private var sortField: SortField = .name
     @State private var sortAscending = true
@@ -100,7 +103,7 @@ struct PartsCatalogPage: View {
             // Smart search banner
             nlFilterBanner
 
-            // Filter chips bar — always visible
+            // Smart-card stat filter bar — always visible
             filterBar
 
             // Sort header
@@ -228,7 +231,7 @@ struct PartsCatalogPage: View {
                 PageHelpSheet(
                     title: "Parts Catalog Help",
                     sections: [
-                        ("Overview", "Browse all parts in your inventory. Search by name or code, filter by category, brand, or stock status using the chips."),
+                        ("Overview", "Browse all parts in your inventory. Search by name or code, or use the smart filter cards to narrow by category, style, type, color, brand, or low stock. Each card shows how many parts match."),
                         ("Actions", "Tap the + button to add a new part. Use the QR scanner to find parts by code. The printer icon lets you print QR labels."),
                         ("Pricing", "Toggle the $ icon to show pricing overlays on each part. Tap a part for full details, long-press for quick edit.")
                     ]
@@ -362,18 +365,26 @@ struct PartsCatalogPage: View {
         .padding(.bottom, DS.Space.xs)
     }
 
-    // MARK: - Filter Bar
+    // MARK: - Filter Bar (smart-card stat filters — GH#67)
 
     @ViewBuilder
     private var filterBar: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
+                // All Parts — clears every filter; badge = parts matching the search only
+                SmartFilterCard(
+                    title: "All Parts",
+                    count: filterCounts?.allParts ?? totalCount,
+                    isSelected: !hasActiveFilters,
+                    action: { clearAllFilters() }
+                )
+
                 // Category
-                filterMenu(
+                smartFilterMenuCard(
                     label: "Category",
-                    icon: "folder.fill",
                     selection: selectedCategoryId,
-                    options: categories.compactMap { ($0.id, $0.name) }
+                    options: categories.compactMap { cat in cat.id.map { ($0, cat.name) } },
+                    counts: filterCounts?.byCategory ?? [:]
                 ) { newValue in
                     selectedCategoryId = newValue
                     // Clear dependent filters
@@ -383,11 +394,11 @@ struct PartsCatalogPage: View {
                 }
 
                 // Style (cascaded from category)
-                filterMenu(
+                smartFilterMenuCard(
                     label: "Style",
-                    icon: "paintpalette.fill",
                     selection: selectedStyleId,
-                    options: filteredStyles.compactMap { ($0.id, $0.name) }
+                    options: filteredStyles.compactMap { style in style.id.map { ($0, style.name) } },
+                    counts: filterCounts?.byStyle ?? [:]
                 ) { newValue in
                     selectedStyleId = newValue
                     selectedTypeId = nil
@@ -395,78 +406,116 @@ struct PartsCatalogPage: View {
                 }
 
                 // Type (cascaded from style)
-                filterMenu(
+                smartFilterMenuCard(
                     label: "Type",
-                    icon: "square.grid.2x2.fill",
                     selection: selectedTypeId,
-                    options: filteredTypes.compactMap { ($0.id, $0.name) }
+                    options: filteredTypes.compactMap { type in type.id.map { ($0, type.name) } },
+                    counts: filterCounts?.byType ?? [:]
                 ) { newValue in
                     selectedTypeId = newValue
                     resetAndLoad()
                 }
 
                 // Color
-                filterMenu(
+                smartFilterMenuCard(
                     label: "Color",
-                    icon: "drop.fill",
                     selection: selectedColorId,
-                    options: colors.compactMap { ($0.id, $0.name) }
+                    options: colors.compactMap { color in color.id.map { ($0, color.name) } },
+                    counts: filterCounts?.byColor ?? [:]
                 ) { newValue in
                     selectedColorId = newValue
                     resetAndLoad()
                 }
 
                 // Brand
-                filterMenu(
+                smartFilterMenuCard(
                     label: "Brand",
-                    icon: "tag.fill",
                     selection: selectedBrandId,
-                    options: brands.compactMap { ($0.id, $0.name) }
+                    options: brands.compactMap { brand in brand.id.map { ($0, brand.name) } },
+                    counts: filterCounts?.byBrand ?? [:]
                 ) { newValue in
                     selectedBrandId = newValue
                     resetAndLoad()
                 }
 
-                // Low stock toggle
-                Button {
-                    lowStockOnly.toggle()
-                    resetAndLoad()
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.caption)
-                        Text("Low Stock")
-                            .font(.subheadline)
+                // Low stock toggle — badge = low-stock parts under current filters
+                SmartFilterCard(
+                    title: "Low Stock",
+                    count: filterCounts?.lowStock ?? 0,
+                    isSelected: lowStockOnly,
+                    action: {
+                        lowStockOnly.toggle()
+                        resetAndLoad()
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(lowStockOnly ? Color.orange.opacity(0.15) : Color.clear)
-                    .clipShape(Capsule())
-                    .overlay(Capsule().stroke(lowStockOnly ? Color.orange.opacity(0.5) : Color.accentColor.opacity(0.3), lineWidth: 1))
-                }
-
-                // Clear all
-                if hasActiveFilters {
-                    Button {
-                        clearAllFilters()
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: "xmark")
-                                .font(.caption2)
-                            Text("Clear")
-                                .font(.caption)
-                        }
-                        .foregroundStyle(.red)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 7)
-                        .background(Capsule().fill(Color.red.opacity(0.08)))
-                    }
-                }
+                )
             }
             .padding(.horizontal)
             .padding(.vertical, 8)
         }
         .background(Color(.secondarySystemGroupedBackground))
+    }
+
+    /// A SmartFilterCard-styled menu for a filter dimension with per-option
+    /// part counts. Badge shows the matching-part count for the current
+    /// selection, or the number of available options when unselected.
+    /// Choosing "All <label>s" from the menu clears the dimension.
+    @ViewBuilder
+    private func smartFilterMenuCard(
+        label: String,
+        selection: Int64?,
+        options: [(Int64, String)],
+        counts: [Int64: Int],
+        onChange: @escaping (Int64?) -> Void
+    ) -> some View {
+        let selectedName = selection.flatMap { sel in options.first { $0.0 == sel }?.1 }
+        let badgeCount = selection.map { counts[$0] ?? 0 }
+            ?? options.filter { counts[$0.0] != nil }.count
+        let isSelected = selection != nil
+
+        Menu {
+            Button("All \(label)s") { onChange(nil) }
+            Divider()
+            ForEach(options, id: \.0) { id, name in
+                Button {
+                    onChange(id)
+                } label: {
+                    let title = "\(name) (\(counts[id] ?? 0))"
+                    if selection == id {
+                        Label(title, systemImage: "checkmark")
+                    } else {
+                        Text(title)
+                    }
+                }
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 4) {
+                    Text(selectedName ?? label)
+                        .font(.subheadline)
+                        .fontWeight(isSelected ? .semibold : .regular)
+                        .lineLimit(1)
+                    Image(systemName: "chevron.down")
+                        .font(.caption2).bold()
+                        .accessibilityHidden(true)
+                }
+                Text("\(badgeCount)")
+                    .font(.title2)
+                    .fontWeight(.bold)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .frame(minWidth: 100, minHeight: 44)
+            .background(isSelected ? Color.accentColor.opacity(0.15) : Color(.systemGray6))
+            .foregroundColor(isSelected ? .accentColor : .primary)
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+            )
+        }
+        .accessibilityLabel(isSelected
+            ? "\(label) filter: \(selectedName ?? ""), \(badgeCount) matching parts"
+            : "\(label) filter, \(badgeCount) options")
     }
 
     private var hasActiveFilters: Bool {
@@ -483,56 +532,6 @@ struct PartsCatalogPage: View {
         selectedBrandId = nil
         lowStockOnly = false
         resetAndLoad()
-    }
-
-    @ViewBuilder
-    private func filterMenu(
-        label: String,
-        icon: String,
-        selection: Int64?,
-        options: [(Int64?, String)],
-        onChange: @escaping (Int64?) -> Void
-    ) -> some View {
-        Menu {
-            Button("All \(label)s") { onChange(nil) }
-            Divider()
-            ForEach(options, id: \.0) { id, name in
-                Button {
-                    onChange(id)
-                } label: {
-                    if selection == id {
-                        Label(name, systemImage: "checkmark")
-                    } else {
-                        Text(name)
-                    }
-                }
-            }
-        } label: {
-            HStack(spacing: 4) {
-                Image(systemName: icon)
-                    .font(.caption2)
-                    .accessibilityHidden(true)
-                Text(selection.flatMap { sel in options.first { $0.0 == sel }?.1 } ?? label)
-                    .font(.caption)
-                    .fontWeight(selection != nil ? .semibold : .regular)
-                    .lineLimit(1)
-                Image(systemName: "chevron.down")
-                    .font(.caption2).bold()
-                    .accessibilityHidden(true)
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 7)
-            .background(
-                Capsule().fill(selection != nil
-                    ? Color.accentColor.opacity(0.15)
-                    : Color(.tertiarySystemGroupedBackground))
-            )
-            .overlay(
-                Capsule().stroke(selection != nil
-                    ? Color.accentColor.opacity(0.4)
-                    : Color.clear, lineWidth: 1)
-            )
-        }
     }
 
     // MARK: - Sort Header
@@ -1121,6 +1120,16 @@ struct PartsCatalogPage: View {
                 offset: offset
             )
 
+            // Facet counts for the smart-card filter bar (same filter state)
+            let counts = try service.getCatalogFilterCounts(
+                search: effectiveSearchText.isEmpty ? nil : effectiveSearchText,
+                categoryId: selectedCategoryId,
+                styleId: selectedStyleId,
+                typeId: selectedTypeId,
+                colorId: selectedColorId,
+                brandId: selectedBrandId
+            )
+
             let prows = result.parts.map { pwd -> CatalogPartRow in
                 let stock = pwd.totalStock
                 let minStock = pwd.part.minStockLevel
@@ -1151,6 +1160,7 @@ struct PartsCatalogPage: View {
             await MainActor.run {
                 totalCount = result.totalCount
                 parts = prows
+                filterCounts = counts
                 isLoading = false
             }
         } catch {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
@@ -468,8 +468,10 @@ struct PartsCatalogPage: View {
         onChange: @escaping (Int64?) -> Void
     ) -> some View {
         let selectedName = selection.flatMap { sel in options.first { $0.0 == sel }?.1 }
+        // When counts haven't loaded yet, fall back to the option count so the
+        // card still conveys available choices instead of a misleading "0".
         let badgeCount = selection.map { counts[$0] ?? 0 }
-            ?? options.filter { counts[$0.0] != nil }.count
+            ?? (counts.isEmpty ? options.count : options.filter { counts[$0.0] != nil }.count)
         let isSelected = selection != nil
 
         Menu {
@@ -1049,6 +1051,10 @@ struct PartsCatalogPage: View {
 
     private func resetAndLoad() {
         currentPage = 1
+        // Clear stale facet badges immediately so the filter bar doesn't keep
+        // showing counts from the previous filter/search state while the new
+        // request is in flight.
+        filterCounts = nil
         Task { await loadData() }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsCatalogPage.swift
@@ -1120,14 +1120,16 @@ struct PartsCatalogPage: View {
                 offset: offset
             )
 
-            // Facet counts for the smart-card filter bar (same filter state)
+            // Facet counts for the smart-card filter bar (same filter state,
+            // including the Low Stock toggle so badges match the visible list)
             let counts = try service.getCatalogFilterCounts(
                 search: effectiveSearchText.isEmpty ? nil : effectiveSearchText,
                 categoryId: selectedCategoryId,
                 styleId: selectedStyleId,
                 typeId: selectedTypeId,
                 colorId: selectedColorId,
-                brandId: selectedBrandId
+                brandId: selectedBrandId,
+                lowStockOnly: lowStockOnly
             )
 
             let prows = result.parts.map { pwd -> CatalogPartRow in

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PartsSuppliersPage.swift
@@ -944,6 +944,7 @@ private struct SupplierDetailSheet: View {
     @State private var recentPOs: [(poId: Int64, poNumber: String, status: String, total: Double, date: String)] = []
     @State private var supplierScores: PartsService.SupplierScores?
     @State private var contacts: [PartsService.SupplierContact] = []
+    @State private var supplierTrace: [PartsService.TraceStep] = []
     @State private var partCount = 0
     @State private var isLoading = true
     @State private var activeSheet: ActiveSheet?
@@ -992,7 +993,10 @@ private struct SupplierDetailSheet: View {
                 // Section 9: Recent Orders
                 recentOrdersSection
 
-                // Section 10: Notes
+                // Section 10: Traceability — receipts from / returns to this supplier
+                traceabilitySection
+
+                // Section 11: Notes
                 if let notes = supplier.notes, !notes.isEmpty {
                     Section("Notes") {
                         Text(notes)
@@ -1462,6 +1466,70 @@ private struct SupplierDetailSheet: View {
         }
     }
 
+    // MARK: - Traceability
+
+    @ViewBuilder
+    private var traceabilitySection: some View {
+        Section {
+            if supplierTrace.isEmpty {
+                Text("No tracked movements for this supplier yet. Receipts and supplier returns appear here once parts are received or sent back.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(supplierTrace, id: \.movementId) { step in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Image(systemName: StockMovement.MovementType.systemImageName(forRawValue: step.movementType))
+                                .font(.caption)
+                                .foregroundStyle(Color.accentColor)
+                                .accessibilityHidden(true)
+                            Text(step.partName ?? "Part #\(step.partId)")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                                .lineLimit(1)
+                            Spacer()
+                            Text("×\(step.qty)")
+                                .font(.caption)
+                                .monospacedDigit()
+                                .foregroundStyle(.secondary)
+                        }
+                        HStack(spacing: 4) {
+                            Text(StockMovement.MovementType.displayName(forRawValue: step.movementType))
+                                .font(.caption2)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Color.accentColor.opacity(0.1))
+                                .clipShape(Capsule())
+                            Text("\(step.fromLocation) → \(step.toLocation)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        HStack {
+                            Text(String(step.date.prefix(10)))
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                            if let ref = step.referenceNumber, !ref.isEmpty {
+                                Text(ref)
+                                    .font(.caption2)
+                                    .monospaced()
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                    }
+                    .frame(minHeight: 44)
+                    .accessibilityElement(children: .combine)
+                }
+            }
+        } header: {
+            Text("Traceability")
+        } footer: {
+            if !supplierTrace.isEmpty {
+                Text("Last \(supplierTrace.count) movements linked to this supplier — receipts into the warehouse and returns sent back.")
+            }
+        }
+    }
+
     // MARK: - Helpers
 
     @ViewBuilder
@@ -1500,6 +1568,7 @@ private struct SupplierDetailSheet: View {
             partCount = try service.getSupplierPartCount(supplierId: supplier.id)
             contacts = try service.getSupplierContacts(supplierId: supplier.id)
             supplierScores = try service.calculateSupplierScores(supplierId: supplier.id)
+            supplierTrace = try service.getSupplierTrace(supplierId: supplier.id, limit: 10)
 
             // Check for existing supplier channel
             if let chatService = appCore.chatService,
@@ -1510,6 +1579,7 @@ private struct SupplierDetailSheet: View {
 
             isLoading = false
         } catch {
+            loadError = userFriendlyError(error, context: "load supplier details")
             isLoading = false
         }
     }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingOverrideFlow.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingOverrideFlow.swift
@@ -4,11 +4,14 @@ import WiredPartCore
 /// Flow for setting pricing at a hierarchy level with override confirmation.
 ///
 /// Presents a multi-step sheet:
-/// 1. Pick the hierarchy level (Category, Style, Type, Brand)
-/// 2. Pick the specific entity at that level
+/// 1. Pick the hierarchy level (Category, Style, Type, Brand, Part)
+/// 2. Pick the specific entity at that level (parts are searchable)
 /// 3. Enter the new markup/margin/fixed price
 /// 4. Preview up to 15 random affected parts (read-only)
 /// 5. If overrides exist, step through them ONE AT A TIME (Replace or Keep)
+///
+/// Part is the most specific level: setting a part target replaces any
+/// existing part-level tier for that part and overrides all inherited tiers.
 struct PricingTierSetSheet: View {
     let onComplete: () async -> Void
     @EnvironmentObject private var appCore: AppCore
@@ -28,6 +31,8 @@ struct PricingTierSetSheet: View {
     @State private var styles: [PartStyle] = []
     @State private var types: [PartType] = []
     @State private var brands: [Brand] = []
+    @State private var partOptions: [(id: Int64, name: String)] = []
+    @State private var partSearchText = ""
 
     // Price input
     @State private var markupText = ""
@@ -61,6 +66,7 @@ struct PricingTierSetSheet: View {
         case style = "Style"
         case type = "Type"
         case brand = "Brand"
+        case part = "Part"
     }
 
     var body: some View {
@@ -143,6 +149,23 @@ struct PricingTierSetSheet: View {
     @ViewBuilder
     private var selectEntityView: some View {
         List {
+            if selectedLevel == .part {
+                Section {
+                    HStack(spacing: 8) {
+                        Image(systemName: "magnifyingglass")
+                            .foregroundStyle(.secondary)
+                            .accessibilityHidden(true)
+                        TextField("Search parts by name or code", text: $partSearchText)
+                            .textFieldStyle(.plain)
+                            .autocorrectionDisabled()
+                            .frame(minHeight: 44)
+                            .onChange(of: partSearchText) { _, _ in
+                                Task { await loadPartOptions() }
+                            }
+                    }
+                }
+            }
+
             Section("Select a \(selectedLevel.rawValue)") {
                 switch selectedLevel {
                 case .category:
@@ -160,6 +183,18 @@ struct PricingTierSetSheet: View {
                 case .brand:
                     ForEach(brands, id: \.id) { brand in
                         entityButton(name: brand.name, id: brand.id ?? 0)
+                    }
+                case .part:
+                    if partOptions.isEmpty {
+                        Text(partSearchText.isEmpty
+                             ? "No parts in the catalog yet."
+                             : "No parts match \"\(partSearchText)\".")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(partOptions, id: \.id) { part in
+                            entityButton(name: part.name, id: part.id)
+                        }
                     }
                 }
             }
@@ -513,6 +548,7 @@ struct PricingTierSetSheet: View {
         case .style: return "paintbrush"
         case .type: return "cube"
         case .brand: return "tag"
+        case .part: return "wrench.and.screwdriver"
         }
     }
 
@@ -532,9 +568,38 @@ struct PricingTierSetSheet: View {
             case .brand:
                 let results = try service.listBrands()
                 brands = results.map(\.brand)
+            case .part:
+                partSearchText = ""
+                await loadPartOptions()
             }
         } catch {
             loadError = userFriendlyError(error, context: "load pricing overrides")
+        }
+    }
+
+    /// Load the part picker options, filtered by the current search text.
+    private func loadPartOptions() async {
+        guard let service = appCore.partsService else {
+            loadError = "Service not available"
+            return
+        }
+        do {
+            let query = partSearchText.trimmingCharacters(in: .whitespaces)
+            let result = try service.listCatalogParts(
+                search: query.isEmpty ? nil : query,
+                sortField: .name,
+                sortAscending: true,
+                limit: 100,
+                offset: 0
+            )
+            partOptions = result.parts.compactMap { pwd in
+                guard let id = pwd.part.id else { return nil }
+                let code = pwd.part.code
+                let name = (code?.isEmpty == false) ? "\(pwd.part.name) (\(code ?? ""))" : pwd.part.name
+                return (id: id, name: name)
+            }
+        } catch {
+            loadError = userFriendlyError(error, context: "load parts")
         }
     }
 
@@ -549,18 +614,19 @@ struct PricingTierSetSheet: View {
             let styId = selectedLevel == .style ? selectedEntityId : nil
             let typId = selectedLevel == .type ? selectedEntityId : nil
             let brnId = selectedLevel == .brand ? selectedEntityId : nil
+            let prtId = selectedLevel == .part ? selectedEntityId : nil
 
             let markup = pricingMode == "markup" ? Double(markupText) : nil
             let margin = pricingMode == "margin" ? Double(marginText) : nil
             let fixed = useFixedPrice ? Double(fixedPriceText) : nil
 
             previewParts = try service.getPreviewParts(
-                categoryId: catId, styleId: styId, typeId: typId, brandId: brnId,
+                categoryId: catId, styleId: styId, typeId: typId, brandId: brnId, partId: prtId,
                 newMarkupPercent: markup, newMarginPercent: margin, newFixedPrice: fixed
             )
 
             conflicts = try service.findOverrideConflicts(
-                categoryId: catId, styleId: styId, typeId: typId, brandId: brnId,
+                categoryId: catId, styleId: styId, typeId: typId, brandId: brnId, partId: prtId,
                 newMarkupPercent: markup, newMarginPercent: margin, newFixedPrice: fixed
             )
 
@@ -593,6 +659,7 @@ struct PricingTierSetSheet: View {
             let styId = selectedLevel == .style ? selectedEntityId : nil
             let typId = selectedLevel == .type ? selectedEntityId : nil
             let brnId = selectedLevel == .brand ? selectedEntityId : nil
+            let prtId = selectedLevel == .part ? selectedEntityId : nil
 
             let markup = pricingMode == "markup" ? Double(markupText) : nil
             let margin = pricingMode == "margin" ? Double(marginText) : nil
@@ -600,7 +667,7 @@ struct PricingTierSetSheet: View {
 
             // Set the tier
             _ = try service.setPricingTier(
-                categoryId: catId, styleId: styId, typeId: typId, brandId: brnId,
+                categoryId: catId, styleId: styId, typeId: typId, brandId: brnId, partId: prtId,
                 markupPercent: markup, marginPercent: margin, fixedSellPrice: fixed
             )
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingOverrideFlow.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingOverrideFlow.swift
@@ -159,10 +159,13 @@ struct PricingTierSetSheet: View {
                             .textFieldStyle(.plain)
                             .autocorrectionDisabled()
                             .frame(minHeight: 44)
-                            .onChange(of: partSearchText) { _, _ in
-                                Task { await loadPartOptions() }
-                            }
                     }
+                }
+                // Tied to partSearchText's identity so SwiftUI cancels any
+                // in-flight load automatically when the text changes again —
+                // avoids untracked Tasks racing and applying stale results.
+                .task(id: partSearchText) {
+                    await loadPartOptions()
                 }
             }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ReceivingRoutingFlow.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ReceivingRoutingFlow.swift
@@ -1163,7 +1163,8 @@ struct ReceivingRoutingFlow: View {
                 qty: receivedQty,
                 returnType: action.rawValue.lowercased(),
                 performedBy: userId,
-                notes: "Damaged on arrival, requesting \(action.rawValue.lowercased())"
+                notes: "Damaged on arrival, requesting \(action.rawValue.lowercased())",
+                receivingSessionId: item.sessionId
             )
             try service.markReceivingSessionItemRouted(
                 itemId: item.id,

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ReceivingRoutingFlow.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/ReceivingRoutingFlow.swift
@@ -1083,7 +1083,8 @@ struct ReceivingRoutingFlow: View {
                 qty: receivedQty,
                 jobId: link.jobId,
                 performedBy: userId,
-                notes: "Received via PO, staged for \(link.jobName)"
+                notes: "Received via PO, staged for \(link.jobName)",
+                receivingSessionId: item.sessionId
             )
             try service.markReceivingSessionItemRouted(
                 itemId: item.id,
@@ -1123,7 +1124,8 @@ struct ReceivingRoutingFlow: View {
                 qty: qtyToStage,
                 jobId: demand.jobId,
                 performedBy: userId,
-                notes: "Cross-job staging from receiving for \(demand.jobName)"
+                notes: "Cross-job staging from receiving for \(demand.jobName)",
+                receivingSessionId: item.sessionId
             )
             try service.markReceivingSessionItemRouted(
                 itemId: item.id,

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -7699,8 +7699,12 @@ public final class PartsService: Sendable {
 
             // Total units received from this supplier.
             // Receiving writers persist the canonical receive family
-            // ('receive', 'receiving', 'receipt') — count all of them so the
-            // quality denominator matches what the receiving flow writes.
+            // ('receive', 'receiving', 'receipt') plus 'receiving_staged' for
+            // deliveries routed straight to job staging
+            // (WarehouseService.stageReceivedPartsForJob) — count all of them
+            // so the quality denominator matches what the receiving flow
+            // writes. Job-return staging also uses 'receiving_staged' but
+            // carries no supplier_id, so the supplier_id filter excludes it.
             let receivedRow = try Row.fetchOne(dbConn, sql: """
                 SELECT COALESCE(SUM(qty), 0) AS total_received
                 FROM stock_movements
@@ -7708,7 +7712,8 @@ public final class PartsService: Sendable {
                 AND movement_type IN (
                     '\(StockMovement.MovementType.receipt.rawValue)',
                     '\(StockMovement.MovementType.receive.rawValue)',
-                    '\(StockMovement.MovementType.receiving.rawValue)'
+                    '\(StockMovement.MovementType.receiving.rawValue)',
+                    '\(StockMovement.MovementType.receivingStaged.rawValue)'
                 )
                 AND deleted_at IS NULL
                 """, arguments: [supplierId])
@@ -8778,13 +8783,21 @@ public final class PartsService: Sendable {
     }
 
     /// Compute smart-card facet counts for the catalog filter bar.
+    ///
+    /// `lowStockOnly` mirrors the list's Low Stock toggle: when true, every
+    /// dimension facet (category/style/type/color/brand) is restricted to
+    /// below-min-stock parts so the badges match what the filtered list shows.
+    /// The Low Stock card's own count excludes the toggle (facet semantics —
+    /// a card never filters by its own dimension), and All Parts stays
+    /// search-only because tapping it resets every filter.
     public func getCatalogFilterCounts(
         search: String? = nil,
         categoryId: Int64? = nil,
         styleId: Int64? = nil,
         typeId: Int64? = nil,
         colorId: Int64? = nil,
-        brandId: Int64? = nil
+        brandId: Int64? = nil,
+        lowStockOnly: Bool = false
     ) throws -> CatalogFilterCounts {
         do { return try db.writer.read { dbConn in
             let lowStockSQL = """
@@ -8802,6 +8815,7 @@ public final class PartsService: Sendable {
                 if let typeId, dimension != "type" { clauses.append("p.type_id = ?"); args.append(typeId) }
                 if let colorId, dimension != "color" { clauses.append("p.color_id = ?"); args.append(colorId) }
                 if let brandId, dimension != "brand" { clauses.append("p.brand_id = ?"); args.append(brandId) }
+                if lowStockOnly, dimension != "lowStock" { clauses.append("(\(lowStockSQL))") }
                 if let search, !search.isEmpty {
                     clauses.append("(p.name LIKE ? OR p.code LIKE ? OR COALESCE(b.name, '') LIKE ?)")
                     let like = "%\(search)%"
@@ -8841,7 +8855,9 @@ public final class PartsService: Sendable {
                 """, arguments: StatementArguments(allArgs)) ?? 0
 
             // "Low Stock": all active dimension filters + below-min condition.
-            let (filteredWhere, filteredArgs) = buildWhere(excluding: nil)
+            // Excludes its own dimension (the low-stock toggle) so the count
+            // is stable whether or not the toggle is active.
+            let (filteredWhere, filteredArgs) = buildWhere(excluding: "lowStock")
             let lowStock = try Int.fetchOne(dbConn, sql: """
                 SELECT COUNT(*) FROM parts p
                 LEFT JOIN brands b ON b.id = p.brand_id AND b.deleted_at IS NULL

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -2967,6 +2967,26 @@ public final class PartsService: Sendable {
         styleId: Int64? = nil,
         typeId: Int64? = nil,
         brandId: Int64? = nil,
+        partId: Int64? = nil,
+        newMarkupPercent: Double? = nil,
+        newMarginPercent: Double? = nil,
+        newFixedPrice: Double? = nil
+    ) throws -> [OverrideConflict] {
+        // Part is the MOST specific pricing level: nothing below it can
+        // conflict, and an existing tier on the same part is replaced by
+        // the setPricingTier upsert. No overrides to review.
+        if partId != nil { return [] }
+        return try findScopedOverrideConflicts(
+            categoryId: categoryId, styleId: styleId, typeId: typeId, brandId: brandId,
+            newMarkupPercent: newMarkupPercent, newMarginPercent: newMarginPercent, newFixedPrice: newFixedPrice
+        )
+    }
+
+    private func findScopedOverrideConflicts(
+        categoryId: Int64? = nil,
+        styleId: Int64? = nil,
+        typeId: Int64? = nil,
+        brandId: Int64? = nil,
         newMarkupPercent: Double? = nil,
         newMarginPercent: Double? = nil,
         newFixedPrice: Double? = nil
@@ -3082,6 +3102,7 @@ public final class PartsService: Sendable {
         styleId: Int64? = nil,
         typeId: Int64? = nil,
         brandId: Int64? = nil,
+        partId: Int64? = nil,
         newMarkupPercent: Double? = nil,
         newMarginPercent: Double? = nil,
         newFixedPrice: Double? = nil,
@@ -3099,6 +3120,7 @@ public final class PartsService: Sendable {
             if let id = styleId { conditions.append("p.style_id = ?"); args.append(id) }
             if let id = typeId { conditions.append("p.type_id = ?"); args.append(id) }
             if let id = brandId { conditions.append("p.brand_id = ?"); args.append(id) }
+            if let id = partId { conditions.append("p.id = ?"); args.append(id) }
 
             let whereClause = conditions.joined(separator: " AND ")
 
@@ -7675,21 +7697,40 @@ public final class PartsService: Sendable {
                 """, arguments: [supplierId])
             let totalPOs: Int = poRow?["total_pos"] ?? 0
 
-            // Total units received from this supplier
+            // Total units received from this supplier.
+            // Receiving writers persist the canonical receive family
+            // ('receive', 'receiving', 'receipt') — count all of them so the
+            // quality denominator matches what the receiving flow writes.
             let receivedRow = try Row.fetchOne(dbConn, sql: """
                 SELECT COALESCE(SUM(qty), 0) AS total_received
                 FROM stock_movements
-                WHERE supplier_id = ? AND movement_type = '\(StockMovement.MovementType.receipt.rawValue)' AND deleted_at IS NULL
+                WHERE supplier_id = ?
+                AND movement_type IN (
+                    '\(StockMovement.MovementType.receipt.rawValue)',
+                    '\(StockMovement.MovementType.receive.rawValue)',
+                    '\(StockMovement.MovementType.receiving.rawValue)'
+                )
+                AND deleted_at IS NULL
                 """, arguments: [supplierId])
             let totalReceived: Int = receivedRow?["total_received"] ?? 0
 
-            // Total units returned TO this supplier
+            // Total units returned TO this supplier.
+            // The supplier-return flow writes movement_type 'return_to_supplier'
+            // (WarehouseService.returnDamagedToSupplier) with no location endpoints,
+            // so those rows are attributed purely by supplier_id. Legacy 'return'
+            // rows only count when they are actually supplier-bound.
             let returnedRow = try Row.fetchOne(dbConn, sql: """
                 SELECT COALESCE(SUM(qty), 0) AS total_returned
                 FROM stock_movements
-                WHERE supplier_id = ? AND movement_type = '\(StockMovement.MovementType.stockReturn.rawValue)' AND deleted_at IS NULL
-                AND from_location_type IN ('warehouse', 'staging')
-                AND to_location_type = 'supplier'
+                WHERE supplier_id = ? AND deleted_at IS NULL
+                AND (
+                    movement_type = '\(StockMovement.MovementType.returnToSupplier.rawValue)'
+                    OR (
+                        movement_type = '\(StockMovement.MovementType.stockReturn.rawValue)'
+                        AND from_location_type IN ('warehouse', 'staging')
+                        AND to_location_type = 'supplier'
+                    )
+                )
                 """, arguments: [supplierId])
             let totalReturned: Int = returnedRow?["total_returned"] ?? 0
 
@@ -8048,6 +8089,8 @@ public final class PartsService: Sendable {
     /// A single step in a part's journey from supplier to job.
     public struct TraceStep: Sendable {
         public let movementId: Int64
+        public let partId: Int64
+        public let partName: String?
         public let date: String
         public let movementType: String     // "receipt", "transfer", "consumption", "return"
         public let fromLocation: String     // e.g. "Supplier: ABC Supply"
@@ -8064,30 +8107,14 @@ public final class PartsService: Sendable {
     public func tracePartMovements(partId: Int64) throws -> [TraceStep] {
         try db.writer.read { dbConn in
             let rows = try Row.fetchAll(dbConn, sql: """
-                SELECT sm.*, u.display_name AS performer_name
+                SELECT sm.*, u.display_name AS performer_name, p.name AS part_name
                 FROM stock_movements sm
                 LEFT JOIN users u ON u.id = sm.performed_by AND u.deleted_at IS NULL
+                LEFT JOIN parts p ON p.id = sm.part_id
                 WHERE sm.part_id = ? AND sm.deleted_at IS NULL
                 ORDER BY sm.created_at ASC
                 """, arguments: [partId])
-
-            return rows.map { row in
-                let fromType: String? = row["from_location_type"]
-                let toType: String? = row["to_location_type"]
-
-                return TraceStep(
-                    movementId: row["id"],
-                    date: row["created_at"] ?? "",
-                    movementType: row["movement_type"] ?? StockMovement.MovementType.transfer.rawValue,
-                    fromLocation: describeLocation(type: fromType),
-                    toLocation: describeLocation(type: toType),
-                    qty: row["qty"],
-                    unitCost: row["unit_cost_at_move"],
-                    performedByName: row["performer_name"],
-                    referenceNumber: row["reference_number"],
-                    notes: row["notes"]
-                )
-            }
+            return try rows.map { try self.traceStep(from: $0, dbConn: dbConn) }
         }
     }
 
@@ -8095,31 +8122,52 @@ public final class PartsService: Sendable {
     public func tracePartFromSupplier(partId: Int64, supplierId: Int64) throws -> [TraceStep] {
         try db.writer.read { dbConn in
             let rows = try Row.fetchAll(dbConn, sql: """
-                SELECT sm.*, u.display_name AS performer_name
+                SELECT sm.*, u.display_name AS performer_name, p.name AS part_name
                 FROM stock_movements sm
                 LEFT JOIN users u ON u.id = sm.performed_by AND u.deleted_at IS NULL
+                LEFT JOIN parts p ON p.id = sm.part_id
                 WHERE sm.part_id = ? AND sm.supplier_id = ? AND sm.deleted_at IS NULL
                 ORDER BY sm.created_at ASC
                 """, arguments: [partId, supplierId])
-
-            return rows.map { row in
-                let fromType: String? = row["from_location_type"]
-                let toType: String? = row["to_location_type"]
-
-                return TraceStep(
-                    movementId: row["id"],
-                    date: row["created_at"] ?? "",
-                    movementType: row["movement_type"] ?? StockMovement.MovementType.transfer.rawValue,
-                    fromLocation: describeLocation(type: fromType),
-                    toLocation: describeLocation(type: toType),
-                    qty: row["qty"],
-                    unitCost: row["unit_cost_at_move"],
-                    performedByName: row["performer_name"],
-                    referenceNumber: row["reference_number"],
-                    notes: row["notes"]
-                )
-            }
+            return try rows.map { try self.traceStep(from: $0, dbConn: dbConn) }
         }
+    }
+
+    /// Recent movements attributed to a supplier across ALL parts — receipts
+    /// from the supplier and returns back to them. Newest first. Backs the
+    /// Traceability section on Supplier detail.
+    public func getSupplierTrace(supplierId: Int64, limit: Int = 10) throws -> [TraceStep] {
+        try db.writer.read { dbConn in
+            let rows = try Row.fetchAll(dbConn, sql: """
+                SELECT sm.*, u.display_name AS performer_name, p.name AS part_name
+                FROM stock_movements sm
+                LEFT JOIN users u ON u.id = sm.performed_by AND u.deleted_at IS NULL
+                LEFT JOIN parts p ON p.id = sm.part_id
+                WHERE sm.supplier_id = ? AND sm.deleted_at IS NULL
+                ORDER BY sm.created_at DESC
+                LIMIT ?
+                """, arguments: [supplierId, limit])
+            return try rows.map { try self.traceStep(from: $0, dbConn: dbConn) }
+        }
+    }
+
+    /// Build a TraceStep from a stock_movements row, resolving location
+    /// endpoints to specific entity names (warehouse/job/truck/staging).
+    private func traceStep(from row: Row, dbConn: Database) throws -> TraceStep {
+        TraceStep(
+            movementId: row["id"],
+            partId: row["part_id"],
+            partName: row["part_name"],
+            date: row["created_at"] ?? "",
+            movementType: row["movement_type"] ?? StockMovement.MovementType.transfer.rawValue,
+            fromLocation: try describeLocation(type: row["from_location_type"], id: row["from_location_id"], dbConn: dbConn),
+            toLocation: try describeLocation(type: row["to_location_type"], id: row["to_location_id"], dbConn: dbConn),
+            qty: row["qty"],
+            unitCost: row["unit_cost_at_move"],
+            performedByName: row["performer_name"],
+            referenceNumber: row["reference_number"],
+            notes: row["notes"]
+        )
     }
 
     /// Get the current location of a part's stock — where is it right now?
@@ -8140,17 +8188,47 @@ public final class PartsService: Sendable {
         }
     }
 
-    /// Describe a location type as a human-readable string
-    private func describeLocation(type: String?) -> String {
+    /// Describe a location endpoint as a human-readable string, resolving the
+    /// specific warehouse/job/truck/staging entity name when an id is present
+    /// (movement-location fidelity — GH#84 traceability).
+    private func describeLocation(type: String?, id: Int64? = nil, dbConn: Database? = nil) throws -> String {
         guard let type = type else { return "Unknown" }
+
+        let genericLabel: String
         switch type.lowercased() {
-        case "supplier": return "Supplier"
-        case "warehouse": return "Warehouse"
-        case "staging": return "Staging Area"
-        case "job": return "Job Site"
-        case "truck", "vehicle": return "Truck"
-        default: return type.capitalized
+        case "supplier": genericLabel = "Supplier"
+        case "warehouse", "shop": genericLabel = "Warehouse"
+        case "staging": genericLabel = "Staging Area"
+        case "job", "pulled": genericLabel = "Job Site"
+        case "truck", "vehicle": genericLabel = "Truck"
+        case "job_return_holding": genericLabel = "Job Return Holding"
+        default: genericLabel = type.capitalized
         }
+
+        guard let id, let dbConn else { return genericLabel }
+
+        // Resolve the concrete entity name; a missing row falls back to the
+        // generic label (movements can outlive their location entities).
+        let nameSQL: String?
+        switch type.lowercased() {
+        case "warehouse", "shop":
+            nameSQL = "SELECT name FROM warehouse_locations WHERE id = ?"
+        case "staging":
+            nameSQL = "SELECT name FROM staging_zones WHERE id = ?"
+        case "truck", "vehicle":
+            nameSQL = "SELECT vehicle_name FROM vehicles WHERE id = ?"
+        case "job", "pulled":
+            nameSQL = "SELECT job_name FROM jobs WHERE id = ?"
+        case "supplier":
+            nameSQL = "SELECT name FROM suppliers WHERE id = ?"
+        default:
+            nameSQL = nil
+        }
+
+        guard let nameSQL else { return genericLabel }
+        guard let name = try String.fetchOne(dbConn, sql: nameSQL, arguments: [id]),
+              !name.isEmpty else { return genericLabel }
+        return "\(genericLabel): \(name)"
     }
 
     // =========================================================================
@@ -8666,6 +8744,124 @@ public final class PartsService: Sendable {
         }
         } catch {
             if isTableNotFoundError(error) { return CatalogSearchResult(parts: [], totalCount: 0) }
+            throw error
+        }
+    }
+
+    // MARK: - Catalog Filter Facet Counts (GH#67 smart-card stat filters)
+
+    /// Per-dimension part counts backing the catalog smart-card filters.
+    ///
+    /// Facet semantics: each dimension's counts are computed with every OTHER
+    /// active filter applied but that dimension's own selection excluded, so a
+    /// filter card can show how many parts each option would match.
+    public struct CatalogFilterCounts: Sendable {
+        /// Parts matching the search text only (no dimension filters) — the "All Parts" card.
+        public let allParts: Int
+        /// Parts matching all active dimension filters AND currently below min stock — the "Low Stock" card.
+        public let lowStock: Int
+        public let byCategory: [Int64: Int]
+        public let byStyle: [Int64: Int]
+        public let byType: [Int64: Int]
+        public let byColor: [Int64: Int]
+        public let byBrand: [Int64: Int]
+
+        public init(allParts: Int, lowStock: Int, byCategory: [Int64: Int], byStyle: [Int64: Int], byType: [Int64: Int], byColor: [Int64: Int], byBrand: [Int64: Int]) {
+            self.allParts = allParts
+            self.lowStock = lowStock
+            self.byCategory = byCategory
+            self.byStyle = byStyle
+            self.byType = byType
+            self.byColor = byColor
+            self.byBrand = byBrand
+        }
+    }
+
+    /// Compute smart-card facet counts for the catalog filter bar.
+    public func getCatalogFilterCounts(
+        search: String? = nil,
+        categoryId: Int64? = nil,
+        styleId: Int64? = nil,
+        typeId: Int64? = nil,
+        colorId: Int64? = nil,
+        brandId: Int64? = nil
+    ) throws -> CatalogFilterCounts {
+        do { return try db.writer.read { dbConn in
+            let lowStockSQL = """
+                p.min_stock_level IS NOT NULL AND \
+                COALESCE((SELECT SUM(s.qty) FROM stock s WHERE s.part_id = p.id AND s.deleted_at IS NULL), 0) < p.min_stock_level
+                """
+
+            /// Build WHERE clauses for the active filters, optionally excluding
+            /// one dimension (the one being faceted).
+            func buildWhere(excluding dimension: String?) -> (sql: String, args: [DatabaseValueConvertible?]) {
+                var clauses = ["p.deleted_at IS NULL"]
+                var args: [DatabaseValueConvertible?] = []
+                if let categoryId, dimension != "category" { clauses.append("p.category_id = ?"); args.append(categoryId) }
+                if let styleId, dimension != "style" { clauses.append("p.style_id = ?"); args.append(styleId) }
+                if let typeId, dimension != "type" { clauses.append("p.type_id = ?"); args.append(typeId) }
+                if let colorId, dimension != "color" { clauses.append("p.color_id = ?"); args.append(colorId) }
+                if let brandId, dimension != "brand" { clauses.append("p.brand_id = ?"); args.append(brandId) }
+                if let search, !search.isEmpty {
+                    clauses.append("(p.name LIKE ? OR p.code LIKE ? OR COALESCE(b.name, '') LIKE ?)")
+                    let like = "%\(search)%"
+                    args.append(like); args.append(like); args.append(like)
+                }
+                return (clauses.joined(separator: " AND "), args)
+            }
+
+            func facetCounts(column: String, dimension: String) throws -> [Int64: Int] {
+                let (whereSQL, args) = buildWhere(excluding: dimension)
+                let rows = try Row.fetchAll(dbConn, sql: """
+                    SELECT p.\(column) AS facet_id, COUNT(*) AS cnt
+                    FROM parts p
+                    LEFT JOIN brands b ON b.id = p.brand_id AND b.deleted_at IS NULL
+                    WHERE \(whereSQL) AND p.\(column) IS NOT NULL
+                    GROUP BY p.\(column)
+                    """, arguments: StatementArguments(args))
+                var counts: [Int64: Int] = [:]
+                for row in rows {
+                    if let id: Int64 = row["facet_id"] { counts[id] = row["cnt"] }
+                }
+                return counts
+            }
+
+            // "All Parts": search text only, no dimension filters.
+            var allWhere = ["p.deleted_at IS NULL"]
+            var allArgs: [DatabaseValueConvertible?] = []
+            if let search, !search.isEmpty {
+                allWhere.append("(p.name LIKE ? OR p.code LIKE ? OR COALESCE(b.name, '') LIKE ?)")
+                let like = "%\(search)%"
+                allArgs.append(like); allArgs.append(like); allArgs.append(like)
+            }
+            let allParts = try Int.fetchOne(dbConn, sql: """
+                SELECT COUNT(*) FROM parts p
+                LEFT JOIN brands b ON b.id = p.brand_id AND b.deleted_at IS NULL
+                WHERE \(allWhere.joined(separator: " AND "))
+                """, arguments: StatementArguments(allArgs)) ?? 0
+
+            // "Low Stock": all active dimension filters + below-min condition.
+            let (filteredWhere, filteredArgs) = buildWhere(excluding: nil)
+            let lowStock = try Int.fetchOne(dbConn, sql: """
+                SELECT COUNT(*) FROM parts p
+                LEFT JOIN brands b ON b.id = p.brand_id AND b.deleted_at IS NULL
+                WHERE \(filteredWhere) AND \(lowStockSQL)
+                """, arguments: StatementArguments(filteredArgs)) ?? 0
+
+            return CatalogFilterCounts(
+                allParts: allParts,
+                lowStock: lowStock,
+                byCategory: try facetCounts(column: "category_id", dimension: "category"),
+                byStyle: try facetCounts(column: "style_id", dimension: "style"),
+                byType: try facetCounts(column: "type_id", dimension: "type"),
+                byColor: try facetCounts(column: "color_id", dimension: "color"),
+                byBrand: try facetCounts(column: "brand_id", dimension: "brand")
+            )
+        }
+        } catch {
+            if isTableNotFoundError(error) {
+                return CatalogFilterCounts(allParts: 0, lowStock: 0, byCategory: [:], byStyle: [:], byType: [:], byColor: [:], byBrand: [:])
+            }
             throw error
         }
     }

--- a/core/Sources/WiredPartCore/Services/PartsService.swift
+++ b/core/Sources/WiredPartCore/Services/PartsService.swift
@@ -8159,14 +8159,38 @@ public final class PartsService: Sendable {
     /// Build a TraceStep from a stock_movements row, resolving location
     /// endpoints to specific entity names (warehouse/job/truck/staging).
     private func traceStep(from row: Row, dbConn: Database) throws -> TraceStep {
-        TraceStep(
+        // Receiving and return-to-supplier movements don't populate
+        // from_location_*/to_location_* on the supplier side (by design in
+        // WarehouseService — see createMovement callers), so fall back to
+        // supplier_id for whichever endpoint is nil rather than rendering
+        // "Unknown" when the row clearly names a supplier.
+        let movementType: String = row["movement_type"] ?? StockMovement.MovementType.transfer.rawValue
+        let supplierId: Int64? = row["supplier_id"]
+        var fromType: String? = row["from_location_type"]
+        var fromId: Int64? = row["from_location_id"]
+        var toType: String? = row["to_location_type"]
+        var toId: Int64? = row["to_location_id"]
+
+        if let supplierId {
+            if movementType == StockMovement.MovementType.returnToSupplier.rawValue, toType == nil {
+                toType = "supplier"
+                toId = supplierId
+            } else if fromType == nil {
+                // Receiving (and similar inbound movements) originate at the
+                // supplier even though from_location_* is left nil.
+                fromType = "supplier"
+                fromId = supplierId
+            }
+        }
+
+        return TraceStep(
             movementId: row["id"],
             partId: row["part_id"],
             partName: row["part_name"],
             date: row["created_at"] ?? "",
-            movementType: row["movement_type"] ?? StockMovement.MovementType.transfer.rawValue,
-            fromLocation: try describeLocation(type: row["from_location_type"], id: row["from_location_id"], dbConn: dbConn),
-            toLocation: try describeLocation(type: row["to_location_type"], id: row["to_location_id"], dbConn: dbConn),
+            movementType: movementType,
+            fromLocation: try describeLocation(type: fromType, id: fromId, dbConn: dbConn),
+            toLocation: try describeLocation(type: toType, id: toId, dbConn: dbConn),
             qty: row["qty"],
             unitCost: row["unit_cost_at_move"],
             performedByName: row["performer_name"],

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -855,7 +855,8 @@ public final class WarehouseService: Sendable {
         scanConfirmed: Bool = false,
         gpsLat: Double? = nil,
         gpsLng: Double? = nil,
-        validatePath: Bool = true
+        validatePath: Bool = true,
+        supplierId: Int64? = nil
     ) throws -> Int64 {
         try db.writer.read { dbConn in
             try Self.requireActiveUser(performedBy, dbConn: dbConn)
@@ -907,14 +908,14 @@ public final class WarehouseService: Sendable {
                      to_location_type, to_location_id, movement_type,
                      reason, notes, performed_by, job_id, photo_path,
                      reference_number, unit_cost_at_move, unit_sell_at_move,
-                     verified_by, scan_confirmed, gps_lat, gps_lng, created_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     verified_by, scan_confirmed, gps_lat, gps_lng, supplier_id, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                 arguments: [partId, qty, fromLocationType, fromLocationId,
                             toLocationType, toLocationId, movementType,
                             reason, notes, performedBy, jobId, photoPath,
                             referenceNumber, unitCostAtMove, unitSellAtMove,
-                            verifiedBy, scanConfirmed ? 1 : 0, gpsLat, gpsLng,
+                            verifiedBy, scanConfirmed ? 1 : 0, gpsLat, gpsLng, supplierId,
                             occurredAt.map(Self.sqliteDateString) ?? Self.sqliteDateString(Date())]
             )
             let movementId = dbConn.lastInsertedRowID
@@ -1923,6 +1924,15 @@ public final class WarehouseService: Sendable {
                 arguments: [sessionId]
             )
 
+            // Resolve the supplier for this session's PO so receiving movements
+            // carry supplier attribution (used by supplier quality scores).
+            let sessionSupplierId = try Int64.fetchOne(dbConn, sql: """
+                SELECT po.supplier_id
+                FROM receiving_sessions rs
+                JOIN purchase_orders po ON po.id = rs.po_id AND po.deleted_at IS NULL
+                WHERE rs.id = ? AND rs.deleted_at IS NULL
+                """, arguments: [sessionId])
+
             // Create shelf stock movements for each received item that was not
             // already routed to staging, return/review, or write-off.
             let items = try Row.fetchAll(
@@ -1954,15 +1964,16 @@ public final class WarehouseService: Sendable {
                 guard partId > 0, shelfQty > 0 else { continue }
                 let unitCost: Double? = item["actual_cost"] as Double?
 
-                // Insert movement
+                // Insert movement (stamped with the PO's supplier so supplier
+                // quality scores can count these units as received)
                 try dbConn.execute(
                     sql: """
                         INSERT INTO stock_movements
                         (part_id, qty, to_location_type, to_location_id,
-                         movement_type, reason, performed_by, unit_cost_at_move, created_at)
-                        VALUES (?, ?, 'warehouse', 1, '\(StockMovement.MovementType.receiving.rawValue)', 'PO receiving', ?, ?, datetime('now'))
+                         movement_type, reason, performed_by, unit_cost_at_move, supplier_id, created_at)
+                        VALUES (?, ?, 'warehouse', 1, '\(StockMovement.MovementType.receiving.rawValue)', 'PO receiving', ?, ?, ?, datetime('now'))
                         """,
-                    arguments: [partId, shelfQty, completedBy, unitCost]
+                    arguments: [partId, shelfQty, completedBy, unitCost, sessionSupplierId]
                 )
 
                 // Add to warehouse stock
@@ -3796,15 +3807,34 @@ public final class WarehouseService: Sendable {
     }
 
     /// Record a supplier return for damaged parts.
+    ///
+    /// Supplier attribution: pass `supplierId` directly, or pass the
+    /// `receivingSessionId` the damaged item came from and the supplier is
+    /// resolved from that session's purchase order. The resolved supplier is
+    /// stamped on the stock movement so supplier quality scores
+    /// (`PartsService.calculateSupplierScores`) can count the returned units.
     @discardableResult
     public func returnDamagedToSupplier(
         partId: Int64,
         qty: Int,
         returnType: String,  // "replacement" or "refund"
         performedBy: Int64,
-        notes: String? = nil
+        notes: String? = nil,
+        supplierId: Int64? = nil,
+        receivingSessionId: Int64? = nil
     ) throws -> Int64 {
-        try createMovement(
+        var resolvedSupplierId = supplierId
+        if resolvedSupplierId == nil, let sessionId = receivingSessionId {
+            resolvedSupplierId = try db.writer.read { dbConn in
+                try Int64.fetchOne(dbConn, sql: """
+                    SELECT po.supplier_id
+                    FROM receiving_sessions rs
+                    JOIN purchase_orders po ON po.id = rs.po_id AND po.deleted_at IS NULL
+                    WHERE rs.id = ? AND rs.deleted_at IS NULL
+                    """, arguments: [sessionId])
+            }
+        }
+        return try createMovement(
             partId: partId,
             qty: qty,
             fromLocationType: nil,
@@ -3814,7 +3844,8 @@ public final class WarehouseService: Sendable {
             movementType: StockMovement.MovementType.returnToSupplier.rawValue,
             reason: "Damaged: \(returnType)",
             notes: notes,
-            performedBy: performedBy
+            performedBy: performedBy,
+            supplierId: resolvedSupplierId
         )
     }
 

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -3760,15 +3760,30 @@ public final class WarehouseService: Sendable {
     }
 
     /// Move received parts to staging for a job (does NOT count toward shelf inventory).
+    ///
+    /// Supplier attribution: pass `supplierId` directly, or pass the
+    /// `receivingSessionId` the items came from and the supplier is resolved
+    /// from that session's purchase order. The resolved supplier is stamped on
+    /// the stock movement so supplier quality scores
+    /// (`PartsService.calculateSupplierScores`) count staged units in the
+    /// received denominator — completeSession skips staged items when it
+    /// writes supplier-stamped shelf movements, so this is the only place
+    /// staged units can pick up their supplier.
     @discardableResult
     public func stageReceivedPartsForJob(
         partId: Int64,
         qty: Int,
         jobId: Int64,
         performedBy: Int64,
-        notes: String? = nil
+        notes: String? = nil,
+        supplierId: Int64? = nil,
+        receivingSessionId: Int64? = nil
     ) throws -> Int64 {
-        try createMovement(
+        let resolvedSupplierId = try resolveSupplierId(
+            supplierId: supplierId,
+            receivingSessionId: receivingSessionId
+        )
+        return try createMovement(
             partId: partId,
             qty: qty,
             fromLocationType: nil,
@@ -3779,8 +3794,28 @@ public final class WarehouseService: Sendable {
             reason: "Received and staged for job",
             notes: notes,
             performedBy: performedBy,
-            jobId: jobId
+            jobId: jobId,
+            supplierId: resolvedSupplierId
         )
+    }
+
+    /// Resolve a supplier for a receiving-flow movement: an explicit
+    /// `supplierId` wins; otherwise the supplier is looked up from the
+    /// receiving session's purchase order. Returns nil when neither resolves.
+    private func resolveSupplierId(
+        supplierId: Int64?,
+        receivingSessionId: Int64?
+    ) throws -> Int64? {
+        if let supplierId { return supplierId }
+        guard let sessionId = receivingSessionId else { return nil }
+        return try db.writer.read { dbConn in
+            try Int64.fetchOne(dbConn, sql: """
+                SELECT po.supplier_id
+                FROM receiving_sessions rs
+                JOIN purchase_orders po ON po.id = rs.po_id AND po.deleted_at IS NULL
+                WHERE rs.id = ? AND rs.deleted_at IS NULL
+                """, arguments: [sessionId])
+        }
     }
 
     /// Record a write-off for used/damaged parts that won't go on shelf.
@@ -3823,17 +3858,10 @@ public final class WarehouseService: Sendable {
         supplierId: Int64? = nil,
         receivingSessionId: Int64? = nil
     ) throws -> Int64 {
-        var resolvedSupplierId = supplierId
-        if resolvedSupplierId == nil, let sessionId = receivingSessionId {
-            resolvedSupplierId = try db.writer.read { dbConn in
-                try Int64.fetchOne(dbConn, sql: """
-                    SELECT po.supplier_id
-                    FROM receiving_sessions rs
-                    JOIN purchase_orders po ON po.id = rs.po_id AND po.deleted_at IS NULL
-                    WHERE rs.id = ? AND rs.deleted_at IS NULL
-                    """, arguments: [sessionId])
-            }
-        }
+        let resolvedSupplierId = try resolveSupplierId(
+            supplierId: supplierId,
+            receivingSessionId: receivingSessionId
+        )
         return try createMovement(
             partId: partId,
             qty: qty,

--- a/core/Tests/WiredPartCoreTests/E2EPartsCatalogTests.swift
+++ b/core/Tests/WiredPartCoreTests/E2EPartsCatalogTests.swift
@@ -659,4 +659,101 @@ struct E2EPartsCatalogTests {
         #expect(cleared.effectiveCost == nil)
         #expect(cleared.source == "none")
     }
+
+    // MARK: - Catalog Filter Facet Counts (GH#67 smart-card stat filters)
+
+    @Test("getCatalogFilterCounts returns per-dimension counts with own-dimension exclusion")
+    func testCatalogFilterCounts() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catA = try env.parts.createCategory(name: "FacetCatA")
+        let catB = try env.parts.createCategory(name: "FacetCatB")
+        let brandX = try E2ETestHelpers.seedBrand(env, name: "FacetBrandX")
+        _ = try env.parts.createPart(categoryId: catA, name: "FacetPart1", code: "FP-1", brandId: brandX)
+        _ = try env.parts.createPart(categoryId: catA, name: "FacetPart2", code: "FP-2")
+        _ = try env.parts.createPart(categoryId: catB, name: "FacetPart3", code: "FP-3", brandId: brandX)
+
+        let unfiltered = try env.parts.getCatalogFilterCounts()
+        #expect(unfiltered.allParts == 3)
+        #expect(unfiltered.byCategory[catA] == 2)
+        #expect(unfiltered.byCategory[catB] == 1)
+        #expect(unfiltered.byBrand[brandX] == 2)
+
+        // With a category filter active:
+        let filtered = try env.parts.getCatalogFilterCounts(categoryId: catA)
+        #expect(filtered.byBrand[brandX] == 1, "brand facet must respect the active category filter")
+        #expect(filtered.byCategory[catB] == 1,
+                "category facet excludes its own selection so other options stay pickable")
+        #expect(filtered.allParts == 3, "All Parts card ignores dimension filters")
+    }
+
+    @Test("getCatalogFilterCounts lowStock counts parts below min stock under current filters")
+    func testCatalogFilterCountsLowStock() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try env.parts.createCategory(name: "LowFacetCat")
+        _ = try env.parts.createPart(categoryId: catId, name: "LowFacetPart", code: "LF-1", minStockLevel: 5)
+        let healthyId = try env.parts.createPart(categoryId: catId, name: "HealthyFacetPart", code: "LF-2", minStockLevel: 5)
+        _ = try E2ETestHelpers.seedStock(env, partId: healthyId, qty: 10)
+
+        let counts = try env.parts.getCatalogFilterCounts(categoryId: catId)
+        #expect(counts.lowStock == 1, "only the part below its min stock level counts as low stock")
+    }
+
+    @Test("getCatalogFilterCounts respects search text")
+    func testCatalogFilterCountsSearch() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try env.parts.createCategory(name: "SearchFacetCat")
+        _ = try env.parts.createPart(categoryId: catId, name: "Copper Elbow", code: "SF-1")
+        _ = try env.parts.createPart(categoryId: catId, name: "PVC Elbow", code: "SF-2")
+
+        let counts = try env.parts.getCatalogFilterCounts(search: "Copper", categoryId: catId)
+        #expect(counts.allParts == 1)
+        #expect(counts.byCategory[catId] == 1)
+    }
+
+    // MARK: - Part-Level Pricing Target (GH#83)
+
+    @Test("getPreviewParts scoped to a single part returns only that part")
+    func testGetPreviewPartsPartLevel() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try env.parts.createCategory(name: "PartTierCat")
+        let p1 = try env.parts.createPart(categoryId: catId, name: "PartTierTarget", code: "PT-1")
+        _ = try env.parts.createPart(categoryId: catId, name: "PartTierOther", code: "PT-2")
+
+        let preview = try env.parts.getPreviewParts(partId: p1, newMarkupPercent: 25)
+        #expect(preview.count == 1)
+        #expect(preview.first?.partId == p1)
+    }
+
+    @Test("findOverrideConflicts at part level returns no conflicts")
+    func testFindOverrideConflictsPartLevel() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try env.parts.createCategory(name: "PartConflictCat")
+        let p1 = try env.parts.createPart(categoryId: catId, name: "PartConflictTarget", code: "PC-1")
+
+        // Even with an existing part tier — the setPricingTier upsert replaces
+        // it, so there is nothing for the user to review one-at-a-time.
+        _ = try env.parts.setPricingTier(partId: p1, markupPercent: 10)
+        let conflicts = try env.parts.findOverrideConflicts(partId: p1, newMarkupPercent: 25)
+        #expect(conflicts.isEmpty, "part is the most specific level — no lower-level overrides exist")
+    }
+
+    @Test("setPricingTier at part level replaces the previous tier for the same part")
+    func testSetPricingTierPartLevelUpsert() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try env.parts.createCategory(name: "PartUpsertCat")
+        let p1 = try env.parts.createPart(categoryId: catId, name: "PartUpsertTarget", code: "PU-1")
+
+        _ = try env.parts.setPricingTier(partId: p1, markupPercent: 10)
+        _ = try env.parts.setPricingTier(partId: p1, markupPercent: 30)
+
+        let rows = try env.db.writer.read { db in
+            try Row.fetchAll(db, sql: """
+                SELECT markup_percent FROM pricing_tiers
+                WHERE part_id = ? AND deleted_at IS NULL
+                """, arguments: [p1])
+        }
+        #expect(rows.count == 1, "only one active part-level tier may exist per part")
+        let markup: Double? = rows.first?["markup_percent"]
+        #expect(markup == 30)
+    }
 }

--- a/core/Tests/WiredPartCoreTests/E2EPartsCatalogTests.swift
+++ b/core/Tests/WiredPartCoreTests/E2EPartsCatalogTests.swift
@@ -698,6 +698,30 @@ struct E2EPartsCatalogTests {
         #expect(counts.lowStock == 1, "only the part below its min stock level counts as low stock")
     }
 
+    @Test("getCatalogFilterCounts lowStockOnly restricts dimension facets to low-stock parts")
+    func testCatalogFilterCountsLowStockOnly() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catA = try env.parts.createCategory(name: "LowOnlyCatA")
+        let catB = try env.parts.createCategory(name: "LowOnlyCatB")
+        let brandX = try E2ETestHelpers.seedBrand(env, name: "LowOnlyBrandX")
+        // catA: one low-stock part (no stock, min 5) + one healthy part
+        _ = try env.parts.createPart(categoryId: catA, name: "LowOnlyLow", code: "LO-1", brandId: brandX, minStockLevel: 5)
+        let healthyA = try env.parts.createPart(categoryId: catA, name: "LowOnlyHealthy", code: "LO-2", brandId: brandX, minStockLevel: 5)
+        _ = try E2ETestHelpers.seedStock(env, partId: healthyA, qty: 10)
+        // catB: one healthy part only
+        let healthyB = try env.parts.createPart(categoryId: catB, name: "LowOnlyHealthyB", code: "LO-3", minStockLevel: 5)
+        _ = try E2ETestHelpers.seedStock(env, partId: healthyB, qty: 10)
+
+        // Regression (GH#67 review): with the Low Stock toggle active, dimension
+        // badges previously counted every part, contradicting the visible list.
+        let counts = try env.parts.getCatalogFilterCounts(lowStockOnly: true)
+        #expect(counts.byCategory[catA] == 1, "category facet must count only low-stock parts when the toggle is on")
+        #expect(counts.byCategory[catB] == nil, "categories with zero low-stock parts must not report a count")
+        #expect(counts.byBrand[brandX] == 1, "brand facet must count only low-stock parts when the toggle is on")
+        #expect(counts.lowStock == 1, "Low Stock card's own count excludes the toggle itself")
+        #expect(counts.allParts == 3, "All Parts stays search-only — tapping it resets every filter")
+    }
+
     @Test("getCatalogFilterCounts respects search text")
     func testCatalogFilterCountsSearch() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/PartsServiceInventoryTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceInventoryTests.swift
@@ -553,6 +553,15 @@ struct PartsServiceInventoryTests {
         #expect(trace.first?.movementType == "return_to_supplier", "newest first")
         #expect(trace.allSatisfy { $0.partName == "Traceable Widget" })
         #expect(trace.allSatisfy { $0.partId == partId })
+
+        // Receiving and return_to_supplier rows leave from/to_location_* nil
+        // on the supplier side (see WarehouseService). traceStep must fall
+        // back to supplier_id so the trace shows the supplier instead of
+        // "Unknown" (GH#84 traceability).
+        let returnStep = try #require(trace.first { $0.movementType == "return_to_supplier" })
+        #expect(returnStep.toLocation == "Supplier: TraceSupplier")
+        let receivingStep = try #require(trace.first { $0.movementType == "receiving" })
+        #expect(receivingStep.fromLocation == "Supplier: TraceSupplier")
     }
 
     @Test("tracePartMovements resolves specific job names for location endpoints")

--- a/core/Tests/WiredPartCoreTests/PartsServiceInventoryTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceInventoryTests.swift
@@ -357,6 +357,187 @@ struct PartsServiceInventoryTests {
         #expect(reliability >= 0 && reliability <= 100, "reliability_score must be in [0, 100]")
     }
 
+    @Test("calculateSupplierScores counts return_to_supplier movements as returned units")
+    func testCalculateSupplierScores_countsReturnToSupplier() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "RTSCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "RTSPart", categoryId: catId)
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "RTSSupplier")
+
+        try env.db.writer.write { db in
+            // 10 units received from the supplier — the receiving flow writes
+            // movement_type 'receiving' with the PO's supplier stamped.
+            try db.execute(sql: """
+                INSERT INTO stock_movements
+                    (part_id, qty, to_location_type, to_location_id, movement_type, supplier_id, performed_by, created_at)
+                VALUES (?, 10, 'warehouse', 1, 'receiving', ?, ?, datetime('now'))
+                """, arguments: [partId, supplierId, env.adminUserId])
+            // 2 units returned — the supplier-return flow writes
+            // movement_type 'return_to_supplier' with NO location endpoints.
+            // Regression (GH#84): the score query only counted 'return' rows
+            // with supplier-bound locations, so returns never affected quality.
+            try db.execute(sql: """
+                INSERT INTO stock_movements
+                    (part_id, qty, movement_type, supplier_id, performed_by, created_at)
+                VALUES (?, 2, 'return_to_supplier', ?, ?, datetime('now'))
+                """, arguments: [partId, supplierId, env.adminUserId])
+        }
+
+        let scores = try env.parts.calculateSupplierScores(supplierId: supplierId)
+        #expect(scores.totalUnitsReceived == 10, "'receiving' movements must count as received units")
+        #expect(scores.totalUnitsReturned == 2, "'return_to_supplier' movements must count as returned units")
+        #expect(scores.qualityScore == 80, "quality = 100 - (2/10 × 100)")
+    }
+
+    @Test("calculateSupplierScores still counts legacy supplier-bound 'return' movements")
+    func testCalculateSupplierScores_countsLegacySupplierBoundReturns() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "LegacyReturnCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "LegacyReturnPart", categoryId: catId)
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "LegacyReturnSupplier")
+
+        try env.db.writer.write { db in
+            // Legacy shape: movement_type 'return' explicitly routed warehouse → supplier
+            try db.execute(sql: """
+                INSERT INTO stock_movements
+                    (part_id, qty, from_location_type, from_location_id, to_location_type, to_location_id,
+                     movement_type, supplier_id, performed_by, created_at)
+                VALUES (?, 4, 'warehouse', 1, 'supplier', ?, 'return', ?, ?, datetime('now'))
+                """, arguments: [partId, supplierId, supplierId, env.adminUserId])
+            // A job return to the warehouse must NOT count against the supplier
+            try db.execute(sql: """
+                INSERT INTO stock_movements
+                    (part_id, qty, from_location_type, from_location_id, to_location_type, to_location_id,
+                     movement_type, supplier_id, performed_by, created_at)
+                VALUES (?, 7, 'job_return_holding', 1, 'warehouse', 1, 'return', ?, ?, datetime('now'))
+                """, arguments: [partId, supplierId, env.adminUserId])
+        }
+
+        let scores = try env.parts.calculateSupplierScores(supplierId: supplierId)
+        #expect(scores.totalUnitsReturned == 4,
+                "legacy supplier-bound 'return' rows count; warehouse-bound job returns do not")
+    }
+
+    @Test("returnDamagedToSupplier stamps supplier attribution resolved from the receiving session")
+    func testReturnDamagedToSupplier_resolvesSupplierFromSession() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "DamagedCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "DamagedPart", categoryId: catId)
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "DamagedSupplier")
+        let poId = try env.orders.createPurchaseOrder(poNumber: "PO-DMG-001", supplierId: supplierId)
+        _ = try env.orders.addPOLineItem(poId: poId, partId: partId, quantity: 5, unitPrice: 1.0)
+        let sessionId = try env.warehouse.startReceivingSession(poId: poId, startedBy: env.adminUserId)
+
+        let movementId = try env.warehouse.returnDamagedToSupplier(
+            partId: partId,
+            qty: 3,
+            returnType: "refund",
+            performedBy: env.adminUserId,
+            receivingSessionId: sessionId
+        )
+
+        let stamped = try env.db.writer.read { db in
+            try Int64.fetchOne(db, sql: "SELECT supplier_id FROM stock_movements WHERE id = ?",
+                               arguments: [movementId])
+        }
+        #expect(stamped == supplierId, "supplier must be resolved from session → PO → supplier")
+
+        let scores = try env.parts.calculateSupplierScores(supplierId: supplierId)
+        #expect(scores.totalUnitsReturned == 3, "damaged return must feed the supplier quality score")
+    }
+
+    @Test("completeSession stamps supplier_id on shelf receiving movements")
+    func testCompleteSession_stampsSupplierOnReceivingMovements() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "RcvStampCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "RcvStampPart", categoryId: catId)
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "RcvStampSupplier")
+        let poId = try env.orders.createPurchaseOrder(poNumber: "PO-STAMP-001", supplierId: supplierId)
+        _ = try env.orders.addPOLineItem(poId: poId, partId: partId, quantity: 4, unitPrice: 2.5)
+        let sessionId = try env.warehouse.startReceivingSession(poId: poId, startedBy: env.adminUserId)
+
+        let itemId: Int64 = try env.db.writer.read { db in
+            try Int64.fetchOne(db, sql: """
+                SELECT id FROM receiving_session_items WHERE session_id = ?
+                """, arguments: [sessionId]) ?? 0
+        }
+        #expect(itemId > 0)
+        try env.warehouse.updateSessionItem(itemId: itemId, receivedQty: 4)
+        try env.warehouse.completeSession(sessionId: sessionId, completedBy: env.adminUserId)
+
+        let stamped = try env.db.writer.read { db in
+            try Int64.fetchOne(db, sql: """
+                SELECT supplier_id FROM stock_movements
+                WHERE part_id = ? AND movement_type = 'receiving'
+                """, arguments: [partId])
+        }
+        #expect(stamped == supplierId, "receiving movement must carry the PO's supplier")
+
+        let scores = try env.parts.calculateSupplierScores(supplierId: supplierId)
+        #expect(scores.totalUnitsReceived == 4, "received units must flow into the quality denominator")
+    }
+
+    // MARK: - Supplier Traceability (GH#84)
+
+    @Test("getSupplierTrace returns supplier-attributed movements newest first with part names")
+    func testGetSupplierTrace() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "TraceCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Traceable Widget", categoryId: catId)
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "TraceSupplier")
+        let otherSupplierId = try E2ETestHelpers.seedSupplier(env, name: "OtherTraceSupplier")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO stock_movements
+                    (part_id, qty, to_location_type, to_location_id, movement_type, supplier_id, performed_by, created_at)
+                VALUES (?, 10, 'warehouse', 1, 'receiving', ?, ?, datetime('now', '-2 days'))
+                """, arguments: [partId, supplierId, env.adminUserId])
+            try db.execute(sql: """
+                INSERT INTO stock_movements
+                    (part_id, qty, movement_type, supplier_id, performed_by, created_at)
+                VALUES (?, 2, 'return_to_supplier', ?, ?, datetime('now', '-1 days'))
+                """, arguments: [partId, supplierId, env.adminUserId])
+            // Different supplier — must not appear
+            try db.execute(sql: """
+                INSERT INTO stock_movements
+                    (part_id, qty, to_location_type, to_location_id, movement_type, supplier_id, performed_by, created_at)
+                VALUES (?, 99, 'warehouse', 1, 'receiving', ?, ?, datetime('now'))
+                """, arguments: [partId, otherSupplierId, env.adminUserId])
+        }
+
+        let trace = try env.parts.getSupplierTrace(supplierId: supplierId, limit: 10)
+        #expect(trace.count == 2)
+        #expect(trace.first?.movementType == "return_to_supplier", "newest first")
+        #expect(trace.allSatisfy { $0.partName == "Traceable Widget" })
+        #expect(trace.allSatisfy { $0.partId == partId })
+    }
+
+    @Test("tracePartMovements resolves specific job names for location endpoints")
+    func testTracePartMovements_locationNameFidelity() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "FidelityCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "FidelityPart", categoryId: catId)
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-FID-1", name: "Fidelity Jobsite")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO stock_movements
+                    (part_id, qty, from_location_type, from_location_id, to_location_type, to_location_id,
+                     movement_type, performed_by, created_at)
+                VALUES (?, 5, 'warehouse', 1, 'job', ?, 'consume', ?, datetime('now'))
+                """, arguments: [partId, jobId, env.adminUserId])
+        }
+
+        let steps = try env.parts.tracePartMovements(partId: partId)
+        let step = try #require(steps.first)
+        #expect(step.toLocation == "Job Site: Fidelity Jobsite",
+                "job endpoints must resolve to the actual job name, not a generic type label")
+        // No warehouse_locations row with id 1 exists in a fresh test DB,
+        // so the from side falls back to the generic label.
+        #expect(step.fromLocation == "Warehouse")
+    }
+
     // MARK: - recalculateAllSupplierScores
 
     @Test("recalculateAllSupplierScores completes without error on empty DB")

--- a/core/Tests/WiredPartCoreTests/PartsServiceInventoryTests.swift
+++ b/core/Tests/WiredPartCoreTests/PartsServiceInventoryTests.swift
@@ -477,6 +477,48 @@ struct PartsServiceInventoryTests {
         #expect(scores.totalUnitsReceived == 4, "received units must flow into the quality denominator")
     }
 
+    @Test("stageReceivedPartsForJob stamps supplier and staged units feed the quality denominator")
+    func testStageReceivedPartsForJob_stampsSupplierAndCountsAsReceived() throws {
+        let env = try E2ETestHelpers.setUp()
+        let catId = try E2ETestHelpers.seedCategory(env, name: "StagedRcvCat")
+        let partId = try E2ETestHelpers.seedPart(env, name: "StagedRcvPart", categoryId: catId)
+        let supplierId = try E2ETestHelpers.seedSupplier(env, name: "StagedRcvSupplier")
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-STG-001", name: "Staged Receiving Job")
+        let poId = try env.orders.createPurchaseOrder(poNumber: "PO-STG-001", supplierId: supplierId)
+        _ = try env.orders.addPOLineItem(poId: poId, partId: partId, quantity: 10, unitPrice: 1.0)
+        let sessionId = try env.warehouse.startReceivingSession(poId: poId, startedBy: env.adminUserId)
+
+        // Regression (GH#84 review): a PO fully staged for a job wrote
+        // 'receiving_staged' with NO supplier_id, so totalUnitsReceived stayed 0
+        // and one damaged return from the same delivery drove quality to 0%.
+        let movementId = try env.warehouse.stageReceivedPartsForJob(
+            partId: partId,
+            qty: 8,
+            jobId: jobId,
+            performedBy: env.adminUserId,
+            receivingSessionId: sessionId
+        )
+
+        let stamped = try env.db.writer.read { db in
+            try Int64.fetchOne(db, sql: "SELECT supplier_id FROM stock_movements WHERE id = ?",
+                               arguments: [movementId])
+        }
+        #expect(stamped == supplierId, "staged receiving must carry the supplier resolved from session → PO")
+
+        _ = try env.warehouse.returnDamagedToSupplier(
+            partId: partId,
+            qty: 2,
+            returnType: "refund",
+            performedBy: env.adminUserId,
+            receivingSessionId: sessionId
+        )
+
+        let scores = try env.parts.calculateSupplierScores(supplierId: supplierId)
+        #expect(scores.totalUnitsReceived == 8, "staged units must count in the received denominator")
+        #expect(scores.totalUnitsReturned == 2, "damaged return from the same delivery counts as returned")
+        #expect(scores.qualityScore == 75, "quality = 100 - (2/8 × 100) — not 0% for a fully-staged PO")
+    }
+
     // MARK: - Supplier Traceability (GH#84)
 
     @Test("getSupplierTrace returns supplier-attributed movements newest first with part names")


### PR DESCRIPTION
Closes #84
Closes #83
Closes #67

**Plan:** docs/plans/beta-readiness-issue-resolution-2026-07.md §3 Batch D + Batch E.

## What changed

### GH#84 — Supplier scores count `return_to_supplier` + traceability UI slice
- **Score counting fix (the PartsService.swift:7690 ↔ WarehouseModels.swift:23 mismatch):** `calculateSupplierScores` returned-units query now counts `return_to_supplier` movements (what `WarehouseService.returnDamagedToSupplier` actually writes) attributed by `supplier_id`, while still counting legacy supplier-bound `return` rows. Received-units query widened to the canonical receive family (`receipt`/`receive`/`receiving`) — previously it only matched `receipt`, which no writer produces.
- **Attribution plumbing (without it the fixed query still counted nothing):** `createMovement` accepts `supplierId`; `returnDamagedToSupplier` resolves the supplier from the receiving session's PO (`receivingSessionId` passed by `ReceivingRoutingFlow`); `completeSession` stamps the PO's supplier on shelf receiving movements. `stock_movements.supplier_id` already exists in the schema — no migration needed.
- **Traceability UI slice:** new `PartsService.getSupplierTrace(supplierId:limit:)`; Supplier detail sheet gains a Traceability section (last 10 receipts/returns with part, movement type, from → to, qty, date, PO reference). Trace location endpoints now resolve concrete warehouse/job/truck/staging/supplier names instead of generic type labels (`describeLocation(type:id:dbConn:)`); `TraceStep` carries `partId`/`partName`.
- Convention fix while touching it: `SupplierDetailSheet.loadAllDetails` surfaces load failures via `loadError` instead of silently swallowing.

### GH#83 — Re-land Part-level target price in PricingOverrideFlow
Scope per thread (WEI-1117 child): the wizard supported Category/Style/Type/Brand only.
- `HierarchyLevel` gains `.part` with a searchable part picker (name/code, backed by `listCatalogParts`).
- `partId` plumbed through `getPreviewParts` / `findOverrideConflicts` / `setPricingTier`.
- Core: `getPreviewParts(partId:)` scopes the preview to the single part; `findOverrideConflicts(partId:)` returns no conflicts — part is the most specific level, and an existing same-part tier is replaced by the `setPricingTier` upsert (consistent with same-scope behavior at every other level).

### GH#67 — Catalog smart-card stat filters (the one remaining WEI-446 gap)
- `PartsCatalogPage` `filterMenu` chips replaced with smart-card stat filters: **All Parts | Category | Style | Type | Color | Brand | Low Stock**, matching the shared `SmartFilterCard` visual pattern used across the app.
- Count badges: All Parts = parts matching search; dimension cards = matching-part count for the selection (or available-option count when unselected); Low Stock = low-stock parts under current filters. Picker rows show per-option part counts.
- New `PartsService.getCatalogFilterCounts` computes faceted counts (own-dimension exclusion so other options stay pickable, search-aware, low-stock stat).
- Cascading behavior (Category → Style → Type) and NL-search filter wiring preserved; stale "chips" help text updated; cards have accessibility labels and ≥44pt targets.

### Salvage check
`git log main..origin/wei-1273-generic-supplier-locks` reviewed: commits are procurement supplier-lock enforcement in `OrdersService`/`IOSProcurementPage` — unrelated to this batch's supplier-score/traceability scope. Nothing cherry-picked.

## Test evidence
Run inside the worktree's `core/`:
- `swift build` → Build complete
- `swift test --filter "PartsServiceInventoryTests"` → 65 tests passed (includes 6 new: return_to_supplier counting, legacy supplier-bound returns, session-resolved supplier stamping on damaged returns, receiving-movement stamping on completeSession, supplier trace ordering/attribution, job-name location fidelity)
- `swift test --filter "E2EPartsCatalogTests"` → 37 tests passed (includes 6 new: facet counts w/ own-dimension exclusion, low-stock facet, search-aware facet, part-level preview, part-level conflicts empty, part-tier upsert)
- `swift test --filter "WarehouseServiceExtTests|PartsServiceCoverageTests|WarehouseAuditTests|PricingCascadeTests"` → 258 tests passed
- `swift test` (full suite) → **2270 tests in 68 suites, all passed**
- App-target files verified with `xcrun swiftc -parse` (PartsSuppliersPage, PricingOverrideFlow, PartsCatalogPage, ReceivingRoutingFlow) → no syntax errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)