### PR TITLE
fix(ui): add wizard escape controls

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingBulkEditSheet.swift
@@ -311,6 +311,23 @@ struct PricingBulkEditSheet: View {
                 }
             }
             .navigationTitle("Review")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        reviewIndex = nil
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "chevron.left")
+                            Text("Back")
+                        }
+                    }
+                    .disabled(isSaving)
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+            }
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingOverrideFlow.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Parts/PricingOverrideFlow.swift
@@ -490,6 +490,19 @@ struct PricingTierSetSheet: View {
                     }
                 }
             }
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        step = .preview
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "chevron.left")
+                            Text("Back")
+                        }
+                    }
+                    .disabled(isSaving)
+                }
+            }
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/PartsFlowWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/PartsFlowWizard.swift
@@ -114,6 +114,10 @@ struct PartsFlowWizard: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
                     Button("Save & Exit") {
                         saveAllProgress(clearDraft: false, andDismiss: true)
                     }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseOnboardingWizard.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/WarehouseOnboardingWizard.swift
@@ -147,6 +147,10 @@ struct WarehouseOnboardingWizard: View {
             .interactiveDismissDisabled(isSaving)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
                     Button("Save & Exit") { saveAndExit() }
                         .disabled(isSaving)
                 }

--- a/Weird Parts IOS/Weird Parts IOSTests/SheetLifecycleRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SheetLifecycleRegressionTests.swift
@@ -119,7 +119,7 @@ final class SheetLifecycleRegressionTests: XCTestCase {
         let review = try Self.methodBody(named: "reviewOneAtATime", in: source)
 
         XCTAssertTrue(
-            review.contains("Button {\n                        reviewIndex = nil"),
+            review.contains("reviewIndex = nil") && review.contains("Label(\"Back\", systemImage: \"chevron.left\")"),
             "Pricing bulk edit's one-at-a-time review step needs an explicit Back path to the preview step."
         )
         XCTAssertTrue(
@@ -133,7 +133,7 @@ final class SheetLifecycleRegressionTests: XCTestCase {
         let resolveConflicts = try Self.braceBalancedBody(after: "private var resolveConflictsView", in: source)
 
         XCTAssertTrue(
-            resolveConflicts.contains("Button {\n                        step = .preview"),
+            resolveConflicts.contains("step = .preview") && resolveConflicts.contains("Label(\"Back\", systemImage: \"chevron.left\")"),
             "Pricing override conflict resolution needs an explicit Back path to the preview step."
         )
         XCTAssertTrue(

--- a/Weird Parts IOS/Weird Parts IOSTests/SheetLifecycleRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SheetLifecycleRegressionTests.swift
@@ -156,31 +156,8 @@ final class SheetLifecycleRegressionTests: XCTestCase {
         return String(source[start.lowerBound..<end.lowerBound])
     }
 
-    /// Extracts the brace-balanced body that follows the first occurrence of
-    /// `anchor` (a `func name(` head, a button label, etc.), so assertions
-    /// stay scoped to the code under test.
     private static func braceBalancedBody(after anchor: String, in source: String) throws -> String {
-        guard let anchorRange = source.range(of: anchor) else {
-            throw XCTSkip("Expected anchor \(anchor) in source")
-        }
-        guard let openBrace = source[anchorRange.upperBound...].firstIndex(of: "{") else {
-            throw XCTSkip("Expected opening brace after \(anchor)")
-        }
-
-        var depth = 0
-        var index = openBrace
-        while index < source.endIndex {
-            let char = source[index]
-            if char == "{" { depth += 1 }
-            if char == "}" { depth -= 1 }
-            let next = source.index(after: index)
-            if depth == 0 {
-                return String(source[openBrace..<next])
-            }
-            index = next
-        }
-
-        throw XCTSkip("Expected closing brace for \(anchor)")
+        try TestSourceSlicer.braceBalancedBody(after: anchor, in: source)
     }
 
     private static func methodBody(named methodName: String, in source: String) throws -> String {

--- a/Weird Parts IOS/Weird Parts IOSTests/SheetLifecycleRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SheetLifecycleRegressionTests.swift
@@ -106,13 +106,43 @@ final class SheetLifecycleRegressionTests: XCTestCase {
             return
         }
         XCTAssertLessThan(
-            dismissRange.lowerBound, completeRange.lowerBound,
+            dismissRange.lowerBound,
+            completeRange.lowerBound,
             "The completion Done button must not defer dismissal behind the parent refresh (issue #736)."
         )
     }
 
-    // MARK: - Helpers
+    // MARK: - Issues #1391 / #1392
 
+    func testPricingBulkEditReviewStepHasExplicitBackAndCancelControls() throws {
+        let source = try Self.readFeatureSource(["Parts", "PricingBulkEditSheet.swift"])
+        let review = try Self.methodBody(named: "reviewOneAtATime", in: source)
+
+        XCTAssertTrue(
+            review.contains("Button {\n                        reviewIndex = nil"),
+            "Pricing bulk edit's one-at-a-time review step needs an explicit Back path to the preview step."
+        )
+        XCTAssertTrue(
+            review.contains("Button(\"Cancel\") { dismiss() }"),
+            "Pricing bulk edit's one-at-a-time review step needs an explicit Cancel path; swipe-only is unavailable on Mac Catalyst."
+        )
+    }
+
+    func testPricingOverrideConflictResolutionHasExplicitBackControl() throws {
+        let source = try Self.readFeatureSource(["Parts", "PricingOverrideFlow.swift"])
+        let resolveConflicts = try Self.braceBalancedBody(after: "private var resolveConflictsView", in: source)
+
+        XCTAssertTrue(
+            resolveConflicts.contains("Button {\n                        step = .preview"),
+            "Pricing override conflict resolution needs an explicit Back path to the preview step."
+        )
+        XCTAssertTrue(
+            source.contains("Button(\"Cancel\") { dismiss() }"),
+            "Pricing override flow must retain the explicit global Cancel path."
+        )
+    }
+
+    // MARK: - Helpers
     /// Slice of `IOSToolDetailPage.swift` covering only `ToolTradeSheet`, so
     /// assertions can't be satisfied by the sibling sheets in the same file.
     private static func toolTradeSheetSource() throws -> String {

--- a/Weird Parts IOS/Weird Parts IOSTests/SheetLifecycleRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SheetLifecycleRegressionTests.swift
@@ -119,7 +119,7 @@ final class SheetLifecycleRegressionTests: XCTestCase {
         let review = try Self.methodBody(named: "reviewOneAtATime", in: source)
 
         XCTAssertTrue(
-            review.contains("reviewIndex = nil") && review.contains("Label(\"Back\", systemImage: \"chevron.left\")"),
+            review.contains("reviewIndex = nil") && review.contains("Image(systemName: \"chevron.left\")") && review.contains("Text(\"Back\")"),
             "Pricing bulk edit's one-at-a-time review step needs an explicit Back path to the preview step."
         )
         XCTAssertTrue(
@@ -133,7 +133,7 @@ final class SheetLifecycleRegressionTests: XCTestCase {
         let resolveConflicts = try Self.braceBalancedBody(after: "private var resolveConflictsView", in: source)
 
         XCTAssertTrue(
-            resolveConflicts.contains("step = .preview") && resolveConflicts.contains("Label(\"Back\", systemImage: \"chevron.left\")"),
+            resolveConflicts.contains("step = .preview") && resolveConflicts.contains("Image(systemName: \"chevron.left\")") && resolveConflicts.contains("Text(\"Back\")"),
             "Pricing override conflict resolution needs an explicit Back path to the preview step."
         )
         XCTAssertTrue(

--- a/Weird Parts IOS/Weird Parts IOSTests/SheetLifecycleRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SheetLifecycleRegressionTests.swift
@@ -119,25 +119,30 @@ final class SheetLifecycleRegressionTests: XCTestCase {
         let review = try Self.methodBody(named: "reviewOneAtATime", in: source)
 
         XCTAssertTrue(
-            review.contains("reviewIndex = nil") && review.contains("Image(systemName: \"chevron.left\")") && review.contains("Text(\"Back\")"),
+            review.contains("reviewIndex = nil")
+                && review.contains("Image(systemName: \"chevron.left\")")
+                && review.contains("Text(\"Back\")"),
             "Pricing bulk edit's one-at-a-time review step needs an explicit Back path to the preview step."
         )
         XCTAssertTrue(
-            review.contains("Button(\"Cancel\") { dismiss() }"),
+            review.contains("Button(\"Cancel\")") && review.contains("dismiss()"),
             "Pricing bulk edit's one-at-a-time review step needs an explicit Cancel path; swipe-only is unavailable on Mac Catalyst."
         )
     }
 
     func testPricingOverrideConflictResolutionHasExplicitBackControl() throws {
         let source = try Self.readFeatureSource(["Parts", "PricingOverrideFlow.swift"])
+        let body = try Self.braceBalancedBody(after: "var body: some View", in: source)
         let resolveConflicts = try Self.braceBalancedBody(after: "private var resolveConflictsView", in: source)
 
         XCTAssertTrue(
-            resolveConflicts.contains("step = .preview") && resolveConflicts.contains("Image(systemName: \"chevron.left\")") && resolveConflicts.contains("Text(\"Back\")"),
+            resolveConflicts.contains("step = .preview")
+                && resolveConflicts.contains("Image(systemName: \"chevron.left\")")
+                && resolveConflicts.contains("Text(\"Back\")"),
             "Pricing override conflict resolution needs an explicit Back path to the preview step."
         )
         XCTAssertTrue(
-            source.contains("Button(\"Cancel\") { dismiss() }"),
+            body.contains("Button(\"Cancel\")") && body.contains("dismiss()"),
             "Pricing override flow must retain the explicit global Cancel path."
         )
     }

--- a/Weird Parts IOS/Weird Parts IOSTests/TestSourceSlicer.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/TestSourceSlicer.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+enum TestSourceSlicer {
+    /// Extracts the brace-balanced body that follows the first occurrence of
+    /// `anchor`, so source-scan assertions stay scoped to the code under test.
+    static func braceBalancedBody(after anchor: String, in source: String) throws -> String {
+        guard let anchorRange = source.range(of: anchor) else {
+            throw XCTSkip("Expected anchor \(anchor) in source")
+        }
+        guard let openBrace = source[anchorRange.upperBound...].firstIndex(of: "{") else {
+            throw XCTSkip("Expected opening brace after \(anchor)")
+        }
+
+        var depth = 0
+        var index = openBrace
+        while index < source.endIndex {
+            let char = source[index]
+            if char == "{" { depth += 1 }
+            if char == "}" { depth -= 1 }
+            let next = source.index(after: index)
+            if depth == 0 {
+                return String(source[openBrace..<next])
+            }
+            index = next
+        }
+
+        throw XCTSkip("Expected closing brace for \(anchor)")
+    }
+}

--- a/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
@@ -114,6 +114,25 @@ final class WarehouseWizardProgressAccessibilityTests: XCTestCase {
         )
     }
 
+    func testPartsFlowWizardProvidesUnconditionalCancelSeparateFromSaveAndExit() throws {
+        let source = try Self.readWarehouseSource("PartsFlowWizard.swift")
+        let toolbar = try Self.braceBalancedBody(after: ".toolbar", in: source)
+
+        XCTAssertTrue(
+            toolbar.contains("Button(\"Cancel\") { dismiss() }"),
+            "Parts-flow setup needs an unconditional Cancel path that does not validate or save before dismissing."
+        )
+        XCTAssertTrue(
+            toolbar.contains("Button(\"Save & Exit\")"),
+            "Parts-flow setup should keep Save & Exit as the explicit validating save path."
+        )
+        XCTAssertLessThan(
+            toolbar.range(of: "Button(\"Cancel\")")?.lowerBound ?? toolbar.endIndex,
+            toolbar.range(of: "Button(\"Save & Exit\")")?.lowerBound ?? toolbar.startIndex,
+            "Cancel should be the leading cancellation action, separate from Save & Exit."
+        )
+    }
+
     func testWarehouseOnboardingWizardUsesSharedAccessibleProgressStepControl() throws {
         let source = try Self.readWarehouseSource("WarehouseOnboardingWizard.swift")
         let progressSection = try Self.progressBarSection(in: source)
@@ -125,6 +144,25 @@ final class WarehouseWizardProgressAccessibilityTests: XCTestCase {
         XCTAssertFalse(
             progressSection.contains(".onTapGesture"),
             "Warehouse onboarding progress dots must not rely on gesture-only Circle tap handlers."
+        )
+    }
+
+    func testWarehouseOnboardingWizardProvidesUnconditionalCancelSeparateFromSaveAndExit() throws {
+        let source = try Self.readWarehouseSource("WarehouseOnboardingWizard.swift")
+        let toolbar = try Self.braceBalancedBody(after: ".toolbar", in: source)
+
+        XCTAssertTrue(
+            toolbar.contains("Button(\"Cancel\") { dismiss() }"),
+            "Warehouse onboarding needs an unconditional Cancel path for fresh Step 1 sessions without a progress row."
+        )
+        XCTAssertTrue(
+            toolbar.contains("Button(\"Save & Exit\") { saveAndExit() }"),
+            "Warehouse onboarding should keep Save & Exit as the explicit save path."
+        )
+        XCTAssertLessThan(
+            toolbar.range(of: "Button(\"Cancel\")")?.lowerBound ?? toolbar.endIndex,
+            toolbar.range(of: "Button(\"Save & Exit\")")?.lowerBound ?? toolbar.startIndex,
+            "Cancel should be the leading cancellation action, separate from Save & Exit."
         )
     }
 
@@ -245,6 +283,32 @@ final class WarehouseWizardProgressAccessibilityTests: XCTestCase {
         let afterStart = source[start.lowerBound...]
         let end = afterStart.range(of: "]")?.upperBound ?? afterStart.endIndex
         return String(afterStart[..<end])
+    }
+
+    /// Extracts the brace-balanced body that follows the first occurrence of
+    /// `anchor`, so assertions stay scoped to the code under test.
+    private static func braceBalancedBody(after anchor: String, in source: String) throws -> String {
+        guard let anchorRange = source.range(of: anchor) else {
+            throw XCTSkip("Expected anchor \(anchor) in source")
+        }
+        guard let openBrace = source[anchorRange.upperBound...].firstIndex(of: "{") else {
+            throw XCTSkip("Expected opening brace after \(anchor)")
+        }
+
+        var depth = 0
+        var index = openBrace
+        while index < source.endIndex {
+            let char = source[index]
+            if char == "{" { depth += 1 }
+            if char == "}" { depth -= 1 }
+            let next = source.index(after: index)
+            if depth == 0 {
+                return String(source[openBrace..<next])
+            }
+            index = next
+        }
+
+        throw XCTSkip("Expected closing brace for \(anchor)")
     }
 
     private static func readWarehouseSource(

--- a/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests.swift
@@ -285,30 +285,8 @@ final class WarehouseWizardProgressAccessibilityTests: XCTestCase {
         return String(afterStart[..<end])
     }
 
-    /// Extracts the brace-balanced body that follows the first occurrence of
-    /// `anchor`, so assertions stay scoped to the code under test.
     private static func braceBalancedBody(after anchor: String, in source: String) throws -> String {
-        guard let anchorRange = source.range(of: anchor) else {
-            throw XCTSkip("Expected anchor \(anchor) in source")
-        }
-        guard let openBrace = source[anchorRange.upperBound...].firstIndex(of: "{") else {
-            throw XCTSkip("Expected opening brace after \(anchor)")
-        }
-
-        var depth = 0
-        var index = openBrace
-        while index < source.endIndex {
-            let char = source[index]
-            if char == "{" { depth += 1 }
-            if char == "}" { depth -= 1 }
-            let next = source.index(after: index)
-            if depth == 0 {
-                return String(source[openBrace..<next])
-            }
-            index = next
-        }
-
-        throw XCTSkip("Expected closing brace for \(anchor)")
+        try TestSourceSlicer.braceBalancedBody(after: anchor, in: source)
     }
 
     private static func readWarehouseSource(


### PR DESCRIPTION
## Summary
- add unconditional Cancel controls beside Save & Exit in the warehouse onboarding and parts-flow wizards
- add explicit Back/Cancel controls to pricing bulk-edit one-at-a-time review
- add explicit Back control to pricing override conflict resolution while retaining global Cancel
- add source-level regression coverage for the Mac Catalyst no-swipe escape paths

Closes #1389
Closes #1390
Closes #1391
Closes #1392

## Verification
- `xcodebuild test -scheme "Weird Parts" -destination "platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5" -only-testing:"Weird Parts IOSTests/WarehouseWizardProgressAccessibilityTests" -only-testing:"Weird Parts IOSTests/SheetLifecycleRegressionTests"`

Local runner path: validated locally with Xcode/iOS simulator on this Mac; CI should route Xcode-required jobs to the self-hosted local Mac runner (`[self-hosted, macOS, ARM64, xcode, ios, local-mac]`).