### PR TITLE
ci: automate trusted first-party PR maintenance

### DIFF
--- a/.github/TRUSTED_AUTOMATION_POLICY.md
+++ b/.github/TRUSTED_AUTOMATION_POLICY.md
@@ -1,0 +1,45 @@
+# Trusted First-Party Automation Policy
+
+## Purpose
+
+Trusted automation keeps Isaac-authored work moving without manual Actions approvals. It does **not** treat every GitHub event, contributor, or marketplace Action as trusted.
+
+## Trusted PR eligibility
+
+A PR is eligible for autonomous maintenance only when all conditions are true:
+
+1. It targets `main` and its head repository is this repository (no fork).
+2. The PR author is listed in `TRUSTED_PR_AUTHORS` (initially `xXKillerNoobYT`).
+3. The head repository owner is this repository's owner.
+4. It is not a draft, has no skip/security/manual labels, and its title does not match the sensitive-change pattern.
+5. Its exact head has no pending or failed required checks.
+6. Any branch-protection requirements are met.
+
+A branch name, a bot review, or a same-repository checkout alone does not prove trust.
+
+## Automation boundaries
+
+| Change origin/type | Automation behavior |
+| --- | --- |
+| Trusted first-party, non-sensitive PR | May rebase, run bounded Codex repair, and queue merge after all gates pass. |
+| External fork or unlisted PR author | Never checked out by a privileged automation workflow; never repaired or merged automatically. |
+| Security, authentication, credentials, encryption, payments, deployment, or policy change | May receive normal read-only checks; excluded from autonomous repair and merge. |
+| Untrusted review/check event | Does not trigger privileged work. Scheduled selection evaluates only eligible PRs. |
+
+## Workflow trigger policy
+
+Privileged maintenance workflows are scheduled from trusted default-branch workflow code and can be manually dispatched in dry-run mode. They do not use `pull_request_target`, and they do not use review/check webhook events as privileged execution triggers.
+
+This avoids GitHub's `action_required` zero-job queue for bot/external review events while retaining the external-contributor approval boundary.
+
+## GitHub Actions settings
+
+- Keep external contributor approval as `all_external_contributors`.
+- Allow GitHub-owned and verified Actions plus the repository owner's explicitly listed action namespace.
+- Keep repository default workflow permissions at `read`; request write permissions only in the individual workflow that needs them.
+- Pin third-party action references before enabling repository-wide SHA pinning.
+- Self-hosted macOS runners execute only trusted repository automation or same-repository PR work after this policy's eligibility check.
+
+## Release boundary
+
+Autonomy never substitutes for release evidence. `main` is TestFlight eligible only after current exact-head iPhone+iPad results are 100% passing with zero unexpected skips and readable result bundles.

--- a/.github/workflows/approved-pr-autofix.yml
+++ b/.github/workflows/approved-pr-autofix.yml
@@ -5,12 +5,11 @@ name: Approved PR Autofix
 # It processes one PR per run and uses bounded Codex fix attempts to avoid loops.
 
 on:
-  pull_request_review:
-    types: [submitted]
-  check_suite:
-    types: [completed]
+  # Evaluate from trusted default-branch workflow code rather than executing
+  # privileged work from review/check events, which can be emitted by external
+  # actors and otherwise become zero-job `action_required` queues.
   schedule:
-    - cron: "17 * * * *"
+    - cron: "*/15 * * * *"
   workflow_dispatch:
     inputs:
       pr_number:
@@ -44,6 +43,9 @@ jobs:
       APPROVED_PR_AUTOFIX_BASE: main
       APPROVED_PR_AUTOFIX_MAX_PRS: "20"
       APPROVED_PR_AUTOFIX_MAX_ATTEMPTS: "3"
+      # Only first-party PR authors explicitly entrusted by Isaac are eligible.
+      APPROVED_PR_AUTOFIX_TRUSTED_PR_AUTHORS: "xXKillerNoobYT"
+      APPROVED_PR_AUTOFIX_REQUIRE_APPROVAL: "0"
       APPROVED_PR_AUTOFIX_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true && '1' || '0' }}
       APPROVED_PR_AUTOFIX_PR_NUMBER: ${{ inputs.pr_number }}
       APPROVED_PR_AUTOFIX_MODEL: gpt-5.5

