### PR TITLE
fix(dispatch): re-land #439 dispatch preferences enforcement

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSShortTermPipelinePage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Scheduling/IOSShortTermPipelinePage.swift
@@ -31,8 +31,8 @@ enum IOSShortTermPipelineCallbackActionHandler {
 
 /// Short-term pipeline page showing jobs ready or near-ready for scheduling.
 ///
-/// Categories: Start Anytime (target: 3), Schedule Needed (target: 2),
-/// Favorite GC (target: 1), Small Jobs (gap fillers). Includes callback
+/// Categories: Start Anytime, Schedule Needed, Favorite GC, and Small Jobs.
+/// Pipeline targets come from saved dispatch preferences. Includes callback
 /// tracking with snooze and AI crew suggestion button.
 struct IOSShortTermPipelinePage: View {
     @EnvironmentObject private var appCore: AppCore
@@ -41,6 +41,11 @@ struct IOSShortTermPipelinePage: View {
     @State private var isLoading = true
     @State private var loadError: String?
     @State private var searchText = ""
+    @State private var pipelineTargets = SchedulingService.PipelineTargets(
+        startAnytime: 3,
+        scheduleNeeded: 2,
+        favoriteGC: 1
+    )
 
     private enum ActiveSheet: String, Identifiable {
         case callback
@@ -179,9 +184,9 @@ struct IOSShortTermPipelinePage: View {
             Section {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 10) {
-                        TargetCard(title: "Start Anytime", count: startAnytimeItems.count, target: 3, color: .green)
-                        TargetCard(title: "Need Schedule", count: scheduleNeededItems.count, target: 2, color: .blue)
-                        TargetCard(title: "Favorite GC", count: favoriteGCItems.count, target: 1, color: .purple)
+                        TargetCard(title: "Start Anytime", count: startAnytimeItems.count, target: pipelineTargets.startAnytime, color: .green)
+                        TargetCard(title: "Need Schedule", count: scheduleNeededItems.count, target: pipelineTargets.scheduleNeeded, color: .blue)
+                        TargetCard(title: "Favorite GC", count: favoriteGCItems.count, target: pipelineTargets.favoriteGC, color: .purple)
                         SmartCard(title: "Small Jobs", count: smallJobItems.count, color: .orange)
                     }
                     .padding(.horizontal, 4)
@@ -192,21 +197,21 @@ struct IOSShortTermPipelinePage: View {
 
             // Start Anytime
             pipelineSection(
-                title: "Start Anytime", target: 3,
+                title: "Start Anytime", target: pipelineTargets.startAnytime,
                 category: "start_anytime", items: startAnytimeItems,
                 icon: "bolt.fill", color: .green
             )
 
             // Schedule Needed
             pipelineSection(
-                title: "Schedule Needed", target: 2,
+                title: "Schedule Needed", target: pipelineTargets.scheduleNeeded,
                 category: "schedule_needed", items: scheduleNeededItems,
                 icon: "calendar.badge.exclamationmark", color: .blue
             )
 
             // Favorite GC
             pipelineSection(
-                title: "Favorite GC", target: 1,
+                title: "Favorite GC", target: pipelineTargets.favoriteGC,
                 category: "favorite_gc", items: favoriteGCItems,
                 icon: "star.fill", color: .purple
             )
@@ -411,6 +416,7 @@ struct IOSShortTermPipelinePage: View {
         isLoading = pipelineItems.isEmpty
         loadError = nil
         do {
+            pipelineTargets = try service.getShortTermPipelineTargets()
             pipelineItems = try service.getShortTermPipeline()
         } catch {
             loadError = userFriendlyError(error, context: "load pipeline data")
@@ -426,6 +432,7 @@ struct IOSShortTermPipelinePage: View {
                 userInfo: [NSLocalizedDescriptionKey: "Scheduling service not available."]
             )
         }
+        pipelineTargets = try service.getShortTermPipelineTargets()
         pipelineItems = try service.getShortTermPipeline()
         loadError = nil
     }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDispatchPreferencesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDispatchPreferencesPage.swift
@@ -223,20 +223,21 @@ struct IOSDispatchPreferencesPage: View {
         }
 
         do {
-            let data: [String: String] = [
-                "dispatch_ai_suggestions_enabled": enableAISuggestions ? "true" : "false",
-                "dispatch_ai_learning_enabled": enableAILearning ? "true" : "false",
-                "dispatch_show_confidence_scores": showConfidenceScores ? "true" : "false",
-                "dispatch_flex_self_assign_enabled": enableFlexSelfAssign ? "true" : "false",
-                "dispatch_flex_require_approval": requireManagerApproval ? "true" : "false",
-                "dispatch_pipeline_start_anytime_target": "\(startAnytimeTarget)",
-                "dispatch_pipeline_schedule_needed_target": "\(scheduleNeededTarget)",
-                "dispatch_pipeline_favorite_gc_target": "\(favoriteGCTarget)",
-                "dispatch_default_view": defaultView,
-                "dispatch_crew_history_months": "\(crewHistoryMonths)",
-                "dispatch_crew_continuity_weight": crewContinuityWeight,
-            ]
-            try service.upsertSettingsMap(data, category: "dispatch")
+            let preferences = SettingsService.DispatchPreferenceSettings(
+                aiSuggestionsEnabled: enableAISuggestions,
+                aiLearningEnabled: enableAILearning,
+                showConfidenceScores: showConfidenceScores,
+                aiSuggestionCount: SettingsService.DispatchPreferenceSettings.defaults.aiSuggestionCount,
+                flexSelfAssignEnabled: enableFlexSelfAssign,
+                flexRequireApproval: requireManagerApproval,
+                pipelineStartAnytimeTarget: startAnytimeTarget,
+                pipelineScheduleNeededTarget: scheduleNeededTarget,
+                pipelineFavoriteGCTarget: favoriteGCTarget,
+                defaultView: defaultView,
+                crewHistoryMonths: crewHistoryMonths,
+                crewContinuityWeight: crewContinuityWeight
+            )
+            try service.updateDispatchPreferences(preferences)
             saveError = nil
             isDirty = false
             saveSuccessMessage = "Dispatch preferences saved."

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDispatchPreferencesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDispatchPreferencesPage.swift
@@ -20,8 +20,12 @@ struct IOSDispatchPreferencesPage: View {
     @State private var showConfidenceScores = false
 
     // Flex Pool
-    @State private var enableFlexSelfAssign = false
-    @State private var requireManagerApproval = true
+    // Defaults mirror SettingsService.DispatchPreferenceSettings.defaults so a
+    // fresh install's toggle state matches what getDispatchPreferences() (and
+    // therefore SchedulingService.fetchFlexPool/claimFlexJob) actually enforces
+    // before any explicit save.
+    @State private var enableFlexSelfAssign = true
+    @State private var requireManagerApproval = false
 
     // Pipeline Targets
     @State private var startAnytimeTarget: Int = 3
@@ -198,8 +202,12 @@ struct IOSDispatchPreferencesPage: View {
             enableAILearning = parser.bool(map, key: "dispatch_ai_learning_enabled", default: true)
             showConfidenceScores = parser.bool(map, key: "dispatch_show_confidence_scores", default: false)
 
-            enableFlexSelfAssign = parser.bool(map, key: "dispatch_flex_self_assign_enabled", default: false)
-            requireManagerApproval = parser.bool(map, key: "dispatch_flex_require_approval", default: true)
+            // Defaults must match SettingsService.DispatchPreferenceSettings.defaults
+            // (flexSelfAssignEnabled: true, flexRequireApproval: false) -- that struct
+            // is what getDispatchPreferences() returns, and what SchedulingService's
+            // fetchFlexPool/claimFlexJob gate on, when no value has ever been saved.
+            enableFlexSelfAssign = parser.bool(map, key: "dispatch_flex_self_assign_enabled", default: true)
+            requireManagerApproval = parser.bool(map, key: "dispatch_flex_require_approval", default: false)
 
             startAnytimeTarget = parser.int(map, key: "dispatch_pipeline_start_anytime_target", default: 3)
             scheduleNeededTarget = parser.int(map, key: "dispatch_pipeline_schedule_needed_target", default: 2)

--- a/Weird Parts IOS/Weird Parts IOSTests/DispatchPreferencesDefaultsRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/DispatchPreferencesDefaultsRegressionTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+
+/// Regression coverage for a divergence found in review of the #439 dispatch
+/// re-land (PR #1375): IOSDispatchPreferencesPage's load-path defaults for
+/// the flex-pool toggles must match
+/// `SettingsService.DispatchPreferenceSettings.defaults` exactly.
+///
+/// `getDispatchPreferences()` returns `.defaults` whenever the `dispatch`
+/// settings category has never been saved, and `SchedulingService`'s
+/// `fetchFlexPool`/`claimFlexJob` now gate on that value. If the page's own
+/// fallback disagrees, a fresh install shows a stale/incorrect toggle state,
+/// and an unrelated save (e.g. only touching crew continuity weight) will
+/// silently persist the page's wrong default -- flipping company-wide
+/// flex-pool behavior with no toggle ever knowingly touched by the user.
+final class DispatchPreferencesDefaultsRegressionTests: XCTestCase {
+    private static let pageFile = "IOSDispatchPreferencesPage"
+    private static let coreDefaultsFile = "SettingsService"
+
+    func testFlexPoolStateDefaultsMatchServiceDefaults() throws {
+        let source = try Self.readSettingsSource(Self.pageFile)
+
+        XCTAssertTrue(
+            source.contains("@State private var enableFlexSelfAssign = true"),
+            "\(Self.pageFile)'s enableFlexSelfAssign @State default must match "
+                + "DispatchPreferenceSettings.defaults.flexSelfAssignEnabled (true)."
+        )
+        XCTAssertTrue(
+            source.contains("@State private var requireManagerApproval = false"),
+            "\(Self.pageFile)'s requireManagerApproval @State default must match "
+                + "DispatchPreferenceSettings.defaults.flexRequireApproval (false)."
+        )
+    }
+
+    func testLoadSettingsFlexPoolFallbacksMatchServiceDefaults() throws {
+        let source = try Self.readSettingsSource(Self.pageFile)
+        let loadBody = try Self.methodBody(named: "loadSettings", in: source)
+
+        XCTAssertTrue(
+            loadBody.contains(
+                "parser.bool(map, key: \"dispatch_flex_self_assign_enabled\", default: true)"
+            ),
+            "\(Self.pageFile).loadSettings() must fall back to `true` for "
+                + "dispatch_flex_self_assign_enabled, matching "
+                + "DispatchPreferenceSettings.defaults.flexSelfAssignEnabled."
+        )
+        XCTAssertTrue(
+            loadBody.contains(
+                "parser.bool(map, key: \"dispatch_flex_require_approval\", default: false)"
+            ),
+            "\(Self.pageFile).loadSettings() must fall back to `false` for "
+                + "dispatch_flex_require_approval, matching "
+                + "DispatchPreferenceSettings.defaults.flexRequireApproval."
+        )
+    }
+
+    /// Cross-checks against the actual core defaults so this test fails loudly
+    /// (rather than silently drifting) if a future change to
+    /// `DispatchPreferenceSettings.defaults` isn't mirrored on the page.
+    func testCoreDefaultsHaveNotChangedUnderThisTest() throws {
+        let coreSource = try Self.readCoreSource(Self.coreDefaultsFile)
+        guard let defaultsRange = coreSource.range(of: "public static let defaults = DispatchPreferenceSettings(") else {
+            throw XCTSkip("Expected DispatchPreferenceSettings.defaults in \(Self.coreDefaultsFile)")
+        }
+        guard let closeParen = coreSource[defaultsRange.upperBound...].range(of: ")") else {
+            throw XCTSkip("Expected closing paren for DispatchPreferenceSettings.defaults")
+        }
+        let defaultsBody = coreSource[defaultsRange.lowerBound..<closeParen.upperBound]
+
+        XCTAssertTrue(
+            defaultsBody.contains("flexSelfAssignEnabled: true"),
+            "DispatchPreferenceSettings.defaults.flexSelfAssignEnabled changed -- "
+                + "update IOSDispatchPreferencesPage's defaults (and this test) to match."
+        )
+        XCTAssertTrue(
+            defaultsBody.contains("flexRequireApproval: false"),
+            "DispatchPreferenceSettings.defaults.flexRequireApproval changed -- "
+                + "update IOSDispatchPreferencesPage's defaults (and this test) to match."
+        )
+    }
+
+    private static func methodBody(named methodName: String, in source: String) throws -> String {
+        guard let nameRange = source.range(of: "func \(methodName)(") else {
+            throw XCTSkip("Expected method \(methodName) in source")
+        }
+        guard let openBrace = source[nameRange.upperBound...].firstIndex(of: "{") else {
+            throw XCTSkip("Expected opening brace for \(methodName)")
+        }
+
+        var depth = 0
+        var index = openBrace
+        while index < source.endIndex {
+            let char = source[index]
+            if char == "{" { depth += 1 }
+            if char == "}" { depth -= 1 }
+            let next = source.index(after: index)
+            if depth == 0 {
+                return String(source[openBrace..<next])
+            }
+            index = next
+        }
+
+        throw XCTSkip("Expected closing brace for \(methodName)")
+    }
+
+    private static func readSettingsSource(
+        _ pageName: String,
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Settings")
+            .appendingPathComponent("\(pageName).swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    private static func readCoreSource(
+        _ fileName: String,
+        file: StaticString = #filePath
+    ) throws -> String {
+        let projectRoot = URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+            .deletingLastPathComponent() // repo root
+        let sourceURL = projectRoot
+            .appendingPathComponent("core")
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("WiredPartCore")
+            .appendingPathComponent("Services")
+            .appendingPathComponent("\(fileName).swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -147,6 +147,7 @@ extension AppDatabase {
         registerMigration105JobRecordsLocalFirst(&migrator)
         registerMigration106POLineItemsBrandId(&migrator)
         registerMigration107BreakPolicyPresets(&migrator)
+        registerMigration109DispatchPreferenceBackfill(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -5929,5 +5930,31 @@ private func registerMigration100POEmailRequestType(_ migrator: inout DatabaseMi
 private func registerMigration107BreakPolicyPresets(_ migrator: inout DatabaseMigrator) {
     migrator.registerMigration("107_break_policy_presets") { db in
         try AppDatabase.seedBreakPolicyPresets(db)
+    }
+}
+
+// MARK: - Migration 109: Dispatch preference backfill (re-lands #439)
+
+private func registerMigration109DispatchPreferenceBackfill(_ migrator: inout DatabaseMigrator) {
+    migrator.registerMigration("109_dispatch_preference_backfill") { db in
+        // Older installs stored the flex-pool approval flag as a bare
+        // `flex_pool_requires_approval` row outside the `dispatch` settings
+        // category (category defaulted to `general`). SettingsService now reads
+        // dispatch preferences as a typed `dispatch`-category group; normalize
+        // the legacy row into the new `dispatch_flex_require_approval` key so
+        // stored data is consistent going forward. `INSERT OR IGNORE` keeps this
+        // idempotent and never overwrites a value already saved under the new
+        // key. The legacy row is left in place (still consulted as a fallback
+        // by SettingsService.getDispatchPreferences) rather than deleted, so
+        // this migration can never lose data if re-run against a restored backup.
+        try db.execute(sql: """
+            INSERT OR IGNORE INTO settings (key, value, category, updated_at)
+            SELECT 'dispatch_flex_require_approval',
+                   CASE WHEN value = '1' THEN 'true' ELSE 'false' END,
+                   'dispatch',
+                   datetime('now')
+            FROM settings
+            WHERE key = 'flex_pool_requires_approval'
+            """)
     }
 }

--- a/core/Sources/WiredPartCore/Services/AIDispatchService.swift
+++ b/core/Sources/WiredPartCore/Services/AIDispatchService.swift
@@ -93,6 +93,11 @@ public final class AIDispatchService: Sendable {
 
     /// Generate 3 dispatch options for a given date.
     public func generateSuggestions(date: String) throws -> [DispatchSuggestion] {
+        let preferences = try SettingsService(db: db).getDispatchPreferences()
+        guard preferences.aiSuggestionsEnabled else {
+            return []
+        }
+
         let weights = loadWeights()
         let workers = try getAvailableWorkers(date: date)
         let jobs = try getJobsNeedingWorkers(date: date)
@@ -113,7 +118,7 @@ public final class AIDispatchService: Sendable {
         // Sort by score descending
         scoreMatrix.sort { $0.score > $1.score }
 
-        // Generate 3 different arrangements
+        // Generate different arrangements
         var suggestions: [DispatchSuggestion] = []
 
         // Option 1: Greedy best-score assignment
@@ -121,19 +126,23 @@ public final class AIDispatchService: Sendable {
         suggestions.append(makeSuggestion(rank: 1, assignments: opt1))
 
         // Option 2: Prioritize team continuity (re-weight and assign)
-        var teamMatrix = scoreMatrix
-        for i in teamMatrix.indices {
-            if teamMatrix[i].factors.contains(where: { $0.category == "team" && $0.isPositive }) {
-                teamMatrix[i].score += 5
+        if preferences.aiSuggestionCount >= 2 {
+            var teamMatrix = scoreMatrix
+            for i in teamMatrix.indices {
+                if teamMatrix[i].factors.contains(where: { $0.category == "team" && $0.isPositive }) {
+                    teamMatrix[i].score += 5
+                }
             }
+            teamMatrix.sort { $0.score > $1.score }
+            let opt2 = greedyAssign(matrix: teamMatrix, workers: workers, jobs: jobs)
+            suggestions.append(makeSuggestion(rank: 2, assignments: opt2))
         }
-        teamMatrix.sort { $0.score > $1.score }
-        let opt2 = greedyAssign(matrix: teamMatrix, workers: workers, jobs: jobs)
-        suggestions.append(makeSuggestion(rank: 2, assignments: opt2))
 
         // Option 3: Spread workers across more jobs (diversity)
-        let opt3 = diverseAssign(matrix: scoreMatrix, workers: workers, jobs: jobs)
-        suggestions.append(makeSuggestion(rank: 3, assignments: opt3))
+        if preferences.aiSuggestionCount >= 3 {
+            let opt3 = diverseAssign(matrix: scoreMatrix, workers: workers, jobs: jobs)
+            suggestions.append(makeSuggestion(rank: 3, assignments: opt3))
+        }
 
         // Sort by total points
         suggestions.sort { $0.totalPoints > $1.totalPoints }
@@ -158,6 +167,11 @@ public final class AIDispatchService: Sendable {
 
     /// Record which suggestion the dispatcher chose (for future weight adjustment).
     public func recordDispatcherChoice(date: String, chosenRank: Int, wasModified: Bool) throws {
+        let preferences = try SettingsService(db: db).getDispatchPreferences()
+        guard preferences.aiLearningEnabled else {
+            return
+        }
+
         do {
             try db.writer.write { dbConn in
                 try dbConn.execute(

--- a/core/Sources/WiredPartCore/Services/SchedulingService.swift
+++ b/core/Sources/WiredPartCore/Services/SchedulingService.swift
@@ -45,6 +45,7 @@ public final class SchedulingService: Sendable {
         case contractorNotFound(Int64)
         case subcontractorScheduleNotFound(Int64)
         case subcontractorScheduleConflict(jobId: Int64, gcId: Int64, date: String)
+        case flexSelfAssignDisabled
     }
 
     // =========================================================================
@@ -1688,6 +1689,29 @@ public final class SchedulingService: Sendable {
         "small_job",
     ]
 
+    /// Saved display targets for the short-term pipeline's readiness categories.
+    public struct PipelineTargets: Codable, Equatable, Sendable {
+        public let startAnytime: Int
+        public let scheduleNeeded: Int
+        public let favoriteGC: Int
+
+        public init(startAnytime: Int, scheduleNeeded: Int, favoriteGC: Int) {
+            self.startAnytime = startAnytime
+            self.scheduleNeeded = scheduleNeeded
+            self.favoriteGC = favoriteGC
+        }
+    }
+
+    /// Get the saved dispatch-preference pipeline target thresholds.
+    public func getShortTermPipelineTargets() throws -> PipelineTargets {
+        let preferences = try SettingsService(db: db).getDispatchPreferences()
+        return PipelineTargets(
+            startAnytime: preferences.pipelineStartAnytimeTarget,
+            scheduleNeeded: preferences.pipelineScheduleNeededTarget,
+            favoriteGC: preferences.pipelineFavoriteGCTarget
+        )
+    }
+
     /// Get the short-term pipeline: active jobs categorized by readiness.
     /// Categories: start_anytime (no blockers), schedule_needed (need dispatch),
     /// favorite_gc (from preferred GCs), small_job (<=2 est. days).
@@ -2402,18 +2426,13 @@ public final class SchedulingService: Sendable {
     ///
     /// Returns an empty array if the `jobs` table is missing (fresh install).
     public func fetchFlexPool(userId: Int64) throws -> [FlexPoolJob] {
-        // Read approval setting first (separate from the jobs query to avoid fragile JOINs).
-        let isApprovalRequired: Bool
-        do {
-            let val = try db.writer.read { dbConn in
-                try String.fetchOne(dbConn,
-                    sql: "SELECT value FROM settings WHERE key = 'flex_pool_requires_approval' LIMIT 1")
-            }
-            isApprovalRequired = (val == "1")
-        } catch {
-            if isTableNotFoundError(error) { isApprovalRequired = false }
-            else { throw error }
+        let preferences = try SettingsService(db: db).getDispatchPreferences()
+        guard preferences.flexSelfAssignEnabled else {
+            return []
         }
+
+        // Read approval setting first (separate from the jobs query to avoid fragile JOINs).
+        let isApprovalRequired = preferences.flexRequireApproval
 
         // Fetch flex-pool jobs visible to this user.
         do {
@@ -2508,17 +2527,11 @@ public final class SchedulingService: Sendable {
     /// sets the user as lead and creates an `active` dispatch entry in a
     /// single transaction.
     public func claimFlexJob(jobId: Int64, userId: Int64) throws {
-        let requiresApproval: Bool
-        do {
-            let val = try db.writer.read { dbConn in
-                try String.fetchOne(dbConn,
-                    sql: "SELECT value FROM settings WHERE key = 'flex_pool_requires_approval' LIMIT 1")
-            }
-            requiresApproval = (val == "1")
-        } catch {
-            if isTableNotFoundError(error) { requiresApproval = false }
-            else { throw error }
+        let preferences = try SettingsService(db: db).getDispatchPreferences()
+        guard preferences.flexSelfAssignEnabled else {
+            throw SchedulingError.flexSelfAssignDisabled
         }
+        let requiresApproval = preferences.flexRequireApproval
 
         try db.writer.write { dbConn in
             // Guard: job + user must exist and not be tombstoned — flex-pool

--- a/core/Sources/WiredPartCore/Services/SettingsService.swift
+++ b/core/Sources/WiredPartCore/Services/SettingsService.swift
@@ -131,6 +131,121 @@ public final class SettingsService: Sendable {
         public static let defaults = PurchaseOrderSettings(groupingMode: .perSupplierMixed)
     }
 
+    public struct DispatchPreferenceSettings: Codable, Equatable, Sendable {
+        public var aiSuggestionsEnabled: Bool
+        public var aiLearningEnabled: Bool
+        public var showConfidenceScores: Bool
+        public var aiSuggestionCount: Int
+        public var flexSelfAssignEnabled: Bool
+        public var flexRequireApproval: Bool
+        public var pipelineStartAnytimeTarget: Int
+        public var pipelineScheduleNeededTarget: Int
+        public var pipelineFavoriteGCTarget: Int
+        public var defaultView: String
+        public var crewHistoryMonths: Int
+        public var crewContinuityWeight: String
+
+        public init(
+            aiSuggestionsEnabled: Bool,
+            aiLearningEnabled: Bool,
+            showConfidenceScores: Bool,
+            aiSuggestionCount: Int,
+            flexSelfAssignEnabled: Bool,
+            flexRequireApproval: Bool,
+            pipelineStartAnytimeTarget: Int,
+            pipelineScheduleNeededTarget: Int,
+            pipelineFavoriteGCTarget: Int,
+            defaultView: String,
+            crewHistoryMonths: Int,
+            crewContinuityWeight: String
+        ) {
+            self.aiSuggestionsEnabled = aiSuggestionsEnabled
+            self.aiLearningEnabled = aiLearningEnabled
+            self.showConfidenceScores = showConfidenceScores
+            self.aiSuggestionCount = aiSuggestionCount
+            self.flexSelfAssignEnabled = flexSelfAssignEnabled
+            self.flexRequireApproval = flexRequireApproval
+            self.pipelineStartAnytimeTarget = pipelineStartAnytimeTarget
+            self.pipelineScheduleNeededTarget = pipelineScheduleNeededTarget
+            self.pipelineFavoriteGCTarget = pipelineFavoriteGCTarget
+            self.defaultView = defaultView
+            self.crewHistoryMonths = crewHistoryMonths
+            self.crewContinuityWeight = crewContinuityWeight
+        }
+
+        public static let defaults = DispatchPreferenceSettings(
+            aiSuggestionsEnabled: true,
+            aiLearningEnabled: true,
+            showConfidenceScores: false,
+            aiSuggestionCount: 3,
+            flexSelfAssignEnabled: true,
+            flexRequireApproval: false,
+            pipelineStartAnytimeTarget: 3,
+            pipelineScheduleNeededTarget: 2,
+            pipelineFavoriteGCTarget: 1,
+            defaultView: "week",
+            crewHistoryMonths: 3,
+            crewContinuityWeight: "medium"
+        )
+
+        public static func fromMap(_ map: [String: String]) -> DispatchPreferenceSettings {
+            let defaults = DispatchPreferenceSettings.defaults
+            return DispatchPreferenceSettings(
+                aiSuggestionsEnabled: bool(map["dispatch_ai_suggestions_enabled"], defaultValue: defaults.aiSuggestionsEnabled),
+                aiLearningEnabled: bool(map["dispatch_ai_learning_enabled"], defaultValue: defaults.aiLearningEnabled),
+                showConfidenceScores: bool(map["dispatch_show_confidence_scores"], defaultValue: defaults.showConfidenceScores),
+                aiSuggestionCount: clampedInt(map["dispatch_ai_suggestion_count"], defaultValue: defaults.aiSuggestionCount, min: 1, max: 3),
+                flexSelfAssignEnabled: bool(map["dispatch_flex_self_assign_enabled"], defaultValue: defaults.flexSelfAssignEnabled),
+                flexRequireApproval: bool(
+                    map["dispatch_flex_require_approval"] ?? map["flex_pool_requires_approval"],
+                    defaultValue: defaults.flexRequireApproval
+                ),
+                pipelineStartAnytimeTarget: clampedInt(map["dispatch_pipeline_start_anytime_target"], defaultValue: defaults.pipelineStartAnytimeTarget, min: 0, max: 20),
+                pipelineScheduleNeededTarget: clampedInt(map["dispatch_pipeline_schedule_needed_target"], defaultValue: defaults.pipelineScheduleNeededTarget, min: 0, max: 20),
+                pipelineFavoriteGCTarget: clampedInt(map["dispatch_pipeline_favorite_gc_target"], defaultValue: defaults.pipelineFavoriteGCTarget, min: 0, max: 20),
+                defaultView: allowed(map["dispatch_default_view"], defaultValue: defaults.defaultView, allowedValues: Set(["day", "week", "month"])),
+                crewHistoryMonths: clampedInt(map["dispatch_crew_history_months"], defaultValue: defaults.crewHistoryMonths, min: 1, max: 12),
+                crewContinuityWeight: allowed(map["dispatch_crew_continuity_weight"], defaultValue: defaults.crewContinuityWeight, allowedValues: Set(["low", "medium", "high"]))
+            )
+        }
+
+        public var storageMap: [String: String] {
+            [
+                "dispatch_ai_suggestions_enabled": aiSuggestionsEnabled ? "true" : "false",
+                "dispatch_ai_learning_enabled": aiLearningEnabled ? "true" : "false",
+                "dispatch_show_confidence_scores": showConfidenceScores ? "true" : "false",
+                "dispatch_ai_suggestion_count": String(aiSuggestionCount),
+                "dispatch_flex_self_assign_enabled": flexSelfAssignEnabled ? "true" : "false",
+                "dispatch_flex_require_approval": flexRequireApproval ? "true" : "false",
+                "dispatch_pipeline_start_anytime_target": String(pipelineStartAnytimeTarget),
+                "dispatch_pipeline_schedule_needed_target": String(pipelineScheduleNeededTarget),
+                "dispatch_pipeline_favorite_gc_target": String(pipelineFavoriteGCTarget),
+                "dispatch_default_view": defaultView,
+                "dispatch_crew_history_months": String(crewHistoryMonths),
+                "dispatch_crew_continuity_weight": crewContinuityWeight,
+            ]
+        }
+
+        private static func bool(_ raw: String?, defaultValue: Bool) -> Bool {
+            guard let raw else { return defaultValue }
+            switch raw.lowercased() {
+            case "true", "1", "yes": return true
+            case "false", "0", "no": return false
+            default: return defaultValue
+            }
+        }
+
+        private static func clampedInt(_ raw: String?, defaultValue: Int, min: Int, max: Int) -> Int {
+            guard let raw, let value = Int(raw) else { return defaultValue }
+            return Swift.max(min, Swift.min(max, value))
+        }
+
+        private static func allowed(_ raw: String?, defaultValue: String, allowedValues: Set<String>) -> String {
+            guard let raw, allowedValues.contains(raw) else { return defaultValue }
+            return raw
+        }
+    }
+
     // MARK: - Helpers
 
     /// Read a single setting value by key. Returns nil when not found.
@@ -278,6 +393,28 @@ public final class SettingsService: Sendable {
             "font_family": theme.fontFamily,
         ], category: "theme")
         return try getTheme()
+    }
+
+    // MARK: - Dispatch Preferences
+
+    /// Get dispatch preferences, filling in defaults for any missing keys.
+    ///
+    /// Falls back to the legacy `flex_pool_requires_approval` key (stored outside
+    /// the `dispatch` category by older builds) when the typed key is absent, so
+    /// upgrading installs keep their previously saved approval requirement.
+    public func getDispatchPreferences() throws -> DispatchPreferenceSettings {
+        var map = try getSettingsByCategory("dispatch")
+        if map["dispatch_flex_require_approval"] == nil,
+           let legacyApproval = try getSettingValue("flex_pool_requires_approval") {
+            map["flex_pool_requires_approval"] = legacyApproval
+        }
+        return DispatchPreferenceSettings.fromMap(map)
+    }
+
+    /// Update dispatch preferences.
+    public func updateDispatchPreferences(_ preferences: DispatchPreferenceSettings) throws -> DispatchPreferenceSettings {
+        try upsertSettingsMap(preferences.storageMap, category: "dispatch")
+        return try getDispatchPreferences()
     }
 
     // MARK: - Generic Settings

--- a/core/Tests/WiredPartCoreTests/AIDispatchServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/AIDispatchServiceTests.swift
@@ -34,6 +34,34 @@ struct AIDispatchServiceTests {
         #expect(suggestions.count >= 0)
     }
 
+    @Test("Generate suggestions returns empty when AI dispatch is disabled")
+    func testSuggestionsDisabledByDispatchPreferences() throws {
+        let env = try E2ETestHelpers.setUp()
+        let service = makeService(env)
+        _ = try E2ETestHelpers.seedJob(env, jobNumber: "J-AI-OFF", name: "Disabled AI Job")
+
+        var preferences = try env.settings.getDispatchPreferences()
+        preferences.aiSuggestionsEnabled = false
+        _ = try env.settings.updateDispatchPreferences(preferences)
+
+        let suggestions = try service.generateSuggestions(date: "2026-03-29")
+        #expect(suggestions.isEmpty)
+    }
+
+    @Test("Generate suggestions respects saved suggestion count")
+    func testSuggestionsRespectSavedSuggestionCount() throws {
+        let env = try E2ETestHelpers.setUp()
+        let service = makeService(env)
+        _ = try E2ETestHelpers.seedJob(env, jobNumber: "J-AI-COUNT", name: "Counted AI Job")
+
+        var preferences = try env.settings.getDispatchPreferences()
+        preferences.aiSuggestionCount = 1
+        _ = try env.settings.updateDispatchPreferences(preferences)
+
+        let suggestions = try service.generateSuggestions(date: "2026-03-29")
+        #expect(suggestions.count <= 1)
+    }
+
     // MARK: - Context
 
     @Test("Get dispatch context as text")
@@ -59,5 +87,27 @@ struct AIDispatchServiceTests {
         let env = try E2ETestHelpers.setUp()
         let service = makeService(env)
         try service.recordDispatcherChoice(date: "2026-03-29", chosenRank: 2, wasModified: true)
+    }
+
+    @Test("Record dispatcher choice is skipped when AI learning is disabled")
+    func testRecordChoiceDisabledByDispatchPreferences() throws {
+        let env = try E2ETestHelpers.setUp()
+        let service = makeService(env)
+
+        var preferences = try env.settings.getDispatchPreferences()
+        preferences.aiLearningEnabled = false
+        _ = try env.settings.updateDispatchPreferences(preferences)
+
+        try service.recordDispatcherChoice(date: "2026-03-29", chosenRank: 1, wasModified: false)
+
+        let count: Int
+        do {
+            count = try env.db.writer.read { db in
+                try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM ai_dispatch_choices") ?? 0
+            }
+        } catch {
+            count = 0
+        }
+        #expect(count == 0)
     }
 }

--- a/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SchedulingServiceTests.swift
@@ -1744,6 +1744,22 @@ struct SchedulingServiceTests {
         #expect(item?.pipelineCategory == "schedule_needed")
     }
 
+    @Test("getShortTermPipelineTargets uses saved dispatch preference thresholds")
+    func testPipelineTargetsUseDispatchPreferences() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        var preferences = try env.settings.getDispatchPreferences()
+        preferences.pipelineStartAnytimeTarget = 9
+        preferences.pipelineScheduleNeededTarget = 4
+        preferences.pipelineFavoriteGCTarget = 2
+        _ = try env.settings.updateDispatchPreferences(preferences)
+
+        let targets = try env.scheduling.getShortTermPipelineTargets()
+        #expect(targets.startAnytime == 9)
+        #expect(targets.scheduleNeeded == 4)
+        #expect(targets.favoriteGC == 2)
+    }
+
     @Test("updateShortTermPipelineCategory persists a manual drag/drop category override")
     func testUpdateShortTermPipelineCategoryPersistsOverride() throws {
         let env = try E2ETestHelpers.setUp()
@@ -2686,6 +2702,35 @@ struct SchedulingServiceTests {
         let jobs = try env.scheduling.fetchFlexPool(userId: env.adminUserId)
         #expect(jobs.count == 1)
         #expect(jobs[0].isApprovalRequired == true)
+    }
+
+    @Test("fetchFlexPool returns empty when self-assign is disabled")
+    func testFetchFlexPoolDisabledByDispatchPreferences() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+
+        var preferences = try env.settings.getDispatchPreferences()
+        preferences.flexSelfAssignEnabled = false
+        _ = try env.settings.updateDispatchPreferences(preferences)
+
+        try env.scheduling.markJobFlexPool(jobId: jobId, isFlexPool: true)
+        let jobs = try env.scheduling.fetchFlexPool(userId: env.adminUserId)
+        #expect(jobs.isEmpty)
+    }
+
+    @Test("claimFlexJob rejects self-assignment when disabled")
+    func testClaimFlexJobDisabledByDispatchPreferences() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env)
+
+        var preferences = try env.settings.getDispatchPreferences()
+        preferences.flexSelfAssignEnabled = false
+        _ = try env.settings.updateDispatchPreferences(preferences)
+
+        try env.scheduling.markJobFlexPool(jobId: jobId, isFlexPool: true)
+        #expect(throws: SchedulingService.SchedulingError.flexSelfAssignDisabled) {
+            try env.scheduling.claimFlexJob(jobId: jobId, userId: env.adminUserId)
+        }
     }
 
     // MARK: - markJobFlexPool with Team Filter

--- a/core/Tests/WiredPartCoreTests/SettingsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/SettingsServiceTests.swift
@@ -335,6 +335,74 @@ struct SettingsServiceTests {
         #expect(updated.startDay == 15)
     }
 
+    // MARK: - Dispatch Preferences
+
+    @Test("getDispatchPreferences returns defaults and updateDispatchPreferences persists typed settings")
+    func testDispatchPreferencesTypedSettings() throws {
+        let db = try freshDB()
+        let svc = SettingsService(db: db)
+
+        let defaults = try svc.getDispatchPreferences()
+        #expect(defaults.aiSuggestionsEnabled)
+        #expect(defaults.aiLearningEnabled)
+        #expect(defaults.aiSuggestionCount == 3)
+        #expect(defaults.flexSelfAssignEnabled)
+        #expect(defaults.pipelineStartAnytimeTarget == 3)
+
+        var custom = defaults
+        custom.aiSuggestionsEnabled = false
+        custom.aiLearningEnabled = false
+        custom.aiSuggestionCount = 1
+        custom.flexSelfAssignEnabled = false
+        custom.flexRequireApproval = true
+        custom.pipelineStartAnytimeTarget = 7
+        custom.pipelineScheduleNeededTarget = 6
+        custom.pipelineFavoriteGCTarget = 5
+        custom.defaultView = "month"
+        custom.crewHistoryMonths = 8
+        custom.crewContinuityWeight = "high"
+
+        let saved = try svc.updateDispatchPreferences(custom)
+        #expect(saved == custom)
+
+        let reloaded = try svc.getDispatchPreferences()
+        #expect(reloaded == custom)
+    }
+
+    @Test("getDispatchPreferences clamps invalid stored dispatch values")
+    func testDispatchPreferencesClampInvalidValues() throws {
+        let db = try freshDB()
+        let svc = SettingsService(db: db)
+
+        try svc.upsertSettingsMap([
+            "dispatch_ai_suggestion_count": "99",
+            "dispatch_pipeline_start_anytime_target": "-3",
+            "dispatch_pipeline_schedule_needed_target": "33",
+            "dispatch_default_view": "decade",
+            "dispatch_crew_history_months": "0",
+            "dispatch_crew_continuity_weight": "extreme",
+        ], category: "dispatch")
+
+        let preferences = try svc.getDispatchPreferences()
+        #expect(preferences.aiSuggestionCount == 3)
+        #expect(preferences.pipelineStartAnytimeTarget == 0)
+        #expect(preferences.pipelineScheduleNeededTarget == 20)
+        #expect(preferences.defaultView == "week")
+        #expect(preferences.crewHistoryMonths == 1)
+        #expect(preferences.crewContinuityWeight == "medium")
+    }
+
+    @Test("getDispatchPreferences falls back to legacy flex_pool_requires_approval key")
+    func testDispatchPreferencesLegacyApprovalFallback() throws {
+        let db = try freshDB()
+        let svc = SettingsService(db: db)
+
+        try svc.upsertSetting(key: "flex_pool_requires_approval", value: "1", category: "general")
+
+        let preferences = try svc.getDispatchPreferences()
+        #expect(preferences.flexRequireApproval)
+    }
+
     // MARK: - Company Profiles
 
     @Test("createCompanyProfile and list")


### PR DESCRIPTION
Contributes to #90 (re-lands #439).

## Provenance

Re-lands rescued commit `8cd7fd36f` ("Enforce dispatch preferences") from `rescue/439-dispatch`, adapted by hand to current `main` — main had drifted far enough (105→107 migrations landed since, `SchedulingError` gained new cases, `IOSDispatchPreferencesPage` gained a `SettingsValueParser` hydration-validation layer, `IOSShortTermPipelinePage` gained drag/drop + callback handling) that a direct cherry-pick conflicted on every touched file. Applied by hand, function-by-function, against current code.

**Gap being closed** (per the 2026-05-13 #90 triage audit comment): zero `dispatch_*` policy reads existed in `core/Sources` — dispatch preferences were saved from the Settings page but never actually enforced by AI dispatch, flex pool, or pipeline workflows.

## What changed vs donor

- Same typed `SettingsService.DispatchPreferenceSettings` contract, same storage keys, same clamping/allow-list validation, same legacy `flex_pool_requires_approval` fallback logic as the donor commit.
- `AIDispatchService.generateSuggestions` / `recordDispatcherChoice`: applied donor's `aiSuggestionsEnabled` / `aiSuggestionCount` / `aiLearningEnabled` gating verbatim — this file hadn't drifted from the donor's parent.
- `SchedulingService`: added `SchedulingError.flexSelfAssignDisabled` as a new case appended to the (now larger) current enum rather than donor's positioning; `fetchFlexPool` / `claimFlexJob` swapped their local `settings` table lookups for `SettingsService.getDispatchPreferences()`, preserving current code's existing table-missing/soft-delete guards; added `SchedulingService.PipelineTargets` + `getShortTermPipelineTargets()` ahead of `getShortTermPipeline()`.
- `IOSDispatchPreferencesPage`: **diverges from donor** — main had since added a `SettingsValueParser` hydration-validation layer (rejects malformed stored values instead of silently defaulting) that didn't exist when the donor commit was authored. Kept that newer, stricter load path intact and only switched the **save** path to persist through `SettingsService.updateDispatchPreferences(_:)` so stored keys match what core now reads.
- `IOSShortTermPipelinePage`: added a `pipelineTargets` state var fetched in both `loadData()` and `refreshPipelineData()`, replacing the hardcoded 3/2/1 targets in the summary cards and section headers — same approach as donor, adapted to the current file's two load entry points (donor's parent only had one).
- **New**: Migration `109_dispatch_preference_backfill` — donor didn't ship a migration (dispatch settings reuse the existing generic `settings` key-value table, no schema change needed). Added one anyway to backfill the legacy `flex_pool_requires_approval` row into the `dispatch` category under the new key name for existing installs, idempotent via `INSERT OR IGNORE`, additive only (legacy row is left in place as a fallback, never deleted/edited).

## Test evidence

```
cd core && swift build   # Build complete
swift test --filter 'SettingsServiceTests|AIDispatchServiceTests|SchedulingServiceTests'
# Test run with 253 tests in 3 suites passed after 10.684 seconds.

swift test   # full suite
# Test run with 2345 tests in 71 suites passed after 138.467 seconds.
```

Ported all donor tests (dispatch preference defaults/clamping, AI-disabled/learning-disabled, flex-self-assign-disabled fetch+claim, pipeline targets) plus one new test for the migration-109 legacy-key-fallback path. `xcrun swiftc -parse` clean on both touched app-target files.

## Risks / follow-ups

- `IOSDispatchPreferencesPage` has no UI control for `aiSuggestionCount` (matches donor — it saves the struct default of `3` on every save). Out of scope for this slice; flagging in case a future UI pass wants to expose it.
- Does **not** close #90 — leaving that to the umbrella tracker per the re-land assignment.

## Update: review fixes

A review flagged an important divergence in `IOSDispatchPreferencesPage`'s load path (untouched by the original slice of this PR) that this PR made consequential:

- `loadSettings()` defaulted `enableFlexSelfAssign` to `false` and `requireManagerApproval` to `true` — the exact opposite of `SettingsService.DispatchPreferenceSettings.defaults` (`flexSelfAssignEnabled: true`, `flexRequireApproval: false`), which is what `getDispatchPreferences()` returns for any install that never saved the `dispatch` category, and which this PR now wires `SchedulingService.fetchFlexPool`/`claimFlexJob` to enforce.
- Concrete failure this caused: a fresh install has flex-pool self-assign enabled per the service layer, but the first time anyone opened Dispatch Preferences the toggle rendered OFF (stale/wrong state vs. what's actually enforced). Saving the page for any unrelated reason (e.g. only changing crew continuity weight) would then silently persist `dispatch_flex_self_assign_enabled: "false"`, disabling flex-pool self-assign company-wide with no toggle ever knowingly touched by the user. Unlike the disclosed `aiSuggestionCount` risk above (harmless because nothing else reads a different value), this one flips behavior that this same PR just made load-bearing.

Fixed:
- Both the `@State` initializers (`enableFlexSelfAssign`, `requireManagerApproval`) and the `parser.bool(...)` fallback defaults in `loadSettings()` now match `DispatchPreferenceSettings.defaults` (`true` / `false`).
- Added `Weird Parts IOSTests/DispatchPreferencesDefaultsRegressionTests.swift` — a source-scanning regression test (same style as `SettingsSaveConfirmationRegressionTests`) that pins the page's flex-pool defaults to the core struct's actual default values, so the two can't silently re-diverge again. It also cross-checks the core defaults themselves so the test fails loudly if `DispatchPreferenceSettings.defaults` changes without a matching update here.

Re-verified: `cd core && swift build` clean, `swift test --filter 'SettingsServiceTests|AIDispatchServiceTests|SchedulingServiceTests'` — 253 tests / 3 suites passed, full `swift test` — 2345 tests / 71 suites passed, `xcrun swiftc -parse` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
