### PR TITLE
fix: derive QR mismatch feedback (#1442)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Scanning/QRScanSheet.swift
@@ -34,18 +34,24 @@ struct QRScanDeliveryGate {
     }
 }
 
-enum QRScanFeedback {
-    static func isTypeMismatch(
+struct QRScanFeedback {
+    let typeMismatch: Bool
+    let message: String
+
+    init(
         isFound: Bool,
         entityType: QREntityType?,
-        expectedType: QREntityType?
-    ) -> Bool {
-        guard isFound, let entityType, let expectedType else { return false }
-        return entityType != expectedType
-    }
-
-    static func resultMessage(isFound: Bool, title: String, code: String) -> String {
-        isFound ? "Found: \(title)" : "Not found: \(code)"
+        expectedType: QREntityType?,
+        title: String,
+        code: String
+    ) {
+        if isFound, let entityType, let expectedType, entityType != expectedType {
+            typeMismatch = true
+            message = "Expected \(expectedType.rawValue), got \(entityType.rawValue)"
+        } else {
+            typeMismatch = false
+            message = isFound ? "Found: \(title)" : "Not found: \(code)"
+        }
     }
 }
 
@@ -72,7 +78,6 @@ struct QRScanSheet: View {
     @State private var resultIsFound = false
     @State private var resultEntityType: QREntityType?
     @State private var resultCode: String?
-    @State private var typeMismatch = false
     @State private var deliveryGate = QRScanDeliveryGate()
 
     // Manual entry
@@ -81,6 +86,17 @@ struct QRScanSheet: View {
     @State private var scanner: IOSQRScanner?
 
     private var isProcessing: Bool { deliveryGate.isProcessing }
+
+    private var resultFeedback: QRScanFeedback? {
+        guard let resultTitle else { return nil }
+        return QRScanFeedback(
+            isFound: resultIsFound,
+            entityType: resultEntityType,
+            expectedType: expectedType,
+            title: resultTitle,
+            code: resultCode ?? ""
+        )
+    }
 
     private var isScannerSupported: Bool {
         #if targetEnvironment(macCatalyst)
@@ -236,24 +252,18 @@ struct QRScanSheet: View {
                 Text(error)
                     .fontWeight(.medium)
                     .foregroundStyle(.red)
-            } else if typeMismatch, let got = resultEntityType, let expected = expectedType {
+            } else if let feedback = resultFeedback, feedback.typeMismatch {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(.orange)
                     .accessibilityHidden(true)
-                Text("Expected \(expected.rawValue), got \(got.rawValue)")
+                Text(feedback.message)
                     .fontWeight(.medium)
                     .foregroundStyle(.orange)
-            } else if let title = resultTitle {
+            } else if let feedback = resultFeedback {
                 Image(systemName: resultIsFound ? "checkmark.circle.fill" : "questionmark.circle.fill")
                     .foregroundStyle(resultIsFound ? .green : .orange)
                     .accessibilityHidden(true)
-                Text(
-                    QRScanFeedback.resultMessage(
-                        isFound: resultIsFound,
-                        title: title,
-                        code: resultCode ?? ""
-                    )
-                )
+                Text(feedback.message)
                     .fontWeight(.medium)
                     .foregroundStyle(resultIsFound ? .green : .orange)
             } else {
@@ -279,15 +289,8 @@ struct QRScanSheet: View {
         if let error = scanError {
             return error
         }
-        if typeMismatch, let got = resultEntityType, let expected = expectedType {
-            return "Expected \(expected.rawValue), got \(got.rawValue)"
-        }
-        if let title = resultTitle {
-            return QRScanFeedback.resultMessage(
-                isFound: resultIsFound,
-                title: title,
-                code: resultCode ?? ""
-            )
+        if let resultFeedback {
+            return resultFeedback.message
         }
         return isScannerSupported ? "Point camera at a QR code" : "Enter a QR code to look it up"
     }
@@ -361,7 +364,6 @@ struct QRScanSheet: View {
             resultIsFound = false
             resultEntityType = nil
             resultCode = nil
-            typeMismatch = false
             return false
         }
         if shouldSkip { return }
@@ -383,12 +385,6 @@ struct QRScanSheet: View {
                 ?? result.fields["code"]
                 ?? result.code
 
-            let gotMismatch = QRScanFeedback.isTypeMismatch(
-                isFound: result.isFound,
-                entityType: result.entityType,
-                expectedType: expectedType
-            )
-
             let shouldAutoComplete = result.isFound
                 && (expectedType == nil || result.entityType == expectedType)
 
@@ -401,7 +397,6 @@ struct QRScanSheet: View {
                 resultIsFound = result.isFound
                 resultEntityType = result.entityType
                 resultCode = result.code
-                typeMismatch = gotMismatch
 
                 // Every result callback mutates parent SwiftUI state. Keep the
                 // callback and dismissal in one MainActor transaction.

--- a/Weird Parts IOS/Weird Parts IOSTests/QRScanSheetRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/QRScanSheetRegressionTests.swift
@@ -115,39 +115,53 @@ final class QRScanSheetRegressionTests: XCTestCase {
 
     func testWrongTypeWarningIsOrangeAndPrecedesSuccessRendering() throws {
         let source = try Self.qrScanSheetSource()
-        let feedback = try Self.braceBalancedBody(after: "private var feedbackStatusView", in: source)
+        let feedbackView = try Self.braceBalancedBody(after: "private var feedbackStatusView", in: source)
+        let feedback = QRScanFeedback(
+            isFound: true,
+            entityType: .job,
+            expectedType: .po,
+            title: "JOB-42",
+            code: "JOB-42"
+        )
 
-        guard let mismatchRange = feedback.range(
-            of: "typeMismatch, let got = resultEntityType, let expected = expectedType"
-        ), let resultRange = feedback.range(of: "else if let title = resultTitle") else {
+        guard let mismatchRange = feedbackView.range(
+            of: "else if let feedback = resultFeedback, feedback.typeMismatch"
+        ), let resultRange = feedbackView.range(of: "else if let feedback = resultFeedback {") else {
             XCTFail("Expected type mismatch to branch before generic result rendering.")
             return
         }
 
         XCTAssertLessThan(mismatchRange.lowerBound, resultRange.lowerBound)
+        XCTAssertTrue(feedback.typeMismatch)
+        XCTAssertEqual(feedback.message, "Expected po, got job")
+        XCTAssertFalse(
+            source.contains("@State private var typeMismatch"),
+            "Mismatch classification must be derived from the current result rather than stored independently."
+        )
         XCTAssertTrue(
-            feedback.contains("Text(\"Expected \\(expected.rawValue), got \\(got.rawValue)\")")
-                && feedback.contains(".foregroundStyle(.orange)"),
+            feedbackView.contains("Text(feedback.message)")
+                && feedbackView.contains(".foregroundStyle(.orange)"),
             "Wrong-type results must show an orange Expected/got warning."
+        )
+        XCTAssertTrue(
+            source.contains("return resultFeedback.message"),
+            "Visible and accessibility result copy must consume the same derived feedback message."
         )
     }
 
     func testNotFoundWithExpectedTypeKeepsNotFoundMessageAndIsNotMismatch() throws {
         let source = try Self.qrScanSheetSource()
         let code = "MANUAL-404"
-        let isMismatch = QRScanFeedback.isTypeMismatch(
+        let feedback = QRScanFeedback(
             isFound: false,
             entityType: nil,
-            expectedType: .po
-        )
-        let message = QRScanFeedback.resultMessage(
-            isFound: false,
+            expectedType: .po,
             title: code,
             code: code
         )
 
-        XCTAssertFalse(isMismatch)
-        XCTAssertEqual(message, "Not found: MANUAL-404")
+        XCTAssertFalse(feedback.typeMismatch)
+        XCTAssertEqual(feedback.message, "Not found: MANUAL-404")
         XCTAssertTrue(
             source.contains("let shouldAutoComplete = result.isFound\n                && (expectedType == nil || result.entityType == expectedType)"),
             "Only found matching results may auto-complete."

--- a/docs/plans/qr-scan-derived-feedback-preservation.md
+++ b/docs/plans/qr-scan-derived-feedback-preservation.md
@@ -1,0 +1,49 @@
+# QR Scan Derived Feedback Preservation
+
+## Scope and source direction
+
+- GitHub tracker: #1442
+- Paperclip implementation: WEI-4883
+- Parent preservation classification: WEI-4869 under WEI-4864
+- Integration base: PR #1441 (`hermes/hermes-205c3f48`)
+- User-visible flow: the shared `QRScanSheet` used by Purchase Orders, Clock In/Out, and Warehouse Movement scanner entry points, including the manual fallback when camera scanning is unavailable.
+- Existing UX direction: preserve PR #1441's loading, error, warning, success, not-found, cancellation, and accessibility presentation. This change introduces no new visual pattern.
+- Backend contract: `QRAutoFillService.processQRScan(_:)` returns `QRAutoFillResult`, whose `isFound`, `entityType`, `fields`, and `code` values determine feedback and whether a matching result may complete.
+
+## Design decision
+
+Mismatch status is derived from the current result snapshot rather than stored independently. A `QRScanFeedback` value receives the current result's found flag, actual entity type, expected entity type, display title, and code. It produces both:
+
+1. `typeMismatch`, used only to select warning versus ordinary result styling.
+2. `message`, used unchanged by both visible status text and the accessibility status label.
+
+This removes the mutable `@State typeMismatch` flag, which could drift from `resultIsFound`, `resultEntityType`, or `expectedType` during loading and retries. The rendered and announced copy therefore share one source of truth.
+
+## Contract-stable feedback
+
+The feedback message contract remains:
+
+- Found wrong type: `Expected <expected raw value>, got <actual raw value>`.
+- Found matching type: `Found: <title>`.
+- Not found: `Not found: <code>`.
+
+The executable preservation case is a found `.job` result when `.po` is expected. It must classify as a mismatch and emit exactly `Expected po, got job`.
+
+## State behavior preserved
+
+- Loading continues to clear stale result fields, show and announce `Looking up…`, and disable Look Up.
+- Scan errors continue to take precedence over result feedback.
+- Not-found results remain retryable and retain their code in the message.
+- Matching found results continue through the existing duplicate-delivery gate, dismiss once, and invoke the callback once.
+- Wrong-type results remain visible as orange warnings and do not dismiss.
+- Cancel continues to dismiss without invoking the callback.
+- Camera support and scanner lifecycle behavior are unchanged.
+
+## Acceptance and verification
+
+- `QRScanSheet` contains no mutable `@State typeMismatch`.
+- Visible and accessibility result copy both consume the same `QRScanFeedback.message`.
+- `QRScanSheetRegressionTests` executes the `.job`/`.po` mismatch and exact-message assertion.
+- Focused regression tests pass on the local Mac.
+- `git diff --check` passes, and the committed worktree is clean.
+- Patch remains limited to `QRScanSheet.swift`, `QRScanSheetRegressionTests.swift`, and this plan.


### PR DESCRIPTION
## Summary

- replace mutable manual-QR mismatch state with a derived `QRScanFeedback` value
- use the same derived message for visible and accessibility result status copy
- add an executable `.job`-found / `.po`-expected regression for exact copy `Expected po, got job`
- document the preservation decision in `docs/plans/qr-scan-derived-feedback-preservation.md`

## Preservation scope

This stacked patch is based on the current PR #1441 integration head and preserves its loading, not-found, matching-success, duplicate-delivery, scanner-dismissal, and accessibility behavior. It does not cherry-pick or alter retained commit `e6f5cfe8` or merged PR #1443.

## Verification

Local Mac / iOS 26.5 simulator:

`xcodebuild test -project 'Weird Parts.xcodeproj' -scheme 'Weird Parts' -destination 'platform=iOS Simulator,id=F1F64952-DBE1-4321-A4D6-BDCDE313D6C7' -only-testing:'Weird Parts IOSTests/QRScanSheetRegressionTests'`

Result: `** TEST SUCCEEDED **` — 10 passed, 0 failed.

`git diff --check` passed before commit.

## Tracking

Refs #1442
Tracked in WEI-4883
Implementation WEI-4883
Parent WEI-4864

CI/local-Mac path: iOS/Xcode validation is expected on the self-hosted local Mac runner (`IA-Mac-WPR2`) for this stacked PR.
Merge tracked in WEI-4901