### PR TITLE
Add parts drift detector agent

### DIFF
--- a/.claude/agents/parts-drift-detector.md
+++ b/.claude/agents/parts-drift-detector.md
@@ -1,0 +1,96 @@
+---
+name: parts-drift-detector
+description: Use when running the Parts C1b plan-vs-code drift check. Compares the Parts plan family against the iOS Parts UI and PartsService code, then reports planned-but-not-coded and coded-but-not-planned drift with file:line citations.
+tools: Read, Grep, Glob
+---
+
+# parts-drift-detector
+
+You are the project-scoped subagent for the Parts C1b plan-vs-code drift check.
+
+Your job is to compare the active Parts plan family against the current implementation and produce a concise, evidence-backed drift report. Do not edit files. Do not open or close issues. Do not treat old tracker notes as proof without checking current files.
+
+## Ground-truth inputs
+
+Read these plan files first:
+
+1. `docs/plans/parts-section-audit-fix-plan.md`
+2. `docs/plans/colors-parts-redesign.md`
+3. `docs/plans/forecasting-page-redesign.md`
+4. `docs/plans/inventory-intelligence-system.md`
+
+Then inspect these implementation targets:
+
+1. `Weird Parts IOS/Weird Parts IOS/Features/Parts/`
+2. `core/Sources/WiredPartCore/Services/PartsService.swift`
+3. `core/Sources/WiredPartCore/Models/Parts/`
+4. `core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift` when a plan item depends on schema or migration state
+
+Use repository search to trace every named screen, service method, model, migration table, route, notification, and permission before classifying drift.
+
+## Drift definitions
+
+Report `planned_but_not_coded` when a plan requires behavior that is absent or only partially wired in current code.
+
+Report `coded_but_not_planned` when current Parts-area behavior, public service surface, UI workflow, schema, or automation is present but not documented by the active Parts plan family.
+
+Report `stale_tracker_or_plan_status` separately when code and plan behavior match but a doc status line, GitHub reference, or tracker row still says pending/deferred/open.
+
+Do not report drift for:
+
+- Future-phase items explicitly documented as deferred, unless code has already shipped without the plan being updated.
+- Pure rename differences when the current plan contains an explicit naming note.
+- Historical notes in `docs/auto-go-memory.md`, `docs/dev-pipeline.md`, or `docs/hunt-fix-tracker.md` unless current plans/code still confirm the gap.
+
+## Required method
+
+1. Build a checklist from the four plan files. Group by subsystem: catalog hierarchy, variants/SKUs, forecasting, pricing, stock/warehouse integration, supplier/brand workflows, schema/migrations, AI/help/context hooks.
+2. For each checklist item, search code by the exact names in the plan and by likely current names. Follow usages to the SwiftUI call site or service method, not just a declaration.
+3. For possible coded-but-not-planned items, scan the Parts UI directory and `PartsService.swift` public methods/properties. Check each surprising capability against the plan-family index before flagging it.
+4. Cite every finding with at least one plan `file:line` and one code `file:line` or `missing target path` note.
+5. Keep the report actionable: prefer one consolidated finding for a repeated root cause instead of one finding per file.
+
+## Output format
+
+Return Markdown with this exact structure:
+
+```markdown
+# Parts C1b Drift Report
+
+## Summary
+- Verdict: PASS | DRIFT FOUND | NEEDS OWNER DECISION
+- Plan files checked: ...
+- Code targets checked: ...
+
+## planned_but_not_coded
+- [severity: critical|high|medium|low] Finding title
+  - Plan: `path:line` — requirement
+  - Code: `path:line` or `missing target path` — evidence
+  - Impact:
+  - Recommended action:
+
+## coded_but_not_planned
+- [severity: critical|high|medium|low] Finding title
+  - Plan: `path:line` or `no matching plan entry found after checking ...`
+  - Code: `path:line` — evidence
+  - Impact:
+  - Recommended action:
+
+## stale_tracker_or_plan_status
+- Finding title
+  - Stale doc: `path:line` — stale status
+  - Current evidence: `path:line` — current state
+  - Recommended action:
+
+## Non-findings / deferred items checked
+- `path:line` — why this is not drift today
+```
+
+If there are no entries in a section, write `None found.`
+
+## Quality bar
+
+- Every non-empty finding must have citations.
+- If evidence is ambiguous, put it under `NEEDS OWNER DECISION` rather than guessing.
+- Do not paste large code blocks; cite paths and lines.
+- Treat GitHub issue #256 as the tracker for this subagent itself, not as evidence about the current Parts implementation.

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ Thumbs.db
 
 # Claude
 .claude/
+!.claude/
+!.claude/agents/
+!.claude/agents/parts-drift-detector.md
 
 # Paperclip runtime state
 .paperclip/

--- a/docs/automation-recommendations.md
+++ b/docs/automation-recommendations.md
@@ -814,7 +814,7 @@ Running total: **23 confirmed gaps / 2 areas** (parts 15 + jobs 8). Scanner prio
 
 **Where:** Agent tool with `subagent_type: feature-dev:code-explorer` (or a custom `.claude/agents/parts-drift-detector.md`)
 
-**Decision:** Add to plan — worth building after PE-COLORS Phase 2 is underway so the drift surface is active.
+**Decision:** Built 2026-07-03 for GitHub #256 after PE-COLORS Phase 2 completed. The project-scoped agent lives at `.claude/agents/parts-drift-detector.md` and has a static guard at `tests/static/test_parts_drift_detector_agent.py` so future edits keep the C1b inputs, output schema, and citation requirements intact.
 
 ---
 
