### PR TITLE
Re-land #80 slice 3: panel schedule PDF export/print/custom header

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
@@ -10,7 +10,6 @@ struct PanelScheduleBuilder: View {
     @State private var selectedCircuit: CircuitEntry?
     @State private var showHiddenCircuitPruneConfirmation = false
     @State private var exportOptions = PanelScheduleExportOptions()
-    @State private var exportURL: URL?
     @State private var exportMessage: String?
     // Anchor rect (in the window's coordinate space) for the Export menu's
     // Print PDF button, so the iPad popover presentation of
@@ -27,7 +26,7 @@ struct PanelScheduleBuilder: View {
             case .circuitEditor: return "circuitEditor"
             case .panelSettings: return "panelSettings"
             case .headerSettings: return "headerSettings"
-            case .share: return "share"
+            case .share(let url): return "share-\(url.absoluteString)"
             }
         }
     }
@@ -342,7 +341,6 @@ struct PanelScheduleBuilder: View {
     private func exportPanelScheduleForShare() {
         do {
             let url = try PanelSchedulePDFExporter(schedule: schedule, options: exportOptions).writeToTemporaryFile()
-            exportURL = url
             activeSheet = .share(url)
         } catch {
             exportMessage = userFriendlyError(error, context: "export panel schedule")
@@ -352,7 +350,6 @@ struct PanelScheduleBuilder: View {
     private func printPanelSchedule() {
         do {
             let url = try PanelSchedulePDFExporter(schedule: schedule, options: exportOptions).writeToTemporaryFile()
-            exportURL = url
 
             let printController = UIPrintInteractionController.shared
             let printInfo = UIPrintInfo(dictionary: nil)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 import WiredPartCore
 
 /// Interactive panel schedule builder for documenting circuit breaker assignments.
@@ -8,14 +9,21 @@ struct PanelScheduleBuilder: View {
 
     @State private var selectedCircuit: CircuitEntry?
     @State private var showHiddenCircuitPruneConfirmation = false
+    @State private var exportOptions = PanelScheduleExportOptions()
+    @State private var exportURL: URL?
+    @State private var exportMessage: String?
 
     private enum ActiveSheet: Identifiable {
         case circuitEditor
         case panelSettings
+        case headerSettings
+        case share(URL)
         var id: String {
             switch self {
             case .circuitEditor: return "circuitEditor"
             case .panelSettings: return "panelSettings"
+            case .headerSettings: return "headerSettings"
+            case .share: return "share"
             }
         }
     }
@@ -41,6 +49,10 @@ struct PanelScheduleBuilder: View {
                 }
             case .panelSettings:
                 PanelSettingsSheet(schedule: $schedule)
+            case .headerSettings:
+                PanelScheduleHeaderSheet(options: $exportOptions)
+            case .share(let url):
+                PanelScheduleShareSheet(items: [url])
             }
         }
         .alert("Remove Hidden Circuits?", isPresented: $showHiddenCircuitPruneConfirmation) {
@@ -50,6 +62,14 @@ struct PanelScheduleBuilder: View {
             }
         } message: {
             Text("Saving will permanently remove \(schedule.circuitsOutsideTotalSpaces.count) hidden circuit\(schedule.circuitsOutsideTotalSpaces.count == 1 ? "" : "s") outside the visible 1–\(schedule.totalSpaces) panel range.")
+        }
+        .alert("Panel schedule export", isPresented: Binding(
+            get: { exportMessage != nil },
+            set: { if !$0 { exportMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) { exportMessage = nil }
+        } message: {
+            Text(exportMessage ?? "")
         }
     }
 
@@ -240,6 +260,30 @@ struct PanelScheduleBuilder: View {
 
             Spacer()
 
+            Menu {
+                Button {
+                    activeSheet = .headerSettings
+                } label: {
+                    Label("Custom Header", systemImage: "text.badge.plus")
+                }
+
+                Button {
+                    exportPanelScheduleForShare()
+                } label: {
+                    Label("Export PDF", systemImage: "doc.fill")
+                }
+
+                Button {
+                    printPanelSchedule()
+                } label: {
+                    Label("Print PDF", systemImage: "printer")
+                }
+            } label: {
+                Label("Export", systemImage: "square.and.arrow.up")
+                    .font(.caption)
+            }
+            .buttonStyle(.bordered)
+
             Button {
                 if schedule.circuitsOutsideTotalSpaces.isEmpty {
                     saveNormalizedSchedule()
@@ -278,6 +322,39 @@ struct PanelScheduleBuilder: View {
         let normalized = schedule.normalizedForPersistence()
         schedule = normalized
         onSave(normalized)
+    }
+
+    // MARK: - Export
+
+    private func exportPanelScheduleForShare() {
+        do {
+            let url = try PanelSchedulePDFExporter(schedule: schedule, options: exportOptions).writeToTemporaryFile()
+            exportURL = url
+            activeSheet = .share(url)
+        } catch {
+            exportMessage = userFriendlyError(error, context: "export panel schedule")
+        }
+    }
+
+    private func printPanelSchedule() {
+        do {
+            let url = try PanelSchedulePDFExporter(schedule: schedule, options: exportOptions).writeToTemporaryFile()
+            exportURL = url
+
+            let printController = UIPrintInteractionController.shared
+            let printInfo = UIPrintInfo(dictionary: nil)
+            printInfo.jobName = "\(schedule.panelName) Panel Schedule"
+            printInfo.outputType = .general
+            printController.printInfo = printInfo
+            printController.printingItem = url
+            printController.present(animated: true) { _, _, error in
+                if let error {
+                    exportMessage = userFriendlyError(error, context: "print panel schedule")
+                }
+            }
+        } catch {
+            exportMessage = userFriendlyError(error, context: "print panel schedule")
+        }
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
@@ -12,6 +12,10 @@ struct PanelScheduleBuilder: View {
     @State private var exportOptions = PanelScheduleExportOptions()
     @State private var exportURL: URL?
     @State private var exportMessage: String?
+    // Anchor rect (in the window's coordinate space) for the Export menu's
+    // Print PDF button, so the iPad popover presentation of
+    // UIPrintInteractionController has a source to point at.
+    @State private var exportMenuAnchorRect: CGRect = .zero
 
     private enum ActiveSheet: Identifiable {
         case circuitEditor
@@ -283,6 +287,15 @@ struct PanelScheduleBuilder: View {
                     .font(.caption)
             }
             .buttonStyle(.bordered)
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .onAppear { exportMenuAnchorRect = proxy.frame(in: .global) }
+                        .onChange(of: proxy.frame(in: .global)) { _, newValue in
+                            exportMenuAnchorRect = newValue
+                        }
+                }
+            )
 
             Button {
                 if schedule.circuitsOutsideTotalSpaces.isEmpty {
@@ -347,14 +360,50 @@ struct PanelScheduleBuilder: View {
             printInfo.outputType = .general
             printController.printInfo = printInfo
             printController.printingItem = url
-            printController.present(animated: true) { _, _, error in
+
+            let completion: UIPrintInteractionController.CompletionHandler = { _, _, error in
                 if let error {
                     exportMessage = userFriendlyError(error, context: "print panel schedule")
                 }
             }
+
+            // `present(animated:completionHandler:)` is documented as
+            // iPhone/iPod-touch only and raises "this method is not supported
+            // on the iPad idiom" at runtime on iPad. The app ships
+            // TARGETED_DEVICE_FAMILY = "1,2" (iPhone + iPad), so both paths
+            // must be handled: iPad requires the popover-anchored
+            // `present(from:in:animated:completionHandler:)`.
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                guard let rootViewController = Self.activeRootViewController() else {
+                    exportMessage = userFriendlyError(
+                        PanelScheduleExportError.outputPathUnavailable,
+                        context: "print panel schedule"
+                    )
+                    return
+                }
+                let anchorRect = exportMenuAnchorRect == .zero
+                    ? CGRect(x: rootViewController.view.bounds.midX, y: rootViewController.view.bounds.midY, width: 1, height: 1)
+                    : rootViewController.view.convert(exportMenuAnchorRect, from: nil)
+                printController.present(
+                    from: anchorRect,
+                    in: rootViewController.view,
+                    animated: true,
+                    completionHandler: completion
+                )
+            } else {
+                printController.present(animated: true, completionHandler: completion)
+            }
         } catch {
             exportMessage = userFriendlyError(error, context: "print panel schedule")
         }
+    }
+
+    /// The current key window's root view controller, used to anchor the
+    /// iPad popover presentation of `UIPrintInteractionController`.
+    private static func activeRootViewController() -> UIViewController? {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+        return scene?.windows.first { $0.isKeyWindow }?.rootViewController
     }
 }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleExport.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleExport.swift
@@ -85,7 +85,11 @@ struct PanelSchedulePDFExporter {
         return "\((safePanelName.isEmpty ? "Panel_Schedule" : safePanelName))_\(date).pdf"
     }
 
-    private func renderPDF(schedule: PanelSchedule) -> Data {
+    // `internal` (not `private`) so tests can call this directly with a raw,
+    // un-normalized schedule — `writeToTemporaryFile()` always normalizes
+    // first, so that entry point alone can never exercise the negative-
+    // `totalSpaces` guard in `drawScheduleTable` below.
+    func renderPDF(schedule: PanelSchedule) -> Data {
         let pageSize = options.paperSize.pageSize
         let renderer = UIGraphicsPDFRenderer(bounds: CGRect(origin: .zero, size: pageSize))
         let margin: CGFloat = 36
@@ -192,7 +196,14 @@ struct PanelSchedulePDFExporter {
 
         // max(..., 0) mirrors the same guard PanelScheduleBuilder's grid uses
         // (#1239) so a malformed non-positive totalSpaces can never produce a
-        // negative range here either.
+        // negative range here either. In practice `writeToTemporaryFile()`
+        // always renders a `normalizedForPersistence()` copy, whose
+        // `clampingTotalSpacesToSupportedRange()` step already forces
+        // totalSpaces positive — so this is defense-in-depth for any future
+        // caller of `renderPDF(schedule:)` that skips normalization, not a
+        // path reachable through the current export/print UI. See
+        // `PanelSchedulePDFExporterTests.testRenderPDFGuardsAgainstNegativeTotalSpacesWhenCalledDirectly`
+        // for direct coverage of this guard (bypassing normalization).
         for row in 0..<max(schedule.totalSpaces / 2, 0) {
             if y + rowHeight > pageSize.height - margin - 38 {
                 break

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleExport.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleExport.swift
@@ -1,0 +1,307 @@
+import SwiftUI
+import UIKit
+import WiredPartCore
+
+// MARK: - Panel Schedule PDF Export
+
+enum PanelScheduleExportError: LocalizedError {
+    case outputPathUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .outputPathUnavailable:
+            return "The generated PDF could not be validated."
+        }
+    }
+}
+
+enum PanelSchedulePaperSize: String, CaseIterable, Identifiable {
+    case letter = "Letter"
+    case legal = "Legal"
+    case a4 = "A4"
+    case cardStock = "Card Stock"
+
+    var id: String { rawValue }
+
+    var pageSize: CGSize {
+        switch self {
+        case .letter:
+            return CGSize(width: 612, height: 792)
+        case .legal:
+            return CGSize(width: 612, height: 1008)
+        case .a4:
+            return CGSize(width: 595, height: 842)
+        case .cardStock:
+            return CGSize(width: 576, height: 720)
+        }
+    }
+}
+
+struct PanelScheduleExportOptions {
+    var paperSize: PanelSchedulePaperSize = .letter
+    var companyName = "WiredPart"
+    var address = ""
+    var phone = ""
+    var licenseNumber = ""
+    var preparedBy = ""
+    var footerNote = ""
+}
+
+struct PanelSchedulePDFExporter {
+    let schedule: PanelSchedule
+    let options: PanelScheduleExportOptions
+
+    func writeToTemporaryFile(fileManager: FileManager = .default) throws -> URL {
+        // Persist-time normalization (clamped totalSpaces, pruned out-of-range
+        // circuits) is the closest equivalent to a "validated" schedule on
+        // current main — `PanelSchedule` does not expose a `validated()`
+        // throwing method here, unlike the donor branch's later panel-editing
+        // lane. Rendering against the normalized copy keeps the export in
+        // sync with what `PanelScheduleBuilder`'s Save action persists.
+        let normalizedSchedule = schedule.normalizedForPersistence()
+
+        let directory = fileManager.temporaryDirectory.appendingPathComponent("PanelSchedules", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let url = directory.appendingPathComponent(filename)
+        let data = renderPDF(schedule: normalizedSchedule)
+        try data.write(to: url, options: .atomic)
+
+        guard fileManager.fileExists(atPath: url.path),
+              ((try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0) > 0 else {
+            throw PanelScheduleExportError.outputPathUnavailable
+        }
+        return url
+    }
+
+    private var filename: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let date = formatter.string(from: Date())
+        let safePanelName = schedule.panelName
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: "_")
+        return "\((safePanelName.isEmpty ? "Panel_Schedule" : safePanelName))_\(date).pdf"
+    }
+
+    private func renderPDF(schedule: PanelSchedule) -> Data {
+        let pageSize = options.paperSize.pageSize
+        let renderer = UIGraphicsPDFRenderer(bounds: CGRect(origin: .zero, size: pageSize))
+        let margin: CGFloat = 36
+
+        return renderer.pdfData { context in
+            context.beginPage()
+
+            var y = margin
+            drawHeader(in: pageSize, margin: margin, y: &y)
+            y += 14
+            drawPanelInfo(schedule: schedule, margin: margin, y: &y)
+            y += 10
+            drawScheduleTable(schedule: schedule, in: pageSize, margin: margin, y: &y)
+            drawFooter(in: pageSize, margin: margin)
+        }
+    }
+
+    private func drawHeader(in pageSize: CGSize, margin: CGFloat, y: inout CGFloat) {
+        let titleAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.boldSystemFont(ofSize: 18),
+            .foregroundColor: UIColor.black
+        ]
+        let bodyAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 9),
+            .foregroundColor: UIColor.darkGray
+        ]
+
+        options.companyName.draw(
+            in: CGRect(x: margin, y: y, width: pageSize.width - margin * 2, height: 24),
+            withAttributes: titleAttributes
+        )
+        y += 24
+
+        let headerLines = [options.address, options.phone, options.licenseNumber]
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        for line in headerLines {
+            line.draw(
+                in: CGRect(x: margin, y: y, width: pageSize.width - margin * 2, height: 13),
+                withAttributes: bodyAttributes
+            )
+            y += 13
+        }
+
+        UIColor.systemGray3.setStroke()
+        UIBezierPath(rect: CGRect(x: margin, y: y + 4, width: pageSize.width - margin * 2, height: 1)).stroke()
+        y += 12
+    }
+
+    private func drawPanelInfo(schedule: PanelSchedule, margin: CGFloat, y: inout CGFloat) {
+        let titleAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.boldSystemFont(ofSize: 16),
+            .foregroundColor: UIColor.black
+        ]
+        let metaAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 10),
+            .foregroundColor: UIColor.darkGray
+        ]
+
+        "\(schedule.panelName) Panel Schedule".draw(
+            in: CGRect(x: margin, y: y, width: 420, height: 22),
+            withAttributes: titleAttributes
+        )
+        y += 24
+
+        let main = schedule.mainBreakerAmps.map { "\($0)A Main" } ?? "MLO"
+        let location = schedule.location?.isEmpty == false ? " | \(schedule.location ?? "")" : ""
+        let metadata = "\(schedule.panelType.rawValue) | \(schedule.totalSpaces) Spaces | \(main) | \(schedule.voltage)V | \(schedule.phase) Phase\(location)"
+        metadata.draw(in: CGRect(x: margin, y: y, width: 520, height: 16), withAttributes: metaAttributes)
+        y += 18
+
+        let prepared = options.preparedBy.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !prepared.isEmpty {
+            "Prepared by: \(prepared)".draw(in: CGRect(x: margin, y: y, width: 420, height: 14), withAttributes: metaAttributes)
+            y += 16
+        }
+    }
+
+    private func drawScheduleTable(schedule: PanelSchedule, in pageSize: CGSize, margin: CGFloat, y: inout CGFloat) {
+        let contentWidth = pageSize.width - margin * 2
+        let rowHeight: CGFloat = 18
+        let halfWidth = (contentWidth - 6) / 2
+        let leftX = margin
+        let rightX = margin + halfWidth + 6
+        let headerAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.boldSystemFont(ofSize: 8),
+            .foregroundColor: UIColor.black
+        ]
+        let cellAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 8),
+            .foregroundColor: UIColor.darkGray
+        ]
+
+        func drawHalfHeader(x: CGFloat) {
+            UIColor.systemGray5.setFill()
+            UIBezierPath(rect: CGRect(x: x, y: y, width: halfWidth, height: rowHeight)).fill()
+            drawRowText("#", x: x + 4, y: y + 4, width: 18, attributes: headerAttributes)
+            drawRowText("A", x: x + 24, y: y + 4, width: 22, attributes: headerAttributes)
+            drawRowText("Circuit", x: x + 48, y: y + 4, width: halfWidth - 52, attributes: headerAttributes)
+        }
+
+        drawHalfHeader(x: leftX)
+        drawHalfHeader(x: rightX)
+        y += rowHeight
+
+        // max(..., 0) mirrors the same guard PanelScheduleBuilder's grid uses
+        // (#1239) so a malformed non-positive totalSpaces can never produce a
+        // negative range here either.
+        for row in 0..<max(schedule.totalSpaces / 2, 0) {
+            if y + rowHeight > pageSize.height - margin - 38 {
+                break
+            }
+
+            let leftSpace = row * 2 + 1
+            let rightSpace = row * 2 + 2
+            drawCircuitRow(schedule: schedule, spaceNumber: leftSpace, x: leftX, width: halfWidth, y: y, attributes: cellAttributes)
+            drawCircuitRow(schedule: schedule, spaceNumber: rightSpace, x: rightX, width: halfWidth, y: y, attributes: cellAttributes)
+            y += rowHeight
+        }
+    }
+
+    private func drawCircuitRow(
+        schedule: PanelSchedule,
+        spaceNumber: Int,
+        x: CGFloat,
+        width: CGFloat,
+        y: CGFloat,
+        attributes: [NSAttributedString.Key: Any]
+    ) {
+        let circuit = schedule.circuits.first { $0.spaceNumber == spaceNumber }
+        UIColor.systemGray4.setStroke()
+        UIBezierPath(rect: CGRect(x: x, y: y, width: width, height: 18)).stroke()
+
+        drawRowText("\(spaceNumber)", x: x + 4, y: y + 4, width: 18, attributes: attributes)
+        drawRowText(circuit?.breakerAmps.map { "\($0)" } ?? "-", x: x + 24, y: y + 4, width: 22, attributes: attributes)
+        drawRowText(circuitDescription(circuit), x: x + 48, y: y + 4, width: width - 52, attributes: attributes)
+    }
+
+    private func circuitDescription(_ circuit: CircuitEntry?) -> String {
+        guard let circuit else { return "SPARE" }
+        if circuit.isSpare || circuit.circuitDescription.isEmpty {
+            return "SPARE"
+        }
+        return circuit.circuitDescription
+    }
+
+    private func drawRowText(
+        _ text: String,
+        x: CGFloat,
+        y: CGFloat,
+        width: CGFloat,
+        attributes: [NSAttributedString.Key: Any]
+    ) {
+        (text as NSString).draw(in: CGRect(x: x, y: y, width: width, height: 12), withAttributes: attributes)
+    }
+
+    private func drawFooter(in pageSize: CGSize, margin: CGFloat) {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 8),
+            .foregroundColor: UIColor.gray
+        ]
+        let date = Date().formatted(.dateTime.month().day().year().hour().minute())
+        let footer = options.footerNote.trimmingCharacters(in: .whitespacesAndNewlines)
+        let left = footer.isEmpty ? "Generated \(date)" : "\(footer) | Generated \(date)"
+        left.draw(
+            in: CGRect(x: margin, y: pageSize.height - margin + 8, width: pageSize.width - margin * 2, height: 12),
+            withAttributes: attributes
+        )
+    }
+}
+
+struct PanelScheduleHeaderSheet: View {
+    @Binding var options: PanelScheduleExportOptions
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Layout") {
+                    Picker("Paper Size", selection: $options.paperSize) {
+                        ForEach(PanelSchedulePaperSize.allCases) { size in
+                            Text(size.rawValue).tag(size)
+                        }
+                    }
+                }
+
+                Section("Company Header") {
+                    TextField("Company Name", text: $options.companyName)
+                    TextField("Address", text: $options.address, axis: .vertical)
+                    TextField("Phone", text: $options.phone)
+                    TextField("License Number", text: $options.licenseNumber)
+                }
+
+                Section("Footer") {
+                    TextField("Prepared By", text: $options.preparedBy)
+                    TextField("Footer Note", text: $options.footerNote, axis: .vertical)
+                }
+            }
+            .navigationTitle("Panel Header")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .fontWeight(.semibold)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+}
+
+struct PanelScheduleShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleExport.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleExport.swift
@@ -211,8 +211,8 @@ struct PanelSchedulePDFExporter {
 
             let leftSpace = row * 2 + 1
             let rightSpace = row * 2 + 2
-            drawCircuitRow(schedule: schedule, spaceNumber: leftSpace, x: leftX, width: halfWidth, y: y, attributes: cellAttributes)
-            drawCircuitRow(schedule: schedule, spaceNumber: rightSpace, x: rightX, width: halfWidth, y: y, attributes: cellAttributes)
+            drawCircuitRow(schedule: schedule, spaceNumber: leftSpace, x: leftX, width: halfWidth, y: y, rowHeight: rowHeight, attributes: cellAttributes)
+            drawCircuitRow(schedule: schedule, spaceNumber: rightSpace, x: rightX, width: halfWidth, y: y, rowHeight: rowHeight, attributes: cellAttributes)
             y += rowHeight
         }
     }
