### PR TITLE
fix(ai): expose overlay bug reporter

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
+++ b/Weird Parts IOS/Weird Parts IOS/AI/IOSAIAssistantPanel.swift
@@ -134,11 +134,29 @@ struct IOSAIAssistantPanel: View {
     private let aiService = FoundationModelsService()
 
     var body: some View {
-        if displayMode == .sheet {
-            sheetContent
-        } else {
-            overlayContent
+        Group {
+            if displayMode == .sheet {
+                sheetContent
+            } else {
+                overlayContent
+            }
         }
+        .sheet(isPresented: $isBugReportPresented) {
+            bugReportSheet
+        }
+    }
+
+    @ViewBuilder
+    private var bugReportSheet: some View {
+        NavigationStack {
+            ReportABugPage(originModule: activeModuleName)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Close") { isBugReportPresented = false }
+                    }
+                }
+        }
+        .presentationDetents([.large])
     }
 
     // MARK: - Sheet Mode
@@ -192,17 +210,6 @@ struct IOSAIAssistantPanel: View {
                         .help("Report a bug")
                         .accessibilityLabel("Report a bug")
                     }
-                }
-                .sheet(isPresented: $isBugReportPresented) {
-                    NavigationStack {
-                        ReportABugPage(originModule: activeModuleName)
-                            .toolbar {
-                                ToolbarItem(placement: .cancellationAction) {
-                                    Button("Close") { isBugReportPresented = false }
-                                }
-                            }
-                    }
-                    .presentationDetents([.large])
                 }
         }
     }
@@ -269,6 +276,16 @@ struct IOSAIAssistantPanel: View {
             .buttonStyle(.plain)
             .help("New conversation")
             .accessibilityLabel("New conversation")
+
+            Button {
+                isBugReportPresented = true
+            } label: {
+                Image(systemName: "ladybug")
+                    .font(.caption)
+            }
+            .buttonStyle(.plain)
+            .help("Report a bug")
+            .accessibilityLabel("Report a bug")
 
             Button {
                 clearCurrentConversation()

--- a/Weird Parts IOS/Weird Parts IOSTests/InAppBugReportingRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/InAppBugReportingRegressionTests.swift
@@ -36,6 +36,19 @@ final class InAppBugReportingRegressionTests: XCTestCase {
             assistantSource.contains("activeModuleName") && assistantSource.contains("HelpContentRegistry.helpFor"),
             "Assistant bug reports must include the active module/page context so reports are actionable."
         )
+
+        guard let overlayHeaderRange = assistantSource.range(of: "private var overlayHeader: some View"),
+              let chatBodyRange = assistantSource.range(of: "// MARK: - Shared Chat Body") else {
+            return XCTFail("Assistant source must keep an overlayHeader section before the shared chat body.")
+        }
+
+        let overlayHeaderSource = String(assistantSource[overlayHeaderRange.lowerBound..<chatBodyRange.lowerBound])
+        XCTAssertTrue(
+            overlayHeaderSource.contains("isBugReportPresented = true")
+                && overlayHeaderSource.contains("Image(systemName: \"ladybug\")")
+                && overlayHeaderSource.contains(".accessibilityLabel(\"Report a bug\")"),
+            "The floating overlay header must expose the same direct, accessible Report a bug action as sheet mode."
+        )
     }
 
     func testStartupFailureCanOpenBugReportDraft() throws {


### PR DESCRIPTION
## Summary
- Adds a compact accessible Report a bug ladybug control to the floating assistant overlay header.
- Keeps the assistant bug-report sheet wired to `ReportABugPage(originModule: activeModuleName)` so reports preserve active page/module context.
- Extends in-app bug-reporting regression coverage to assert the overlay header exposes the direct accessible report action.

Closes #1397

## Verification
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -derivedDataPath .tmp/xcode-gh1397 -only-testing:"Weird Parts IOSTests/InAppBugReportingRegressionTests"`
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone,OS=26.5' -derivedDataPath .tmp/xcode-gh1397-merge -only-testing:"Weird Parts IOSTests/InAppBugReportingRegressionTests"`
- `python3 scripts/guard-tracked-artifacts.py`

## CI / review
- Branch updated with current `origin/main`; PR is mergeable as of head `894de434`.
- Copilot review requested with `gh pr edit 1406 --add-reviewer @copilot`.