### PR TITLE
fix: Fleet polish re-land — detents, trailer nav, search empty state (#278)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSAssignDriverSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSAssignDriverSheet.swift
@@ -79,6 +79,7 @@ struct IOSAssignDriverSheet: View {
                 Text(loadError ?? "")
             }
         }
+        .presentationDetents([.large])
     }
 
     // MARK: - Sections

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSCreateTrailerSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSCreateTrailerSheet.swift
@@ -72,6 +72,7 @@ struct IOSCreateTrailerSheet: View {
                 }
             }
         }
+        .presentationDetents([.large])
     }
 
     var onSaved: (() -> Void)?

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSCreateVehicleSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSCreateVehicleSheet.swift
@@ -77,6 +77,7 @@ struct IOSCreateVehicleSheet: View {
                 }
             }
         }
+        .presentationDetents([.large])
     }
 
     // MARK: - Sections

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMyTruckPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSMyTruckPage.swift
@@ -318,21 +318,31 @@ struct IOSMyTruckPage: View {
     private var trailerSection: some View {
         if let stats = vehicleStats, stats.hasTrailer {
             Section {
-                HStack {
-                    Image(systemName: "truck.box.fill")
-                        .foregroundStyle(.blue)
-                        .accessibilityHidden(true)
-                    VStack(alignment: .leading) {
-                        Text(stats.trailerName ?? "Trailer")
-                            .font(.subheadline).fontWeight(.medium)
-                        Text("Attached")
-                            .font(.caption).foregroundStyle(.green)
+                if let trailerId = stats.trailerId {
+                    NavigationLink(destination: IOSTrailerDetailPage(trailerId: trailerId)) {
+                        trailerRow(stats)
                     }
-                    Spacer()
+                } else {
+                    trailerRow(stats)
                 }
             } header: {
                 Text("Trailer")
             }
+        }
+    }
+
+    private func trailerRow(_ stats: FleetService.MyVehicleStats) -> some View {
+        HStack {
+            Image(systemName: "truck.box.fill")
+                .foregroundStyle(.blue)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading) {
+                Text(stats.trailerName ?? "Trailer")
+                    .font(.subheadline).fontWeight(.medium)
+                Text("Attached")
+                    .font(.caption).foregroundStyle(.green)
+            }
+            Spacer()
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTrailersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/IOSTrailersPage.swift
@@ -105,11 +105,7 @@ struct IOSTrailersPage: View {
             } else if let error = loadError {
                 ErrorStateView(message: error) { loadData() }
             } else if filteredTrailers.isEmpty {
-                EmptyStateView(
-                    icon: "shippingbox",
-                    title: "No Trailers",
-                    message: "No trailers found."
-                )
+                trailersEmptyState
             } else {
                 List(filteredTrailers, id: \.id) { trailer in
                     NavigationLink(destination: IOSTrailerDetailPage(trailerId: trailer.id)) {
@@ -136,9 +132,38 @@ struct IOSTrailersPage: View {
         }
     }
 
+    @ViewBuilder
+    private var trailersEmptyState: some View {
+        if isSearching {
+            EmptyStateView(
+                icon: "magnifyingglass",
+                title: "No Trailers",
+                message: "No trailers match \"\(trimmedSearchText)\".",
+                actionLabel: "Clear Search",
+                actionIcon: "xmark.circle"
+            ) {
+                searchText = ""
+            }
+        } else {
+            EmptyStateView(
+                icon: "shippingbox",
+                title: "No Trailers",
+                message: "No trailers found."
+            )
+        }
+    }
+
+    private var isSearching: Bool {
+        !trimmedSearchText.isEmpty
+    }
+
+    private var trimmedSearchText: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private var filteredTrailers: [FleetService.TrailerListItem] {
-        guard !searchText.isEmpty else { return trailers }
-        let query = searchText.lowercased()
+        guard isSearching else { return trailers }
+        let query = trimmedSearchText.lowercased()
         return trailers.filter {
             $0.trailerNumber.lowercased().contains(query) ||
             $0.trailerType.lowercased().contains(query) ||

--- a/Weird Parts IOS/Weird Parts IOS/Features/Fleet/PreTripInspectionView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Fleet/PreTripInspectionView.swift
@@ -99,6 +99,7 @@ struct PreTripInspectionView: View {
             }
             .task { loadChecklist() }
         }
+        .presentationDetents([.large])
     }
 
     // MARK: - Form

--- a/Weird Parts IOS/Weird Parts IOSTests/FleetSheetPresentationDetentsTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/FleetSheetPresentationDetentsTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+final class FleetSheetPresentationDetentsTests: XCTestCase {
+    func testHeavyFleetSheetsPinLargePresentationDetent() throws {
+        let sheetFiles = [
+            "IOSCreateVehicleSheet.swift",
+            "IOSCreateTrailerSheet.swift",
+            "IOSAssignDriverSheet.swift",
+            "PreTripInspectionView.swift"
+        ]
+
+        for file in sheetFiles {
+            let source = try String(contentsOfFile: fleetSourcePath(file), encoding: .utf8)
+            XCTAssertTrue(
+                source.contains(".presentationDetents([.large])"),
+                "\(file) should explicitly pin the large sheet detent."
+            )
+        }
+    }
+
+    private func fleetSourcePath(_ fileName: String) -> String {
+        let testFile = URL(fileURLWithPath: #filePath)
+        return testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Fleet")
+            .appendingPathComponent(fileName)
+            .path
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/IOSTrailersEmptyStateTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/IOSTrailersEmptyStateTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+final class IOSTrailersEmptyStateTests: XCTestCase {
+    func testTrailersPageShowsSearchAwareAndFirstRunEmptyStates() throws {
+        let source = try String(contentsOfFile: fleetSourcePath("IOSTrailersPage.swift"), encoding: .utf8)
+
+        XCTAssertTrue(
+            source.contains("if isSearching"),
+            "The empty state should branch on whether the user has entered a non-empty search query."
+        )
+        XCTAssertTrue(
+            source.contains("message: \"No trailers match \\\"\\(trimmedSearchText)\\\".\""),
+            "A non-empty search with no matches should show search-aware no-results copy."
+        )
+        XCTAssertTrue(
+            source.contains("actionLabel: \"Clear Search\""),
+            "The search no-results empty state should expose a clear-search affordance."
+        )
+        XCTAssertTrue(
+            source.contains("searchText = \"\""),
+            "The clear-search affordance should reset the trailers search text."
+        )
+        XCTAssertTrue(
+            source.contains("message: \"No trailers found.\""),
+            "An empty search with no trailers should keep the generic first-run empty state."
+        )
+        XCTAssertTrue(
+            source.contains("searchText.trimmingCharacters(in: .whitespacesAndNewlines)"),
+            "Whitespace-only input should not force the no-results search empty state."
+        )
+    }
+
+    private func fleetSourcePath(_ fileName: String) -> String {
+        let testFile = URL(fileURLWithPath: #filePath)
+        return testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Fleet")
+            .appendingPathComponent(fileName)
+            .path
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/MyTruckTrailerNavigationTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/MyTruckTrailerNavigationTests.swift
@@ -13,7 +13,7 @@ final class MyTruckTrailerNavigationTests: XCTestCase {
             "The attached trailer row should navigate to the trailer detail page with the attached trailer id."
         )
         XCTAssertTrue(
-            source.contains("} else {\n                    trailerRow(stats)\n                }"),
+            source.range(of: #"\}\s*else\s*\{\s*trailerRow\(stats\)\s*\}"#, options: .regularExpression) != nil,
             "When the trailer id is unavailable, the attached trailer row should render without NavigationLink chrome."
         )
     }

--- a/Weird Parts IOS/Weird Parts IOSTests/MyTruckTrailerNavigationTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/MyTruckTrailerNavigationTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+final class MyTruckTrailerNavigationTests: XCTestCase {
+    func testAttachedTrailerNavigatesOnlyWhenTrailerIdExists() throws {
+        let source = try String(contentsOfFile: fleetSourcePath("IOSMyTruckPage.swift"), encoding: .utf8)
+
+        XCTAssertTrue(
+            source.contains("if let trailerId = stats.trailerId"),
+            "The attached trailer row should only become navigable when the stats payload includes a trailer id."
+        )
+        XCTAssertTrue(
+            source.contains("NavigationLink(destination: IOSTrailerDetailPage(trailerId: trailerId))"),
+            "The attached trailer row should navigate to the trailer detail page with the attached trailer id."
+        )
+        XCTAssertTrue(
+            source.contains("} else {\n                    trailerRow(stats)\n                }"),
+            "When the trailer id is unavailable, the attached trailer row should render without NavigationLink chrome."
+        )
+    }
+
+    private func fleetSourcePath(_ fileName: String) -> String {
+        let testFile = URL(fileURLWithPath: #filePath)
+        return testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Fleet")
+            .appendingPathComponent(fileName)
+            .path
+    }
+}


### PR DESCRIPTION
Closes #278

Re-lands the three stranded May commits `6ce2848b6` / `d1648d4e0` / `e0d706c66`, rescued from `codex/wei-1028-auth-hardening` (201 ahead / 318 behind main — the work never merged; see the 2026-07-02 status audit on the issue). Cherry-picked onto current main via `rescue/278-detents`, `rescue/278-trailer-nav`, `rescue/278-search-empty`.

## What changed

**1. Presentation detents (re-land of `6ce2848b6`, clean pick)**
- `.presentationDetents([.large])` pinned on the four heavy Fleet sheets: `IOSCreateVehicleSheet`, `IOSCreateTrailerSheet`, `IOSAssignDriverSheet`, `PreTripInspectionView` (attached to each body's top-level `NavigationStack`).
- Adds `FleetSheetPresentationDetentsTests` guarding all four.

**2. My Truck trailer navigation (re-land of `d1648d4e0`, clean pick)**
- The attached-trailer row in `IOSMyTruckPage` is now a real `NavigationLink` to `IOSTrailerDetailPage(trailerId:)` when `FleetService.MyVehicleStats.trailerId` is present (already plumbed on main at `FleetService.swift:1181`); stays a static row when the id is absent, so no dead navigation chrome.
- Makes the existing help copy ("Tap the row to see trailer details", `IOSMyTruckPage.swift:474`) accurate.
- Adds `MyTruckTrailerNavigationTests`.

**3. Trailers search-aware empty state (re-land of `e0d706c66`, conflicted — adapted)**
- The donor commit used `ContentUnavailableView`, but main has since migrated this page to the shared `EmptyStateView` component. Re-applied the same logic using `EmptyStateView`, matching the identical search-empty pattern in `IOSTeamsPage` (magnifyingglass icon + "Clear Search" action that resets `searchText`).
- Non-empty trimmed search with no matches shows `No trailers match "<query>".` with a Clear Search button; empty search keeps the generic `No trailers found.` first-run state; whitespace-only queries are treated as no search.
- Adds `IOSTrailersEmptyStateTests` (assertions adapted to the `EmptyStateView` implementation).

## Test evidence
- `xcrun swiftc -parse` passes (exit 0) on all 9 touched Swift files.
- The three new tests are source-scan assertions; all 13 assertions were replicated verbatim against the branch and pass. Not run under `xcodebuild test` in this environment (no simulator run) — the test target is a `PBXFileSystemSynchronizedRootGroup`, so the new test files are picked up automatically by CI.
- No `core/` changes, so no `swift build` / `swift test` needed there.
- Diff re-checked visually after conflict resolution; no conflict markers, no drive-by changes (164 insertions / 17 deletions across 9 files, all Fleet feature + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)