### PR TITLE
test(jobs): loosen geofence alert assertion

### DIFF
--- a/Weird Parts IOS/Weird Parts IOSTests/GeofenceAlertViewRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/GeofenceAlertViewRegressionTests.swift
@@ -55,7 +55,12 @@ final class GeofenceAlertViewRegressionTests: XCTestCase {
 
         XCTAssertTrue(source.contains("Button(\"Not Now\")"))
         XCTAssertTrue(source.contains("dismissAlertWithoutServiceCall()"))
-        XCTAssertTrue(source.contains("@MainActor\n    private func dismissAlertWithoutServiceCall()"))
+        XCTAssertNotNil(
+            source.range(
+                of: #"@MainActor\s+private\s+func\s+dismissAlertWithoutServiceCall\s*\(\s*\)"#,
+                options: .regularExpression
+            )
+        )
         XCTAssertTrue(source.contains("geofenceManager.acknowledgeExit()"))
         XCTAssertTrue(source.contains(".interactiveDismissDisabled(isProcessing)"))
         XCTAssertTrue(clockPageSource.contains("onDismiss: {"))


### PR DESCRIPTION
## Summary
- Follow up on Copilot's PR #1400 review by making the geofence regression assertion formatting-tolerant.
- Use a whitespace-tolerant regex so the test still proves `@MainActor` is attached to `dismissAlertWithoutServiceCall()` without coupling to exact Xcode indentation/newlines.

Follow-up to #1400 / #1388.

## Verification
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -derivedDataPath /tmp/wpr2-gh1388-followup2-deriveddata -only-testing:"Weird Parts IOSTests/GeofenceAlertViewRegressionTests"` — passed (3 tests).
