### PR TITLE
fix(jobs): add geofence alert escape

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/GeofenceAlertView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/GeofenceAlertView.swift
@@ -200,11 +200,23 @@ struct GeofenceAlertView: View {
                     .padding(.bottom, 32)
                 }
             }
-            .interactiveDismissDisabled(true)
+            .interactiveDismissDisabled(isProcessing)
             .navigationTitle("Location Alert")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Not Now") {
+                        dismissAlertWithoutServiceCall()
+                    }
+                    .disabled(isProcessing)
+                    .accessibilityHint("Dismisses this location alert without changing your clock entry")
+                }
+            }
             .alert("Error", isPresented: $showError) {
                 Button("OK", role: .cancel) { }
+                Button("Not Now") {
+                    dismissAlertWithoutServiceCall()
+                }
             } message: {
                 Text(errorMessage ?? "An unknown error occurred.")
             }
@@ -312,6 +324,13 @@ struct GeofenceAlertView: View {
             showError = true
             isProcessing = false
         }
+    }
+
+    @MainActor
+    private func dismissAlertWithoutServiceCall() {
+        geofenceManager.acknowledgeExit()
+        isProcessing = false
+        onResolved()
     }
 
     // MARK: - Load Jobs

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
@@ -230,13 +230,20 @@ struct IOSClockPage: View {
                 breakTimer?.invalidate(); breakTimer = nil
                 NotificationCenter.default.post(name: .clockPageInactive, object: nil)
             }
-            .fullScreenCover(isPresented: $geofenceManager.didExitJobRegion) {
+            .fullScreenCover(
+                isPresented: $geofenceManager.didExitJobRegion,
+                onDismiss: {
+                    if geofenceManager.exitTime != nil || geofenceManager.exitLocation != nil {
+                        geofenceManager.acknowledgeExit()
+                        loadData()
+                    }
+                }
+            ) {
                 GeofenceAlertView(
                     geofenceManager: geofenceManager,
                     onResolved: { loadData() }
                 )
                 .environmentObject(appCore)
-                .interactiveDismissDisabled(true)
             }
             .sheet(item: $activeSheet) { sheet in
                 switch sheet {

--- a/Weird Parts IOS/Weird Parts IOSTests/GeofenceAlertViewRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/GeofenceAlertViewRegressionTests.swift
@@ -49,6 +49,28 @@ final class GeofenceAlertViewRegressionTests: XCTestCase {
         )
     }
 
+    func testGeofenceAlertHasServiceIndependentDismissEscape() throws {
+        let source = try Self.readGeofenceAlertSource()
+        let clockPageSource = try Self.readClockPageSource()
+
+        XCTAssertTrue(source.contains("Button(\"Not Now\")"))
+        XCTAssertTrue(source.contains("dismissAlertWithoutServiceCall()"))
+        XCTAssertTrue(source.contains("@MainActor\n    private func dismissAlertWithoutServiceCall()"))
+        XCTAssertTrue(source.contains("geofenceManager.acknowledgeExit()"))
+        XCTAssertTrue(source.contains(".interactiveDismissDisabled(isProcessing)"))
+        XCTAssertTrue(clockPageSource.contains("onDismiss: {"))
+        XCTAssertTrue(clockPageSource.contains("if geofenceManager.exitTime != nil || geofenceManager.exitLocation != nil"))
+        XCTAssertTrue(clockPageSource.contains("geofenceManager.acknowledgeExit()"))
+        XCTAssertFalse(
+            source.contains(".interactiveDismissDisabled(true)"),
+            "The geofence alert must not hard-disable every dismissal path while idle."
+        )
+        XCTAssertFalse(
+            clockPageSource.contains(".interactiveDismissDisabled(true)"),
+            "IOSClockPage must not re-disable the geofence full-screen cover after the alert view enables an idle escape path."
+        )
+    }
+
     private static func readGeofenceAlertSource(file: StaticString = #filePath) throws -> String {
         let testFileURL = URL(fileURLWithPath: "\(file)")
         let projectRoot = testFileURL
@@ -58,6 +80,19 @@ final class GeofenceAlertViewRegressionTests: XCTestCase {
             .appendingPathComponent("Weird Parts IOS")
             .appendingPathComponent("App")
             .appendingPathComponent("GeofenceAlertView.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    private static func readClockPageSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Jobs")
+            .appendingPathComponent("IOSClockPage.swift")
         return try String(contentsOf: sourceURL, encoding: .utf8)
     }
 }


### PR DESCRIPTION
## Summary
- Add a visible Not Now escape to the geofence full-screen alert that acknowledges locally without requiring JobsService/currentUser.
- Keep interactive dismissal disabled only while processing instead of hard-disabled forever.
- Remove the Clock page cover-level hard dismissal block and add regression coverage.

Closes #1388

## Verification
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -only-testing:"Weird Parts IOSTests/GeofenceAlertViewRegressionTests"` — passed (3 tests).
- `xcodebuild build -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=macOS,variant=Mac Catalyst'` — passed with one pre-existing warning in `IOSDispatchPreferencesPage.swift`.
