### PR TITLE
test(ios): isolate critical conflict fixture

### DIFF
--- a/Weird Parts IOS/Weird Parts IOSTests/PanelQualityInstructionBannerRegressionTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/PanelQualityInstructionBannerRegressionTests.swift
@@ -178,7 +178,7 @@ final class PanelQualityInstructionBannerRegressionTests: XCTestCase {
                         arguments: [recordId]
                     )
                 }
-                try insertConflict(
+                let insertedConflictId = try insertConflict(
                     db: db,
                     recordId: recordId,
                     fieldName: field,
@@ -186,7 +186,7 @@ final class PanelQualityInstructionBannerRegressionTests: XCTestCase {
                     remoteValue: "22"
                 )
                 let conflict = try XCTUnwrap(
-                    ConflictResolver.getUnreviewedConflicts(db: db).first { $0.fieldName == field }
+                    ConflictResolver.getUnreviewedConflicts(db: db).first { $0.id == insertedConflictId }
                 )
                 guard case .critical = SyncConflictClassifier.classify(conflict) else {
                     return XCTFail("Expected persisted Parts field \(field) to require an explicit critical choice")
@@ -212,13 +212,14 @@ final class PanelQualityInstructionBannerRegressionTests: XCTestCase {
         }
     }
 
+    @discardableResult
     private func insertConflict(
         db: AppDatabase,
         recordId: Int64 = 1,
         fieldName: String,
         localValue: String,
         remoteValue: String
-    ) throws {
+    ) throws -> Int64 {
         try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
@@ -232,6 +233,7 @@ final class PanelQualityInstructionBannerRegressionTests: XCTestCase {
                     "2026-07-14T09:00:00Z", "2026-07-14T10:00:00Z", "2026-07-14T10:00:00Z",
                 ]
             )
+            return dbConn.lastInsertedRowID
         }
     }
 


### PR DESCRIPTION
## Summary
- capture the exact `_conflict_log` row ID inserted by each critical-field regression case
- resolve/classify that inserted row instead of the first seed conflict sharing the field name
- preserve all keep-local and keep-remote persistence assertions across Parts cost, markup, and stock thresholds

## Tests
- `xcodebuild -project "Weird Parts.xcodeproj" -scheme "Weird Parts" -destination 'platform=iOS Simulator,name=WEI3988-iPhone' -parallel-testing-enabled NO -only-testing:"Weird Parts IOSTests/PanelQualityInstructionBannerRegressionTests" test` — 6/6 passed
- focused local/remote `ConflictScreenshotCaptureUITests` on `WEI3988-iPhone` — 2/2 passed; neither test skipped
- `git diff --check`

Stacked on PR #1431 (`WEI-4544-the-front-end-draft-look`) so the fix can land into the branch under verification without duplicating its implementation diff.

Closes #1453
Refs #1431
Tracked in WEI-4937

Merge tracked in WEI-4938