@@ -223,11 +223,12 @@ struct PanelSchedulePDFExporter {
         x: CGFloat,
         width: CGFloat,
         y: CGFloat,
+        rowHeight: CGFloat,
         attributes: [NSAttributedString.Key: Any]
     ) {
         let circuit = schedule.circuits.first { $0.spaceNumber == spaceNumber }
         UIColor.systemGray4.setStroke()
-        UIBezierPath(rect: CGRect(x: x, y: y, width: width, height: 18)).stroke()
+        UIBezierPath(rect: CGRect(x: x, y: y, width: width, height: rowHeight)).stroke()
 
         drawRowText("\(spaceNumber)", x: x + 4, y: y + 4, width: 18, attributes: attributes)
         drawRowText(circuit?.breakerAmps.map { "\($0)" } ?? "-", x: x + 24, y: y + 4, width: 22, attributes: attributes)

--- a/Weird Parts IOS/Weird Parts IOSTests/PanelSchedulePDFExporterTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PanelSchedulePDFExporterTests.swift
@@ -39,10 +39,17 @@ final class PanelSchedulePDFExporterTests: XCTestCase {
         XCTAssertTrue(blankURL.lastPathComponent.hasPrefix("Panel_Schedule_"), "Blank panel names should fall back to a default filename stem.")
     }
 
-    func testExportRendersAgainstNormalizedScheduleNotRawInput() throws {
-        // A malformed totalSpaces (mirrors #1239) must not crash rendering; the
-        // exporter should normalize before drawing the table, same as the
-        // builder's Save action does.
+    func testExportNormalizesMalformedTotalSpacesBeforeRendering() throws {
+        // A malformed totalSpaces (mirrors #1239) must not crash rendering.
+        // `writeToTemporaryFile()` always renders a `normalizedForPersistence()`
+        // copy, so this exercises the *normalization* path — by the time
+        // `renderPDF`/`drawScheduleTable` see the schedule, totalSpaces has
+        // already been clamped up to a positive supported size (20, the
+        // default). It does NOT exercise the negative-totalSpaces guard
+        // inside `drawScheduleTable` itself; see
+        // `testRenderPDFGuardsAgainstNegativeTotalSpacesWhenCalledDirectly`
+        // below for a test that bypasses normalization to cover that guard
+        // directly.
         var schedule = PanelSchedule(panelName: "Bad Panel", totalSpaces: -4)
         schedule.circuits = [CircuitEntry(spaceNumber: 1, breakerAmps: 20, circuitDescription: "Test", isSpare: false)]
 
@@ -52,5 +59,22 @@ final class PanelSchedulePDFExporterTests: XCTestCase {
 
         let data = try Data(contentsOf: url)
         XCTAssertGreaterThan(data.count, 0, "Exporting a schedule with a malformed totalSpaces should still normalize and render, not crash or produce an empty file.")
+    }
+
+    func testRenderPDFGuardsAgainstNegativeTotalSpacesWhenCalledDirectly() throws {
+        // Directly exercises the `max(schedule.totalSpaces / 2, 0)` guard in
+        // `drawScheduleTable` by calling the `internal` `renderPDF(schedule:)`
+        // entry point with a raw, un-normalized negative `totalSpaces` —
+        // bypassing `writeToTemporaryFile()`'s `normalizedForPersistence()`
+        // step entirely, since that step would otherwise clamp the value to
+        // a positive size (20) before rendering and make this branch
+        // unreachable through the normal export/print flow.
+        var schedule = PanelSchedule(panelName: "Bad Panel", totalSpaces: -4)
+        schedule.circuits = [CircuitEntry(spaceNumber: 1, breakerAmps: 20, circuitDescription: "Test", isSpare: false)]
+
+        let exporter = PanelSchedulePDFExporter(schedule: schedule, options: PanelScheduleExportOptions())
+        let data = exporter.renderPDF(schedule: schedule)
+
+        XCTAssertGreaterThan(data.count, 0, "Rendering directly with a negative totalSpaces must not crash and must still produce PDF output.")
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/PanelSchedulePDFExporterTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PanelSchedulePDFExporterTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+import WiredPartCore
+@testable import Weird_Parts
+
+/// Regression coverage for GitHub #80 slice 3 (panel schedule PDF export),
+/// re-landing rescued commit `22f5a5c31`.
+@MainActor
+final class PanelSchedulePDFExporterTests: XCTestCase {
+    func testWriteToTemporaryFileProducesNonEmptyPDFInScopedDirectory() throws {
+        var schedule = PanelSchedule(panelName: "Main Panel A")
+        schedule.circuits = [
+            CircuitEntry(spaceNumber: 1, breakerAmps: 20, breakerType: .single, circuitDescription: "Kitchen Outlets", isSpare: false),
+            CircuitEntry(spaceNumber: 2, breakerAmps: 15, breakerType: .single, circuitDescription: "Living Room Lights", isSpare: false)
+        ]
+        let exporter = PanelSchedulePDFExporter(schedule: schedule, options: PanelScheduleExportOptions())
+
+        let url = try exporter.writeToTemporaryFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertTrue(url.path.contains("PanelSchedules"), "PDF should be written under the scoped PanelSchedules temp directory.")
+        XCTAssertEqual(url.pathExtension, "pdf")
+
+        let data = try Data(contentsOf: url)
+        XCTAssertGreaterThan(data.count, 0, "Exported PDF must not be empty.")
+    }
+
+    func testFilenameSanitizesPanelNameAndFallsBackWhenEmpty() throws {
+        let unsafeSchedule = PanelSchedule(panelName: "Main / Panel #1 (2026)")
+        let unsafeURL = try PanelSchedulePDFExporter(schedule: unsafeSchedule, options: PanelScheduleExportOptions())
+            .writeToTemporaryFile()
+        defer { try? FileManager.default.removeItem(at: unsafeURL) }
+        XCTAssertFalse(unsafeURL.lastPathComponent.contains("/"), "Sanitized filename must not retain path-unsafe characters.")
+        XCTAssertFalse(unsafeURL.lastPathComponent.contains("#"), "Sanitized filename must not retain path-unsafe characters.")
+
+        let blankSchedule = PanelSchedule(panelName: "   ")
+        let blankURL = try PanelSchedulePDFExporter(schedule: blankSchedule, options: PanelScheduleExportOptions())
+            .writeToTemporaryFile()
+        defer { try? FileManager.default.removeItem(at: blankURL) }
+        XCTAssertTrue(blankURL.lastPathComponent.hasPrefix("Panel_Schedule_"), "Blank panel names should fall back to a default filename stem.")
+    }
+
+    func testExportRendersAgainstNormalizedScheduleNotRawInput() throws {
+        // A malformed totalSpaces (mirrors #1239) must not crash rendering; the
+        // exporter should normalize before drawing the table, same as the
+        // builder's Save action does.
+        var schedule = PanelSchedule(panelName: "Bad Panel", totalSpaces: -4)
+        schedule.circuits = [CircuitEntry(spaceNumber: 1, breakerAmps: 20, circuitDescription: "Test", isSpare: false)]
+
+        let url = try PanelSchedulePDFExporter(schedule: schedule, options: PanelScheduleExportOptions())
+            .writeToTemporaryFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let data = try Data(contentsOf: url)
+        XCTAssertGreaterThan(data.count, 0, "Exporting a schedule with a malformed totalSpaces should still normalize and render, not crash or produce an empty file.")
+    }
+}

--- a/docs/plans/ios-notebooks-pages.md
+++ b/docs/plans/ios-notebooks-pages.md
@@ -282,6 +282,17 @@ A dedicated tool for building electrical panel schedules. This is a first-class 
 - Share sheet for email/AirDrop
 - Save to job notebook automatically
 
+### Implementation Note — 2026-07-02
+
+GitHub #80 slice 3 delivered a bounded iOS PDF export/print path in `PanelScheduleBuilder.swift` / `PanelScheduleExport.swift` (re-landing rescued commit `22f5a5c31`, originally pushed 2026-05-15 on a branch that was never merged and has since been deleted):
+
+- The builder's Export menu opens a custom header sheet for paper size (Letter/Legal/A4/Card Stock), company name, address, phone, license number, prepared by, and footer note.
+- PDF generation writes only to the app temporary `PanelSchedules/` directory with a sanitized filename, then validates the file exists and has non-zero size before share/print.
+- Export uses the native share sheet for email/AirDrop/Files handoff.
+- Print uses `UIPrintInteractionController` with the same generated PDF path.
+- Rendering runs against `schedule.normalizedForPersistence()` so the exported table matches what Save would persist; main does not yet have a `PanelSchedule.validated()` throwing method (that belongs to the separate drag-drop/validation lane, still not landed), so this slice normalizes instead of validating.
+- Header drag-drop designer, reusable header templates, logo placement, and automatic save-back-to-notebook remain future enhancements beyond this bounded delivery — as do drag-and-drop circuits, dual breakers, and circuit-type color coding, which are a different #80 slice (WEI-1134) not covered here.
+
 ---
 
 ## 7. Templates


### PR DESCRIPTION
Contributes to #80 (re-lands PDF export).

## Provenance

Re-lands rescued commit `22f5a5c31` ("Add panel schedule PDF export") from `origin/rescue/80-pdf-export`. This commit was pushed 2026-05-15 to branch `WEI-342-sync-github-issues-into-paperclip-and-prioritize-backlog` as part of the WEI-1135 lane, reported complete in the #80 issue thread, but was never carried by a PR — that branch has since been deleted from origin. The 2026-07-02 status audit on #80 confirmed `PanelScheduleExport.swift` does not exist on `main` and the Export/Print UI is absent from `PanelScheduleBuilder.swift`.

## What changed vs. the donor commit

`main` has diverged substantially since May (the parallel WEI-1134 drag-drop/validation lane never landed either, and other panel-schedule work such as #1239's negative-space guard landed independently), so this was hand-adapted rather than cherry-picked cleanly:

- **`PanelSchedule.validated()` does not exist on `main`.** The donor's `writeToTemporaryFile()` called it before rendering. Replaced with `schedule.normalizedForPersistence()`, which already exists on `main` and is what the builder's own Save action uses — this keeps the exported table consistent with what gets persisted, without depending on the still-unlanded WEI-1134 validation lane.
- **`CircuitEntry.secondaryCircuitDescription` / classification do not exist on `main`.** Both belong to the separate WEI-1134 (drag/drop + dual-breaker) lane, which is a different #80 slice and out of scope here. Dropped the donor's secondary-circuit line from the PDF row rendering accordingly.
- **`main`'s toolbar has no `Menu` yet.** Added the Export menu (Custom Header / Export PDF / Print PDF) fresh, alongside the existing Settings/Save buttons — the donor's diff assumed the same toolbar shape, which happened to still match.
- Added `.presentationDetents([.medium, .large])` to the new `PanelScheduleHeaderSheet` (a `Form`-based sheet), matching current sheet conventions elsewhere in the app (donor commit predates this being enforced).
- Error handling routes through the existing `userFriendlyError(_:context:)` helper (already on `main`) via an alert, no silent `try?`.
- **No DB schema change is needed for this slice** — PDF export is a pure rendering feature over the existing `PanelSchedule`/`CircuitEntry` structs. Migration number 111 was assigned but is unused; current migration max on `main` is 107, so 111 remains free for a future slice that actually needs it.

## Test evidence

- `xcodebuild build -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'generic/platform=iOS Simulator' -quiet` — clean build, exit 0, no new warnings.
- Added `PanelSchedulePDFExporterTests.swift` (not carried by the donor commit, which shipped no tests for this slice): non-empty PDF output written under the scoped temp `PanelSchedules/` directory, filename sanitization + blank-name fallback, and rendering against a malformed negative `totalSpaces` (mirrors the #1239 guard) without crashing or producing an empty file.
- `xcodebuild test ... -only-testing:"Weird Parts IOSTests/PanelSchedulePDFExporterTests" -only-testing:"Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests"` — all 6 tests pass (3 new + 3 pre-existing, confirming the toolbar edit didn't regress existing accessibility/save-normalization coverage).
- `core/` was not touched by this slice (no data model or migration change), so the core Swift package test suite was not re-run.

## Explicitly out of scope (tracked separately)

- Panel drag/drop, dual-breaker validation, `CircuitClassification`, `PanelSchedule.validated()` — WEI-1134, rescued as `691c0ffc2` on `origin/rescue/80-panel-dnd`, not touched here.
- `/` command palette, expanded block metadata — WEI-1132/1133, rescued as `38d1a092f` on `origin/rescue/80-slash-palette`, not touched here.

Does not close #80 — slices for drag/drop and the command palette remain stranded and need their own re-land PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)