### PR TITLE
ci: route PR merge maintenance to self-hosted runner

### DIFF
--- a/.github/workflows/artifact-guard.yml
+++ b/.github/workflows/artifact-guard.yml
@@ -18,10 +18,10 @@ permissions:
 jobs:
   tracked-artifacts:
     name: Tracked artifact guard
-    # Pure-python guard — no Xcode needed. Owner authorized cloud-runner spend
-    # (2026-07-02) so lightweight PR gates run on hosted Linux in parallel
-    # instead of queueing behind the single local Mac runner.
-    runs-on: ubuntu-latest
+    # Pure-python guard — no Xcode needed, but this private repo currently
+    # sees GitHub-hosted zero-step failures (runner_id=0), so run on WPR2's
+    # self-hosted Mac labels until hosted capacity/billing is restored.
+    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
     timeout-minutes: 5
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,9 +33,11 @@ jobs:
   required-codeql-compat:
     name: CodeQL
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    # Echo-only compatibility context — no Xcode needed. Owner authorized
-    # cloud-runner spend (2026-07-02) so this gate never queues behind the Mac.
-    runs-on: ubuntu-latest
+    # Echo-only compatibility context — no Xcode needed, but this private repo
+    # currently sees GitHub-hosted zero-step failures (runner_id=0), so keep
+    # required PR gates on WPR2's self-hosted Mac labels until hosted
+    # capacity/billing is restored.
+    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
     timeout-minutes: 5
     steps:
       - name: Required CodeQL compatibility gate
@@ -44,7 +46,7 @@ jobs:
           echo "The Swift scanner job remains named Analyze (swift)."
 
   # PR-level required gate. The full Swift analysis hangs on GitHub-hosted
-  # macOS and is too slow to gate every PR, so PRs get this fast hosted-Linux
+  # macOS and is too slow to gate every PR, so PRs get this fast recovery
   # gate under the same required check name, while push/schedule events run
   # the real analysis on the local Mac runner (job below). The two jobs' `if`
   # conditions are mutually exclusive, so the "Analyze (swift)" check context
@@ -52,7 +54,7 @@ jobs:
   analyze-pr-gate:
     name: Analyze (swift)
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
     timeout-minutes: 5
     steps:
       - name: Swift CodeQL PR recovery gate

--- a/.github/workflows/pr-merge-maintenance.yml
+++ b/.github/workflows/pr-merge-maintenance.yml
@@ -34,10 +34,10 @@ permissions:
 
 jobs:
   maintain-prs:
-    # Pure gh/bash automation — no Xcode needed. Owner authorized cloud-runner
-    # spend (2026-07-02); running the train-feeder on hosted Linux means PRs
-    # keep rebasing/merging even while the Mac runner is busy with CodeQL.
-    runs-on: ubuntu-latest
+    # Scheduled merge-train automation uses the private WPR2 self-hosted Mac
+    # runners so private-repo GitHub-hosted capacity/billing failures do not
+    # produce zero-step runs (runner_id=0) and stall PR maintenance.
+    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
     timeout-minutes: 10
     env:
       # Use a PAT when configured: GITHUB_TOKEN-authored update-branch merge


### PR DESCRIPTION
## Summary
- Routes the PR Merge Maintenance workflow from `ubuntu-latest` to the WPR2 self-hosted macOS runner label set.
- Applies the same zero-step failure fix to sibling PR gates (`Artifact Guard`, CodeQL compatibility, and `Analyze (swift)` PR recovery) after the PR opened with runner_id=0/no-step failures on `ubuntu-latest`.
- Updates comments to document the private-repo hosted-capacity/billing failure mode this avoids.

## Paperclip trace
- WEI-4588
- Parent: WEI-4587

## Verification
- `ruby -e 'require "yaml"; %w[.github/workflows/pr-merge-maintenance.yml .github/workflows/artifact-guard.yml .github/workflows/codeql.yml].each { |f| YAML.load_file(f); puts "yaml ok #{f}" }'`\n- `bash -n scripts/pr-merge-maintenance.sh`\n- `python3 scripts/guard-tracked-artifacts.py --self-test`\n- `python3 scripts/guard-tracked-artifacts.py`\n- Manual PR Merge Maintenance workflow_dispatch dry-run on this branch: https://github.com/xXKillerNoobYT/Weird-Part-Run-2/actions/runs/29295340662\n- Completed job `maintain-prs`: runner_id `22`, runner_name `IA-Mac-WPR2-2`, labels `[self-hosted, macOS, ARM64, xcode, ios, local-mac]`, conclusion `success`, non-empty steps.