### PR TITLE
fix(ai): add overlay bug report entry point

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
+++ b/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
@@ -194,17 +194,22 @@ struct IOSAIAssistantPanel: View {
                     }
                 }
                 .sheet(isPresented: $isBugReportPresented) {
-                    NavigationStack {
-                        ReportABugPage(originModule: activeModuleName)
-                            .toolbar {
-                                ToolbarItem(placement: .cancellationAction) {
-                                    Button("Close") { isBugReportPresented = false }
-                                }
-                            }
-                    }
-                    .presentationDetents([.large])
+                    bugReportSheet
                 }
         }
+    }
+
+    @ViewBuilder
+    private var bugReportSheet: some View {
+        NavigationStack {
+            ReportABugPage(originModule: activeModuleName)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Close") { isBugReportPresented = false }
+                    }
+                }
+        }
+        .presentationDetents([.large])
     }
 
     // MARK: - Overlay Mode
@@ -233,6 +238,9 @@ struct IOSAIAssistantPanel: View {
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .shadow(color: .black.opacity(0.15), radius: 12, y: 4)
         .padding(DeviceContext.isLargeScreen ? 12 : 0)
+        .sheet(isPresented: $isBugReportPresented) {
+            bugReportSheet
+        }
     }
 
     @ViewBuilder
@@ -279,6 +287,16 @@ struct IOSAIAssistantPanel: View {
             .buttonStyle(.plain)
             .disabled(messages.isEmpty || isClearingConversation)
             .accessibilityLabel("Clear conversation")
+
+            Button {
+                isBugReportPresented = true
+            } label: {
+                Image(systemName: "ladybug")
+                    .font(.caption)
+            }
+            .buttonStyle(.plain)
+            .help("Report a bug")
+            .accessibilityLabel("Report a bug")
 
             Button {
                 isVisible = false

--- a/Weird Parts IOS/Weird Parts IOSTests/InAppBugReportingRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/InAppBugReportingRegressionTests.swift
@@ -32,6 +32,16 @@ final class InAppBugReportingRegressionTests: XCTestCase {
             assistantSource.contains("isBugReportPresented") && assistantSource.contains("ReportABugPage(originModule: activeModuleName)"),
             "The assistant must expose a direct report action for assistant mistakes or page-specific app bugs."
         )
+        let overlayHeaderSource = try TestSourceSlicer.braceBalancedBody(
+            after: "private var overlayHeader: some View",
+            in: assistantSource
+        )
+        XCTAssertTrue(
+            overlayHeaderSource.contains("isBugReportPresented = true")
+                && overlayHeaderSource.contains("Image(systemName: \"ladybug\")")
+                && overlayHeaderSource.contains("accessibilityLabel(\"Report a bug\")"),
+            "The floating assistant overlay must expose the same Report a bug entry point as sheet mode."
+        )
         XCTAssertTrue(
             assistantSource.contains("activeModuleName") && assistantSource.contains("HelpContentRegistry.helpFor"),
             "Assistant bug reports must include the active module/page context so reports are actionable."


### PR DESCRIPTION
## Summary
- Add a compact `Report a bug` ladybug action to the floating AI assistant overlay header.
- Reuse the assistant bug-report sheet for both sheet and overlay modes so `activeModuleName` stays attached to reports.
- Extend the in-app bug-report regression test to assert the overlay header exposes the report action, icon, and accessibility label.

Closes #1397

## Verification
- `git diff --check`
- `xcodebuild test -workspace "Weird Parts.xcworkspace" -scheme "WiredPart-iOS" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -only-testing:"Weird Parts IOSTests/InAppBugReportingRegressionTests"` — passed.

## CI / runner note
- Local Mac runner path used for focused verification: `/Users/IA/GitHub/Weird-Part-Run-2/.paperclip/worktrees/WEI-4139-wpr2-beta-github-issue-burn-down-merge-chain` on the local Xcode simulator (`WEI3988-iPhone`, iOS 26.5).