### PR TITLE
fix(warehouse): add onboarding cancel exit

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseOnboardingWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseOnboardingWizard.swift
@@ -147,6 +147,10 @@ struct WarehouseOnboardingWizard: View {
             .interactiveDismissDisabled(isSaving)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
                     Button("Save & Exit") { saveAndExit() }
                         .disabled(isSaving)
                 }

--- a/Weird Parts IOS/Weird Parts IOSTests/BetaDeadEndControlsRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/BetaDeadEndControlsRegressionTests.swift
@@ -209,6 +209,21 @@ final class BetaDeadEndControlsRegressionTests: XCTestCase {
         )
     }
 
+    // MARK: - #1389: Warehouse onboarding must have an unconditional exit
+
+    func testWarehouseOnboardingProvidesCancelSeparateFromSaveAndExit() throws {
+        let source = try Self.readSource("Features/Warehouse/WarehouseOnboardingWizard.swift")
+
+        XCTAssertTrue(
+            source.contains("ToolbarItem(placement: .cancellationAction)") && source.contains("Button(\"Cancel\") { dismiss() }"),
+            "Warehouse onboarding must expose a plain Cancel action that dismisses directly, even before a progress row exists."
+        )
+        XCTAssertTrue(
+            source.contains("ToolbarItem(placement: .confirmationAction)") && source.contains("Button(\"Save & Exit\") { saveAndExit() }"),
+            "Save & Exit should remain available as the save path, but it must not be the wizard's only exit."
+        )
+    }
+
     // MARK: - Helper
 
     private static func readSource(_ relativePath: String, file: StaticString = #filePath) throws -> String {


### PR DESCRIPTION
Closes #1389.

## Summary
- Add a direct Cancel toolbar action to WarehouseOnboardingWizard so fresh Step 1 sessions can dismiss without requiring a progress row.
- Keep Save & Exit as the explicit save path in the confirmation toolbar slot.
- Add a regression source-scan test locking the separate Cancel and Save & Exit controls.

## Verification
- xcodebuild test -project "Weird Parts.xcodeproj" -scheme "Weird Parts" -destination id=AF194B12-E749-4469-9E3D-F70E7D7B5CEA -only-testing:"Weird Parts IOSTests/BetaDeadEndControlsRegressionTests/testWarehouseOnboardingProvidesCancelSeparateFromSaveAndExit"

Local runner path: verified on local iOS simulator via the self-hosted Mac/Xcode environment.