--- a/.github/workflows/pr-merge-maintenance.yml
+++ b/.github/workflows/pr-merge-maintenance.yml
@@ -2,8 +2,7 @@ name: PR Merge Maintenance
 
 # Fires:
 #   - When a push lands on main (a merge just happened → rebase the next PR)
-#   - When a check suite completes on any PR branch (scan finished → maybe merge now)
-#   - Hourly schedule as a safety net
+#   - Every 15 minutes from trusted default-branch workflow code
 #   - Manual dispatch for one-off runs / debugging
 #
 # ONE PR per run: rebase → wait for scan → fix if failing → merge → triggers next.
@@ -11,10 +10,8 @@ name: PR Merge Maintenance
 on:
   push:
     branches: [main]
-  check_suite:
-    types: [completed]
   schedule:
-    - cron: "0 * * * *"
+    - cron: "*/15 * * * *"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -46,6 +43,8 @@ jobs:
       # until the owner creates the fine-grained PAT (Contents + PRs, R/W).
       GH_TOKEN: ${{ secrets.PR_MAINTENANCE_PAT || github.token }}
       PR_MAINTENANCE_BASE: main
+      PR_MAINTENANCE_TRUSTED_PR_AUTHORS: "xXKillerNoobYT"
+      PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW: "0"
       PR_MAINTENANCE_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true && '1' || '0' }}
 
     steps:

--- a/scripts/approved-pr-autofix.sh
+++ b/scripts/approved-pr-autofix.sh
@@ -20,6 +20,13 @@ DRY_RUN="${APPROVED_PR_AUTOFIX_DRY_RUN:-0}"
 TARGET_PR="${APPROVED_PR_AUTOFIX_PR_NUMBER:-}"
 CODEX_MODEL="${APPROVED_PR_AUTOFIX_MODEL:-gpt-5.5}"
 VALIDATE="${APPROVED_PR_AUTOFIX_VALIDATE:-auto}"
+# Trusted first-party work can progress without a manual GitHub approval click;
+# exact-head checks and sensitive-change exclusions still fail closed.
+REQUIRE_APPROVAL="${APPROVED_PR_AUTOFIX_REQUIRE_APPROVAL:-1}"
+# Comma-separated GitHub logins authorized to originate autonomous PR work.
+# Same-repository location alone is not sufficient: collaborators can create
+# branches, so PR author identity is checked separately.
+TRUSTED_PR_AUTHORS="${APPROVED_PR_AUTOFIX_TRUSTED_PR_AUTHORS:-xXKillerNoobYT}"
 SKIP_LABELS="${APPROVED_PR_AUTOFIX_SKIP_LABELS:-security,security-sensitive,manual-review,manual-merge,do-not-merge,no-autofix}"
 SKIP_TITLE_REGEX="${APPROVED_PR_AUTOFIX_SKIP_TITLE_REGEX:-security|sqlcipher|encryption|auth|payment|credential|secret|keychain}"
 MARKER="approved-pr-autofix:v1"
@@ -34,6 +41,19 @@ for cmd in gh jq git codex; do
 done
 
 IFS=',' read -r -a SKIP_LABEL_ARRAY <<<"$SKIP_LABELS"
