### PR TITLE
fix(beta): address bug reporter review follow-ups

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Shared/BugReportErrorLog.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/BugReportErrorLog.swift
@@ -36,13 +36,16 @@ final class BugReportErrorLog: ObservableObject {
         guard let message else { return }
         let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        let normalizedContext = context?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let storedContext = normalizedContext?.isEmpty == true ? nil : normalizedContext
 
-        if let last = entries.first, last.message == trimmed, last.context == context {
+        if let last = entries.first, last.message == trimmed, last.context == storedContext {
             return
         }
 
         entries.insert(
-            Entry(message: trimmed, context: context, timestamp: Date()),
+            Entry(message: trimmed, context: storedContext, timestamp: Date()),
             at: 0
         )
         if entries.count > Self.capacity {

--- a/core/Sources/WiredPartCore/BugReportComposer.swift
+++ b/core/Sources/WiredPartCore/BugReportComposer.swift
@@ -187,8 +187,6 @@ public enum BugReportComposer {
         guard let timestamp = entry.timestamp else {
             return message
         }
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        return "\(formatter.string(from: timestamp)) — \(message)"
+        return "\(CoreFormatters.iso8601.string(from: timestamp)) — \(message)"
     }
 }


### PR DESCRIPTION
Follow-up to merged PR #1382 / GH #574.

What changed:
- Normalize BugReportErrorLog.record context the same way as messages so whitespace-only contexts do not render as empty parentheses and duplicate contexts dedupe correctly.
- Reuse CoreFormatters.iso8601 in BugReportComposer instead of allocating a formatter per recent error.

Verification:
- cd core && swift test --filter BugReportComposerTests — 16 tests, 0 failures.
- Parsed touched app/core Swift files with xcrun swiftc -parse against the iPhone simulator SDK.
