### PR TITLE
docs(build): finalize stale macOS scheme cleanup

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -152,7 +152,7 @@ These live outside the feature folders (`Scanning/`, `Sync/`, `Auth/`, `AI/`) an
 ## 5) What WiredPart Does NOT Do (Current Scope)
 
 - No cloud backend, cloud accounts, or internet sync — sync is between nearby company devices only.
-- iOS only (an experimental macOS scheme exists in the workspace, but Apple platforms are the only target).
+- iOS-first: Mac compatibility is via the iOS app target when Xcode exposes a Mac Catalyst destination; no standalone macOS scheme is shipped.
 - No third-party analytics or tracking; all data stays on company devices.
 
 See [BETA-TESTER-GUIDE.md](BETA-TESTER-GUIDE.md) for beta-specific known limitations.


### PR DESCRIPTION
## Summary
- final docs alignment after the stale `WiredPart-macOS` scheme removal landed on `main`
- update `docs/FEATURES.md` so scope says Mac compatibility is via the iOS app target / Mac Catalyst, not a standalone macOS scheme

Closes #1386

## Verification
- `git diff --check`
- `python3 scripts/guard-tracked-artifacts.py`
- `xcodebuild -list -workspace "Weird Parts.xcworkspace"`
- `git grep -n -E 'WiredPart-macOS|group:mac|group:ios-app|container:mac|container:ios-app' -- . ':!docs/testing/wei-1985-apple-ecosystem-ux-audit-scope-matrix.md' ':!docs/testing/wei-3091-stage-9-beta-smoke-package.md'` returned no stale workspace/scheme references outside historical docs
- `xcodebuild -workspace "Weird Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'generic/platform=iOS Simulator' -derivedDataPath .tmp/DerivedData-gh1386-20260703000821 build` → `** BUILD SUCCEEDED **` (only pre-existing `updateDispatchPreferences` unused-result warnings)
- `xcodebuild -workspace "Weird Parts.xcworkspace" -scheme "WiredPart-macOS" -showdestinations` now fails with `workspace ... does not contain a scheme named "WiredPart-macOS"`, confirming the broken scheme is gone

Local runner path: verified locally with Xcode on the Mac/self-hosted-runner class environment required for iOS/macOS build work.
