### PR TITLE
feat(quality): Wave-2 PR 4 — People destructive sweep (#1421)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactDetailPage.swift
@@ -223,7 +223,7 @@ private struct EditContactSheet: View {
                         .disabled(firstName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard contact changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContactsPage.swift
@@ -362,7 +362,7 @@ private struct AddContactSheet: View {
                         .disabled(firstName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || phone.isEmpty)
                 }
             }
-            .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard contact changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContractorDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContractorDetailPage.swift
@@ -340,7 +340,7 @@ private struct AddContractorNoteSheet: View {
                         .disabled(content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard contractor changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContractorsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSContractorsPage.swift
@@ -200,7 +200,7 @@ private struct AddContractorSheet: View {
                         .disabled(companyName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard contractor changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSCustomersPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSCustomersPage.swift
@@ -233,7 +233,7 @@ private struct AddCustomerSheet: View {
                         .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard customer changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeeDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeeDetailPage.swift
@@ -282,7 +282,7 @@ struct IOSEmployeeDetailPage: View {
                                     Button(role: .destructive) {
                                         skillToRemove = PendingSkill(id: skillId, name: skill.skillName)
                                     } label: {
-                                        Label("Delete", systemImage: "trash")
+                                        Label("Remove", systemImage: "minus.circle")
                                     }
                                 }
                             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeeDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeeDetailPage.swift
@@ -979,7 +979,7 @@ private struct AddCertificationSheet: View {
                         .disabled(isSaving || certType.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || certName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .alert("Discard skill changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard certification changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {
@@ -1075,7 +1075,7 @@ private struct AddSkillSheet: View {
                         .disabled(isSaving || skillName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .alert("Discard certification changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard skill changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeeDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeeDetailPage.swift
@@ -18,6 +18,12 @@ struct IOSEmployeeDetailPage: View {
     @State private var canManageHats = false
     @State private var combinedPermissions: [String] = []
     @State private var certificationToRemove: Certification?
+    /// Skill pending removal — swipe sets it; the confirm executes.
+    private struct PendingSkill {
+        let id: Int64
+        let name: String
+    }
+    @State private var skillToRemove: PendingSkill?
 
     private enum ActiveSheet: String, Identifiable {
         case editContact
@@ -46,6 +52,35 @@ struct IOSEmployeeDetailPage: View {
         .navigationTitle(employee?.displayName ?? "Employee")
         .refreshable { loadData() }
         .task { loadData() }
+        .confirmDestruction(
+            ofRecordNamed: certificationToRemove?.certName ?? "",
+            noun: "certification",
+            actionLabel: "Remove",
+            actionVerb: "removes",
+            isPresented: Binding(
+                get: { certificationToRemove != nil },
+                set: { if !$0 { certificationToRemove = nil } }
+            ),
+            messageSuffix: "It will no longer appear on the employee profile."
+        ) {
+            if let certificationToRemove {
+                removeCertification(certificationToRemove)
+            }
+        }
+        .confirmDestruction(
+            ofRecordNamed: skillToRemove?.name ?? "",
+            noun: "skill",
+            actionLabel: "Remove",
+            actionVerb: "removes",
+            isPresented: Binding(
+                get: { skillToRemove != nil },
+                set: { if !$0 { skillToRemove = nil } }
+            )
+        ) {
+            if let skillToRemove {
+                removeSkill(id: skillToRemove.id)
+            }
+        }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button("Edit") { activeSheet = .editContact }
@@ -130,21 +165,6 @@ struct IOSEmployeeDetailPage: View {
                     ]
                 )
             }
-        }
-        .alert("Remove certification?", isPresented: Binding(
-            get: { certificationToRemove != nil },
-            set: { if !$0 { certificationToRemove = nil } }
-        )) {
-            Button("Remove", role: .destructive) {
-                if let certificationToRemove {
-                    removeCertification(certificationToRemove)
-                }
-            }
-            Button("Cancel", role: .cancel) {
-                certificationToRemove = nil
-            }
-        } message: {
-            Text("This certification will no longer appear on the employee profile.")
         }
     }
 
@@ -260,7 +280,7 @@ struct IOSEmployeeDetailPage: View {
                             .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                                 if canManageHats, let skillId = skill.id {
                                     Button(role: .destructive) {
-                                        removeSkill(id: skillId)
+                                        skillToRemove = PendingSkill(id: skillId, name: skill.skillName)
                                     } label: {
                                         Label("Delete", systemImage: "trash")
                                     }
@@ -855,7 +875,7 @@ private struct EditEmployeeContactSheet: View {
                         .disabled(isSaving || displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard employee changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {
@@ -959,7 +979,7 @@ private struct AddCertificationSheet: View {
                         .disabled(isSaving || certType.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || certName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard skill changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {
@@ -1055,7 +1075,7 @@ private struct AddSkillSheet: View {
                         .disabled(isSaving || skillName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard certification changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeesPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSEmployeesPage.swift
@@ -323,7 +323,7 @@ private struct AddEmployeeSheet: View {
                         .disabled(displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || pin.count < 4)
                 }
             }
-            .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard employee changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSHatsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSHatsPage.swift
@@ -373,16 +373,33 @@ private struct HatDetailSheet: View {
             permissionsSection
         }
         .listStyle(.insetGrouped)
+        // Two confirms with disjoint presentation: named-record for a single
+        // swipe, count-aware when edit-mode delete spans multiple rows.
         .confirmDestruction(
             ofRecordNamed: pendingMemberName,
             noun: "member",
             actionLabel: "Remove",
             actionVerb: "removes",
             isPresented: Binding(
-                get: { pendingMemberRemoval != nil },
+                get: { (pendingMemberRemoval?.count ?? 0) == 1 },
                 set: { if !$0 { pendingMemberRemoval = nil } }
             ),
             messageSuffix: "They keep their account; only the hat assignment is removed."
+        ) {
+            if let offsets = pendingMemberRemoval {
+                removeMember(at: offsets)
+            }
+        }
+        .confirmDestruction(
+            of: "member",
+            count: pendingMemberRemoval?.count ?? 0,
+            actionLabel: "Remove",
+            actionVerb: "removes",
+            isPresented: Binding(
+                get: { (pendingMemberRemoval?.count ?? 0) > 1 },
+                set: { if !$0 { pendingMemberRemoval = nil } }
+            ),
+            messageSuffix: "They keep their accounts; only the hat assignments are removed."
         ) {
             if let offsets = pendingMemberRemoval {
                 removeMember(at: offsets)

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSHatsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSHatsPage.swift
@@ -15,6 +15,14 @@ struct IOSHatsPage: View {
     @State private var searchText = ""
     @State private var loadError: String?
     @State private var hatToDelete: PeopleService.HatListItem?
+
+    /// States the permissions consequence and, when employees hold the hat,
+    /// exactly how many lose it.
+    private var hatDeleteConsequence: String {
+        let base = "All of its permissions are removed with it."
+        guard let count = hatToDelete?.userCount, count > 0 else { return base }
+        return "\(base) \(count) employee\(count == 1 ? "" : "s") currently hold\(count == 1 ? "s" : "") this hat."
+    }
     private enum ActiveSheet: Identifiable {
         case addHat
         case help
@@ -79,22 +87,20 @@ struct IOSHatsPage: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
             }
-            .alert(
-                "Delete Hat?",
+            .confirmDestruction(
+                ofRecordNamed: hatToDelete?.name ?? "",
+                noun: "hat",
+                actionLabel: "Delete",
                 isPresented: Binding(
                     get: { hatToDelete != nil },
                     set: { if !$0 { hatToDelete = nil } }
-                )
+                ),
+                messageSuffix: hatDeleteConsequence
             ) {
-                Button("Cancel", role: .cancel) { hatToDelete = nil }
-                Button("Delete", role: .destructive) {
-                    if let hat = hatToDelete {
-                        deleteHat(hat)
-                        hatToDelete = nil
-                    }
+                if let hat = hatToDelete {
+                    deleteHat(hat)
+                    hatToDelete = nil
                 }
-            } message: {
-                Text("This will remove the role and all its permissions. This cannot be undone.")
             }
     }
 
@@ -266,7 +272,7 @@ private struct AddHatSheet: View {
                         .disabled(hatName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard hat changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {
@@ -308,6 +314,16 @@ private struct HatDetailSheet: View {
     @State private var loadError: String?
     @State private var canManageHats = false
     @State private var showAddEmployee = false
+    /// Swipe sets the pending offsets; the confirmation executes the removal.
+    @State private var pendingMemberRemoval: IndexSet?
+
+    /// Names the member when the swipe covers one row; blank otherwise so the
+    /// confirm falls back to "this member".
+    private var pendingMemberName: String {
+        guard let offsets = pendingMemberRemoval, offsets.count == 1,
+              let index = offsets.first, members.indices.contains(index) else { return "" }
+        return members[index].displayName
+    }
 
     var body: some View {
         NavigationStack {
@@ -357,6 +373,21 @@ private struct HatDetailSheet: View {
             permissionsSection
         }
         .listStyle(.insetGrouped)
+        .confirmDestruction(
+            ofRecordNamed: pendingMemberName,
+            noun: "member",
+            actionLabel: "Remove",
+            actionVerb: "removes",
+            isPresented: Binding(
+                get: { pendingMemberRemoval != nil },
+                set: { if !$0 { pendingMemberRemoval = nil } }
+            ),
+            messageSuffix: "They keep their account; only the hat assignment is removed."
+        ) {
+            if let offsets = pendingMemberRemoval {
+                removeMember(at: offsets)
+            }
+        }
     }
 
     @ViewBuilder
@@ -370,7 +401,7 @@ private struct HatDetailSheet: View {
                 ForEach(members) { member in
                     memberRow(member)
                 }
-                .onDelete(perform: removeMember)
+                .onDelete { offsets in pendingMemberRemoval = offsets }
             } else {
                 ForEach(members) { member in
                     memberRow(member)

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSHatsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSHatsPage.swift
@@ -458,7 +458,9 @@ private struct HatDetailSheet: View {
             loadError = "People service unavailable"
             return
         }
-        for index in offsets {
+        // Offsets sit in pendingMemberRemoval while the confirm is up; a
+        // refresh can shrink `members` in the meantime, so bounds-check.
+        for index in offsets where members.indices.contains(index) {
             let member = members[index]
             do {
                 try service.toggleHatAssignment(employeeId: member.id, hatId: hat.id, assign: false)

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamDetailPage.swift
@@ -118,13 +118,17 @@ struct IOSTeamDetailPage: View {
             noun: "member",
             actionLabel: "Remove",
             actionVerb: "removes",
-            isPresented: $showRemoveMemberConfirm,
+            isPresented: Binding(
+                get: { showRemoveMemberConfirm },
+                // Clears the pending member on ANY dismissal (Cancel included),
+                // not just confirm.
+                set: { showRemoveMemberConfirm = $0; if !$0 { memberToRemove = nil } }
+            ),
             messageSuffix: "They keep their account; only the team membership is removed."
         ) {
             if let member = memberToRemove {
                 Task { await removeMember(member) }
             }
-            memberToRemove = nil
         }
         .task { await loadData() }
         .refreshable { await loadData() }

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamDetailPage.swift
@@ -104,26 +104,27 @@ struct IOSTeamDetailPage: View {
                 )
             }
         }
-        .alert("Delete Team?", isPresented: $showDeleteConfirm) {
-            Button("Delete", role: .destructive) {
-                Task { await deleteTeam() }
-            }
-            Button("Cancel", role: .cancel) { }
-        } message: {
-            Text("This will remove the team. Members will not be deleted.")
+        .confirmDestruction(
+            ofRecordNamed: team?.name ?? "",
+            noun: "team",
+            actionLabel: "Delete",
+            isPresented: $showDeleteConfirm,
+            messageSuffix: "Members keep their accounts; only the team is removed."
+        ) {
+            Task { await deleteTeam() }
         }
-        .alert("Remove Member?", isPresented: $showRemoveMemberConfirm) {
-            Button("Remove", role: .destructive) {
-                if let member = memberToRemove {
-                    Task { await removeMember(member) }
-                }
-                memberToRemove = nil
-            }
-            Button("Cancel", role: .cancel) { memberToRemove = nil }
-        } message: {
+        .confirmDestruction(
+            ofRecordNamed: memberToRemove?.name ?? "",
+            noun: "member",
+            actionLabel: "Remove",
+            actionVerb: "removes",
+            isPresented: $showRemoveMemberConfirm,
+            messageSuffix: "They keep their account; only the team membership is removed."
+        ) {
             if let member = memberToRemove {
-                Text("Remove \(member.name) from this team?")
+                Task { await removeMember(member) }
             }
+            memberToRemove = nil
         }
         .task { await loadData() }
         .refreshable { await loadData() }
@@ -348,7 +349,7 @@ private struct EditTeamSheet: View {
                         .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard team changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {

--- a/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/People/IOSTeamsPage.swift
@@ -318,7 +318,7 @@ private struct AddTeamSheet: View {
                         .disabled(teamName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            .alert("Discard team changes?", isPresented: $showDiscardAlert) {
                 Button("Discard", role: .destructive) { dismiss() }
                 Button("Keep Editing", role: .cancel) {}
             } message: {


### PR DESCRIPTION
## What this is

Panel-quality Wave 2, fourth and final PR (umbrella #1421) — the People destructive sweep, closing out every Wave-2 checklist item.

**Highlights:**
- **Two actions destroyed data with no confirmation at all** — swipe-deleting an employee skill and swipe-removing a hat member both fired instantly. Both now confirm, naming the record (pending-state pattern; the removal body is unchanged and runs only on confirm).
- **Named-record upgrades** (rubric criterion 8): certification removal ('Remove ‘OSHA 30’?'), team delete, hat delete — which now also states the full consequence: permissions removed **and** 'N employees currently hold this hat' (from `userCount`).
- **12 discard-unsaved dialogs standardized** with thing-names ('Discard employee changes?', 'Discard contractor changes?' …) — existing buttons, roles, and bindings untouched; counts deliberately not forced onto dirty forms (per the Settings-pass precedent).
- All confirms use the shared `confirmDestruction` helper / `DestructiveConfirmationCopy` builders (16 behavioral tests already pin the copy contract, including blank-name fallbacks).

## Verification
- **Full iOS unit suite: TEST SUCCEEDED** — run on the **local self-hosted Mac runner path** (cloud PR gates cover CodeQL/Analyze(swift)/artifact guard; they do not run the iOS suite)
- No core changes; no new test files needed (the helper's behavioral tests + no page pins the old titles, verified by grep)

## Review notes
Sites were classified by the 6-area audit that drove #1424/#1425/#1426. Implementation applied inline (subagent capacity was exhausted at the time), same patterns as the three merged area passes.

Umbrella: #1421 — after this merges, Wave 2 is complete and Wave 3 (LoadState consolidation, filter-bar contract tests, legend/mode-banner components, missed-dimension audits) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)