### PR TITLE
Fix geofence alert escape

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/GeofenceAlertView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/GeofenceAlertView.swift
@@ -200,11 +200,23 @@ struct GeofenceAlertView: View {
                     .padding(.bottom, 32)
                 }
             }
-            .interactiveDismissDisabled(true)
+            .interactiveDismissDisabled(isProcessing)
             .navigationTitle("Location Alert")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Not Now") {
+                        dismissWithoutServiceCall()
+                    }
+                    .disabled(isProcessing)
+                    .accessibilityHint("Dismisses the location alert without calling job services")
+                }
+            }
             .alert("Error", isPresented: $showError) {
                 Button("OK", role: .cancel) { }
+                Button("Dismiss Alert", role: .destructive) {
+                    dismissWithoutServiceCall()
+                }
             } message: {
                 Text(errorMessage ?? "An unknown error occurred.")
             }
@@ -312,6 +324,13 @@ struct GeofenceAlertView: View {
             showError = true
             isProcessing = false
         }
+    }
+
+    @MainActor
+    private func dismissWithoutServiceCall() {
+        geofenceManager.acknowledgeExit()
+        isProcessing = false
+        onResolved()
     }
 
     // MARK: - Load Jobs

--- a/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Jobs/IOSClockPage.swift
@@ -236,7 +236,6 @@ struct IOSClockPage: View {
                     onResolved: { loadData() }
                 )
                 .environmentObject(appCore)
-                .interactiveDismissDisabled(true)
             }
             .sheet(item: $activeSheet) { sheet in
                 switch sheet {

--- a/Weird Parts IOS/Weird Parts IOSTests/GeofenceAlertViewRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/GeofenceAlertViewRegressionTests.swift
@@ -49,6 +49,33 @@ final class GeofenceAlertViewRegressionTests: XCTestCase {
         )
     }
 
+    func testGeofenceAlertHasManualDismissPathThatDoesNotCallJobServices() throws {
+        let source = try Self.readGeofenceAlertSource()
+        let clockPageSource = try Self.readClockPageSource()
+
+        XCTAssertTrue(source.contains("Button(\"Not Now\")"))
+        XCTAssertTrue(source.contains("Button(\"Dismiss Alert\", role: .destructive)"))
+        XCTAssertTrue(source.contains("private func dismissWithoutServiceCall()"))
+        XCTAssertTrue(source.contains("geofenceManager.acknowledgeExit()"))
+        XCTAssertTrue(source.contains("onResolved()"))
+        XCTAssertTrue(source.contains(".interactiveDismissDisabled(isProcessing)"))
+        XCTAssertFalse(
+            clockPageSource.contains(".interactiveDismissDisabled(true)"),
+            "The full-screen geofence alert must not be hard-locked by the presenting Clock page."
+        )
+
+        let dismissFunction = try XCTUnwrap(source.range(of: "private func dismissWithoutServiceCall()"))
+        let dismissBody = source[dismissFunction.lowerBound..<source.endIndex]
+        let dismissEnd = try XCTUnwrap(dismissBody.range(of: "// MARK: - Load Jobs"))
+        let manualDismissSource = String(dismissBody[..<dismissEnd.lowerBound])
+
+        XCTAssertFalse(manualDismissSource.contains("appCore.jobsService"))
+        XCTAssertFalse(manualDismissSource.contains("getActiveClockEntry"))
+        XCTAssertFalse(manualDismissSource.contains("clockOut"))
+        XCTAssertFalse(manualDismissSource.contains("switchClockedInJob"))
+        XCTAssertFalse(manualDismissSource.contains("toggleSupplyRun"))
+    }
+
     private static func readGeofenceAlertSource(file: StaticString = #filePath) throws -> String {
         let testFileURL = URL(fileURLWithPath: "\(file)")
         let projectRoot = testFileURL
@@ -58,6 +85,19 @@ final class GeofenceAlertViewRegressionTests: XCTestCase {
             .appendingPathComponent("Weird Parts IOS")
             .appendingPathComponent("App")
             .appendingPathComponent("GeofenceAlertView.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    private static func readClockPageSource(file: StaticString = #filePath) throws -> String {
+        let testFileURL = URL(fileURLWithPath: "\(file)")
+        let projectRoot = testFileURL
+            .deletingLastPathComponent() // Weird Parts IOSTests
+            .deletingLastPathComponent() // Weird Parts IOS
+        let sourceURL = projectRoot
+            .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Features")
+            .appendingPathComponent("Jobs")
+            .appendingPathComponent("IOSClockPage.swift")
         return try String(contentsOf: sourceURL, encoding: .utf8)
     }
 }


### PR DESCRIPTION
## Summary
- add a visible Not Now escape to the geofence alert that acknowledges locally without calling job services
- let the alert control interactive dismissal instead of the presenting Clock page hard-locking it
- add regression coverage that the manual dismiss path does not touch job services

Closes #1388

## Verification
- xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:"Weird Parts IOSTests/GeofenceAlertViewRegressionTests"