### PR TITLE
fix: repair manual QR scan feedback

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
@@ -1,8 +1,38 @@
 import SwiftUI
 import WiredPartCore
+#if canImport(UIKit)
+import UIKit
+#endif
 #if !targetEnvironment(macCatalyst)
 import VisionKit
 #endif
+
+struct QRScanDeliveryGate {
+    private(set) var activePayload: String?
+    private(set) var completedPayload: String?
+
+    var isProcessing: Bool { activePayload != nil }
+
+    mutating func claim(_ payload: String) -> Bool {
+        guard activePayload == nil, completedPayload != payload else { return false }
+        activePayload = payload
+        return true
+    }
+
+    mutating func finish(_ payload: String, shouldComplete: Bool) -> Bool {
+        guard activePayload == payload else { return false }
+        activePayload = nil
+        guard shouldComplete, completedPayload != payload else { return false }
+        completedPayload = payload
+        return true
+    }
+
+    mutating func fail(_ payload: String) {
+        if activePayload == payload {
+            activePayload = nil
+        }
+    }
+}
 
 /// Reusable QR scan sheet. Present as a `.sheet`, get a callback with the result.
 /// Automatically dismisses after a successful scan that matches the expected type.
@@ -28,12 +58,14 @@ struct QRScanSheet: View {
     @State private var resultEntityType: QREntityType?
     @State private var resultCode: String?
     @State private var typeMismatch = false
-    @State private var isProcessing = false
+    @State private var deliveryGate = QRScanDeliveryGate()
 
     // Manual entry
     @State private var manualCode = ""
 
     @State private var scanner: IOSQRScanner?
+
+    private var isProcessing: Bool { deliveryGate.isProcessing }
 
     private var isScannerSupported: Bool {
         #if targetEnvironment(macCatalyst)
@@ -71,6 +103,9 @@ struct QRScanSheet: View {
             .onDisappear {
                 scanner?.stopScanning()
             }
+            .onChange(of: statusAccessibilityLabel) { _, status in
+                announceStatus(status)
+            }
         }
         .presentationDetents([.medium])
         .presentationDragIndicator(.visible)
@@ -96,11 +131,6 @@ struct QRScanSheet: View {
                 .stroke(Color.white.opacity(0.5), lineWidth: 2)
                 .frame(width: 250, height: 250)
 
-            if isProcessing {
-                ProgressView()
-                    .tint(.white)
-                    .scaleEffect(1.5)
-            }
         }
     }
 
@@ -109,42 +139,9 @@ struct QRScanSheet: View {
     @ViewBuilder
     private var bottomSection: some View {
         VStack(spacing: 12) {
-            // Result feedback
-            if let error = scanError {
-                Label(error, systemImage: "exclamationmark.triangle.fill")
-                    .font(.subheadline)
-                    .foregroundStyle(.red)
-                    .padding(.horizontal)
-                    .padding(.top, 12)
-            } else if let title = resultTitle {
-                HStack(spacing: 8) {
-                    Image(systemName: resultIsFound ? "checkmark.circle.fill" : "questionmark.circle.fill")
-                        .foregroundStyle(resultIsFound ? .green : .orange)
-                        .accessibilityHidden(true)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(resultIsFound ? "Found: \(title)" : "Not found: \(resultCode ?? "")")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                        if typeMismatch, let got = resultEntityType, let expected = expectedType {
-                            Text("Expected \(expected.rawValue), got \(got.rawValue)")
-                                .font(.caption)
-                                .foregroundStyle(.orange)
-                        }
-                    }
-                }
+            feedbackStatusView
                 .padding(.horizontal)
                 .padding(.top, 12)
-            } else {
-                HStack(spacing: 8) {
-                    Image(systemName: "viewfinder")
-                        .foregroundStyle(.secondary)
-                        .accessibilityHidden(true)
-                    Text("Point camera at a QR code")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.top, 12)
-            }
 
             // Manual entry
             HStack(spacing: 8) {
@@ -154,10 +151,13 @@ struct QRScanSheet: View {
                     .onSubmit { processManualEntry() }
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
+                    .accessibilityLabel("QR code")
+                    .accessibilityIdentifier("qrScanManualCodeField")
 
                 Button("Look Up") { processManualEntry() }
                     .buttonStyle(.bordered)
                     .disabled(manualCode.isBlankRequiredText || isProcessing)
+                    .accessibilityIdentifier("qrScanLookUpButton")
             }
             .padding(.horizontal)
             .padding(.bottom, 12)
@@ -185,32 +185,92 @@ struct QRScanSheet: View {
                     .textFieldStyle(.roundedBorder)
                     .submitLabel(.search)
                     .onSubmit { processManualEntry() }
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .accessibilityLabel("QR code")
+                    .accessibilityIdentifier("qrScanManualCodeField")
 
                 Button("Look Up") { processManualEntry() }
                     .buttonStyle(.borderedProminent)
                     .disabled(manualCode.isBlankRequiredText || isProcessing)
+                    .accessibilityIdentifier("qrScanLookUpButton")
             }
             .padding(.horizontal, 24)
 
-            if let error = scanError {
-                Label(error, systemImage: "exclamationmark.triangle.fill")
-                    .font(.subheadline)
-                    .foregroundStyle(.red)
-            }
-
-            if let title = resultTitle {
-                HStack(spacing: 8) {
-                    Image(systemName: resultIsFound ? "checkmark.circle.fill" : "questionmark.circle.fill")
-                        .foregroundStyle(resultIsFound ? .green : .orange)
-                        .accessibilityHidden(true)
-                    Text(resultIsFound ? "Found: \(title)" : "Not found")
-                        .font(.subheadline)
-                }
-            }
+            feedbackStatusView
+                .padding(.horizontal, 24)
 
             Spacer()
         }
         .background(Color(.systemBackground))
+    }
+
+    @ViewBuilder
+    private var feedbackStatusView: some View {
+        HStack(spacing: 8) {
+            if isProcessing {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityHidden(true)
+                Text("Looking up…")
+                    .fontWeight(.medium)
+            } else if let error = scanError {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+                    .accessibilityHidden(true)
+                Text(error)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.red)
+            } else if typeMismatch, let got = resultEntityType, let expected = expectedType {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .accessibilityHidden(true)
+                Text("Expected \(expected.rawValue), got \(got.rawValue)")
+                    .fontWeight(.medium)
+                    .foregroundStyle(.orange)
+            } else if let title = resultTitle {
+                Image(systemName: resultIsFound ? "checkmark.circle.fill" : "questionmark.circle.fill")
+                    .foregroundStyle(resultIsFound ? .green : .orange)
+                    .accessibilityHidden(true)
+                Text(resultIsFound ? "Found: \(title)" : "Not found: \(resultCode ?? "")")
+                    .fontWeight(.medium)
+                    .foregroundStyle(resultIsFound ? .green : .orange)
+            } else {
+                Image(systemName: "viewfinder")
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+                Text(isScannerSupported ? "Point camera at a QR code" : "Enter a QR code to look it up")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .font(.subheadline)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("qrScanStatus")
+        .accessibilityLabel(statusAccessibilityLabel)
+        .accessibilityAddTraits(.updatesFrequently)
+    }
+
+    private var statusAccessibilityLabel: String {
+        if isProcessing {
+            return "Looking up…"
+        }
+        if let error = scanError {
+            return error
+        }
+        if typeMismatch, let got = resultEntityType, let expected = expectedType {
+            return "Expected \(expected.rawValue), got \(got.rawValue)"
+        }
+        if let title = resultTitle {
+            return resultIsFound ? "Found: \(title)" : "Not found: \(resultCode ?? "")"
+        }
+        return isScannerSupported ? "Point camera at a QR code" : "Enter a QR code to look it up"
+    }
+
+    private func announceStatus(_ status: String) {
+        #if canImport(UIKit)
+        UIAccessibility.post(notification: .announcement, argument: status)
+        #endif
     }
 
     // MARK: - Scanning
@@ -269,15 +329,21 @@ struct QRScanSheet: View {
         // Claim the processing slot atomically on MainActor. Camera streams can
         // deliver the same payload again while the first database lookup awaits.
         let shouldSkip = await MainActor.run {
-            if isProcessing { return true }
-            if let current = resultCode, current == payload, resultIsFound { return true }
+            guard deliveryGate.claim(payload) else { return true }
 
-            isProcessing = true
             scanError = nil
+            resultTitle = nil
+            resultIsFound = false
+            resultEntityType = nil
+            resultCode = nil
             typeMismatch = false
             return false
         }
         if shouldSkip { return }
+
+        // Let SwiftUI render and announce the loading state before the local
+        // synchronous lookup begins, even when the database responds quickly.
+        await Task.yield()
 
         do {
             let service = QRAutoFillService(db: db)
@@ -298,24 +364,27 @@ struct QRScanSheet: View {
                 && (expectedType == nil || result.entityType == expectedType)
 
             await MainActor.run {
+                let shouldComplete = deliveryGate.finish(
+                    payload,
+                    shouldComplete: shouldAutoComplete
+                )
                 resultTitle = title
                 resultIsFound = result.isFound
                 resultEntityType = result.entityType
                 resultCode = result.code
                 typeMismatch = gotMismatch
-                isProcessing = false
 
                 // Every result callback mutates parent SwiftUI state. Keep the
                 // callback and dismissal in one MainActor transaction.
-                if shouldAutoComplete {
+                if shouldComplete {
                     dismiss()
                     onResult(result)
                 }
             }
         } catch {
             await MainActor.run {
+                deliveryGate.fail(payload)
                 scanError = userFriendlyError(error, context: "scan item")
-                isProcessing = false
             }
         }
     }

--- a/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
@@ -34,6 +34,21 @@ struct QRScanDeliveryGate {
     }
 }
 
+enum QRScanFeedback {
+    static func isTypeMismatch(
+        isFound: Bool,
+        entityType: QREntityType?,
+        expectedType: QREntityType?
+    ) -> Bool {
+        guard isFound, let entityType, let expectedType else { return false }
+        return entityType != expectedType
+    }
+
+    static func resultMessage(isFound: Bool, title: String, code: String) -> String {
+        isFound ? "Found: \(title)" : "Not found: \(code)"
+    }
+}
+
 /// Reusable QR scan sheet. Present as a `.sheet`, get a callback with the result.
 /// Automatically dismisses after a successful scan that matches the expected type.
 ///
@@ -232,7 +247,13 @@ struct QRScanSheet: View {
                 Image(systemName: resultIsFound ? "checkmark.circle.fill" : "questionmark.circle.fill")
                     .foregroundStyle(resultIsFound ? .green : .orange)
                     .accessibilityHidden(true)
-                Text(resultIsFound ? "Found: \(title)" : "Not found: \(resultCode ?? "")")
+                Text(
+                    QRScanFeedback.resultMessage(
+                        isFound: resultIsFound,
+                        title: title,
+                        code: resultCode ?? ""
+                    )
+                )
                     .fontWeight(.medium)
                     .foregroundStyle(resultIsFound ? .green : .orange)
             } else {
@@ -262,7 +283,11 @@ struct QRScanSheet: View {
             return "Expected \(expected.rawValue), got \(got.rawValue)"
         }
         if let title = resultTitle {
-            return resultIsFound ? "Found: \(title)" : "Not found: \(resultCode ?? "")"
+            return QRScanFeedback.resultMessage(
+                isFound: resultIsFound,
+                title: title,
+                code: resultCode ?? ""
+            )
         }
         return isScannerSupported ? "Point camera at a QR code" : "Enter a QR code to look it up"
     }
@@ -358,7 +383,11 @@ struct QRScanSheet: View {
                 ?? result.fields["code"]
                 ?? result.code
 
-            let gotMismatch = expectedType != nil && result.entityType != expectedType
+            let gotMismatch = QRScanFeedback.isTypeMismatch(
+                isFound: result.isFound,
+                entityType: result.entityType,
+                expectedType: expectedType
+            )
 
             let shouldAutoComplete = result.isFound
                 && (expectedType == nil || result.entityType == expectedType)

--- a/Weird Parts IOS/Weird Parts IOSTests/QRScanSheetRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/QRScanSheetRegressionTests.swift
@@ -1,8 +1,10 @@
 import XCTest
+@testable import Weird_Parts
 
+@MainActor
 final class QRScanSheetRegressionTests: XCTestCase {
     func testScanResultCallbackRunsInsideMainActorDismissBlock() throws {
-        let source = try String(contentsOfFile: scanningSourcePath("QRScanSheet.swift"), encoding: .utf8)
+        let source = try Self.qrScanSheetSource()
         let normalized = normalizedSource(source)
 
         XCTAssertTrue(
@@ -10,7 +12,7 @@ final class QRScanSheetRegressionTests: XCTestCase {
             "QRScanSheet should use MainActor.run for result-state and dismissal updates."
         )
         XCTAssertTrue(
-            normalized.contains("ifshouldAutoComplete{dismiss()onResult(result)}"),
+            normalized.contains("ifshouldComplete{dismiss()onResult(result)}"),
             "QRScanSheet must invoke onResult(result) in the same MainActor block as dismiss()."
         )
         XCTAssertFalse(
@@ -20,20 +22,159 @@ final class QRScanSheetRegressionTests: XCTestCase {
     }
 
     func testDuplicateScanGuardPreventsOverlappingProcessing() throws {
-        let source = try String(contentsOfFile: scanningSourcePath("QRScanSheet.swift"), encoding: .utf8)
+        let source = try Self.qrScanSheetSource()
         let normalized = normalizedSource(source)
 
         XCTAssertTrue(
-            normalized.contains("letshouldSkip=awaitMainActor.run{ifisProcessing{returntrue}"),
+            normalized.contains("letshouldSkip=awaitMainActor.run{guarddeliveryGate.claim(payload)else{returntrue}"),
             "QRScanSheet should claim its processing slot on MainActor before async lookup work."
         )
         XCTAssertTrue(
-            normalized.contains("ifletcurrent=resultCode,current==payload,resultIsFound{returntrue}"),
-            "QRScanSheet should retain the completed-payload duplicate guard."
+            normalized.contains("ifshouldSkip{return}"),
+            "Overlapping scans should return without starting another lookup."
+        )
+    }
+
+    func testDeliveryGateInvokesCompletionOnceForDuplicatePayload() {
+        var gate = QRScanDeliveryGate()
+        var callbackCount = 0
+        let payload = #"{"app":"wiredpart","version":2,"type":"po","id":42,"code":"PO-42"}"#
+
+        for _ in 0..<2 {
+            guard gate.claim(payload) else { continue }
+            if gate.finish(payload, shouldComplete: true) {
+                callbackCount += 1
+            }
+        }
+
+        let isProcessing = gate.isProcessing
+        let completedPayload = gate.completedPayload
+        XCTAssertEqual(callbackCount, 1)
+        XCTAssertFalse(isProcessing)
+        XCTAssertEqual(completedPayload, payload)
+    }
+
+    func testDeliveryGateReleasesMismatchAndFailureForRetry() {
+        var gate = QRScanDeliveryGate()
+
+        XCTAssertTrue(gate.claim("JOB-1"))
+        XCTAssertFalse(gate.finish("JOB-1", shouldComplete: false))
+        XCTAssertTrue(gate.claim("JOB-1"), "A wrong-type or not-found result must remain retryable.")
+        gate.fail("JOB-1")
+        XCTAssertTrue(gate.claim("JOB-1"), "A failed lookup must release the processing slot.")
+    }
+
+    func testManualFallbackAndCameraBottomReuseOneStatusView() throws {
+        let source = try Self.qrScanSheetSource()
+        let bottom = try Self.braceBalancedBody(after: "private var bottomSection", in: source)
+        let manual = try Self.braceBalancedBody(after: "private var manualOnlyView", in: source)
+
+        XCTAssertTrue(
+            source.contains("private var feedbackStatusView: some View"),
+            "QRScanSheet should keep scan feedback in one reusable status view."
+        )
+        XCTAssertTrue(bottom.contains("feedbackStatusView"))
+        XCTAssertTrue(manual.contains("feedbackStatusView"))
+    }
+
+    func testProcessingStateShowsAccessibleLookingUpAndDisablesLookup() throws {
+        let source = try Self.qrScanSheetSource()
+        let feedback = try Self.braceBalancedBody(after: "private var feedbackStatusView", in: source)
+        let processingClaim = try Self.braceBalancedBody(after: "let shouldSkip = await MainActor.run", in: source)
+
+        XCTAssertTrue(
+            feedback.contains("ProgressView()") && feedback.contains("Text(\"Looking up…\")"),
+            "Processing feedback must include both a spinner and visible Looking up text."
         )
         XCTAssertTrue(
-            normalized.contains("isProcessing=true") && normalized.contains("ifshouldSkip{return}"),
-            "Overlapping scans should return without starting another lookup."
+            source.contains(".disabled(manualCode.isBlankRequiredText || isProcessing)"),
+            "Look Up must remain disabled while processing."
+        )
+        XCTAssertTrue(
+            feedback.contains(".accessibilityIdentifier(\"qrScanStatus\")")
+                && feedback.contains(".accessibilityLabel(statusAccessibilityLabel)")
+                && feedback.contains(".accessibilityAddTraits(.updatesFrequently)"),
+            "The status view needs a stable accessibility identifier and update semantics for VoiceOver."
+        )
+        XCTAssertTrue(
+            source.contains("UIAccessibility.post(notification: .announcement, argument: status)"),
+            "Status changes should be announced to VoiceOver."
+        )
+        XCTAssertTrue(
+            processingClaim.contains("resultTitle = nil")
+                && processingClaim.contains("resultCode = nil")
+                && processingClaim.contains("resultEntityType = nil"),
+            "Starting a new lookup must clear stale prior results while Looking up is shown."
+        )
+        XCTAssertTrue(
+            source.contains("await Task.yield()"),
+            "QRScanSheet should yield once so SwiftUI can render and announce loading before synchronous lookup work."
+        )
+    }
+
+    func testWrongTypeWarningIsOrangeAndPrecedesSuccessRendering() throws {
+        let source = try Self.qrScanSheetSource()
+        let feedback = try Self.braceBalancedBody(after: "private var feedbackStatusView", in: source)
+
+        guard let mismatchRange = feedback.range(
+            of: "typeMismatch, let got = resultEntityType, let expected = expectedType"
+        ), let resultRange = feedback.range(of: "else if let title = resultTitle") else {
+            XCTFail("Expected type mismatch to branch before generic result rendering.")
+            return
+        }
+
+        XCTAssertLessThan(mismatchRange.lowerBound, resultRange.lowerBound)
+        XCTAssertTrue(
+            feedback.contains("Text(\"Expected \\(expected.rawValue), got \\(got.rawValue)\")")
+                && feedback.contains(".foregroundStyle(.orange)"),
+            "Wrong-type results must show an orange Expected/got warning."
+        )
+    }
+
+    func testNotFoundMessageIncludesCodeAndDoesNotDismiss() throws {
+        let source = try Self.qrScanSheetSource()
+        let feedback = try Self.braceBalancedBody(after: "private var feedbackStatusView", in: source)
+
+        XCTAssertTrue(
+            feedback.contains("\"Not found: \\(resultCode ?? \"\")\""),
+            "Not-found feedback must include the entered/scanned code."
+        )
+        XCTAssertTrue(
+            source.contains("let shouldAutoComplete = result.isFound\n                && (expectedType == nil || result.entityType == expectedType)"),
+            "Only found matching results may auto-complete."
+        )
+    }
+
+    func testMatchingSuccessUsesSingleMainActorCompletionPath() throws {
+        let source = try Self.qrScanSheetSource()
+        let processPayload = try Self.methodBody(named: "processPayload", in: source)
+
+        XCTAssertTrue(
+            processPayload.contains("guard deliveryGate.claim(payload) else { return true }")
+                && processPayload.contains("if shouldSkip { return }"),
+            "QR payload processing must atomically claim the delivery gate."
+        )
+        XCTAssertTrue(
+            processPayload.contains("let shouldAutoComplete = result.isFound\n                && (expectedType == nil || result.entityType == expectedType)"),
+            "Only found results matching the expected type may auto-complete."
+        )
+        XCTAssertTrue(
+            processPayload.contains("if shouldComplete {\n                    dismiss()\n                    onResult(result)\n                }"),
+            "Matching success should dismiss and invoke the callback from one MainActor branch."
+        )
+        XCTAssertEqual(processPayload.components(separatedBy: "onResult(result)").count - 1, 1)
+    }
+
+    func testCancelDoesNotInvokeCallbackAndManualFieldsAreNamedQRCode() throws {
+        let source = try Self.qrScanSheetSource()
+        let toolbar = try Self.braceBalancedBody(after: ".toolbar", in: source)
+
+        XCTAssertTrue(toolbar.contains("Button(\"Cancel\") { dismiss() }"))
+        XCTAssertFalse(toolbar.contains("onResult"))
+        XCTAssertEqual(
+            source.components(separatedBy: ".accessibilityLabel(\"QR code\")").count - 1,
+            2,
+            "Both manual QR entry fields must expose the explicit accessible name QR code."
         )
     }
 
@@ -41,14 +182,21 @@ final class QRScanSheetRegressionTests: XCTestCase {
         source.replacingOccurrences(of: #"\s+"#, with: "", options: .regularExpression)
     }
 
-    private func scanningSourcePath(_ fileName: String) -> String {
-        appSourceRoot().appendingPathComponent("Scanning").appendingPathComponent(fileName).path
-    }
-
-    private func appSourceRoot() -> URL {
-        URL(fileURLWithPath: #filePath)
+    private static func qrScanSheetSource(file: StaticString = #filePath) throws -> String {
+        let sourceURL = URL(fileURLWithPath: "\(file)")
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("Weird Parts IOS")
+            .appendingPathComponent("Scanning")
+            .appendingPathComponent("QRScanSheet.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    private static func braceBalancedBody(after anchor: String, in source: String) throws -> String {
+        try TestSourceSlicer.braceBalancedBody(after: anchor, in: source)
+    }
+
+    private static func methodBody(named methodName: String, in source: String) throws -> String {
+        try braceBalancedBody(after: "func \(methodName)(", in: source)
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSTests/QRScanSheetRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/QRScanSheetRegressionTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import WiredPartCore
 @testable import Weird_Parts
 
 @MainActor
@@ -131,14 +132,22 @@ final class QRScanSheetRegressionTests: XCTestCase {
         )
     }
 
-    func testNotFoundMessageIncludesCodeAndDoesNotDismiss() throws {
+    func testNotFoundWithExpectedTypeKeepsNotFoundMessageAndIsNotMismatch() throws {
         let source = try Self.qrScanSheetSource()
-        let feedback = try Self.braceBalancedBody(after: "private var feedbackStatusView", in: source)
-
-        XCTAssertTrue(
-            feedback.contains("\"Not found: \\(resultCode ?? \"\")\""),
-            "Not-found feedback must include the entered/scanned code."
+        let code = "MANUAL-404"
+        let isMismatch = QRScanFeedback.isTypeMismatch(
+            isFound: false,
+            entityType: nil,
+            expectedType: .po
         )
+        let message = QRScanFeedback.resultMessage(
+            isFound: false,
+            title: code,
+            code: code
+        )
+
+        XCTAssertFalse(isMismatch)
+        XCTAssertEqual(message, "Not found: MANUAL-404")
         XCTAssertTrue(
             source.contains("let shouldAutoComplete = result.isFound\n                && (expectedType == nil || result.entityType == expectedType)"),
             "Only found matching results may auto-complete."


### PR DESCRIPTION
## Summary
- unify camera/manual QR feedback into one accessible status surface
- show and announce Looking up… while clearing stale results
- render wrong-type finds as orange Expected/got warnings and preserve entered codes for not-found feedback
- gate duplicate deliveries with executable callback-count coverage so matching callbacks dismiss and run once

## Verification
- Xcode focused test: QRScanSheetRegressionTests — 10 passed, 0 failed, 0 skipped
- Build log: /Users/IA/Library/Developer/XcodeBuildMCP/workspaces/Weird-Part-Run-2-e023e4333fdf/logs/test_sim_2026-07-14T12-20-34-765Z_pid38637_b2c2d7ad.log
- GitHub mergeability: MERGEABLE / CLEAN against PR #1441 head a92fa874
- QA viewport/screenshots/accessibility follow-up remains in WEI-4692 after this nested fix lands

Closes #1442
Refs #1441

Tracked in WEI-4700
Merge tracked in WEI-4711
Parent QA: WEI-4692