### PR TITLE
fix: centralize sheet presentation detents

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
@@ -72,6 +72,8 @@ struct QRScanSheet: View {
                 scanner?.stopScanning()
             }
         }
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
     }
 
     private var scanTitle: String {

--- a/Weird Parts IOS/Weird Parts IOS/Shared/FormSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/FormSheet.swift
@@ -63,5 +63,7 @@ struct FormSheet<Content: View>: View {
                 onDiscard: { dismiss() }
             )
         }
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
     }
 }

--- a/Weird Parts IOS/Weird Parts IOS/Shared/SheetDismissWrapper.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Shared/SheetDismissWrapper.swift
@@ -60,6 +60,7 @@ struct SheetDismissWrapper<Content: View>: View {
                 }
                 .environment(\.sheetDismiss, dismissAction)
         }
+        .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/SharedSheetPresentationDetentsTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SharedSheetPresentationDetentsTests.swift
@@ -4,9 +4,10 @@ final class SharedSheetPresentationDetentsTests: XCTestCase {
     func testSharedHelpAndDismissWrappersUseMediumLargePresentationDetents() throws {
         for file in ["PageHelpSheet.swift", "SheetDismissWrapper.swift"] {
             let source = try String(contentsOfFile: sharedSourcePath(file), encoding: .utf8)
-            XCTAssertTrue(
-                source.contains(".presentationDetents([.medium, .large])"),
-                "\(file) should provide medium/large sheet detents for app-wide short informational sheets."
+            assertContainsDetents(
+                source,
+                expectedDetents: "[.medium, .large]",
+                message: "\(file) should provide medium/large sheet detents for app-wide short informational sheets."
             )
             XCTAssertTrue(
                 source.contains(".presentationDragIndicator(.visible)"),
@@ -17,9 +18,10 @@ final class SharedSheetPresentationDetentsTests: XCTestCase {
 
     func testSharedFormSheetPinsLargePresentationDetent() throws {
         let source = try String(contentsOfFile: sharedSourcePath("FormSheet.swift"), encoding: .utf8)
-        XCTAssertTrue(
-            source.contains(".presentationDetents([.large])"),
-            "FormSheet should keep create/edit forms full-size while making the detent explicit."
+        assertContainsDetents(
+            source,
+            expectedDetents: "[.large]",
+            message: "FormSheet should keep create/edit forms full-size while making the detent explicit."
         )
         XCTAssertTrue(
             source.contains(".presentationDragIndicator(.visible)"),
@@ -29,14 +31,26 @@ final class SharedSheetPresentationDetentsTests: XCTestCase {
 
     func testQRScanSheetUsesMediumPresentationDetent() throws {
         let source = try String(contentsOfFile: scanningSourcePath("QRScanSheet.swift"), encoding: .utf8)
-        XCTAssertTrue(
-            source.contains(".presentationDetents([.medium])"),
-            "QRScanSheet should use a medium sheet detent for quick scan/manual-entry flows."
+        assertContainsDetents(
+            source,
+            expectedDetents: "[.medium]",
+            message: "QRScanSheet should use a medium sheet detent for quick scan/manual-entry flows."
         )
         XCTAssertTrue(
             source.contains(".presentationDragIndicator(.visible)"),
             "QRScanSheet should expose a visible drag indicator with its detent."
         )
+    }
+
+    private func assertContainsDetents(_ source: String, expectedDetents: String, message: String) {
+        let normalizedSource = source.replacingOccurrences(
+            of: #"\s+"#,
+            with: "",
+            options: .regularExpression
+        )
+        let normalizedExpected = ".presentationDetents(\(expectedDetents))"
+            .replacingOccurrences(of: #"\s+"#, with: "", options: .regularExpression)
+        XCTAssertTrue(normalizedSource.contains(normalizedExpected), message)
     }
 
     private func sharedSourcePath(_ fileName: String) -> String {

--- a/Weird Parts IOS/Weird Parts IOSTests/SharedSheetPresentationDetentsTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/SharedSheetPresentationDetentsTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+final class SharedSheetPresentationDetentsTests: XCTestCase {
+    func testSharedHelpAndDismissWrappersUseMediumLargePresentationDetents() throws {
+        for file in ["PageHelpSheet.swift", "SheetDismissWrapper.swift"] {
+            let source = try String(contentsOfFile: sharedSourcePath(file), encoding: .utf8)
+            XCTAssertTrue(
+                source.contains(".presentationDetents([.medium, .large])"),
+                "\(file) should provide medium/large sheet detents for app-wide short informational sheets."
+            )
+            XCTAssertTrue(
+                source.contains(".presentationDragIndicator(.visible)"),
+                "\(file) should expose a visible drag indicator with its detents."
+            )
+        }
+    }
+
+    func testSharedFormSheetPinsLargePresentationDetent() throws {
+        let source = try String(contentsOfFile: sharedSourcePath("FormSheet.swift"), encoding: .utf8)
+        XCTAssertTrue(
+            source.contains(".presentationDetents([.large])"),
+            "FormSheet should keep create/edit forms full-size while making the detent explicit."
+        )
+        XCTAssertTrue(
+            source.contains(".presentationDragIndicator(.visible)"),
+            "FormSheet should expose a visible drag indicator with its explicit detent."
+        )
+    }
+
+    func testQRScanSheetUsesMediumPresentationDetent() throws {
+        let source = try String(contentsOfFile: scanningSourcePath("QRScanSheet.swift"), encoding: .utf8)
+        XCTAssertTrue(
+            source.contains(".presentationDetents([.medium])"),
+            "QRScanSheet should use a medium sheet detent for quick scan/manual-entry flows."
+        )
+        XCTAssertTrue(
+            source.contains(".presentationDragIndicator(.visible)"),
+            "QRScanSheet should expose a visible drag indicator with its detent."
+        )
+    }
+
+    private func sharedSourcePath(_ fileName: String) -> String {
+        appSourceRoot()
+            .appendingPathComponent("Shared")
+            .appendingPathComponent(fileName)
+            .path
+    }
+
+    private func scanningSourcePath(_ fileName: String) -> String {
+        appSourceRoot()
+            .appendingPathComponent("Scanning")
+            .appendingPathComponent(fileName)
+            .path
+    }
+
+    private func appSourceRoot() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Weird Parts IOS")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds centralized sheet detents to the app-wide shared wrappers used by short informational sheets, generic create/edit form sheets, and QR scanner sheets.
- Keeps form sheets explicitly large while giving shared dismiss/help-style sheets medium+large and QR scan sheets medium.
- Adds XCTest guard coverage so these central detents do not regress.

## Tests
- `xcodebuild test -project "Weird Parts IOS/Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI4477-iPhone,OS=26.5' -only-testing:"Weird Parts IOSTests/SharedSheetPresentationDetentsTests"` — passed.

Refs #248
