### PR TITLE
Re-land #80 slash command palette + panel drag/drop (slices 1+2)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/AddNotebookEntrySheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/AddNotebookEntrySheet.swift
@@ -35,6 +35,46 @@ struct AddNotebookEntrySheet: View {
         var checked: Bool
     }
 
+    private struct SlashCommand: Identifiable {
+        let id: String
+        let command: String
+        let title: String
+        let subtitle: String
+        let systemImage: String
+        let blockType: String
+        let headingLevel: Int?
+    }
+
+    private let slashCommands: [SlashCommand] = [
+        SlashCommand(id: "h1", command: "/h1", title: "Heading 1", subtitle: "Large section header", systemImage: "textformat.size.larger", blockType: "heading", headingLevel: 1),
+        SlashCommand(id: "h2", command: "/h2", title: "Heading 2", subtitle: "Medium sub-header", systemImage: "textformat.size", blockType: "heading", headingLevel: 2),
+        SlashCommand(id: "h3", command: "/h3", title: "Heading 3", subtitle: "Small sub-header", systemImage: "textformat", blockType: "heading", headingLevel: 3),
+        SlashCommand(id: "checklist", command: "/checklist", title: "Checklist", subtitle: "Checkbox list items", systemImage: "checklist", blockType: "checklist", headingLevel: nil),
+        SlashCommand(id: "photo", command: "/photo", title: "Photo", subtitle: "Camera or library placeholder", systemImage: "photo", blockType: "photo", headingLevel: nil),
+        SlashCommand(id: "part", command: "/part", title: "Part Reference", subtitle: "Tappable part reference placeholder", systemImage: "shippingbox", blockType: "part_reference", headingLevel: nil),
+        SlashCommand(id: "panel", command: "/panel", title: "Panel Schedule", subtitle: "Embedded panel schedule block", systemImage: "bolt", blockType: "panel_schedule", headingLevel: nil),
+        SlashCommand(id: "divider", command: "/divider", title: "Divider", subtitle: "Horizontal separator", systemImage: "minus", blockType: "divider", headingLevel: nil),
+        SlashCommand(id: "quote", command: "/quote", title: "Quote", subtitle: "Indented quote block", systemImage: "quote.opening", blockType: "quote", headingLevel: nil),
+        SlashCommand(id: "callout", command: "/callout", title: "Callout", subtitle: "Highlighted note", systemImage: "exclamationmark.bubble", blockType: "callout", headingLevel: nil),
+        SlashCommand(id: "table", command: "/table", title: "Table", subtitle: "Simple grid placeholder", systemImage: "tablecells", blockType: "table", headingLevel: nil),
+        SlashCommand(id: "code", command: "/code", title: "Code", subtitle: "Monospace code block", systemImage: "chevron.left.forwardslash.chevron.right", blockType: "code", headingLevel: nil),
+        SlashCommand(id: "todo", command: "/todo", title: "To-Do", subtitle: "Work item with status tracking", systemImage: "circle", blockType: "todo", headingLevel: nil)
+    ]
+
+    private var slashQuery: String? {
+        guard !isEditing, content.hasPrefix("/") else { return nil }
+        return String(content.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private var filteredSlashCommands: [SlashCommand] {
+        guard let query = slashQuery, !query.isEmpty else { return slashCommands }
+        return slashCommands.filter { command in
+            command.command.dropFirst().lowercased().contains(query) ||
+            command.title.lowercased().contains(query) ||
+            command.subtitle.lowercased().contains(query)
+        }
+    }
+
     var body: some View {
         NavigationStack {
             Form {
@@ -45,12 +85,25 @@ struct AddNotebookEntrySheet: View {
                             Text("Text").tag("text")
                             Text("Heading").tag("heading")
                             Text("Checklist").tag("checklist")
+                            Text("Photo").tag("photo")
+                            Text("Part Reference").tag("part_reference")
+                            Text("Panel Schedule").tag("panel_schedule")
                             Text("To-Do").tag("todo")
+                            Text("Quote").tag("quote")
                             Text("Callout").tag("callout")
+                            Text("Table").tag("table")
+                            Text("Code").tag("code")
                             Text("Divider").tag("divider")
                         }
                         .pickerStyle(.menu)
+                        Text("Type / in the content field to open the command palette.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
+                }
+
+                if slashQuery != nil {
+                    commandPaletteSection
                 }
 
                 // Type-specific fields
@@ -66,6 +119,24 @@ struct AddNotebookEntrySheet: View {
 
                 case "callout":
                     calloutFields
+
+                case "quote":
+                    quoteFields
+
+                case "code":
+                    codeFields
+
+                case "photo":
+                    photoFields
+
+                case "part_reference":
+                    partReferenceFields
+
+                case "panel_schedule":
+                    panelScheduleFields
+
+                case "table":
+                    tableFields
 
                 case "divider":
                     Section {
@@ -87,8 +158,14 @@ struct AddNotebookEntrySheet: View {
                                 shortcutRow("/h2 Title", "Heading level 2")
                                 shortcutRow("/h3 Title", "Heading level 3")
                                 shortcutRow("/checklist", "New checklist")
+                                shortcutRow("/photo Caption", "Photo placeholder")
+                                shortcutRow("/part Name", "Part reference placeholder")
+                                shortcutRow("/panel Name", "Panel schedule block")
+                                shortcutRow("/quote Text", "Quote block")
                                 shortcutRow("/todo Task", "New to-do item")
                                 shortcutRow("/callout Text", "Callout block")
+                                shortcutRow("/table Title", "Table placeholder")
+                                shortcutRow("/code Text", "Code block")
                                 shortcutRow("/divider", "Horizontal divider")
                             }
                         }
@@ -146,6 +223,41 @@ struct AddNotebookEntrySheet: View {
     }
 
     // MARK: - Type-Specific Field Groups
+
+    private var commandPaletteSection: some View {
+        Section("Command Palette") {
+            if filteredSlashCommands.isEmpty {
+                Text("No matching commands")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(filteredSlashCommands) { command in
+                    Button {
+                        applySlashCommand(command)
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: command.systemImage)
+                                .frame(width: 28, height: 28)
+                                .foregroundStyle(.blue)
+                                .accessibilityHidden(true)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(command.title)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.primary)
+                                Text("\(command.command) - \(command.subtitle)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                        }
+                        .frame(minHeight: 44)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(command.title), \(command.command)")
+                }
+            }
+        }
+    }
 
     private var textFields: some View {
         Group {
@@ -223,7 +335,93 @@ struct AddNotebookEntrySheet: View {
         }
     }
 
+    private var quoteFields: some View {
+        Section("Quote") {
+            TextEditor(text: $content)
+                .frame(minHeight: 80)
+        }
+    }
+
+    private var codeFields: some View {
+        Section("Code") {
+            TextEditor(text: $content)
+                .font(.system(.body, design: .monospaced))
+                .frame(minHeight: 100)
+        }
+    }
+
+    private var photoFields: some View {
+        Group {
+            Section("Photo Caption") {
+                TextField("Photo caption", text: $title)
+            }
+            Section {
+                Text("Photo capture and library selection will attach to this block in the next media pass.")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+        }
+    }
+
+    private var partReferenceFields: some View {
+        Section("Part Reference") {
+            TextField("Part name, SKU, or note", text: $title)
+        }
+    }
+
+    private var panelScheduleFields: some View {
+        Section("Panel Schedule") {
+            TextField("Panel name", text: $title)
+            Text("Open the notebook panel builder after adding this block to edit breaker assignments.")
+                .foregroundStyle(.secondary)
+                .font(.caption)
+        }
+    }
+
+    private var tableFields: some View {
+        Group {
+            Section("Table Title (Optional)") {
+                TextField("Table title", text: $title)
+            }
+            Section("Table Notes") {
+                TextEditor(text: $content)
+                    .frame(minHeight: 80)
+            }
+        }
+    }
+
     // MARK: - Shortcut Commands
+
+    private func applySlashCommand(_ command: SlashCommand) {
+        let trailingText = trailingTextAfterCommand(command.command)
+        blockType = command.blockType
+        if let level = command.headingLevel {
+            headingLevel = level
+        }
+
+        switch command.blockType {
+        case "heading", "todo", "photo", "part_reference", "panel_schedule":
+            title = trailingText
+            content = ""
+        case "checklist":
+            title = trailingText
+            content = ""
+            if checklistItems.isEmpty {
+                checklistItems.append(ChecklistItemInput(text: "", checked: false))
+            }
+        case "divider":
+            title = ""
+            content = ""
+        default:
+            content = trailingText
+        }
+    }
+
+    private func trailingTextAfterCommand(_ command: String) -> String {
+        let raw = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard raw.lowercased().hasPrefix(command.lowercased()) else { return "" }
+        return String(raw.dropFirst(command.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
     private func processShortcutCommand(_ text: String) {
         guard !isEditing else { return }
@@ -258,6 +456,27 @@ struct AddNotebookEntrySheet: View {
         } else if text == "/divider" {
             blockType = "divider"
             content = ""
+        } else if text.hasPrefix("/quote ") {
+            blockType = "quote"
+            content = String(text.dropFirst(7))
+        } else if text.hasPrefix("/code ") {
+            blockType = "code"
+            content = String(text.dropFirst(6))
+        } else if text.hasPrefix("/table ") {
+            blockType = "table"
+            content = String(text.dropFirst(7))
+        } else if text.hasPrefix("/photo ") {
+            blockType = "photo"
+            title = String(text.dropFirst(7))
+            content = ""
+        } else if text.hasPrefix("/part ") {
+            blockType = "part_reference"
+            title = String(text.dropFirst(6))
+            content = ""
+        } else if text.hasPrefix("/panel ") {
+            blockType = "panel_schedule"
+            title = String(text.dropFirst(7))
+            content = ""
         }
     }
 
@@ -280,6 +499,9 @@ struct AddNotebookEntrySheet: View {
         switch blockType {
         case "heading": return title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         case "todo": return title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case "photo": return title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case "part_reference": return title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case "panel_schedule": return title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         case "divider": return false
         case "checklist": return checklistItems.filter({ !$0.text.isEmpty }).isEmpty
         default: return title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -308,6 +530,7 @@ struct AddNotebookEntrySheet: View {
                     blockData: blockType == "checklist" ? nil : blockData,
                     headingLevel: blockType == "heading" ? headingLevel : nil,
                     checklistItems: blockType == "checklist" ? blockData : nil,
+                    referenceType: blockType == "part_reference" ? "part" : nil,
                     updatedBy: userId
                 )
             } else {
@@ -326,6 +549,7 @@ struct AddNotebookEntrySheet: View {
                     blockData: blockType == "checklist" ? nil : blockData,
                     headingLevel: blockType == "heading" ? headingLevel : nil,
                     checklistItems: blockType == "checklist" ? blockData : nil,
+                    referenceType: blockType == "part_reference" ? "part" : nil,
                     createdBy: userId
                 )
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/AddNotebookEntrySheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/AddNotebookEntrySheet.swift
@@ -412,6 +412,12 @@ struct AddNotebookEntrySheet: View {
         case "divider":
             title = ""
             content = ""
+        case "quote", "code":
+            title = ""
+            content = trailingText
+        case "table":
+            title = trailingText
+            content = ""
         default:
             content = trailingText
         }
@@ -458,13 +464,16 @@ struct AddNotebookEntrySheet: View {
             content = ""
         } else if text.hasPrefix("/quote ") {
             blockType = "quote"
+            title = ""
             content = String(text.dropFirst(7))
         } else if text.hasPrefix("/code ") {
             blockType = "code"
+            title = ""
             content = String(text.dropFirst(6))
         } else if text.hasPrefix("/table ") {
             blockType = "table"
-            content = String(text.dropFirst(7))
+            title = String(text.dropFirst(7))
+            content = ""
         } else if text.hasPrefix("/photo ") {
             blockType = "photo"
             title = String(text.dropFirst(7))

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/AddNotebookEntrySheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/AddNotebookEntrySheet.swift
@@ -403,6 +403,11 @@ struct AddNotebookEntrySheet: View {
         case "heading", "todo", "photo", "part_reference", "panel_schedule":
             title = trailingText
             content = ""
+        case "table":
+            // The table UI shows a title field and the hint is `/table Title`,
+            // so the trailing text is the title, not content.
+            title = trailingText
+            content = ""
         case "checklist":
             title = trailingText
             content = ""
@@ -413,11 +418,13 @@ struct AddNotebookEntrySheet: View {
             title = ""
             content = ""
         case "quote", "code":
+            // These blocks have no title field in their editors, so clear any
+            // previously-entered title to avoid persisting hidden title data.
             title = ""
             content = trailingText
-        case "table":
-            title = trailingText
-            content = ""
+        case "callout":
+            // Callout keeps its optional title field; only fill content.
+            content = trailingText
         default:
             content = trailingText
         }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -902,6 +902,7 @@ struct IOSNotebookDetailPage: View {
                     Rectangle()
                         .fill(.secondary.opacity(0.45))
                         .frame(width: 3)
+                        .accessibilityHidden(true)
                     Text(entry.content)
                         .font(.callout)
                         .italic()

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -897,6 +897,27 @@ struct IOSNotebookDetailPage: View {
                     Text(entry.content).font(.subheadline)
                 }
 
+            case "quote":
+                HStack(alignment: .top, spacing: 10) {
+                    Rectangle()
+                        .fill(.secondary.opacity(0.45))
+                        .frame(width: 3)
+                    Text(entry.content)
+                        .font(.callout)
+                        .italic()
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+
+            case "code":
+                Text(entry.content)
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(.secondary.opacity(0.12))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+
             case "photo":
                 if let path = entry.photoPath, let url = URL(string: path) {
                     AsyncImage(url: url) { image in
@@ -952,14 +973,39 @@ struct IOSNotebookDetailPage: View {
                 .padding(.vertical, 4)
 
             case "table":
-                HStack {
-                    Image(systemName: "tablecells")
-                        .foregroundStyle(.purple)
-                        .accessibilityHidden(true)
-                    Text(entry.title ?? "Table").font(.subheadline)
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Image(systemName: "tablecells")
+                            .foregroundStyle(.purple)
+                            .accessibilityHidden(true)
+                        Text(entry.title ?? "Table").font(.subheadline).bold()
+                    }
+                    if !entry.content.isEmpty {
+                        Text(entry.content)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
                 .padding(8)
                 .background(.purple.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            case "panel_schedule":
+                HStack {
+                    Image(systemName: "bolt.fill")
+                        .foregroundStyle(.yellow)
+                        .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(entry.title ?? "Panel Schedule")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        Text("Open the panel builder to edit breaker assignments")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(8)
+                .background(.yellow.opacity(0.12))
                 .clipShape(RoundedRectangle(cornerRadius: 6))
 
             case "todo":
@@ -1878,8 +1924,11 @@ private struct NotebookConflictResolutionSheet: View {
         case "checklist": return "checklist"
         case "photo": return "photo"
         case "part_reference": return "shippingbox"
+        case "panel_schedule": return "bolt"
         case "divider": return "minus"
         case "callout": return "exclamationmark.bubble"
+        case "quote": return "quote.opening"
+        case "code": return "chevron.left.forwardslash.chevron.right"
         case "table": return "tablecells"
         case "todo": return "circle"
         default: return "text.alignleft"

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
@@ -8,6 +8,8 @@ struct PanelScheduleBuilder: View {
 
     @State private var selectedCircuit: CircuitEntry?
     @State private var showHiddenCircuitPruneConfirmation = false
+    @State private var movingCircuitId: String?
+    @State private var validationMessage: String?
 
     private enum ActiveSheet: Identifiable {
         case circuitEditor
@@ -51,6 +53,14 @@ struct PanelScheduleBuilder: View {
         } message: {
             Text("Saving will permanently remove \(schedule.circuitsOutsideTotalSpaces.count) hidden circuit\(schedule.circuitsOutsideTotalSpaces.count == 1 ? "" : "s") outside the visible 1–\(schedule.totalSpaces) panel range.")
         }
+        .alert("Panel schedule issue", isPresented: Binding(
+            get: { validationMessage != nil },
+            set: { if !$0 { validationMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) { validationMessage = nil }
+        } message: {
+            Text(validationMessage ?? "")
+        }
     }
 
     // MARK: - Panel Header
@@ -88,6 +98,16 @@ struct PanelScheduleBuilder: View {
 
     private var panelGrid: some View {
         VStack(spacing: 1) {
+            if let movingCircuit = movingCircuitDescription {
+                Text("Move \(movingCircuit): tap a destination space or drag it onto the grid.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(.blue.opacity(0.08))
+            }
+
             // Column headers
             HStack(spacing: 0) {
                 Text("#").font(.caption2).bold().frame(width: 22)
@@ -129,7 +149,11 @@ struct PanelScheduleBuilder: View {
 
     private func circuitCell(spaceNumber: Int, circuit: CircuitEntry?, isLeft: Bool) -> some View {
         Button {
-            openCircuitEditor(spaceNumber: spaceNumber, circuit: circuit)
+            if movingCircuitId != nil {
+                moveSelectedCircuit(to: spaceNumber)
+            } else {
+                openCircuitEditor(spaceNumber: spaceNumber, circuit: circuit)
+            }
         } label: {
             HStack(spacing: 2) {
                 if isLeft {
@@ -139,13 +163,29 @@ struct PanelScheduleBuilder: View {
                     Text(circuit?.breakerAmps.map { "\($0)" } ?? "—")
                         .font(.caption).fontDesign(.monospaced)
                         .frame(width: 26, alignment: .center)
-                    Text((circuit?.circuitDescription).flatMap { $0.isEmpty ? nil : $0 } ?? "SPARE")
-                        .font(.caption).lineLimit(1)
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text((circuit?.circuitDescription).flatMap { $0.isEmpty ? nil : $0 } ?? "SPARE")
+                            .font(.caption).lineLimit(1)
+                        if let secondary = circuit?.secondaryCircuitDescription, !secondary.isEmpty {
+                            Text("+ \(secondary)")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
                     Spacer()
                 } else {
                     Spacer()
-                    Text((circuit?.circuitDescription).flatMap { $0.isEmpty ? nil : $0 } ?? "SPARE")
-                        .font(.caption).lineLimit(1)
+                    VStack(alignment: .trailing, spacing: 0) {
+                        Text((circuit?.circuitDescription).flatMap { $0.isEmpty ? nil : $0 } ?? "SPARE")
+                            .font(.caption).lineLimit(1)
+                        if let secondary = circuit?.secondaryCircuitDescription, !secondary.isEmpty {
+                            Text("+ \(secondary)")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
                     Text(circuit?.breakerAmps.map { "\($0)" } ?? "—")
                         .font(.caption).fontDesign(.monospaced)
                         .frame(width: 26, alignment: .center)
@@ -158,18 +198,73 @@ struct PanelScheduleBuilder: View {
             .padding(.vertical, 6)
             .frame(minHeight: 44)
             .background(circuitBackground(circuit))
+            .overlay {
+                if movingCircuitId != nil {
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(.blue.opacity(0.45), style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                }
+            }
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .draggable(circuit?.id ?? "")
+        .dropDestination(for: String.self) { ids, _ in
+            guard let id = ids.first, !id.isEmpty else { return false }
+            moveCircuit(id: id, to: spaceNumber)
+            return true
+        }
+        .contextMenu {
+            if let circuit {
+                Button {
+                    movingCircuitId = circuit.id
+                } label: {
+                    Label("Move Circuit", systemImage: "arrow.left.arrow.right")
+                }
+                Button {
+                    openCircuitEditor(spaceNumber: spaceNumber, circuit: circuit)
+                } label: {
+                    Label("Edit Circuit", systemImage: "pencil")
+                }
+            }
+        }
         .accessibilityLabel(circuitAccessibilityLabel(spaceNumber: spaceNumber, circuit: circuit))
         .accessibilityValue(circuitAccessibilityValue(circuit))
-        .accessibilityHint("Opens the editor for circuit \(spaceNumber).")
+        .accessibilityHint(movingCircuitId != nil ? "Moves the selected circuit here." : "Opens the editor for circuit \(spaceNumber).")
         .accessibilityIdentifier("panel-schedule-circuit-\(spaceNumber)")
+        .accessibilityAction(named: Text(circuit == nil ? "Place selected circuit here" : "Move circuit")) {
+            if let circuit {
+                movingCircuitId = circuit.id
+            } else if movingCircuitId != nil {
+                moveSelectedCircuit(to: spaceNumber)
+            }
+        }
     }
 
     private func openCircuitEditor(spaceNumber: Int, circuit: CircuitEntry?) {
         selectedCircuit = circuit ?? CircuitEntry(spaceNumber: spaceNumber)
         activeSheet = .circuitEditor
+    }
+
+    private var movingCircuitDescription: String? {
+        guard let movingCircuitId,
+              let circuit = schedule.circuits.first(where: { $0.id == movingCircuitId }) else {
+            return nil
+        }
+        return circuit.circuitDescription.isEmpty ? "circuit \(circuit.spaceNumber)" : circuit.circuitDescription
+    }
+
+    private func moveSelectedCircuit(to spaceNumber: Int) {
+        guard let movingCircuitId else { return }
+        moveCircuit(id: movingCircuitId, to: spaceNumber)
+    }
+
+    private func moveCircuit(id: String, to spaceNumber: Int) {
+        do {
+            try schedule.moveCircuit(id: id, to: spaceNumber)
+            movingCircuitId = nil
+        } catch {
+            validationMessage = error.localizedDescription
+        }
     }
 
     private func circuitDisplayName(_ circuit: CircuitEntry?) -> String {
@@ -193,10 +288,14 @@ struct PanelScheduleBuilder: View {
             details.append("No amp rating")
         }
         details.append("\(circuit.breakerType.rawValue) breaker")
+        details.append(circuit.classification.rawValue)
 
         let description = circuit.circuitDescription.trimmingCharacters(in: .whitespacesAndNewlines)
         if !description.isEmpty {
             details.append(description)
+        }
+        if let secondary = circuit.secondaryCircuitDescription?.trimmingCharacters(in: .whitespacesAndNewlines), !secondary.isEmpty {
+            details.append("plus \(secondary)")
         }
         if let fedFrom = circuit.isFedFrom?.trimmingCharacters(in: .whitespacesAndNewlines), !fedFrom.isEmpty {
             details.append("fed from \(fedFrom)")
@@ -206,6 +305,14 @@ struct PanelScheduleBuilder: View {
 
     private func circuitBackground(_ circuit: CircuitEntry?) -> Color {
         guard let circuit, !circuit.isSpare else { return .yellow.opacity(0.05) }
+        switch circuit.classification {
+        case .lighting: return .cyan.opacity(0.12)
+        case .receptacle: return .orange.opacity(0.12)
+        case .motor: return .red.opacity(0.12)
+        case .spare: return .yellow.opacity(0.1)
+        case .blank: return .gray.opacity(0.1)
+        case .special: break
+        }
         switch circuit.breakerType {
         case .double: return .blue.opacity(0.1)
         case .tandem: return .purple.opacity(0.1)
@@ -232,15 +339,28 @@ struct PanelScheduleBuilder: View {
 
             // Legend
             HStack(spacing: 8) {
-                legendDot(.blue, "240V")
+                legendDot(.cyan, "Light")
+                legendDot(.orange, "Recept")
+                legendDot(.red, "Motor")
+                legendDot(.blue, "Double")
                 legendDot(.purple, "Tandem")
-                legendDot(.green, "GFI/AFI")
-                legendDot(.yellow, "Spare")
             }
+            .lineLimit(1)
 
             Spacer()
 
+            if movingCircuitId != nil {
+                Button {
+                    movingCircuitId = nil
+                } label: {
+                    Label("Cancel Move", systemImage: "xmark.circle")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+            }
+
             Button {
+                guard validateBeforeSave() else { return }
                 if schedule.circuitsOutsideTotalSpaces.isEmpty {
                     saveNormalizedSchedule()
                 } else {
@@ -267,10 +387,30 @@ struct PanelScheduleBuilder: View {
 
     private func updateCircuit(_ circuit: CircuitEntry) {
         let normalized = circuit.normalizedForPersistence()
-        if let index = schedule.circuits.firstIndex(where: { $0.spaceNumber == normalized.spaceNumber }) {
-            schedule.circuits[index] = normalized
+        var candidate = schedule
+        if let index = candidate.circuits.firstIndex(where: { $0.spaceNumber == normalized.spaceNumber }) {
+            candidate.circuits[index] = normalized
         } else {
-            schedule.circuits.append(normalized)
+            candidate.circuits.append(normalized)
+        }
+        do {
+            try candidate.validated()
+            schedule = candidate
+        } catch {
+            validationMessage = error.localizedDescription
+        }
+    }
+
+    /// Runs position validation before the existing #1239 prune/save flow.
+    /// Returns `false` (and surfaces `validationMessage`) if the schedule has
+    /// an unresolved double-breaker span or space conflict.
+    private func validateBeforeSave() -> Bool {
+        do {
+            try schedule.validated()
+            return true
+        } catch {
+            validationMessage = error.localizedDescription
+            return false
         }
     }
 
@@ -305,6 +445,11 @@ struct CircuitEditorSheet: View {
                             Text(type.rawValue).tag(type)
                         }
                     }
+                    Picker("Classification", selection: $circuit.classification) {
+                        ForEach(CircuitClassification.allCases, id: \.self) { classification in
+                            Text(classification.rawValue).tag(classification)
+                        }
+                    }
                 }
                 Section("Circuit") {
                     TextField("Description (e.g. Kitchen Outlets)", text: $circuit.circuitDescription)
@@ -319,6 +464,10 @@ struct CircuitEditorSheet: View {
                     TextField("Fed From (e.g. MDP)", text: Binding(
                         get: { circuit.isFedFrom ?? "" },
                         set: { circuit.isFedFrom = $0.isEmpty ? nil : $0 }
+                    ))
+                    TextField("Second Circuit (tandem/dual only)", text: Binding(
+                        get: { circuit.secondaryCircuitDescription ?? "" },
+                        set: { circuit.secondaryCircuitDescription = $0.isEmpty ? nil : $0 }
                     ))
                     Toggle("Spare", isOn: $circuit.isSpare)
                 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
@@ -254,9 +254,12 @@ struct PanelScheduleBuilder: View {
 
     private func moveSelectedCircuit(to spaceNumber: Int) {
         guard let movingCircuitId else { return }
-        moveCircuit(id: movingCircuitId, to: spaceNumber)
+        _ = moveCircuit(id: movingCircuitId, to: spaceNumber)
     }
 
+    /// Attempts to move a circuit and returns whether it succeeded. Callers that
+    /// bridge to SwiftUI drag-and-drop must propagate this so a rejected move
+    /// (validation failure) cancels the drop instead of appearing to succeed.
     @discardableResult
     private func moveCircuit(id: String, to spaceNumber: Int) -> Bool {
         do {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
@@ -210,8 +210,7 @@ struct PanelScheduleBuilder: View {
         .draggable(circuit?.id ?? "")
         .dropDestination(for: String.self) { ids, _ in
             guard let id = ids.first, !id.isEmpty else { return false }
-            moveCircuit(id: id, to: spaceNumber)
-            return true
+            return moveCircuit(id: id, to: spaceNumber)
         }
         .contextMenu {
             if let circuit {
@@ -258,12 +257,15 @@ struct PanelScheduleBuilder: View {
         moveCircuit(id: movingCircuitId, to: spaceNumber)
     }
 
-    private func moveCircuit(id: String, to spaceNumber: Int) {
+    @discardableResult
+    private func moveCircuit(id: String, to spaceNumber: Int) -> Bool {
         do {
             try schedule.moveCircuit(id: id, to: spaceNumber)
             movingCircuitId = nil
+            return true
         } catch {
             validationMessage = error.localizedDescription
+            return false
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
@@ -305,21 +305,25 @@ struct PanelScheduleBuilder: View {
 
     private func circuitBackground(_ circuit: CircuitEntry?) -> Color {
         guard let circuit, !circuit.isSpare else { return .yellow.opacity(0.05) }
+        // Breaker-type safety coloring (GFCI/AFCI/dual-function) takes priority: it's the
+        // pre-existing, safety-relevant visual cue and must stay reachable regardless of
+        // classification, per #1379 review — classification color coding is additive, not
+        // a replacement for it.
+        switch circuit.breakerType {
+        case .gfci, .afci, .dualFunction: return .green.opacity(0.1)
+        case .double: return .blue.opacity(0.1)
+        case .tandem: return .purple.opacity(0.1)
+        case .spare: return .yellow.opacity(0.1)
+        case .blank: return .gray.opacity(0.1)
+        case .single: break
+        }
         switch circuit.classification {
         case .lighting: return .cyan.opacity(0.12)
         case .receptacle: return .orange.opacity(0.12)
         case .motor: return .red.opacity(0.12)
         case .spare: return .yellow.opacity(0.1)
         case .blank: return .gray.opacity(0.1)
-        case .special: break
-        }
-        switch circuit.breakerType {
-        case .double: return .blue.opacity(0.1)
-        case .tandem: return .purple.opacity(0.1)
-        case .gfci, .afci, .dualFunction: return .green.opacity(0.1)
-        case .spare: return .yellow.opacity(0.1)
-        case .blank: return .gray.opacity(0.1)
-        default: return .clear
+        case .special: return .clear
         }
     }
 
@@ -344,6 +348,8 @@ struct PanelScheduleBuilder: View {
                 legendDot(.red, "Motor")
                 legendDot(.blue, "Double")
                 legendDot(.purple, "Tandem")
+                legendDot(.green, "GFI/AFI")
+                legendDot(.yellow, "Spare")
             }
             .lineLimit(1)
 

--- a/Weird Parts IOS/Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PanelScheduleBuilderAccessibilityTests.swift
@@ -89,6 +89,45 @@ final class PanelScheduleBuilderAccessibilityTests: XCTestCase {
         )
     }
 
+    func testCircuitBackgroundKeepsBreakerSafetyColorReachableAlongsideClassification() throws {
+        let source = try Self.readNotebookSource("PanelScheduleBuilder.swift")
+
+        XCTAssertTrue(
+            source.contains("private func circuitBackground(_ circuit: CircuitEntry?) -> Color"),
+            "circuitBackground should remain the single source of circuit cell background color."
+        )
+        XCTAssertTrue(
+            source.contains("case .gfci, .afci, .dualFunction: return .green.opacity(0.1)"),
+            "GFCI/AFCI/dual-function breakers must keep their green safety highlight regardless of classification (#1379 review)."
+        )
+
+        // The breakerType switch (which carries the GFCI/AFCI/dual-function safety color)
+        // must run before the classification switch bails out early for every non-special
+        // case, otherwise any classified circuit makes the breaker-type coloring unreachable.
+        guard let breakerSwitchRange = source.range(of: "switch circuit.breakerType {"),
+              let classificationSwitchRange = source.range(of: "switch circuit.classification {") else {
+            XCTFail("Expected both circuit.breakerType and circuit.classification switches in circuitBackground.")
+            return
+        }
+        XCTAssertTrue(
+            breakerSwitchRange.lowerBound < classificationSwitchRange.lowerBound,
+            "The breaker-type safety-color switch must run before the classification switch so GFCI/AFCI/dual-function coloring is not shadowed by an early classification return."
+        )
+    }
+
+    func testPanelLegendIncludesSafetyRelevantBreakerEntries() throws {
+        let source = try Self.readNotebookSource("PanelScheduleBuilder.swift")
+
+        XCTAssertTrue(
+            source.contains("legendDot(.green, \"GFI/AFI\")"),
+            "The panel legend must keep a GFI/AFI entry so sighted users can still identify safety breakers visually."
+        )
+        XCTAssertTrue(
+            source.contains("legendDot(.yellow, \"Spare\")"),
+            "The panel legend must keep a Spare entry."
+        )
+    }
+
     private static func readNotebookSource(_ filename: String, file: StaticString = #filePath) throws -> String {
         let testFileURL = URL(fileURLWithPath: "\(file)")
         let projectRoot = testFileURL

--- a/core/Sources/WiredPartCore/Models/Notebooks/PanelScheduleModels.swift
+++ b/core/Sources/WiredPartCore/Models/Notebooks/PanelScheduleModels.swift
@@ -101,6 +101,80 @@ public struct PanelSchedule: Codable, Identifiable, Sendable {
             circuit.spaceNumber < 1 || circuit.spaceNumber > totalSpaces
         }
     }
+
+    // MARK: - Circuit Position Validation (drag/drop + move mode)
+
+    /// Validation errors for the *visible* panel range (1...totalSpaces).
+    /// This is independent of the #1239 clamping/pruning above, which
+    /// repairs a malformed `totalSpaces` itself; this instead validates
+    /// circuit *placement* within an already-valid panel size — same-side
+    /// double-breaker span and space occupancy conflicts.
+    public var validationErrors: [PanelScheduleValidationError] {
+        var errors: [PanelScheduleValidationError] = []
+        var occupied: [Int: CircuitEntry] = [:]
+        for circuit in circuits {
+            guard (1...max(totalSpaces, 1)).contains(circuit.spaceNumber) else { continue }
+            for space in occupiedSpaces(for: circuit) {
+                guard (1...max(totalSpaces, 1)).contains(space) else {
+                    errors.append(.doubleBreakerOutOfRange(space: circuit.spaceNumber))
+                    continue
+                }
+                if let existing = occupied[space], existing.id != circuit.id {
+                    errors.append(.spaceConflict(space: space, first: existing.spaceNumber, second: circuit.spaceNumber))
+                } else {
+                    occupied[space] = circuit
+                }
+            }
+        }
+        return errors
+    }
+
+    public var isValid: Bool {
+        validationErrors.isEmpty
+    }
+
+    public func validated() throws {
+        if let error = validationErrors.first {
+            throw error
+        }
+    }
+
+    /// Spaces a circuit occupies. Double breakers reserve the matching space
+    /// two positions down on the same side (1+3, 2+4, ...).
+    public func occupiedSpaces(for circuit: CircuitEntry) -> [Int] {
+        guard circuit.breakerType == .double else {
+            return [circuit.spaceNumber]
+        }
+        return [circuit.spaceNumber, circuit.spaceNumber + 2]
+    }
+
+    /// Inserts or replaces a circuit by id (falling back to matching space
+    /// number for callers still keying off position), validating the result
+    /// before committing.
+    public mutating func upsertCircuit(_ circuit: CircuitEntry) throws {
+        var candidate = self
+        if let index = candidate.circuits.firstIndex(where: { $0.id == circuit.id || $0.spaceNumber == circuit.spaceNumber }) {
+            candidate.circuits[index] = circuit
+        } else {
+            candidate.circuits.append(circuit)
+        }
+        try candidate.validated()
+        self = candidate
+    }
+
+    /// Moves an existing circuit to a new space (drag/drop or tap-to-move),
+    /// validating the destination before committing.
+    public mutating func moveCircuit(id circuitId: String, to targetSpace: Int) throws {
+        guard let index = circuits.firstIndex(where: { $0.id == circuitId }) else {
+            throw PanelScheduleValidationError.circuitNotFound
+        }
+        var moved = circuits[index]
+        moved.spaceNumber = targetSpace
+        var candidate = self
+        candidate.circuits[index] = moved
+        try candidate.validated()
+        self = candidate
+    }
 }
 
 /// Panel types in electrical installations.
@@ -109,6 +183,7 @@ public enum PanelType: String, Codable, Sendable, CaseIterable {
     case subPanel = "Sub Panel"
     case disconnect = "Disconnect"
     case loadCenter = "Load Center"
+    case smallPanel = "Small Panel"
 }
 
 /// A single circuit entry in a panel schedule.
@@ -122,6 +197,8 @@ public struct CircuitEntry: Codable, Identifiable, Sendable {
     public var conduit: String?
     public var isSpare: Bool
     public var isFedFrom: String?
+    public var classification: CircuitClassification
+    public var secondaryCircuitDescription: String?
 
     public init(
         id: String = UUID().uuidString,
@@ -132,7 +209,9 @@ public struct CircuitEntry: Codable, Identifiable, Sendable {
         wire: String? = nil,
         conduit: String? = nil,
         isSpare: Bool = true,
-        isFedFrom: String? = nil
+        isFedFrom: String? = nil,
+        classification: CircuitClassification = .spare,
+        secondaryCircuitDescription: String? = nil
     ) {
         self.id = id
         self.spaceNumber = spaceNumber
@@ -143,6 +222,40 @@ public struct CircuitEntry: Codable, Identifiable, Sendable {
         self.conduit = conduit
         self.isSpare = isSpare
         self.isFedFrom = isFedFrom
+        self.classification = classification
+        self.secondaryCircuitDescription = secondaryCircuitDescription
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case spaceNumber
+        case breakerAmps
+        case breakerType
+        case circuitDescription
+        case wire
+        case conduit
+        case isSpare
+        case isFedFrom
+        case classification
+        case secondaryCircuitDescription
+    }
+
+    /// Custom decode so panel JSON saved before `classification` and
+    /// `secondaryCircuitDescription` existed keeps decoding without errors.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(String.self, forKey: .id) ?? UUID().uuidString
+        spaceNumber = try container.decode(Int.self, forKey: .spaceNumber)
+        breakerAmps = try container.decodeIfPresent(Int.self, forKey: .breakerAmps)
+        breakerType = try container.decodeIfPresent(BreakerType.self, forKey: .breakerType) ?? .spare
+        circuitDescription = try container.decodeIfPresent(String.self, forKey: .circuitDescription) ?? ""
+        wire = try container.decodeIfPresent(String.self, forKey: .wire)
+        conduit = try container.decodeIfPresent(String.self, forKey: .conduit)
+        isSpare = try container.decodeIfPresent(Bool.self, forKey: .isSpare) ?? (breakerType == .spare)
+        isFedFrom = try container.decodeIfPresent(String.self, forKey: .isFedFrom)
+        classification = try container.decodeIfPresent(CircuitClassification.self, forKey: .classification)
+            ?? (isSpare ? .spare : .special)
+        secondaryCircuitDescription = try container.decodeIfPresent(String.self, forKey: .secondaryCircuitDescription)
     }
 
     /// Returns a persistable copy where spare circuits cannot keep hidden
@@ -157,6 +270,8 @@ public struct CircuitEntry: Codable, Identifiable, Sendable {
         normalized.wire = nil
         normalized.conduit = nil
         normalized.isFedFrom = nil
+        normalized.classification = .spare
+        normalized.secondaryCircuitDescription = nil
         return normalized
     }
 }
@@ -171,4 +286,31 @@ public enum BreakerType: String, Codable, Sendable, CaseIterable {
     case dualFunction = "Dual Function"
     case spare = "Spare"
     case blank = "Blank"
+}
+
+/// Classification used for panel schedule color coding and downstream reporting.
+public enum CircuitClassification: String, Codable, Sendable, CaseIterable {
+    case lighting = "Lighting"
+    case receptacle = "Receptacle"
+    case motor = "Motor"
+    case spare = "Spare"
+    case blank = "Blank"
+    case special = "Special"
+}
+
+public enum PanelScheduleValidationError: Error, LocalizedError, Equatable, Sendable {
+    case spaceConflict(space: Int, first: Int, second: Int)
+    case doubleBreakerOutOfRange(space: Int)
+    case circuitNotFound
+
+    public var errorDescription: String? {
+        switch self {
+        case .spaceConflict(let space, let first, let second):
+            return "Space \(space) is already occupied by circuits \(first) and \(second)."
+        case .doubleBreakerOutOfRange(let space):
+            return "Double breaker at space \(space) must have the matching space below it on the same side."
+        case .circuitNotFound:
+            return "Circuit could not be found."
+        }
+    }
 }

--- a/core/Sources/WiredPartCore/Services/NotebooksService.swift
+++ b/core/Sources/WiredPartCore/Services/NotebooksService.swift
@@ -1044,7 +1044,10 @@ public final class NotebooksService: Sendable {
             try ServicePermissionGate.requirePermission(dbConn, userId: updatedBy, permissionKey: "manage_notebooks")
 
             guard let existing = try Row.fetchOne(dbConn, sql: """
-                SELECT title, content, block_data, heading_level, checklist_items
+                SELECT title, content, block_data, heading_level, checklist_items,
+                       photo_path, reference_type, reference_id,
+                       task_status, task_due_date, task_assigned_to, task_parts_note,
+                       work_classification, warranty_timer_end, is_question
                 FROM notebook_entries
                 WHERE id = ? AND deleted_at IS NULL
                 """, arguments: [entryId]) else { return }
@@ -1055,6 +1058,16 @@ public final class NotebooksService: Sendable {
             let oldBlockData = existing["block_data"] as String?
             let oldHeadingLevel = existing["heading_level"] as Int?
             let oldChecklistItems = existing["checklist_items"] as String?
+            let oldPhotoPath = existing["photo_path"] as String?
+            let oldReferenceType = existing["reference_type"] as String?
+            let oldReferenceId = existing["reference_id"] as Int64?
+            let oldTaskStatus = existing["task_status"] as String?
+            let oldTaskDueDate = existing["task_due_date"] as String?
+            let oldTaskAssignedTo = existing["task_assigned_to"] as Int64?
+            let oldTaskPartsNote = existing["task_parts_note"] as String?
+            let oldWorkClassification = existing["work_classification"] as String?
+            let oldWarrantyTimerEnd = existing["warranty_timer_end"] as String?
+            let oldIsQuestionInt = existing["is_question"] as Int?
 
             try dbConn.execute(sql: """
                 UPDATE notebook_entries
@@ -1093,11 +1106,33 @@ public final class NotebooksService: Sendable {
                     oldValues[field] = old ?? NSNull()
                 }
             }
+            func trackInt64(_ field: String, old: Int64?, new: Int64?) {
+                if old != new {
+                    changedFields[field] = new ?? NSNull()
+                    oldValues[field] = old ?? NSNull()
+                }
+            }
             trackString("title", old: oldTitle, new: newTitle)
             trackString("content", old: oldContent, new: content)
             trackString("block_data", old: oldBlockData, new: blockData)
             trackInt("heading_level", old: oldHeadingLevel, new: headingLevel)
             trackString("checklist_items", old: oldChecklistItems, new: checklistItems)
+            // COALESCE(?, col) means a nil parameter leaves the column untouched, so the
+            // effective new value for change-log purposes is `param ?? old`.
+            trackString("photo_path", old: oldPhotoPath, new: photoPath ?? oldPhotoPath)
+            trackString("reference_type", old: oldReferenceType, new: referenceType ?? oldReferenceType)
+            trackInt64("reference_id", old: oldReferenceId, new: referenceId ?? oldReferenceId)
+            trackString("task_status", old: oldTaskStatus, new: taskStatus ?? oldTaskStatus)
+            trackString("task_due_date", old: oldTaskDueDate, new: taskDueDate ?? oldTaskDueDate)
+            trackInt64("task_assigned_to", old: oldTaskAssignedTo, new: taskAssignedTo ?? oldTaskAssignedTo)
+            trackString("task_parts_note", old: oldTaskPartsNote, new: taskPartsNote ?? oldTaskPartsNote)
+            trackString("work_classification", old: oldWorkClassification, new: workClassification ?? oldWorkClassification)
+            trackString("warranty_timer_end", old: oldWarrantyTimerEnd, new: warrantyTimerEnd ?? oldWarrantyTimerEnd)
+            trackInt(
+                "is_question",
+                old: oldIsQuestionInt,
+                new: isQuestion.map { $0 ? 1 : 0 } ?? oldIsQuestionInt
+            )
 
             if !changedFields.isEmpty {
                 let changedFieldsData = try JSONSerialization.data(withJSONObject: changedFields, options: [.sortedKeys])

--- a/core/Sources/WiredPartCore/Services/NotebooksService.swift
+++ b/core/Sources/WiredPartCore/Services/NotebooksService.swift
@@ -1029,14 +1029,23 @@ public final class NotebooksService: Sendable {
         headingLevel: Int? = nil,
         checklistItems: String? = nil,
         photoPath: String? = nil,
+        clearPhotoPath: Bool = false,
         referenceType: String? = nil,
+        clearReferenceType: Bool = false,
         referenceId: Int64? = nil,
+        clearReferenceId: Bool = false,
         taskStatus: String? = nil,
+        clearTaskStatus: Bool = false,
         taskDueDate: String? = nil,
+        clearTaskDueDate: Bool = false,
         taskAssignedTo: Int64? = nil,
+        clearTaskAssignedTo: Bool = false,
         taskPartsNote: String? = nil,
+        clearTaskPartsNote: Bool = false,
         workClassification: String? = nil,
+        clearWorkClassification: Bool = false,
         warrantyTimerEnd: String? = nil,
+        clearWarrantyTimerEnd: Bool = false,
         isQuestion: Bool? = nil,
         updatedBy: Int64
     ) throws {
@@ -1072,23 +1081,30 @@ public final class NotebooksService: Sendable {
             try dbConn.execute(sql: """
                 UPDATE notebook_entries
                 SET title = ?, content = ?, block_data = ?, heading_level = ?, checklist_items = ?,
-                    photo_path = COALESCE(?, photo_path),
-                    reference_type = COALESCE(?, reference_type),
-                    reference_id = COALESCE(?, reference_id),
-                    task_status = COALESCE(?, task_status),
-                    task_due_date = COALESCE(?, task_due_date),
-                    task_assigned_to = COALESCE(?, task_assigned_to),
-                    task_parts_note = COALESCE(?, task_parts_note),
-                    work_classification = COALESCE(?, work_classification),
-                    warranty_timer_end = COALESCE(?, warranty_timer_end),
+                    photo_path = CASE WHEN ? = 1 THEN NULL ELSE COALESCE(?, photo_path) END,
+                    reference_type = CASE WHEN ? = 1 THEN NULL ELSE COALESCE(?, reference_type) END,
+                    reference_id = CASE WHEN ? = 1 THEN NULL ELSE COALESCE(?, reference_id) END,
+                    task_status = CASE WHEN ? = 1 THEN NULL ELSE COALESCE(?, task_status) END,
+                    task_due_date = CASE WHEN ? = 1 THEN NULL ELSE COALESCE(?, task_due_date) END,
+                    task_assigned_to = CASE WHEN ? = 1 THEN NULL ELSE COALESCE(?, task_assigned_to) END,
+                    task_parts_note = CASE WHEN ? = 1 THEN NULL ELSE COALESCE(?, task_parts_note) END,
+                    work_classification = CASE WHEN ? = 1 THEN NULL ELSE COALESCE(?, work_classification) END,
+                    warranty_timer_end = CASE WHEN ? = 1 THEN NULL ELSE COALESCE(?, warranty_timer_end) END,
                     is_question = COALESCE(?, is_question),
                     updated_by = ?, updated_at = datetime('now')
                 WHERE id = ? AND deleted_at IS NULL
                 """, arguments: [
                     newTitle, content, blockData, headingLevel, checklistItems,
-                    photoPath, referenceType, referenceId,
-                    taskStatus, taskDueDate, taskAssignedTo, taskPartsNote,
-                    workClassification, warrantyTimerEnd, isQuestion.map { $0 ? 1 : 0 },
+                    clearPhotoPath ? 1 : 0, photoPath,
+                    clearReferenceType ? 1 : 0, referenceType,
+                    clearReferenceId ? 1 : 0, referenceId,
+                    clearTaskStatus ? 1 : 0, taskStatus,
+                    clearTaskDueDate ? 1 : 0, taskDueDate,
+                    clearTaskAssignedTo ? 1 : 0, taskAssignedTo,
+                    clearTaskPartsNote ? 1 : 0, taskPartsNote,
+                    clearWorkClassification ? 1 : 0, workClassification,
+                    clearWarrantyTimerEnd ? 1 : 0, warrantyTimerEnd,
+                    isQuestion.map { $0 ? 1 : 0 },
                     updatedBy, entryId
                 ])
 
@@ -1117,17 +1133,17 @@ public final class NotebooksService: Sendable {
             trackString("block_data", old: oldBlockData, new: blockData)
             trackInt("heading_level", old: oldHeadingLevel, new: headingLevel)
             trackString("checklist_items", old: oldChecklistItems, new: checklistItems)
-            // COALESCE(?, col) means a nil parameter leaves the column untouched, so the
-            // effective new value for change-log purposes is `param ?? old`.
-            trackString("photo_path", old: oldPhotoPath, new: photoPath ?? oldPhotoPath)
-            trackString("reference_type", old: oldReferenceType, new: referenceType ?? oldReferenceType)
-            trackInt64("reference_id", old: oldReferenceId, new: referenceId ?? oldReferenceId)
-            trackString("task_status", old: oldTaskStatus, new: taskStatus ?? oldTaskStatus)
-            trackString("task_due_date", old: oldTaskDueDate, new: taskDueDate ?? oldTaskDueDate)
-            trackInt64("task_assigned_to", old: oldTaskAssignedTo, new: taskAssignedTo ?? oldTaskAssignedTo)
-            trackString("task_parts_note", old: oldTaskPartsNote, new: taskPartsNote ?? oldTaskPartsNote)
-            trackString("work_classification", old: oldWorkClassification, new: workClassification ?? oldWorkClassification)
-            trackString("warranty_timer_end", old: oldWarrantyTimerEnd, new: warrantyTimerEnd ?? oldWarrantyTimerEnd)
+            // When a clear* flag is true the column is set to NULL; otherwise CASE WHEN falls
+            // through to COALESCE(param, col), so nil param = leave unchanged (keep old value).
+            trackString("photo_path", old: oldPhotoPath, new: clearPhotoPath ? nil : (photoPath ?? oldPhotoPath))
+            trackString("reference_type", old: oldReferenceType, new: clearReferenceType ? nil : (referenceType ?? oldReferenceType))
+            trackInt64("reference_id", old: oldReferenceId, new: clearReferenceId ? nil : (referenceId ?? oldReferenceId))
+            trackString("task_status", old: oldTaskStatus, new: clearTaskStatus ? nil : (taskStatus ?? oldTaskStatus))
+            trackString("task_due_date", old: oldTaskDueDate, new: clearTaskDueDate ? nil : (taskDueDate ?? oldTaskDueDate))
+            trackInt64("task_assigned_to", old: oldTaskAssignedTo, new: clearTaskAssignedTo ? nil : (taskAssignedTo ?? oldTaskAssignedTo))
+            trackString("task_parts_note", old: oldTaskPartsNote, new: clearTaskPartsNote ? nil : (taskPartsNote ?? oldTaskPartsNote))
+            trackString("work_classification", old: oldWorkClassification, new: clearWorkClassification ? nil : (workClassification ?? oldWorkClassification))
+            trackString("warranty_timer_end", old: oldWarrantyTimerEnd, new: clearWarrantyTimerEnd ? nil : (warrantyTimerEnd ?? oldWarrantyTimerEnd))
             trackInt(
                 "is_question",
                 old: oldIsQuestionInt,

--- a/core/Sources/WiredPartCore/Services/NotebooksService.swift
+++ b/core/Sources/WiredPartCore/Services/NotebooksService.swift
@@ -96,6 +96,10 @@ public final class NotebooksService: Sendable {
         public let photoPath: String?
         public let referenceType: String?
         public let referenceId: Int64?
+        public let taskStatus: String?
+        public let taskDueDate: String?
+        public let taskAssignedTo: Int64?
+        public let taskPartsNote: String?
         // Classification fields (45D)
         public let workClassification: String?
         public let classificationReviewed: Bool
@@ -110,6 +114,8 @@ public final class NotebooksService: Sendable {
             blockData: String? = nil, headingLevel: Int? = nil,
             checklistItems: String? = nil, photoPath: String? = nil,
             referenceType: String? = nil, referenceId: Int64? = nil,
+            taskStatus: String? = nil, taskDueDate: String? = nil,
+            taskAssignedTo: Int64? = nil, taskPartsNote: String? = nil,
             workClassification: String? = nil, classificationReviewed: Bool = false,
             warrantyTimerEnd: String? = nil, isQuestion: Bool = false
         ) {
@@ -128,6 +134,10 @@ public final class NotebooksService: Sendable {
             self.photoPath = photoPath
             self.referenceType = referenceType
             self.referenceId = referenceId
+            self.taskStatus = taskStatus
+            self.taskDueDate = taskDueDate
+            self.taskAssignedTo = taskAssignedTo
+            self.taskPartsNote = taskPartsNote
             self.workClassification = workClassification
             self.classificationReviewed = classificationReviewed
             self.warrantyTimerEnd = warrantyTimerEnd
@@ -293,6 +303,7 @@ public final class NotebooksService: Sendable {
                        COALESCE(ne.is_completed, 0) as is_completed, ne.created_at,
                        ne.block_type, ne.block_data, ne.heading_level, ne.checklist_items,
                        ne.photo_path, ne.reference_type, ne.reference_id,
+                       ne.task_status, ne.task_due_date, ne.task_assigned_to, ne.task_parts_note,
                        ne.work_classification, COALESCE(ne.classification_reviewed, 0) as classification_reviewed,
                        ne.warranty_timer_end, COALESCE(ne.is_question, 0) as is_question,
                        COALESCE(u.display_name, u.email, 'Unknown') AS created_by_name
@@ -320,6 +331,10 @@ public final class NotebooksService: Sendable {
                     photoPath: row["photo_path"] as String?,
                     referenceType: row["reference_type"] as String?,
                     referenceId: row["reference_id"] as Int64?,
+                    taskStatus: row["task_status"] as String?,
+                    taskDueDate: row["task_due_date"] as String?,
+                    taskAssignedTo: row["task_assigned_to"] as Int64?,
+                    taskPartsNote: row["task_parts_note"] as String?,
                     workClassification: row["work_classification"] as String?,
                     classificationReviewed: (row["classification_reviewed"] as Int?) == 1,
                     warrantyTimerEnd: row["warranty_timer_end"] as String?,
@@ -729,6 +744,7 @@ public final class NotebooksService: Sendable {
                            COALESCE(ne.is_completed, 0) as is_completed, ne.created_at,
                            ne.block_type, ne.block_data, ne.heading_level, ne.checklist_items,
                            ne.photo_path, ne.reference_type, ne.reference_id,
+                           ne.task_status, ne.task_due_date, ne.task_assigned_to, ne.task_parts_note,
                            ne.work_classification, COALESCE(ne.classification_reviewed, 0) as classification_reviewed,
                            ne.warranty_timer_end, COALESCE(ne.is_question, 0) as is_question,
                            COALESCE(u.display_name, u.email, 'Unknown') AS created_by_name
@@ -758,6 +774,10 @@ public final class NotebooksService: Sendable {
                         photoPath: row["photo_path"] as String?,
                         referenceType: row["reference_type"] as String?,
                         referenceId: row["reference_id"] as Int64?,
+                        taskStatus: row["task_status"] as String?,
+                        taskDueDate: row["task_due_date"] as String?,
+                        taskAssignedTo: row["task_assigned_to"] as Int64?,
+                        taskPartsNote: row["task_parts_note"] as String?,
                         workClassification: row["work_classification"] as String?,
                         classificationReviewed: (row["classification_reviewed"] as Int?) == 1,
                         warrantyTimerEnd: row["warranty_timer_end"] as String?,
@@ -944,6 +964,16 @@ public final class NotebooksService: Sendable {
         blockData: String? = nil,
         headingLevel: Int? = nil,
         checklistItems: String? = nil,
+        photoPath: String? = nil,
+        referenceType: String? = nil,
+        referenceId: Int64? = nil,
+        taskStatus: String? = nil,
+        taskDueDate: String? = nil,
+        taskAssignedTo: Int64? = nil,
+        taskPartsNote: String? = nil,
+        workClassification: String? = nil,
+        warrantyTimerEnd: String? = nil,
+        isQuestion: Bool = false,
         createdBy: Int64,
         sortOrder: Int? = nil
     ) throws -> Int64 {
@@ -968,16 +998,23 @@ public final class NotebooksService: Sendable {
 
             let storedBlockData = blockType == "checklist" ? nil : blockData
             let storedChecklistItems = checklistItems ?? (blockType == "checklist" ? blockData : nil)
+            let persistedTaskStatus = taskStatus ?? (blockType == "todo" ? "open" : nil)
 
             try dbConn.execute(sql: """
                 INSERT INTO notebook_entries
                 (section_id, notebook_id, title, content, entry_type, block_type, block_data,
-                 heading_level, checklist_items, field_required, is_deleted, is_completed,
-                 sort_order, created_by, created_at, updated_at)
-                VALUES (?, ?, ?, ?, 'note', ?, ?, ?, ?, 0, 0, 0, ?, ?, datetime('now'), datetime('now'))
+                 heading_level, checklist_items, photo_path, reference_type, reference_id,
+                 task_status, task_due_date, task_assigned_to, task_parts_note,
+                 work_classification, warranty_timer_end, is_question,
+                 field_required, is_deleted, is_completed, sort_order, created_by, created_at, updated_at)
+                VALUES (?, ?, ?, ?, 'note', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                        0, 0, 0, ?, ?, datetime('now'), datetime('now'))
                 """, arguments: [
                     sectionId, notebookId, title ?? "", content, blockType, storedBlockData,
-                    headingLevel, storedChecklistItems, order, createdBy
+                    headingLevel, storedChecklistItems, photoPath, referenceType, referenceId,
+                    persistedTaskStatus, taskDueDate, taskAssignedTo, taskPartsNote,
+                    workClassification, warrantyTimerEnd, isQuestion ? 1 : 0,
+                    order, createdBy
                 ])
             return dbConn.lastInsertedRowID
         }
@@ -991,6 +1028,16 @@ public final class NotebooksService: Sendable {
         blockData: String?,
         headingLevel: Int? = nil,
         checklistItems: String? = nil,
+        photoPath: String? = nil,
+        referenceType: String? = nil,
+        referenceId: Int64? = nil,
+        taskStatus: String? = nil,
+        taskDueDate: String? = nil,
+        taskAssignedTo: Int64? = nil,
+        taskPartsNote: String? = nil,
+        workClassification: String? = nil,
+        warrantyTimerEnd: String? = nil,
+        isQuestion: Bool? = nil,
         updatedBy: Int64
     ) throws {
         try db.writer.write { dbConn in
@@ -1012,9 +1059,25 @@ public final class NotebooksService: Sendable {
             try dbConn.execute(sql: """
                 UPDATE notebook_entries
                 SET title = ?, content = ?, block_data = ?, heading_level = ?, checklist_items = ?,
+                    photo_path = COALESCE(?, photo_path),
+                    reference_type = COALESCE(?, reference_type),
+                    reference_id = COALESCE(?, reference_id),
+                    task_status = COALESCE(?, task_status),
+                    task_due_date = COALESCE(?, task_due_date),
+                    task_assigned_to = COALESCE(?, task_assigned_to),
+                    task_parts_note = COALESCE(?, task_parts_note),
+                    work_classification = COALESCE(?, work_classification),
+                    warranty_timer_end = COALESCE(?, warranty_timer_end),
+                    is_question = COALESCE(?, is_question),
                     updated_by = ?, updated_at = datetime('now')
                 WHERE id = ? AND deleted_at IS NULL
-                """, arguments: [newTitle, content, blockData, headingLevel, checklistItems, updatedBy, entryId])
+                """, arguments: [
+                    newTitle, content, blockData, headingLevel, checklistItems,
+                    photoPath, referenceType, referenceId,
+                    taskStatus, taskDueDate, taskAssignedTo, taskPartsNote,
+                    workClassification, warrantyTimerEnd, isQuestion.map { $0 ? 1 : 0 },
+                    updatedBy, entryId
+                ])
 
             var changedFields: [String: Any] = [:]
             var oldValues: [String: Any] = [:]
@@ -1198,6 +1261,7 @@ public final class NotebooksService: Sendable {
                            COALESCE(ne.is_completed, 0) as is_completed, ne.created_at,
                            ne.block_type, ne.block_data, ne.heading_level, ne.checklist_items,
                            ne.photo_path, ne.reference_type, ne.reference_id,
+                           ne.task_status, ne.task_due_date, ne.task_assigned_to, ne.task_parts_note,
                            ne.work_classification, COALESCE(ne.classification_reviewed, 0) as classification_reviewed,
                            ne.warranty_timer_end, COALESCE(ne.is_question, 0) as is_question,
                            COALESCE(u.display_name, u.email, 'Unknown') AS created_by_name
@@ -1228,6 +1292,10 @@ public final class NotebooksService: Sendable {
                         photoPath: row["photo_path"] as String?,
                         referenceType: row["reference_type"] as String?,
                         referenceId: row["reference_id"] as Int64?,
+                        taskStatus: row["task_status"] as String?,
+                        taskDueDate: row["task_due_date"] as String?,
+                        taskAssignedTo: row["task_assigned_to"] as Int64?,
+                        taskPartsNote: row["task_parts_note"] as String?,
                         workClassification: row["work_classification"] as String?,
                         classificationReviewed: (row["classification_reviewed"] as Int?) == 1,
                         warrantyTimerEnd: row["warranty_timer_end"] as String?,

--- a/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
@@ -187,6 +187,70 @@ struct NotebooksServiceTests {
         #expect(oldValues["title"] as? String == "Original heading")
     }
 
+    @Test("Updating task/reference/photo metadata on a block entry records change history for each field")
+    func testUpdateBlockEntryMetadataRecordsChangeHistoryForNewFields() throws {
+        let env = try E2ETestHelpers.setUp()
+
+        let nbId = try env.notebooks.createNotebook(
+            title: "Metadata Blocks",
+            notebookType: "general",
+            createdBy: env.adminUserId
+        )
+        let sectionId = try env.notebooks.createSection(
+            notebookId: nbId, groupId: nil, name: "Info"
+        )
+        let entryId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "todo",
+            title: "Follow up",
+            content: nil,
+            createdBy: env.adminUserId
+        )
+
+        try env.notebooks.updateBlockEntry(
+            entryId: entryId,
+            content: nil,
+            blockData: nil,
+            photoPath: "photos/entry.jpg",
+            referenceType: "part",
+            referenceId: 42,
+            taskStatus: "in_progress",
+            taskDueDate: "2026-08-01",
+            taskAssignedTo: env.adminUserId,
+            taskPartsNote: "Need breaker",
+            workClassification: "electrical",
+            warrantyTimerEnd: "2026-09-01",
+            isQuestion: true,
+            updatedBy: env.adminUserId
+        )
+
+        let historyRows = try env.db.writer.read { dbConn in
+            try Row.fetchAll(dbConn, sql: """
+                SELECT changed_fields, old_values
+                FROM _change_log
+                WHERE table_name = 'notebook_entries'
+                  AND record_id = ?
+                  AND operation = 'UPDATE'
+                ORDER BY id DESC
+                """, arguments: [entryId])
+        }
+        #expect(historyRows.count == 1)
+        let changedFieldsJSON = try #require(historyRows.first?["changed_fields"] as String?)
+        let changedFieldsData = try #require(changedFieldsJSON.data(using: .utf8))
+        let changedFields = try #require(JSONSerialization.jsonObject(with: changedFieldsData) as? [String: Any])
+
+        #expect(changedFields["photo_path"] as? String == "photos/entry.jpg")
+        #expect(changedFields["reference_type"] as? String == "part")
+        #expect(changedFields["reference_id"] as? Int64 == 42)
+        #expect(changedFields["task_status"] as? String == "in_progress")
+        #expect(changedFields["task_due_date"] as? String == "2026-08-01")
+        #expect(changedFields["task_assigned_to"] as? Int64 == env.adminUserId)
+        #expect(changedFields["task_parts_note"] as? String == "Need breaker")
+        #expect(changedFields["work_classification"] as? String == "electrical")
+        #expect(changedFields["warranty_timer_end"] as? String == "2026-09-01")
+        #expect(changedFields["is_question"] as? Int64 == 1)
+    }
+
     @Test("Creating checklist block entries stores checklist items in the canonical column")
     func testCreateChecklistBlockEntryStoresChecklistItems() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/NotebooksServiceTests.swift
@@ -1915,6 +1915,96 @@ struct NotebooksServiceTests {
         #expect(notebookId == nbId)
     }
 
+    @Test("createBlockEntry preserves palette block metadata")
+    func testCreateBlockEntryPreservesPaletteBlockMetadata() throws {
+        let env = try E2ETestHelpers.setUp()
+        let nbId = try env.notebooks.createNotebook(
+            title: "Palette Notebook",
+            notebookType: "general",
+            jobId: nil,
+            createdBy: env.adminUserId
+        )
+        let sectionId = try env.notebooks.createSection(
+            notebookId: nbId, groupId: nil, name: "Section A"
+        )
+        let panelJson = "{\"panelType\":\"Load Center\",\"circuits\":[{\"position\":1,\"label\":\"Kitchen\"}]}"
+        let tableNotes = "Part, Qty\nEMT, 12"
+
+        let headingId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "heading",
+            title: "Panel Notes",
+            headingLevel: 2,
+            createdBy: env.adminUserId
+        )
+        let photoId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "photo",
+            title: "Panel photo",
+            photoPath: "file:///tmp/panel.jpg",
+            createdBy: env.adminUserId
+        )
+        let partId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "part_reference",
+            title: "Breaker",
+            referenceType: "part",
+            referenceId: 42,
+            createdBy: env.adminUserId
+        )
+        let panelId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "panel_schedule",
+            title: "Main Panel",
+            blockData: panelJson,
+            createdBy: env.adminUserId
+        )
+        let tableId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "table",
+            title: "Materials",
+            content: tableNotes,
+            createdBy: env.adminUserId
+        )
+        let todoId = try env.notebooks.createBlockEntry(
+            sectionId: sectionId,
+            blockType: "todo",
+            title: "Return for warranty check",
+            taskStatus: "in_progress",
+            taskDueDate: "2026-05-20",
+            taskAssignedTo: env.adminUserId,
+            taskPartsNote: "Bring replacement GFCI",
+            workClassification: "warranty",
+            warrantyTimerEnd: "2026-06-20T00:00:00Z",
+            isQuestion: true,
+            createdBy: env.adminUserId
+        )
+
+        let hierarchy = try env.notebooks.getNotebookHierarchy(notebookId: nbId)
+        let entries = hierarchy.ungroupedSections.flatMap(\.entries)
+        let byId = Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+
+        #expect(byId[headingId]?.blockType == "heading")
+        #expect(byId[headingId]?.headingLevel == 2)
+        #expect(byId[photoId]?.photoPath == "file:///tmp/panel.jpg")
+        #expect(byId[partId]?.referenceType == "part")
+        #expect(byId[partId]?.referenceId == 42)
+        #expect(byId[panelId]?.blockData == panelJson)
+        #expect(byId[tableId]?.content == tableNotes)
+        #expect(byId[todoId]?.taskStatus == "in_progress")
+        #expect(byId[todoId]?.taskDueDate == "2026-05-20")
+        #expect(byId[todoId]?.taskAssignedTo == env.adminUserId)
+        #expect(byId[todoId]?.taskPartsNote == "Bring replacement GFCI")
+        #expect(byId[todoId]?.workClassification == "warranty")
+        #expect(byId[todoId]?.warrantyTimerEnd == "2026-06-20T00:00:00Z")
+        #expect(byId[todoId]?.isQuestion == true)
+
+        let detail = try env.notebooks.getNotebookDetail(id: nbId)
+        let detailTodo = try #require(detail.entries.first { $0.id == todoId })
+        #expect(detailTodo.taskStatus == "in_progress")
+        #expect(detailTodo.taskPartsNote == "Bring replacement GFCI")
+    }
+
     @Test("listNotebooks hides job name for soft-deleted job")
     func testListNotebooksHidesDeletedJobName() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/PanelScheduleTests.swift
+++ b/core/Tests/WiredPartCoreTests/PanelScheduleTests.swift
@@ -133,4 +133,136 @@ struct PanelScheduleTests {
         #expect(persisted.totalSpaces == 20)
         #expect(persisted.circuits.map(\.spaceNumber) == [1])
     }
+
+    // MARK: - Circuit classification, drag/drop move, and position validation
+
+    @Test("Double breakers reserve same-side adjacent spaces")
+    func doubleBreakerOverlapIsRejected() throws {
+        let doubleBreaker = CircuitEntry(
+            id: "a",
+            spaceNumber: 1,
+            breakerAmps: 30,
+            breakerType: .double,
+            circuitDescription: "Range",
+            isSpare: false,
+            classification: .special
+        )
+        let occupiedLowerSpace = CircuitEntry(
+            id: "b",
+            spaceNumber: 3,
+            breakerAmps: 20,
+            breakerType: .single,
+            circuitDescription: "Kitchen",
+            isSpare: false,
+            classification: .receptacle
+        )
+        let schedule = PanelSchedule(totalSpaces: 20, circuits: [doubleBreaker, occupiedLowerSpace])
+
+        #expect(schedule.validationErrors.contains(.spaceConflict(space: 3, first: 1, second: 3)))
+    }
+
+    @Test("Double breakers cannot hang past the last same-side space")
+    func doubleBreakerOutOfRangeIsRejected() throws {
+        let schedule = PanelSchedule(
+            totalSpaces: 20,
+            circuits: [
+                CircuitEntry(
+                    spaceNumber: 19,
+                    breakerAmps: 40,
+                    breakerType: .double,
+                    circuitDescription: "Condenser",
+                    isSpare: false,
+                    classification: .motor
+                )
+            ]
+        )
+
+        #expect(schedule.validationErrors.contains(.doubleBreakerOutOfRange(space: 19)))
+    }
+
+    @Test("Moving a circuit preserves metadata and validates the destination")
+    func moveCircuitPreservesClassification() throws {
+        var schedule = PanelSchedule(
+            totalSpaces: 20,
+            circuits: [
+                CircuitEntry(
+                    id: "lighting-1",
+                    spaceNumber: 1,
+                    breakerAmps: 15,
+                    breakerType: .single,
+                    circuitDescription: "Hall lights",
+                    isSpare: false,
+                    classification: .lighting
+                )
+            ]
+        )
+
+        try schedule.moveCircuit(id: "lighting-1", to: 5)
+
+        let moved = try #require(schedule.circuits.first)
+        #expect(moved.spaceNumber == 5)
+        #expect(moved.classification == .lighting)
+        #expect(moved.circuitDescription == "Hall lights")
+    }
+
+    @Test("Moving a circuit into an occupied space is rejected and the schedule is unchanged")
+    func moveCircuitIntoConflictIsRejected() throws {
+        var schedule = PanelSchedule(
+            totalSpaces: 20,
+            circuits: [
+                CircuitEntry(id: "a", spaceNumber: 1, circuitDescription: "Office", isSpare: false, classification: .receptacle),
+                CircuitEntry(id: "b", spaceNumber: 2, circuitDescription: "Shop", isSpare: false, classification: .receptacle)
+            ]
+        )
+
+        #expect(throws: PanelScheduleValidationError.self) {
+            try schedule.moveCircuit(id: "a", to: 2)
+        }
+        // Schedule must be unchanged after a rejected move.
+        #expect(schedule.circuits.first { $0.id == "a" }?.spaceNumber == 1)
+    }
+
+    @Test("Moving an unknown circuit id throws circuitNotFound")
+    func moveUnknownCircuitThrows() throws {
+        var schedule = PanelSchedule(totalSpaces: 20, circuits: [])
+        #expect(throws: PanelScheduleValidationError.circuitNotFound) {
+            try schedule.moveCircuit(id: "missing", to: 1)
+        }
+    }
+
+    @Test("Circuit classification decodes old panel JSON safely")
+    func classificationDefaultsWhenDecodingLegacyJSON() throws {
+        let json = """
+        {
+          "id": "schedule",
+          "panelName": "Panel A",
+          "panelType": "Load Center",
+          "totalSpaces": 20,
+          "mainBreakerAmps": 200,
+          "voltage": 240,
+          "phase": 1,
+          "circuits": [
+            {
+              "id": "legacy",
+              "spaceNumber": 1,
+              "breakerType": "Single",
+              "circuitDescription": "Kitchen",
+              "isSpare": false
+            }
+          ]
+        }
+        """
+
+        let schedule = try JSONDecoder().decode(PanelSchedule.self, from: Data(json.utf8))
+
+        #expect(schedule.circuits.first?.classification == .special)
+    }
+
+    @Test("Small panel type is available and normalizes for persistence")
+    func smallPanelTypeSupported() throws {
+        #expect(PanelType.allCases.contains(.smallPanel))
+        let schedule = PanelSchedule(panelType: .smallPanel, totalSpaces: 8)
+        #expect(schedule.panelType == .smallPanel)
+        #expect(PanelSchedule.supportedTotalSpaces.contains(schedule.totalSpaces))
+    }
 }

--- a/docs/plans/ios-notebooks-pages.md
+++ b/docs/plans/ios-notebooks-pages.md
@@ -264,6 +264,27 @@ A dedicated tool for building electrical panel schedules. This is a first-class 
 - **Auto-numbering:** odd on left, even on right (standard panel layout)
 - **Color coding:** by circuit type (lighting, receptacle, motor, etc.)
 
+### Implementation Update — 2026-07-02
+
+- Re-landed the stranded slash command palette (`/h1`…`/todo`, all target block
+  types) in `AddNotebookEntrySheet.swift`, adapted to main's current picker
+  (which already had photo/part_reference rendering) rather than the original
+  May donor baseline. Quote and code blocks render in `IOSNotebookDetailPage.swift`.
+- Re-landed panel circuit drag/drop, tap-based move mode, VoiceOver move
+  actions, and `CircuitClassification` (lighting/receptacle/motor/spare/blank/special)
+  color coding in `PanelScheduleBuilder.swift` and `PanelScheduleModels.swift`.
+- Circuit position validation (same-side double-breaker span, space-occupancy
+  conflicts) lives on `PanelSchedule` (`validationErrors`, `upsertCircuit`,
+  `moveCircuit`) and composes with the existing #1239 `totalSpaces` clamping —
+  it does not replace it. Panel type space limits stay driven by the shared
+  `PanelSchedule.supportedTotalSpaces` list rather than per-type ranges, so the
+  #1239 fix's single source of truth for panel sizing is preserved.
+- No new migration was required: `task_status`/`task_due_date`/`task_assigned_to`/
+  `task_parts_note` already exist on `notebook_entries`, and panel circuit
+  classification persists inside the existing `block_data` JSON blob.
+- Print layouts, PDF export, and custom headers remain a separate lane
+  (tracked in the WEI-1135 stranded commit, not part of this pass).
+
 ### Print Layout
 
 - **Custom paper sizes:** Letter, Legal, A4, Card Stock (various sizes)


### PR DESCRIPTION
Contributes to #80 (re-lands slash palette + panel drag/drop).

## Provenance

Re-lands rescued commits `38d1a092f` (slash command palette, +460 lines) and `691c0ffc2` (panel schedule drag/drop, move mode, classification, +425 lines) from the deleted `WEI-342-sync-github-issues-into-paperclip-and-prioritize-backlog` branch. Those commits were never merged; main moved substantially since May (permission-gated writes + change-log tracking on `NotebooksService`, the #1239 panel-crash fix on `PanelScheduleModels`/`PanelScheduleBuilder`). This PR hand-adapts both donor commits onto current main as a single PR since they share the notebooks editor surface, per the 2026-07-02 status-audit comment on #80.

## What changed vs. the donor commits

**Slash palette (`38d1a092f`):**
- `AddNotebookEntrySheet.swift`: filterable `/` command palette covering all target block types (H1/H2/H3, checklist, photo, part reference, panel schedule, divider, quote, callout, table, code, to-do) plus shorthand transforms for each — adapted to main's picker, which had already grown `photo`/`part_reference` options beyond the donor's 6-type baseline. Wired through main's *current* `createBlockEntry`/`updateBlockEntry` signatures (permission gate + change-log tracking), not the donor's simpler ones.
- `IOSNotebookDetailPage.swift`: added `quote`/`code`/`panel_schedule` detail rendering (`photo`/`part_reference` rendering already existed on main).
- `NotebooksService.swift`: extended `NotebookEntryRow` and all **three** hierarchy/detail/warranty-review SELECT sites (donor only touched two — main gained a third, `getPendingWarrantyClassifications`, since May) with `task_status`/`task_due_date`/`task_assigned_to`/`task_parts_note`. **No migration was needed** — those columns already exist in the base `notebook_entries` table on main. Extended `createBlockEntry`/`updateBlockEntry` to persist photo/reference/task metadata while preserving main's permission gate and change-log tracking.

**Panel drag/drop (`691c0ffc2`):**
- `PanelScheduleModels.swift`: added `CircuitClassification` (lighting/receptacle/motor/spare/blank/special), a `smallPanel` `PanelType` case, `secondaryCircuitDescription`, and circuit-position validation (`upsertCircuit`, `moveCircuit`, `validationErrors`) for same-side double-breaker span and space-occupancy conflicts. **Deliberately dropped** the donor's per-panel-type `allowedSpaces` ranges — main's #1239 crash fix (`normalizedTotalSpaces`, `pruningCircuitsOutsideTotalSpaces`) relies on one shared `supportedTotalSpaces` list as its single source of truth for panel sizing; introducing per-type ranges would have conflicted with that fix. Position validation is additive on top of it, not a replacement.
- `PanelScheduleBuilder.swift`: drag/drop plus tap-based move mode, VoiceOver move actions, classification color coding + picker, secondary circuit description field, and validation-gated Save. Preserved main's existing hidden-circuit-prune confirmation flow (`#1239`) and `normalizedForPersistence()` calls.

No new migration: task metadata columns already exist on `notebook_entries`, and panel circuit classification persists inside the existing `block_data` JSON blob column — nothing here required a schema change.

## Test evidence

```
cd core && swift test
✔ Test run with 2344 tests in 71 suites passed after 91.823 seconds.
```

Includes 8 new tests: 1 in `NotebooksServiceTests` (`testCreateBlockEntryPreservesPaletteBlockMetadata`, adapted to main's `NotebookEntryRow`/hierarchy shape) and 7 in `PanelScheduleTests` (double-breaker overlap/out-of-range, move preserves classification, move-into-conflict rejected + schedule unchanged, move-unknown-id throws, legacy-JSON classification decode default, small panel type supported).

App-target files (`AddNotebookEntrySheet.swift`, `IOSNotebookDetailPage.swift`, `PanelScheduleBuilder.swift`) parse clean via `xcrun swiftc -parse` (no syntax/parse errors); full `xcodebuild` wasn't run in this environment, so the diffs were also re-checked visually against the rest of the file for type/API correctness (`.draggable`/`.dropDestination` on `String` already used elsewhere in this codebase, e.g. `ZoneGridCanvas.swift`, confirming the APIs are available at the 26.2 deployment target).

## Scope not included

Print layouts, PDF export, and custom headers (the stranded `22f5a5c31` / WEI-1135 commit) are a separate lane and not part of this PR. Advisory edit locks and Foundation Models conflict merge (WEI-1136) already merged via #873 and are untouched here.

Does not close #80 — remaining checklist items (print/export) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)