+IFS=',' read -r -a TRUSTED_AUTHOR_ARRAY <<<"$TRUSTED_PR_AUTHORS"
+
+is_trusted_author() {
+  local author="$1" candidate normalized_author normalized_candidate
+  normalized_author="$(printf "%s" "$author" | tr '[:upper:]' '[:lower:]')"
+  for candidate in "${TRUSTED_AUTHOR_ARRAY[@]}"; do
+    candidate="$(printf "%s" "$candidate" | xargs)"
+    [[ -z "$candidate" ]] && continue
+    normalized_candidate="$(printf "%s" "$candidate" | tr '[:upper:]' '[:lower:]')"
+    [[ "$normalized_candidate" == "$normalized_author" ]] && return 0
+  done
+  return 1
+}
 
 run_or_log() {
   if [[ "$DRY_RUN" == "1" ]]; then
@@ -192,10 +212,10 @@ commit_and_push_if_changed() {
 
 select_prs() {
   if [[ -n "$TARGET_PR" ]]; then
-    gh pr view "$TARGET_PR" --repo "$REPO" --json number,title,isDraft,labels,headRepositoryOwner,headRefName,headRefOid,mergeStateStatus,mergeable,reviewDecision,autoMergeRequest | jq -c '[.]'
+    gh pr view "$TARGET_PR" --repo "$REPO" --json number,title,isDraft,labels,author,headRepositoryOwner,headRefName,headRefOid,mergeStateStatus,mergeable,reviewDecision,autoMergeRequest | jq -c '[.]'
   else
     gh pr list --repo "$REPO" --base "$BASE" --state open --limit "$MAX_PRS" \
-      --json number,title,isDraft,labels,headRepositoryOwner,headRefName,headRefOid,mergeStateStatus,mergeable,reviewDecision,autoMergeRequest
+      --json number,title,isDraft,labels,author,headRepositoryOwner,headRefName,headRefOid,mergeStateStatus,mergeable,reviewDecision,autoMergeRequest
   fi
 }
 
@@ -208,6 +228,7 @@ while IFS= read -r pr; do
   title="$(jq -r '.title' <<<"$pr")"
   is_draft="$(jq -r '.isDraft' <<<"$pr")"
   labels_json="$(jq -c '[.labels[]?.name]' <<<"$pr")"
+  author="$(jq -r '.author.login // ""' <<<"$pr")"
   head_owner="$(jq -r '.headRepositoryOwner.login // ""' <<<"$pr")"
   head_branch="$(jq -r '.headRefName' <<<"$pr")"
   head_sha="$(jq -r '.headRefOid' <<<"$pr")"
@@ -217,11 +238,18 @@ while IFS= read -r pr; do
 
   echo ""
   echo "--- PR #$number: $title"
-  echo "    review=$review_decision state=$merge_state mergeable=$mergeable draft=$is_draft branch=$head_branch sha=${head_sha:0:8}"
+  echo "    author=${author:-<unknown>} review=$review_decision state=$merge_state mergeable=$mergeable draft=$is_draft branch=$head_branch sha=${head_sha:0:8}"
 
   [[ "$is_draft" == "true" ]] && { echo "    skip: draft"; continue; }
   [[ "$head_owner" != "$repo_owner" ]] && { echo "    skip: fork/untrusted head owner"; continue; }
-  [[ "$review_decision" != "APPROVED" ]] && { echo "    skip: not approved"; continue; }
+  if ! is_trusted_author "$author"; then
+    echo "    skip: PR author is not in APPROVED_PR_AUTOFIX_TRUSTED_PR_AUTHORS"
+    continue
+  fi
+  if [[ "$REQUIRE_APPROVAL" == "1" && "$review_decision" != "APPROVED" ]]; then
+    echo "    skip: approval required by APPROVED_PR_AUTOFIX_REQUIRE_APPROVAL"
+    continue
+  fi
   if has_skip_label "$labels_json" || [[ "$title" =~ $SKIP_TITLE_REGEX ]]; then
     echo "    skip: manual/security label or title"
     continue

--- a/scripts/pr-merge-maintenance.sh
+++ b/scripts/pr-merge-maintenance.sh
@@ -29,6 +29,9 @@ REPO="${1:-${GITHUB_REPOSITORY:-}}"
 BASE="${PR_MAINTENANCE_BASE:-main}"
 MAX_PRS="${PR_MAINTENANCE_MAX_PRS:-}"
 DRY_RUN="${PR_MAINTENANCE_DRY_RUN:-0}"
+# Same-repository branches can still be opened by collaborators; require an
+# explicit PR-author allowlist before automated rebase or merge.
+TRUSTED_PR_AUTHORS="${PR_MAINTENANCE_TRUSTED_PR_AUTHORS:-xXKillerNoobYT}"
 SKIP_LABELS="${PR_MAINTENANCE_SKIP_LABELS:-security,security-sensitive,manual-review,manual-merge,do-not-merge}"
 SKIP_TITLE_REGEX="${PR_MAINTENANCE_SKIP_TITLE_REGEX:-security|sqlcipher|encryption|auth|payment|credential|secret|keychain}"
 
@@ -42,6 +45,19 @@ for cmd in gh jq; do
 done
 
 IFS=',' read -r -a SKIP_LABEL_ARRAY <<<"$SKIP_LABELS"
+IFS=',' read -r -a TRUSTED_AUTHOR_ARRAY <<<"$TRUSTED_PR_AUTHORS"
+
+is_trusted_author() {
+  local author="$1" candidate normalized_author normalized_candidate
+  normalized_author="$(printf "%s" "$author" | tr '[:upper:]' '[:lower:]')"
+  for candidate in "${TRUSTED_AUTHOR_ARRAY[@]}"; do
+    candidate="$(printf "%s" "$candidate" | xargs)"
+    [[ -z "$candidate" ]] && continue
+    normalized_candidate="$(printf "%s" "$candidate" | tr '[:upper:]' '[:lower:]')"
+    [[ "$normalized_candidate" == "$normalized_author" ]] && return 0
+  done
+  return 1
+}
 
 has_skip_label() {
   local labels_json="$1" label
@@ -90,6 +106,7 @@ pr_data_json="$(gh api --paginate --slurp "repos/$REPO/pulls?state=open&base=$BA
       title:            (.title // ""),
       isDraft:          (.draft // false),
       labels:           [(.labels // [])[].name],
+      author:           (.user.login // ""),
       headOwner:        (.head.repo.owner.login // ""),
       mergeable:        (if .mergeable == true then "MERGEABLE"
                          elif .mergeable == false then "CONFLICTING"
@@ -128,12 +145,13 @@ while IFS= read -r pr; do
   mergeable="$(jq -r   '.mergeable // "UNKNOWN"'         <<<"$pr")"
   auto_merge="$(jq -r  '.autoMerge'                      <<<"$pr")"
   labels_json="$(jq -c '.labels'                         <<<"$pr")"
+  author="$(jq -r      '.author // ""'                     <<<"$pr")"
   head_owner="$(jq -r  '.headOwner'                      <<<"$pr")"
   head_sha="$(jq -r    '.headSha'                        <<<"$pr")"
 
   echo ""
   echo "--- PR #$number: $title"
-  echo "    state=$merge_state mergeable=$mergeable autoMerge=$auto_merge draft=$is_draft"
+  echo "    author=${author:-<unknown>} state=$merge_state mergeable=$mergeable autoMerge=$auto_merge draft=$is_draft"
 
   # --- Skip conditions ---
   if [[ "$is_draft" == "true" ]]; then
@@ -141,6 +159,9 @@ while IFS= read -r pr; do
 
   if [[ "$head_owner" != "$repo_owner" ]]; then
     echo "    skip: fork (manual only)"; continue; fi
+
+  if ! is_trusted_author "$author"; then
+    echo "    skip: PR author is not in PR_MAINTENANCE_TRUSTED_PR_AUTHORS"; continue; fi
 
   if has_skip_label "$labels_json" || [[ "$title" =~ $SKIP_TITLE_REGEX ]]; then
     echo "    skip: security/manual label or title"; continue; fi
@@ -205,11 +226,11 @@ while IFS= read -r pr; do
     fi
   fi
 
-  # --- Copilot review gate (owner directive: every PR gets a Copilot review
-  #     before merge). Cloud PR checks now go green in seconds — faster than
-  #     Copilot can review — so the merge must wait for the review explicitly.
-  #     Set PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW=0 to bypass (not recommended). ---
-  if [[ "${PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW:-1}" == "1" ]]; then
+  # Legacy Copilot-only review gate is disabled: this repository uses the
+  # trusted first-party Codex path plus exact-head checks instead.
+  # It may be explicitly re-enabled only for a deliberately configured legacy
+  # migration, never as the default merge requirement.
+  if [[ "${PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW:-0}" == "1" ]]; then
     # A GraphQL API failure must FAIL CLOSED (never merge on unknown review
     # state). We probe once and treat empty/failed output as "not satisfied".
     # Review nodes carry author login + state so a PENDING/DISMISSED review


### PR DESCRIPTION
## Purpose

Implements the trusted first-party automation policy requested by Isaac.

- Scheduled default-branch evaluation replaces bot/external review/check event triggers that created zero-job `action_required` queues.
- Only PRs authored by `xXKillerNoobYT` from the same repository are eligible for repair/rebase/merge automation.
- Forks and sensitive changes remain excluded.
- Legacy Copilot review gate is disabled; the automation path is Codex-only plus exact-head checks.

## Verification

- `bash -n scripts/approved-pr-autofix.sh`
- `bash -n scripts/pr-merge-maintenance.sh`
- static workflow trust checks: no `pull_request_target`, no `check_suite` privileged triggers, 15-minute trusted scheduled evaluation
- dry-run merge maintenance selected a trusted same-repo PR and emitted only the expected dry-run merge command

## Follow-up

Repository-level Actions settings (default workflow token read, selected-actions owner namespace, and SHA pinning after action refs are pinned) are intentionally applied only after this policy PR is validated and merged.