@@ -825,7 +825,7 @@ Running total: **23 confirmed gaps / 2 areas** (parts 15 + jobs 8). Scanner prio
 | PartsService SQL column validator hook | Hook | High | APPROVED 2026-04-18 | ✅ BUILT (iter 8, commit pending) |
 | `parts-sql-schema-checker` skill | Skill | High | APPROVED (already built) | ✅ BUILT (pre-existing skill, #254 closed) |
 | `parts-xcode-phase2-generator` | Skill | Low | REJECTED 2026-04-18 | ❌ Removed — duplicates xcode-planner-and-review |
-| `parts-drift-detector` subagent | Subagent | Medium | DEFERRED 2026-04-18 | ⏸ Revisit when PE-COLORS Phase 2 code starts landing (#256) |
+| `parts-drift-detector` subagent | Subagent | Medium | BUILT 2026-07-03 | ✅ Project agent at `.claude/agents/parts-drift-detector.md`; static guard `tests/static/test_parts_drift_detector_agent.py`; closes #256 |
 
 **Want more?** Run `/claude-automation-recommender` scoped to a different area or category.
 

--- a/docs/dev-qa.md
+++ b/docs/dev-qa.md
@@ -146,6 +146,7 @@ _None. All clusters have been answered — see Answered Clusters below and Proce
 
 4. **[Subagent] parts-drift-detector** — An Agent-tool subagent that reads parts plans and outputs "planned-but-not-coded" and "coded-but-not-planned" items with file:line citations, to speed up C1b plan-vs-code drift checks from ~10 min to ~2 min. Priority: **medium**. Best timing: after PE-COLORS Phase 2 begins so the drift surface is active. Tracked as open GitHub issue [#256](https://github.com/xXKillerNoobYT/Weird-Part-Run-2/issues/256).
    > **Answer (2026-04-18):** **DEFER — build when PE-COLORS Phase 2 begins.** Matches the recommendation's own timing guidance. Drift detection is only valuable once there's actively-drifting code to detect. Leave #256 open; revisit when Phase 2 code starts landing.
+   > **✅ BUILT 2026-07-03.** Project-scoped agent added at `.claude/agents/parts-drift-detector.md`. Static guard added at `tests/static/test_parts_drift_detector_agent.py` to require the four Parts plan inputs, Parts UI/service/model/schema targets, structured drift output sections, and file:line citation rules. Closes #256.
 
 ---
 

--- a/tests/static/test_parts_drift_detector_agent.py
+++ b/tests/static/test_parts_drift_detector_agent.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Static guard for the project-scoped parts-drift-detector agent.
+
+Run from the repo root with:
+    python3 tests/static/test_parts_drift_detector_agent.py
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT = REPO_ROOT / ".claude/agents/parts-drift-detector.md"
+
+
+class PartsDriftDetectorAgentTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.agent_text = AGENT.read_text(encoding="utf-8") if AGENT.exists() else ""
+
+    def test_agent_definition_exists_with_claude_frontmatter(self):
+        self.assertTrue(AGENT.exists())
+        self.assertTrue(self.agent_text.startswith("---\n"))
+        self.assertIn("name: parts-drift-detector", self.agent_text)
+        self.assertIn("tools: Read, Grep, Glob", self.agent_text)
+
+    def test_agent_covers_required_plan_inputs_and_code_targets(self):
+        required_paths = [
+            "docs/plans/parts-section-audit-fix-plan.md",
+            "docs/plans/colors-parts-redesign.md",
+            "docs/plans/forecasting-page-redesign.md",
+            "docs/plans/inventory-intelligence-system.md",
+            "Weird Parts IOS/Weird Parts IOS/Features/Parts/",
+            "core/Sources/WiredPartCore/Services/PartsService.swift",
+            "core/Sources/WiredPartCore/Models/Parts/",
+            "core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift",
+        ]
+        missing = [path for path in required_paths if path not in self.agent_text]
+        self.assertEqual([], missing)
+
+    def test_agent_requires_structured_drift_output_sections(self):
+        required_sections = [
+            "## Summary",
+            "## planned_but_not_coded",
+            "## coded_but_not_planned",
+            "## stale_tracker_or_plan_status",
+            "## Non-findings / deferred items checked",
+        ]
+        missing = [section for section in required_sections if section not in self.agent_text]
+        self.assertEqual([], missing)
+
+    def test_agent_requires_file_line_citations_for_findings(self):
+        citation_rules = [
+            "Every non-empty finding must have citations.",
+            "at least one plan `file:line` and one code `file:line`",
+            "Do not paste large code blocks; cite paths and lines.",
+        ]
+        missing = [rule for rule in citation_rules if rule not in self.agent_text]
+        self.assertEqual([], missing)
+
+    def test_agent_defines_both_drift_directions_and_status_staleness(self):
+        expected_terms = [
+            "planned_but_not_coded",
+            "coded_but_not_planned",
+            "stale_tracker_or_plan_status",
+            "NEEDS OWNER DECISION",
+        ]
+        missing = [term for term in expected_terms if term not in self.agent_text]
+        self.assertEqual([], missing)
+        self.assertRegex(
+            self.agent_text,
+            re.compile(r"Report `planned_but_not_coded` when.*absent", re.DOTALL),
+        )
+        self.assertRegex(
+            self.agent_text,
+            re.compile(r"Report `coded_but_not_planned` when.*not documented", re.DOTALL),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Adds the project-scoped `.claude/agents/parts-drift-detector.md` agent for the Parts C1b plan-vs-code drift check.
- Adds a static guard that preserves required plan inputs, code targets, output sections, and file:line citation rules.
- Refreshes automation/dev-QA docs from deferred to built.

Closes #256

## Verification
- `python3 tests/static/test_parts_drift_detector_agent.py`
- `python3 -m unittest discover -s tests/static -p 'test_*.py'`\n