### PR TITLE
feat: parts-drift-detector subagent + C1b drift helper (#256)

### DIFF
--- a/.claude/agents/parts-drift-detector.md
+++ b/.claude/agents/parts-drift-detector.md
@@ -1,0 +1,163 @@
+---
+name: parts-drift-detector
+description: >-
+  Compares the Parts-domain plan files in docs/plans/ against the actual iOS +
+  core code and emits a bidirectional drift report (planned-but-not-coded /
+  coded-but-not-planned) with file:line citations. Use for the AUTO GO and
+  hunt-fix "C1b — plan-vs-code drift" check on the Parts area; it turns a ~10
+  minute manual eyeball into a ~2 minute scoped read. Invoke via the Agent tool
+  with subagent_type "parts-drift-detector", or launch it whenever someone asks
+  to "check parts drift", "diff the parts plans against the code", or verify the
+  PE-COLORS / forecasting / inventory-intelligence plans are in sync with the
+  implementation.
+tools: Bash, Read, Grep, Glob
+---
+
+You are **parts-drift-detector**, a read-only auditing subagent for the
+WiredPart iOS repo. Your one job is to compare the **Parts-domain plan files**
+against the **actual code** and produce an honest, cited **drift report**. You
+do not edit code, you do not fix drift, you do not open issues — you *detect and
+report*. A human (or the calling AUTO GO / hunt-fix loop) decides what to do
+with your findings.
+
+## Why you exist
+
+The Parts area is the largest surface in the program: `PartsService.swift` is
+~9,000 lines, the iOS feature dir has ~24 files, and the design is spread across
+a family of specialised plans rather than one doc. The AUTO GO / hunt-fix
+checklist item **C1b (plan-vs-code drift)** requires comparing those plans to
+the code every iteration. Done by hand that is a slow, error-prone eyeball pass.
+You make it fast and repeatable. Drift is **bi-directional** and *both
+directions matter*:
+
+- **planned_but_not_coded** — the plan describes something the code does not yet
+  have. Left unflagged, planned work is silently forgotten.
+- **coded_but_not_planned** — the code has something no plan mentions. Left
+  unflagged, the plan rots and future readers trust a stale map.
+
+## Inputs (the Parts plan family)
+
+Read these plan files under `docs/plans/` (skip any that do not exist — the
+family evolves):
+
+- `parts-section-audit-fix-plan.md` — cross-cutting audit + critical-fix tracker
+  (also the index of the whole plan family — read its "Plan-Family Index" table)
+- `colors-parts-redesign.md` — PE-COLORS variants / per-SKU brand linkage /
+  General Mode. Phase 1 (schema+CRUD) is done; **Phase 2 (Categories UI) and
+  Phase 3 (General Mode orders UI) are the live drift surface.**
+- `forecasting-page-redesign.md` — forecasting page (Prompts 23A-23H)
+- `inventory-intelligence-system.md` — forecasting backbone + wishlist +
+  procurement planner (mostly implemented; Part F advanced features are future)
+- `ios-part-number-hierarchy.md` — part-number generation rules
+- `ios-brands-suppliers-editing.md` — brand-supplier link UI + carry-status
+- `ios-supplier-system.md` — supplier scoring / traceability / contacts
+- `supplier-communication-bridge-plan.md` — supplier comm channels
+
+These plans use **"File → change" tables** (e.g. a row
+`| CategoriesTreeView.swift | Render SKU rows … |`). Those filenames and the
+described behaviors are your machine-checkable anchors. Plans also cite exact
+**method names** (e.g. `resolveGeneralLineItem`, `searchParts`), **struct
+names** (`ColorBrandSKU`), **migration numbers/columns**, and **prompt IDs**
+(`23C`, `PE-046`) — use all of them as anchors.
+
+## Code targets
+
+- iOS: `Weird Parts IOS/Weird Parts IOS/Features/Parts/` (SwiftUI pages,
+  sheets, sections, routers)
+- Core: `core/Sources/WiredPartCore/Services/PartsService.swift` (methods),
+  plus `PartsModels.swift`, `OrdersService.swift`, `WishlistService.swift`, and
+  `core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift` (schema)
+
+## Procedure
+
+Work in this order. **Cite file:line for every claim** — a finding without a
+citation is not a finding.
+
+1. **Run the mechanical first-pass.** Execute the helper and read its output:
+
+   ```bash
+   scripts/parts-drift-report.sh --markdown
+   ```
+
+   (Add `--json` if you want to parse it programmatically.) This gives you a
+   file-level skeleton: which plan-named `.swift` files are missing from the
+   repo (planned_but_not_coded candidates) and which Parts iOS files no plan
+   mentions (coded_but_not_planned candidates). **Treat this as a lead list, not
+   the answer** — it only knows filenames, not behavior. If the script errors or
+   is absent, fall back to doing the file-level diff yourself with Glob + Grep.
+
+2. **Read the plans.** For each plan file that exists, read it in full (they are
+   short). Extract the concrete claims: File→change table rows, named methods,
+   named structs, migration numbers + columns, prompt IDs, and any explicit
+   "Status:" line (a plan that says "Phase 2 pending" is *telling you* to expect
+   planned_but_not_coded — that is expected drift, not a defect).
+
+3. **Verify each planned claim against the code.** For every anchor from step 2:
+   - Filenames → `Glob`/`find` to confirm the file exists at the expected path.
+   - Methods → `Grep` for `func <name>` in the target service; capture the
+     line. A method named in the plan but absent in the service is
+     planned_but_not_coded.
+   - Structs/columns → `Grep` in `PartsModels.swift` /
+     `AppDatabase+Migrations.swift`.
+   - Behavior (e.g. "stat cards become tappable toggle filters") → open the
+     named view and confirm the mechanism exists; if the plan describes behavior
+     X and the view still does Y, that is drift with a file:line to the Y.
+
+4. **Verify each coded surface against the plans.** For every Parts iOS file and
+   every public `PartsService` method NOT clearly covered by a plan, decide: is
+   it genuinely unplanned (drift), or is it plan-adjacent (a helper the plan
+   implies)? Only report the genuinely unmentioned ones.
+
+5. **Classify every finding's severity** — do not report all drift as equal:
+   - **Expected / acceptable** — plan explicitly marks it future/pending, or an
+     open issue already tracks it (say which: e.g. "tracked #242/#243",
+     "Phase 2 pending per plan header"). Report it, labeled acceptable, so the
+     C1b check can record "known drift, not blocking."
+   - **Actionable** — plan and code genuinely disagree with no tracking, OR a
+     plan doc is now factually wrong about the code (stale status line, renamed
+     file, changed method count). These are the ones a human should act on
+     (update the plan, or file/close an issue).
+
+## Output format
+
+Emit **only** the report below as your final message — no preamble, no "I will
+now…", no code edits. Keep it scannable. Every bullet cites `path:line`.
+
+```
+# Parts drift report — <date>
+
+Scanned: <N> plan files, Parts iOS dir, PartsService. Helper: <ran / fell back>.
+
+## Planned but not coded
+- [ACCEPTABLE|ACTIONABLE] <plan claim> — planned in `docs/plans/<file>:<line>`,
+  absent in code. <tracking note if any>
+- ... (or "None — all planned surface is implemented.")
+
+## Coded but not planned
+- [ACCEPTABLE|ACTIONABLE] `<CodeFile.swift>:<line>` / `func <name>` exists but
+  no plan mentions it. <one-line what-it-is>
+- ... (or "None — all Parts code is covered by a plan.")
+
+## Stale plan facts
+- `docs/plans/<file>:<line>` says "<quote>" but code shows <reality>
+  (`<path>:<line>`). (or "None.")
+
+## Verdict
+<one sentence: zero actionable drift → C1b clean; OR N actionable items listed
+above need a plan update / issue.> Acceptable/future drift: <count>.
+```
+
+## Rules
+
+- **Read-only. Never edit code, plans, or issues.** You surface drift; you do
+  not resolve it.
+- **No uncited claims.** Every finding carries `path:line`. If you cannot cite
+  it, you have not verified it — do not report it.
+- **Do not confuse "future" with "broken."** A plan that says a phase is pending
+  and code that lacks that phase is *in agreement*. Label it ACCEPTABLE and move
+  on; do not pad the actionable list.
+- **Stay scoped to Parts.** If you notice drift in another area, ignore it — a
+  different invocation covers that area.
+- **Be honest about coverage.** If a plan was too vague to verify a claim, or
+  you ran out of budget before checking everything, say so in the Verdict rather
+  than implying a clean pass.

--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,12 @@ Thumbs.db
 *.swo
 *~
 
-# Claude
-.claude/
+# Claude — ignore runtime/session state, but track committed agent definitions.
+# Note: exclude the *contents* of .claude/ (not the dir itself) so the
+# negation for .claude/agents/ can take effect (git won't descend into an
+# excluded directory).
+.claude/*
+!.claude/agents/
 
 # Paperclip runtime state
 .paperclip/

--- a/docs/automation-recommendations.md
+++ b/docs/automation-recommendations.md
@@ -812,9 +812,9 @@ Running total: **23 confirmed gaps / 2 areas** (parts 15 + jobs 8). Scanner prio
 
 **Why:** C1b (plan-vs-code drift) currently requires a human-readable comparison of `parts-section-audit-fix-plan.md` and `colors-parts-redesign.md` against the codebase. As PE-COLORS Phase 2 is implemented over multiple iterations, drift will evolve. A subagent that reads both plans and outputs a checklist of "planned but not coded" and "coded but not planned" items (with file:line citations) would make each C1b check take 2 minutes instead of 10.
 
-**Where:** Agent tool with `subagent_type: feature-dev:code-explorer` (or a custom `.claude/agents/parts-drift-detector.md`)
+**Where:** `.claude/agents/parts-drift-detector.md` (custom subagent), backed by the mechanical first-pass helper `scripts/parts-drift-report.sh`.
 
-**Decision:** Add to plan — worth building after PE-COLORS Phase 2 is underway so the drift surface is active.
+**Decision:** ✅ BUILT 2026-07-02 (#256). PE-COLORS Phase 2 is complete (#237–#240 closed), so the drift surface is active. The subagent reads the full Parts plan family, runs the helper for a file-level skeleton, then verifies method/struct/migration/behavior anchors and emits a bidirectional drift report (planned-but-not-coded / coded-but-not-planned) with file:line citations for the C1b check.
 
 ---
 
@@ -825,7 +825,7 @@ Running total: **23 confirmed gaps / 2 areas** (parts 15 + jobs 8). Scanner prio
 | PartsService SQL column validator hook | Hook | High | APPROVED 2026-04-18 | ✅ BUILT (iter 8, commit pending) |
 | `parts-sql-schema-checker` skill | Skill | High | APPROVED (already built) | ✅ BUILT (pre-existing skill, #254 closed) |
 | `parts-xcode-phase2-generator` | Skill | Low | REJECTED 2026-04-18 | ❌ Removed — duplicates xcode-planner-and-review |
-| `parts-drift-detector` subagent | Subagent | Medium | DEFERRED 2026-04-18 | ⏸ Revisit when PE-COLORS Phase 2 code starts landing (#256) |
+| `parts-drift-detector` subagent | Subagent | Medium | BUILT 2026-07-02 | ✅ BUILT (#256) — `.claude/agents/parts-drift-detector.md` + `scripts/parts-drift-report.sh` |
 
 **Want more?** Run `/claude-automation-recommender` scoped to a different area or category.
 

--- a/scripts/parts-drift-report.sh
+++ b/scripts/parts-drift-report.sh
@@ -34,8 +34,7 @@
 #        the script can be safely chained in a pipeline without false CI fails.)
 #   1  — Fatal error (missing repo layout, no plan files, bad args).
 #
-# Requirements: bash 3.2+ (macOS default), grep, find, sort. jq optional
-# (only for pretty-printing --json; falls back to hand-rolled JSON if absent).
+# Requirements: bash 3.2+ (macOS default), basename, find, grep, sed, sort.
 
 set -euo pipefail
 

--- a/scripts/parts-drift-report.sh
+++ b/scripts/parts-drift-report.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# parts-drift-report.sh — Mechanical first-pass for the parts-drift-detector
+# subagent (GitHub #256). Speeds up the AUTO GO / hunt-fix "C1b — plan-vs-code
+# drift" check for the Parts domain from ~10 min to ~2 min.
+#
+# What it does (grep-level, zero judgement):
+#   1. PLANNED-BUT-NOT-CODED — pulls every `SomeFile.swift` filename mentioned
+#      in the parts-domain plan files under docs/plans/ and reports which of
+#      those files DO NOT exist anywhere in the repo. A missing file is a strong
+#      signal the plan is ahead of the code.
+#   2. CODED-BUT-NOT-PLANNED — lists every .swift file under the Parts iOS
+#      feature dir and reports which filenames are NEVER mentioned in any
+#      parts-domain plan. An unmentioned file is a candidate for "code ahead of
+#      plan" (may be legitimately new, or a plan that needs an update).
+#
+# This script deliberately does NOT decide whether drift is acceptable — that
+# is the subagent's job (.claude/agents/parts-drift-detector.md). It only
+# surfaces the mechanical file-level anchors so the subagent can spend its
+# reasoning budget on the semantic diff (method signatures, UI behavior,
+# migration columns) instead of eyeballing filenames.
+#
+# Usage:
+#   scripts/parts-drift-report.sh [--json] [--markdown] [--quiet]
+#
+# Flags:
+#   --json       Emit machine-readable JSON (for the subagent to parse).
+#   --markdown   Emit a Markdown report (default is plain text).
+#   --quiet      Suppress the human header/footer; body only.
+#   -h|--help    Show this help.
+#
+# Exit codes:
+#   0  — Ran successfully. Drift MAY still be present; this is a report, not a
+#        gate. Check the body. (Non-zero exit is reserved for tool failures so
+#        the script can be safely chained in a pipeline without false CI fails.)
+#   1  — Fatal error (missing repo layout, no plan files, bad args).
+#
+# Requirements: bash 3.2+ (macOS default), grep, find, sort. jq optional
+# (only for pretty-printing --json; falls back to hand-rolled JSON if absent).
+
+set -euo pipefail
+
+# --- Locate repo root (script lives in scripts/) ------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PLANS_DIR="$ROOT_DIR/docs/plans"
+PARTS_IOS_DIR="$ROOT_DIR/Weird Parts IOS/Weird Parts IOS/Features/Parts"
+
+# Parts-domain plan family (per docs/plans/parts-section-audit-fix-plan.md index).
+# These are the plans the C1b Parts drift check reads.
+PARTS_PLANS=(
+  "parts-section-audit-fix-plan.md"
+  "colors-parts-redesign.md"
+  "forecasting-page-redesign.md"
+  "inventory-intelligence-system.md"
+  "ios-part-number-hierarchy.md"
+  "ios-brands-suppliers-editing.md"
+  "ios-supplier-system.md"
+  "supplier-communication-bridge-plan.md"
+)
+
+# --- Arg parsing --------------------------------------------------------------
+FORMAT="text"
+QUIET=0
+
+usage() {
+  # Print the leading comment block (help text) up to the first blank line
+  # after the shebang, minus the leading "# ".
+  sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json)     FORMAT="json" ;;
+    --markdown) FORMAT="markdown" ;;
+    --quiet)    QUIET=1 ;;
+    -h|--help)  usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; echo "Try --help." >&2; exit 1 ;;
+  esac
+  shift
+done
+
+# --- Sanity checks ------------------------------------------------------------
+if [[ ! -d "$PLANS_DIR" ]]; then
+  echo "Fatal: plans dir not found: ${PLANS_DIR#"$ROOT_DIR"/}" >&2
+  exit 1
+fi
+if [[ ! -d "$PARTS_IOS_DIR" ]]; then
+  echo "Fatal: Parts iOS feature dir not found: ${PARTS_IOS_DIR#"$ROOT_DIR"/}" >&2
+  exit 1
+fi
+
+# Keep only plan files that actually exist (plan family evolves over time).
+EXISTING_PLANS=()
+for p in "${PARTS_PLANS[@]}"; do
+  [[ -f "$PLANS_DIR/$p" ]] && EXISTING_PLANS+=("$PLANS_DIR/$p")
+done
+if [[ ${#EXISTING_PLANS[@]} -eq 0 ]]; then
+  echo "Fatal: none of the expected parts-domain plan files exist under ${PLANS_DIR#"$ROOT_DIR"/}" >&2
+  exit 1
+fi
+
+# --- 1. Filenames mentioned in the plans (planned surface) --------------------
+# Extract every token matching *.swift from every plan file, dedupe.
+# grep -oE gives us just the filename tokens even inside table cells / prose.
+mentioned_swift() {
+  grep -hoE '[A-Za-z0-9_+.-]+\.swift' "${EXISTING_PLANS[@]}" 2>/dev/null \
+    | sort -u
+}
+
+# --- 2. Actual Parts iOS .swift files (coded surface) -------------------------
+coded_parts_swift() {
+  find "$PARTS_IOS_DIR" -maxdepth 1 -type f -name '*.swift' -exec basename {} \; \
+    | sort -u
+}
+
+# --- Compute PLANNED-BUT-NOT-CODED --------------------------------------------
+# For each .swift mentioned in a plan, is there a file with that basename
+# anywhere in the repo (iOS app OR core package)? If not → planned-but-not-coded.
+PLANNED_MISSING=()
+while IFS= read -r fname; do
+  [[ -z "$fname" ]] && continue
+  # Search the whole repo for a file with this basename (exclude VCS + build).
+  if ! find "$ROOT_DIR" \
+        -type d \( -name '.git' -o -name '.build' -o -name 'DerivedData' \) -prune -o \
+        -type f -name "$fname" -print 2>/dev/null | grep -q .; then
+    PLANNED_MISSING+=("$fname")
+  fi
+done < <(mentioned_swift)
+
+# --- Compute CODED-BUT-NOT-PLANNED --------------------------------------------
+# For each Parts iOS .swift file, is its basename mentioned in ANY plan? If not
+# → coded-but-not-planned candidate.
+MENTIONED_LIST="$(mentioned_swift)"
+CODED_UNPLANNED=()
+while IFS= read -r fname; do
+  [[ -z "$fname" ]] && continue
+  if ! grep -qxF "$fname" <<<"$MENTIONED_LIST"; then
+    CODED_UNPLANNED+=("$fname")
+  fi
+done < <(coded_parts_swift)
+
+# --- Rendering ----------------------------------------------------------------
+n_plans=${#EXISTING_PLANS[@]}
+n_planned_missing=${#PLANNED_MISSING[@]}
+n_coded_unplanned=${#CODED_UNPLANNED[@]}
+
+json_array() {
+  # $@ = items → JSON string array, no external deps.
+  local out="[" first=1 item
+  for item in "$@"; do
+    [[ $first -eq 0 ]] && out+=","
+    # Escape backslashes and double quotes.
+    item=${item//\\/\\\\}
+    item=${item//\"/\\\"}
+    out+="\"$item\""
+    first=0
+  done
+  out+="]"
+  printf '%s' "$out"
+}
+
+case "$FORMAT" in
+  json)
+    printf '{\n'
+    printf '  "plans_scanned": %d,\n' "$n_plans"
+    printf '  "planned_but_not_coded": %s,\n' "$(json_array "${PLANNED_MISSING[@]+"${PLANNED_MISSING[@]}"}")"
+    printf '  "coded_but_not_planned": %s\n' "$(json_array "${CODED_UNPLANNED[@]+"${CODED_UNPLANNED[@]}"}")"
+    printf '}\n'
+    ;;
+  markdown)
+    [[ $QUIET -eq 0 ]] && {
+      printf '# Parts drift — mechanical first-pass\n\n'
+      printf 'Scanned **%d** parts-domain plan file(s) under `docs/plans/`.\n\n' "$n_plans"
+      printf '> This is a file-level anchor report only. Semantic drift (method\n'
+      printf '> signatures, UI behavior, migration columns) is judged by the\n'
+      printf '> `parts-drift-detector` subagent, not this script.\n\n'
+    }
+    printf '## Planned but not coded (%d)\n\n' "$n_planned_missing"
+    if [[ $n_planned_missing -eq 0 ]]; then
+      printf '_None — every `.swift` named in the plans exists in the repo._\n\n'
+    else
+      printf 'Files named in a plan but not found anywhere in the repo:\n\n'
+      for f in "${PLANNED_MISSING[@]}"; do printf -- '- `%s`\n' "$f"; done
+      printf '\n'
+    fi
+    printf '## Coded but not planned (%d)\n\n' "$n_coded_unplanned"
+    if [[ $n_coded_unplanned -eq 0 ]]; then
+      printf '_None — every Parts iOS file is named in at least one plan._\n\n'
+    else
+      printf 'Parts iOS `.swift` files not mentioned in any parts-domain plan:\n\n'
+      for f in "${CODED_UNPLANNED[@]}"; do printf -- '- `%s`\n' "$f"; done
+      printf '\n'
+    fi
+    ;;
+  text|*)
+    [[ $QUIET -eq 0 ]] && {
+      echo "parts-drift-report — mechanical first-pass ($n_plans plan file(s) scanned)"
+      echo "NOTE: file-level anchors only; semantic drift is the subagent's job."
+      echo
+    }
+    echo "PLANNED BUT NOT CODED ($n_planned_missing):"
+    if [[ $n_planned_missing -eq 0 ]]; then
+      echo "  (none)"
+    else
+      for f in "${PLANNED_MISSING[@]}"; do echo "  - $f"; done
+    fi
+    echo
+    echo "CODED BUT NOT PLANNED ($n_coded_unplanned):"
+    if [[ $n_coded_unplanned -eq 0 ]]; then
+      echo "  (none)"
+    else
+      for f in "${CODED_UNPLANNED[@]}"; do echo "  - $f"; done
+    fi
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
Closes #256.

## What & why

Builds the `parts-drift-detector` subagent (deferred in `docs/automation-recommendations.md` until PE-COLORS Phase 2 was active — Phase 2 is now complete, #237–#240 closed). It automates the AUTO GO / hunt-fix **C1b — plan-vs-code drift** check for the Parts domain, turning a ~10-minute manual eyeball into a ~2-minute scoped read.

Drift is bi-directional and both directions matter: **planned-but-not-coded** (plan ahead of code — work silently forgotten) and **coded-but-not-planned** (code ahead of plan — the map rots). The subagent reports both, plus stale-plan-facts, each with `file:line` citations and an ACCEPTABLE/ACTIONABLE severity so the C1b check can record "known future drift, not blocking" vs. "act on this."

## What changed

- **`.claude/agents/parts-drift-detector.md`** — the subagent (Claude Code agent format: `name` / `description` / `tools` frontmatter + system prompt; read-only tools `Bash, Read, Grep, Glob`). Reads the full Parts plan family under `docs/plans/`, runs the helper for a file-level skeleton, then verifies method / struct / migration / behavior anchors against `Weird Parts IOS/.../Features/Parts/` and `core/.../PartsService.swift` (+ models, migrations). Emits a fixed, scannable report. Explicitly instructed **not** to confuse "future/pending per plan" with "broken."
- **`scripts/parts-drift-report.sh`** — the mechanical first-pass the subagent runs first. Cross-references every `*.swift` filename named in the parts plans against files actually present in the repo (both directions). Modes: default text, `--markdown`, `--json`, `--quiet`. bash 3.2-compatible (macOS default), `set -euo pipefail`, empty-array-safe JSON, no hard `jq` dependency. Deliberately exits 0 always (report, not a gate) so it can be chained without false CI fails.
- **`.gitignore`** — the repo gitignores all of `.claude/`. Changed the rule to exclude `.claude/*` **contents** (not the directory) with a `!.claude/agents/` negation, so the committed agent definition is tracked while runtime/session state (`settings.json`, logs) stays ignored.
- **`docs/automation-recommendations.md`** — refreshed the stale #256 recommendation block + summary-table row from `DEFERRED 2026-04-18` to `BUILT 2026-07-02`.

## Schema

No schema changes — pure internal tooling + docs. No new migration; the migration registry is untouched.

## Test evidence

- `bash -n scripts/parts-drift-report.sh` — clean.
- Ran the helper against the live repo in **all** output modes (text / `--markdown` / `--json` / `--quiet`) — correct output. Current real result: 4 planned-but-not-coded (`BrandSupplierPickerSheet.swift`, `IOSPOCreationPage.swift`, `IOSPartsHierarchyPage.swift`, `SupplierService.swift` — all genuine Phase 2/Phase 3 surface the plans predict), 8 coded-but-not-planned Parts iOS files.
- Spot-checked true positives with `find` (the 4 "missing" files genuinely don't exist anywhere in the repo; `PartsRouter.swift` correctly stays off the missing list and on the unplanned list).
- Verified empty-array JSON path is safe under `set -u`, and that special-char (`"`, `\`) filenames escape correctly.
- Verified the `.gitignore` negation: `.claude/agents/parts-drift-detector.md` is tracked; `.claude/settings.json`, `.claude/settings.local.json`, and `.claude/*.log` remain ignored.
- No Swift changed, so `swift build` / `swift test` were not run (out of scope for this diff — internal tooling only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)