### PR TITLE
ci: enforce exact-head iPhone and iPad beta gate

### DIFF
--- a/.github/workflows/artifact-guard.yml
+++ b/.github/workflows/artifact-guard.yml
@@ -18,17 +18,30 @@ permissions:
 jobs:
   tracked-artifacts:
     name: Tracked artifact guard
-    # Pure-python guard — no Xcode needed, but this private repo currently
-    # sees GitHub-hosted zero-step failures (runner_id=0), so run on WPR2's
-    # self-hosted Mac labels until hosted capacity/billing is restored.
-    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
+    # Fork heads run only on GitHub-hosted infrastructure and fail before
+    # checkout. Same-repository PRs and main pushes retain the private Mac
+    # runner so untrusted code can never reach the local machine.
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && '["ubuntu-latest"]' || '["self-hosted","macOS","ARM64","xcode","ios","local-mac"]') }}
     timeout-minutes: 5
     steps:
+      - name: Reject untrusted fork without using the Mac runner
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::error::Fork pull requests cannot execute repository code on WPR2's self-hosted Mac runners. A trusted maintainer must reproduce the head in a same-repository branch before the artifact guard can pass."
+          exit 1
+
       - name: Checkout repository
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/checkout@v4
 
+      - name: Validate fail-closed artifact-guard source policy
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        run: python3 scripts/ci/validate-artifact-guard-source.py
+
       - name: Verify guard catches representative artifacts
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: python3 scripts/guard-tracked-artifacts.py --self-test
 
       - name: Fail on tracked local runtime artifacts
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: python3 scripts/guard-tracked-artifacts.py

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ token.json
 
 # Temporary files
 .tmp/
+/artifacts/
 __pycache__/
 **/__pycache__/
 *.py[cod]

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -569,16 +569,19 @@ final class Weird_Parts_IOSUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Database Size"].waitForExistence(timeout: 5), "Backup page should show database size")
         captureWEI3988("01-backups-before-create")
 
-        // `rowAccessibility` deliberately exposes this row with a stable
-        // identifier and sentence-case VoiceOver label. Keep the smoke coupled
-        // to that accessible contract, not title-cased visual copy.
-        let createBackup = app.descendants(matching: .any)["settings-backups-create-backup-button"]
+        let createBackup = app.descendants(matching: .any)["settings-backups-create-backup-button"].firstMatch
         XCTAssertTrue(createBackup.waitForExistence(timeout: 10), "Create Backup Now action should be available")
-        XCTAssertTrue(createBackup.isHittable, "Create backup action should be hittable")
+        XCTAssertEqual(createBackup.label, "Create backup now", "Backup action should expose its stable accessible name")
         createBackup.tap()
-        let backupCreated = NSPredicate(format: "value == %@", "Backup created")
-        expectation(for: backupCreated, evaluatedWith: createBackup, handler: nil)
-        waitForExpectations(timeout: 15)
+        let backupCreated = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "value == %@", "Backup created"),
+            object: createBackup
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [backupCreated], timeout: 15),
+            .completed,
+            "Manual backup action should complete with visible and accessible success state"
+        )
         XCTAssertTrue(app.staticTexts["Stored Backups"].waitForExistence(timeout: 5), "Backup count row should remain visible after backup creation")
         captureWEI3988("02-backups-created")
 

--- a/docs/plans/ios-beta-pr-gate.md
+++ b/docs/plans/ios-beta-pr-gate.md
@@ -36,7 +36,7 @@ Add `scripts/ci/run-ios-beta-gate.sh` as the execution layer. It:
 5. Runs all app/core unit and regression tests from `WiredPart-iOS`, excluding the broad UI-test target from that phase.
 6. Runs the bounded `WiredPart-iOS-Stage9-Smokes` deterministic UI plan on the same simulator; this includes the maintained viewport harness without invoking manual screenshot catalogs.
 7. Writes an `.xcresult`, Xcode log, and machine-readable summary for both phases in every lane.
-8. Bounds each Xcode phase at 40 minutes. A source-validated runtime assertion budgets a possible recovery boot as well as the initial boot, reserving 18 minutes of the 120-minute job envelope for result packaging, cleanup, and artifact upload.
+8. Bounds unit/regression Xcode work at 40 minutes and the deterministic UI-smoke plan at 15 minutes. If—and only if—the UI-test runner exits during its known pre-test bootstrap termination (`Early unexpected exit` plus signal `term`, Xcode status 65), the gate preserves the first attempt's log/status/raw `.xcresult` and retries that same smoke plan once with the same 15-minute bound. Product assertion failures, timeouts, skipped tests, and other Xcode failures stay red without retry. A source-validated runtime assertion budgets a possible recovery boot plus both bounded UI-smoke attempts, reserving 18 minutes of the 120-minute job envelope for result packaging, cleanup, and artifact upload.
 9. Fails if Xcode fails or times out, the result bundle is missing, zero tests execute, any test fails, or any executed test is skipped.
 10. Shuts down/deletes the run-owned simulator and removes DerivedData on exit; an `always()` cleanup step repeats simulator removal after an interrupted script.
 
@@ -77,7 +77,7 @@ Runner unavailability, simulator-runtime drift, disk pressure, or GitHub Actions
 ## Validation
 
 - Shell syntax: `bash -n scripts/ci/run-ios-beta-gate.sh`
-- Recovery decision regression: `IOS_BETA_GATE_SELF_TEST=1 bash scripts/ci/run-ios-beta-gate.sh ipad`
+- Recovery decision regression (CoreLocation and exact UI-test bootstrap signature only): `IOS_BETA_GATE_SELF_TEST=1 bash scripts/ci/run-ios-beta-gate.sh ipad`
 - Workflow parse: Ruby/Psych or `actionlint` when available
 - Source assertions: trusted-PR guard, exact SHA checkout, two device contexts, local runner labels, artifact upload under `if: always()`
 - Local runner canary: execute one phone and one tablet lane with the current repository SHA and inspect `xcresulttool` summaries

--- a/docs/plans/ios-beta-pr-gate.md
+++ b/docs/plans/ios-beta-pr-gate.md
@@ -1,0 +1,86 @@
+# iOS Beta PR Gate
+
+Status: Approved owner requirement captured in WEI-5356 / GitHub #1480
+Owner: CTO
+Repository: `xXKillerNoobYT/Weird-Part-Run-2`
+
+## Purpose
+
+`main` is the TestFlight beta integration branch. A pull request must not merge based on the echo-only `Analyze (swift)` compatibility context. Same-repository pull requests targeting `main` require real Xcode build/test evidence for both compact iPhone and regular-width iPad simulator classes at the exact pull-request head.
+
+This PR gate does not archive, export, upload, or submit to App Store Connect. TestFlight archive/upload remains a separate post-merge `main` operation that requires an authenticated App Store Connect session.
+
+## Design
+
+### Workflow
+
+Add `.github/workflows/ios-beta-gate.yml` with a two-entry matrix:
+
+- `iPhone`: iPhone 16 Pro simulator on iOS 26.5
+- `iPad`: iPad Air 13-inch (M2) simulator on iOS 26.5
+
+Each matrix entry runs on the repo's self-hosted Mac labels:
+
+`[self-hosted, macOS, ARM64, xcode, ios, local-mac]`
+
+The workflow is limited to trusted same-repository pull requests targeting `main`. A pull request head update cancels stale in-flight work. Each lane checks out `github.event.pull_request.head.sha` explicitly and verifies `HEAD` equals that SHA before invoking Xcode.
+
+### Deterministic runner
+
+Add `scripts/ci/run-ios-beta-gate.sh` as the execution layer. It:
+
+1. Records expected SHA, actual SHA, runner, Xcode, runtime, and device-class metadata.
+2. Requires at least 60 GiB free on the volume backing `RUNNER_TEMP`; insufficient capacity fails before Xcode.
+3. Verifies the requested iOS runtime and simulator device type exist.
+4. Creates a run-owned temporary simulator and DerivedData directory; simulator boot is bounded at 15 minutes so runtime failures return control for cleanup/evidence upload.
+5. Runs all app/core unit and regression tests from `WiredPart-iOS`, excluding the broad UI-test target from that phase.
+6. Runs the bounded `WiredPart-iOS-Stage9-Smokes` deterministic UI plan on the same simulator; this includes the maintained viewport harness without invoking manual screenshot catalogs.
+7. Writes an `.xcresult`, Xcode log, and machine-readable summary for both phases in every lane.
+8. Bounds each Xcode phase at 50 minutes so the script can package partial evidence before the 120-minute job timeout.
+9. Fails if Xcode fails or times out, the result bundle is missing, zero tests execute, any test fails, or any executed test is skipped.
+10. Shuts down/deletes the run-owned simulator and removes DerivedData on exit; an `always()` cleanup step repeats simulator removal after an interrupted script.
+
+### Evidence and retention
+
+Each lane uploads its log, summary, metadata, and zipped `.xcresult` even when the gate fails. Artifacts are retained for seven days. GitHub Actions run/check URLs remain the durable audit index.
+
+### Required checks
+
+After the workflow has produced check runs on its own PR head, require both stable contexts on protected `main` with strict/current-head enforcement:
+
+- `iOS Beta Gate (iPhone)`
+- `iOS Beta Gate (iPad)`
+
+Keep required conversation resolution enabled. Do not remove `Analyze (swift)` as part of this change; CodeQL policy changes are separate.
+
+Paperclip PR disposition must classify missing, queued, cancelled, stale-head, or failed device contexts as not merge-ready.
+
+## Dependencies
+
+- Self-hosted runner online with labels `self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`.
+- Xcode with iOS 26.5 simulator runtime.
+- At least 60 GiB free on the runner temp volume.
+- GitHub branch-administration permission to add required contexts after canary evidence exists.
+
+Runner unavailability, simulator-runtime drift, disk pressure, or GitHub Actions outage are infrastructure failures. They remain red/pending; no echo-only substitute is permitted.
+
+## Acceptance criteria
+
+- A same-repository PR to `main` produces distinct phone and tablet checks at its exact head SHA.
+- Both checks execute non-empty unit/regression and deterministic UI-smoke phases with zero failures and zero unexpected skips.
+- Insufficient disk, absent runtime/device type, Xcode failure, missing/invalid result, timeout, cancellation, or runner outage cannot report success.
+- `.xcresult`, log, summary, and provenance metadata are available on both success and failure.
+- Branch protection requires both current-head contexts after the canary run.
+- Ordinary PRs perform no archive, export, TestFlight upload, or App Store Connect operation.
+
+## Validation
+
+- Shell syntax: `bash -n scripts/ci/run-ios-beta-gate.sh`
+- Workflow parse: Ruby/Psych or `actionlint` when available
+- Source assertions: trusted-PR guard, exact SHA checkout, two device contexts, local runner labels, artifact upload under `if: always()`
+- Local runner canary: execute one phone and one tablet lane with the current repository SHA and inspect `xcresulttool` summaries
+- GitHub readback: PR check runs show both contexts on the current head; branch protection API lists both with `strict: true`
+
+## Rollback
+
+Revert the workflow and script only if the gate itself is defective. While repairing it, keep merges fail-closed. Do not replace it with an echo/status-only success path. Removing required contexts requires explicit owner approval because it weakens the beta gate.

--- a/docs/plans/ios-beta-pr-gate.md
+++ b/docs/plans/ios-beta-pr-gate.md
@@ -23,7 +23,7 @@ Each matrix entry runs on the repo's self-hosted Mac labels:
 
 `[self-hosted, macOS, ARM64, xcode, ios, local-mac]`
 
-The workflow is limited to trusted same-repository pull requests targeting `main`. A pull request head update cancels stale in-flight work. Each lane checks out `github.event.pull_request.head.sha` explicitly and verifies `HEAD` equals that SHA before invoking Xcode.
+Trusted same-repository pull requests targeting `main` run on the self-hosted Mac. Fork pull requests route the same stable iPhone/iPad contexts to `ubuntu-latest`, fail explicitly before checkout, and never execute untrusted code on the Mac. This prevents GitHub's skipped-job success semantics from satisfying either required context. A pull request head update cancels stale in-flight work. Each trusted lane checks out `github.event.pull_request.head.sha` explicitly and verifies `HEAD` equals that SHA before invoking Xcode.
 
 ### Deterministic runner
 
@@ -32,11 +32,11 @@ Add `scripts/ci/run-ios-beta-gate.sh` as the execution layer. It:
 1. Records expected SHA, actual SHA, runner, Xcode, runtime, and device-class metadata.
 2. Requires at least 60 GiB free on the volume backing `RUNNER_TEMP`; insufficient capacity fails before Xcode.
 3. Verifies the requested iOS runtime and simulator device type exist.
-4. Creates a run-owned temporary simulator and DerivedData directory; simulator boot is bounded at 15 minutes so runtime failures return control for cleanup/evidence upload.
+4. Creates a run-owned temporary simulator and DerivedData directory; the boot command is bounded at 2 minutes and boot readiness at 10 minutes so runtime failures return control for cleanup/evidence upload.
 5. Runs all app/core unit and regression tests from `WiredPart-iOS`, excluding the broad UI-test target from that phase.
 6. Runs the bounded `WiredPart-iOS-Stage9-Smokes` deterministic UI plan on the same simulator; this includes the maintained viewport harness without invoking manual screenshot catalogs.
 7. Writes an `.xcresult`, Xcode log, and machine-readable summary for both phases in every lane.
-8. Bounds each Xcode phase at 50 minutes so the script can package partial evidence before the 120-minute job timeout.
+8. Bounds each Xcode phase at 40 minutes. A source-validated runtime assertion caps the two Xcode phases plus simulator boot at 92 minutes, reserving 20 minutes of the 120-minute job envelope for result packaging, cleanup, and artifact upload.
 9. Fails if Xcode fails or times out, the result bundle is missing, zero tests execute, any test fails, or any executed test is skipped.
 10. Shuts down/deletes the run-owned simulator and removes DerivedData on exit; an `always()` cleanup step repeats simulator removal after an interrupted script.
 
@@ -67,6 +67,7 @@ Runner unavailability, simulator-runtime drift, disk pressure, or GitHub Actions
 ## Acceptance criteria
 
 - A same-repository PR to `main` produces distinct phone and tablet checks at its exact head SHA.
+- A fork PR produces the same two required contexts as explicit failures on `ubuntu-latest`; it cannot run on the self-hosted Mac or pass through skipped-job semantics.
 - Both checks execute non-empty unit/regression and deterministic UI-smoke phases with zero failures and zero unexpected skips.
 - Insufficient disk, absent runtime/device type, Xcode failure, missing/invalid result, timeout, cancellation, or runner outage cannot report success.
 - `.xcresult`, log, summary, and provenance metadata are available on both success and failure.

--- a/docs/plans/ios-beta-pr-gate.md
+++ b/docs/plans/ios-beta-pr-gate.md
@@ -77,7 +77,7 @@ Runner unavailability, simulator-runtime drift, disk pressure, or GitHub Actions
 ## Validation
 
 - Shell syntax: `bash -n scripts/ci/run-ios-beta-gate.sh`
-- Recovery decision regression (CoreLocation and exact UI-test bootstrap signature only): `IOS_BETA_GATE_SELF_TEST=1 bash scripts/ci/run-ios-beta-gate.sh ipad`
+- Recovery decision regression (CoreLocation, exact UI-test bootstrap signature, and missing-first-`.xcresult` retry rejection): `IOS_BETA_GATE_SELF_TEST=1 bash scripts/ci/run-ios-beta-gate.sh ipad`
 - Workflow parse: Ruby/Psych or `actionlint` when available
 - Source assertions: trusted-PR guard, exact SHA checkout, two device contexts, local runner labels, artifact upload under `if: always()`
 - Local runner canary: execute one phone and one tablet lane with the current repository SHA and inspect `xcresulttool` summaries

--- a/docs/plans/ios-beta-pr-gate.md
+++ b/docs/plans/ios-beta-pr-gate.md
@@ -32,11 +32,11 @@ Add `scripts/ci/run-ios-beta-gate.sh` as the execution layer. It:
 1. Records expected SHA, actual SHA, runner, Xcode, runtime, and device-class metadata.
 2. Requires at least 60 GiB free on the volume backing `RUNNER_TEMP`; insufficient capacity fails before Xcode.
 3. Verifies the requested iOS runtime and simulator device type exist.
-4. Creates a run-owned temporary simulator and DerivedData directory; the boot command is bounded at 2 minutes and boot readiness at 10 minutes so runtime failures return control for cleanup/evidence upload.
+4. Creates a run-owned temporary simulator and DerivedData directory; the boot command is bounded at 2 minutes and boot readiness at 10 minutes. When only the iPad first boot exhausts that bound while `CoreLocationMigrator.migrator` is active, it captures diagnostics, deletes that run-owned simulator, and performs exactly one fresh 10-minute boot attempt. All other boot failures and a second migration failure remain nonzero failures.
 5. Runs all app/core unit and regression tests from `WiredPart-iOS`, excluding the broad UI-test target from that phase.
 6. Runs the bounded `WiredPart-iOS-Stage9-Smokes` deterministic UI plan on the same simulator; this includes the maintained viewport harness without invoking manual screenshot catalogs.
 7. Writes an `.xcresult`, Xcode log, and machine-readable summary for both phases in every lane.
-8. Bounds each Xcode phase at 40 minutes. A source-validated runtime assertion caps the two Xcode phases plus simulator boot at 92 minutes, reserving 20 minutes of the 120-minute job envelope for result packaging, cleanup, and artifact upload.
+8. Bounds each Xcode phase at 40 minutes. A source-validated runtime assertion budgets a possible recovery boot as well as the initial boot, reserving 18 minutes of the 120-minute job envelope for result packaging, cleanup, and artifact upload.
 9. Fails if Xcode fails or times out, the result bundle is missing, zero tests execute, any test fails, or any executed test is skipped.
 10. Shuts down/deletes the run-owned simulator and removes DerivedData on exit; an `always()` cleanup step repeats simulator removal after an interrupted script.
 
@@ -77,6 +77,7 @@ Runner unavailability, simulator-runtime drift, disk pressure, or GitHub Actions
 ## Validation
 
 - Shell syntax: `bash -n scripts/ci/run-ios-beta-gate.sh`
+- Recovery decision regression: `IOS_BETA_GATE_SELF_TEST=1 bash scripts/ci/run-ios-beta-gate.sh ipad`
 - Workflow parse: Ruby/Psych or `actionlint` when available
 - Source assertions: trusted-PR guard, exact SHA checkout, two device contexts, local runner labels, artifact upload under `if: always()`
 - Local runner canary: execute one phone and one tablet lane with the current repository SHA and inspect `xcresulttool` summaries

--- a/docs/runbooks/local-mac-actions-runner.md
+++ b/docs/runbooks/local-mac-actions-runner.md
@@ -43,6 +43,33 @@ runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
 
 Keep cloud runners only for intentionally minimal jobs that do not need the Mac runner and are not contributing to PR blockages.
 
+## iOS beta PR gate
+
+Tracking: GitHub #1480 / Paperclip WEI-5356. Design: `docs/plans/ios-beta-pr-gate.md`.
+
+Every same-repository PR targeting `main` must produce both current-head checks:
+
+- `iOS Beta Gate (iPhone)`
+- `iOS Beta Gate (iPad)`
+
+The workflow is `.github/workflows/ios-beta-gate.yml`; deterministic execution is in `scripts/ci/run-ios-beta-gate.sh`. Each lane verifies the checked-out SHA, requires at least 60 GiB free on the runner temp volume, creates a run-owned iOS 26.5 simulator, runs the `WiredPart-iOS` unit/regression phase plus the bounded `WiredPart-iOS-Stage9-Smokes` UI plan, and uploads logs, summaries, metadata, and `.xcresult` evidence even on failure.
+
+Missing, queued, cancelled, stale-head, skipped-test, zero-test, disk-capacity, simulator-runtime, timeout, and runner-offline outcomes are non-mergeable. Do not substitute `Analyze (swift)` or another echo/status-only check for either device lane.
+
+Ordinary PR gates never archive or upload to App Store Connect. TestFlight upload is a separate post-merge `main` operation and requires an authenticated App Store Connect session.
+
+### Disk-capacity response
+
+If either lane reports less than 60 GiB free:
+
+1. Keep the check red and the PR out of the merge queue.
+2. Inspect the runner volume and generated caches/artifacts without deleting live worktrees or unique work.
+3. Perform only evidence-backed safe cleanup; route uncertain or broad deletion through a bounded cleanup issue.
+4. Rerun both device lanes at the unchanged PR head and use the new check/artifact URLs as evidence.
+5. Recheck free space after the run because a successful build can still expose a capacity trend.
+
+Review the gate on every PR. A repeated capacity failure, missing runtime, malformed result bundle, or unavailable runner creates/updates a Paperclip CI blocker after the first reproducible occurrence; do not wait for a merge attempt.
+
 ## Paperclip communication
 
 PR-info, merge, review, and blocker issues should mention this local-runner path whenever CI status is discussed. Do not repeatedly ask Isaac to correct cloud Actions/billing blockers without first checking the local Mac runner.

--- a/scripts/ci/run-ios-beta-gate.sh
+++ b/scripts/ci/run-ios-beta-gate.sh
@@ -255,6 +255,8 @@ command -v xcrun >/dev/null || fail "xcrun is required"
 
 available_kib="$(df -Pk "$runner_temp" | awk 'NR == 2 {print $4}')"
 [[ "$available_kib" =~ ^[0-9]+$ ]] || fail "could not determine free disk space for $runner_temp"
+[[ "$minimum_free_gib" =~ ^[0-9]+$ ]] && (( minimum_free_gib > 0 )) || \
+  fail "MINIMUM_FREE_GIB must be a positive integer (got: $minimum_free_gib)"
 required_kib=$((minimum_free_gib * 1024 * 1024))
 available_gib=$((available_kib / 1024 / 1024))
 echo "available_free_gib=$available_gib" >> "$metadata_file"

--- a/scripts/ci/run-ios-beta-gate.sh
+++ b/scripts/ci/run-ios-beta-gate.sh
@@ -255,8 +255,6 @@ command -v xcrun >/dev/null || fail "xcrun is required"
 
 available_kib="$(df -Pk "$runner_temp" | awk 'NR == 2 {print $4}')"
 [[ "$available_kib" =~ ^[0-9]+$ ]] || fail "could not determine free disk space for $runner_temp"
-[[ "$minimum_free_gib" =~ ^[0-9]+$ ]] && (( minimum_free_gib > 0 )) || \
-  fail "MINIMUM_FREE_GIB must be a positive integer (got: $minimum_free_gib)"
 required_kib=$((minimum_free_gib * 1024 * 1024))
 available_gib=$((available_kib / 1024 / 1024))
 echo "available_free_gib=$available_gib" >> "$metadata_file"

--- a/scripts/ci/validate-artifact-guard-source.py
+++ b/scripts/ci/validate-artifact-guard-source.py
@@ -66,6 +66,22 @@ def mapping_entries(mapping)
   end
 end
 
+def step_syntax_errors(step)
+  errors = []
+  walk(step) do |node|
+    if node.is_a?(Psych::Nodes::Alias)
+      errors << "workflow step contains a YAML alias"
+    elsif node.is_a?(Psych::Nodes::Mapping)
+      node.children.each_slice(2) do |key, _value|
+        if key.is_a?(Psych::Nodes::Scalar) && key.value == "<<"
+          errors << "workflow step contains a YAML mapping merge key"
+        end
+      end
+    end
+  end
+  errors.uniq
+end
+
 document = Psych.parse_stream(STDIN.read)
 anchors = anchors_for(document)
 steps = []
@@ -77,7 +93,7 @@ walk(document) do |node|
   step_list.children.each do |step|
     next unless step.is_a?(Psych::Nodes::Mapping)
     step_entries = mapping_entries(step)
-    steps << %w[if uses run].each_with_object({}) do |field, result|
+    steps << %w[if uses run].each_with_object({ "syntax_errors" => step_syntax_errors(step) }) do |field, result|
       result[field] = scalar_metadata(step_entries[field], anchors) if step_entries.key?(field)
     end
   end
@@ -159,6 +175,8 @@ def validate(workflow: str) -> list[str]:
             "uses fields must use plain or quoted scalars; aliases, tags, anchors, "
             "and block scalars are not allowed"
         )
+    if any(step.get("syntax_errors") for step in steps):
+        errors.append("workflow steps must not use YAML aliases or mapping merge keys")
 
     # Pinning a checkout version is a supply-chain choice, not a trust boundary.
     # Guard every actions/checkout@* invocation so a later version bump cannot
@@ -248,6 +266,10 @@ def run_self_test() -> int:
         "- name: Checkout repository after fork rejection\n        if: always()\n        uses: \"actions/checkout@v5\"",
         "- name: &checkout_v5 actions/checkout@v5\n        if: always()\n        uses: *checkout_v5",
     )
+    unsafe_always_merged_checkout = unsafe_always_quoted_checkout.replace(
+        "- name: Checkout repository after fork rejection\n        if: always()\n        uses: \"actions/checkout@v5\"",
+        f"- &trusted_checkout\n        name: Trusted checkout template\n        if: {TRUSTED_CONDITION}\n        uses: actions/checkout@v4\n      - <<: *trusted_checkout\n        name: Checkout repository after fork rejection\n        if: always()",
+    )
     unsafe_unguarded_repository_code = f"""jobs:
   tracked-artifacts:
     runs-on: {DYNAMIC_RUNNER}
@@ -283,6 +305,7 @@ def run_self_test() -> int:
         "later always() folded actions/checkout@v5 after trusted checkout": unsafe_always_folded_checkout,
         "later always() literal actions/checkout@v5 after trusted checkout": unsafe_always_literal_checkout,
         "later always() aliased actions/checkout@v5 after trusted checkout": unsafe_always_aliased_checkout,
+        "later always() merged actions/checkout@v4 after trusted checkout": unsafe_always_merged_checkout,
         "unguarded repository-code step": unsafe_unguarded_repository_code,
     }
     valid_failures = {

--- a/scripts/ci/validate-artifact-guard-source.py
+++ b/scripts/ci/validate-artifact-guard-source.py
@@ -72,7 +72,14 @@ def validate(workflow: str) -> list[str]:
     if not reject_steps:
         errors.append("fork rejection must be a fork-conditioned nonzero-exit run step")
 
-    checkout_steps = [step for step in steps if step.get("uses") == "actions/checkout@v4"]
+    # Pinning a checkout version is a supply-chain choice, not a trust boundary.
+    # Guard every actions/checkout@* invocation so a later version bump cannot
+    # bypass the trusted-source condition.
+    checkout_steps = [
+        step
+        for step in steps
+        if step.get("uses", "").startswith("actions/checkout@")
+    ]
     if not checkout_steps:
         errors.append("workflow must have a trusted checkout step")
     for step in checkout_steps:
@@ -122,7 +129,7 @@ def run_self_test() -> int:
         uses: actions/checkout@v4
       - name: Checkout repository after fork rejection
         if: always()
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Run artifact guard
         if: {TRUSTED_CONDITION}
         run: python3 scripts/guard-tracked-artifacts.py
@@ -142,7 +149,7 @@ def run_self_test() -> int:
 """
     fixtures = {
         "dynamic fork-to-self-hosted-Mac runner": unsafe_dynamic_fork_runner,
-        "later always() checkout after trusted checkout": unsafe_always_checkout,
+        "later always() actions/checkout@v5 after trusted checkout": unsafe_always_checkout,
         "unguarded repository-code step": unsafe_unguarded_repository_code,
     }
     failures = [name for name, fixture in fixtures.items() if not validate(fixture)]

--- a/scripts/ci/validate-artifact-guard-source.py
+++ b/scripts/ci/validate-artifact-guard-source.py
@@ -117,6 +117,9 @@ def run_self_test() -> int:
       - name: Reject untrusted fork without using the Mac runner
         if: {FORK_CONDITION}
         run: exit 1
+      - name: Checkout repository
+        if: {TRUSTED_CONDITION}
+        uses: actions/checkout@v4
       - name: Checkout repository after fork rejection
         if: always()
         uses: actions/checkout@v4
@@ -124,9 +127,23 @@ def run_self_test() -> int:
         if: {TRUSTED_CONDITION}
         run: python3 scripts/guard-tracked-artifacts.py
 """
+    unsafe_unguarded_repository_code = f"""jobs:
+  tracked-artifacts:
+    runs-on: {DYNAMIC_RUNNER}
+    steps:
+      - name: Reject untrusted fork without using the Mac runner
+        if: {FORK_CONDITION}
+        run: exit 1
+      - name: Checkout repository
+        if: {TRUSTED_CONDITION}
+        uses: actions/checkout@v4
+      - name: Run repository-controlled command without source guard
+        run: python3 scripts/guard-tracked-artifacts.py
+"""
     fixtures = {
         "dynamic fork-to-self-hosted-Mac runner": unsafe_dynamic_fork_runner,
-        "later always() checkout": unsafe_always_checkout,
+        "later always() checkout after trusted checkout": unsafe_always_checkout,
+        "unguarded repository-code step": unsafe_unguarded_repository_code,
     }
     failures = [name for name, fixture in fixtures.items() if not validate(fixture)]
     if failures:

--- a/scripts/ci/validate-artifact-guard-source.py
+++ b/scripts/ci/validate-artifact-guard-source.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import re
 import sys
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github/workflows/artifact-guard.yml"
 
-FORK_RUNNER = '["ubuntu-latest"]'
-TRUSTED_RUNNER = '["self-hosted","macOS","ARM64","xcode","ios","local-mac"]'
 FORK_CONDITION = (
     "github.event_name == 'pull_request' && "
     "github.event.pull_request.head.repo.full_name != github.repository"
@@ -20,67 +19,133 @@ TRUSTED_CONDITION = (
     "github.event_name != 'pull_request' || "
     "github.event.pull_request.head.repo.full_name == github.repository"
 )
+DYNAMIC_RUNNER = (
+    "${{ fromJSON(github.event_name == 'pull_request' && "
+    "github.event.pull_request.head.repo.full_name != github.repository && "
+    "'[\"ubuntu-latest\"]' || "
+    "'[\"self-hosted\",\"macOS\",\"ARM64\",\"xcode\",\"ios\",\"local-mac\"]') }}"
+)
+STEP_START = re.compile(r"^      -(?:\s|$)")
+FIELD = re.compile(r"^        (?P<name>if|uses|run):\s*(?P<value>.*)$")
+
+
+def _steps(workflow: str) -> list[dict[str, str]]:
+    """Extract each workflow step's security-relevant fields without YAML coercion."""
+    steps: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for line in workflow.splitlines():
+        if STEP_START.match(line):
+            current = {}
+            steps.append(current)
+            continue
+        if current is None:
+            continue
+        match = FIELD.match(line)
+        if match:
+            current[match.group("name")] = match.group("value").strip()
+        elif current.get("run", "").startswith("|") and line.startswith("          "):
+            current["run"] += f"\n{line.strip()}"
+    return steps
 
 
 def validate(workflow: str) -> list[str]:
     """Return fail-closed policy violations for the workflow source."""
-    required_fragments = {
-        "fork jobs route to GitHub-hosted infrastructure": FORK_RUNNER,
-        "same-repository jobs retain the labeled Mac runner": TRUSTED_RUNNER,
-        "fork path is explicitly rejected": "Reject untrusted fork without using the Mac runner",
-        "fork rejection condition is present": FORK_CONDITION,
-        "fork rejection exits nonzero": "exit 1",
-        "checkout is limited to trusted PRs and pushes": f"if: {TRUSTED_CONDITION}\n        uses: actions/checkout@v4",
-        "source policy validation is limited to trusted PRs and pushes": (
-            f"if: {TRUSTED_CONDITION}\n"
-            "        run: python3 scripts/ci/validate-artifact-guard-source.py"
-        ),
-        "artifact guard self-test is limited to trusted PRs and pushes": (
-            f"if: {TRUSTED_CONDITION}\n"
-            "        run: python3 scripts/guard-tracked-artifacts.py --self-test"
-        ),
-        "artifact guard execution is limited to trusted PRs and pushes": (
-            f"if: {TRUSTED_CONDITION}\n"
-            "        run: python3 scripts/guard-tracked-artifacts.py"
-        ),
-    }
-    errors = [
-        f"workflow invariant missing: {description} ({fragment!r})"
-        for description, fragment in required_fragments.items()
-        if fragment not in workflow
-    ]
+    errors: list[str] = []
+    lines = workflow.splitlines()
 
-    if "runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]" in workflow:
+    # The runner expression is security-critical: its fork branch must select only
+    # GitHub-hosted infrastructure, while the other branch is the trusted Mac.
+    runner_lines = [line.strip() for line in lines if line.startswith("    runs-on:")]
+    if runner_lines != [f"runs-on: {DYNAMIC_RUNNER}"]:
+        errors.append(
+            "dynamic runner must exactly route forks to ubuntu-latest and trusted sources to the labeled Mac"
+        )
+    if any("runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]" in line for line in lines):
         errors.append("workflow has an unconditional self-hosted runner assignment")
-    if "uses: actions/checkout@v4\n" in workflow and "if: " not in workflow.split(
-        "uses: actions/checkout@v4", maxsplit=1
-    )[0].rsplit("- name:", maxsplit=1)[-1]:
-        errors.append("checkout can run without a trusted-source condition")
+
+    steps = _steps(workflow)
+    reject_steps = [
+        step
+        for step in steps
+        if step.get("if") == FORK_CONDITION and "exit 1" in step.get("run", "")
+    ]
+    if not reject_steps:
+        errors.append("fork rejection must be a fork-conditioned nonzero-exit run step")
+
+    checkout_steps = [step for step in steps if step.get("uses") == "actions/checkout@v4"]
+    if not checkout_steps:
+        errors.append("workflow must have a trusted checkout step")
+    for step in checkout_steps:
+        if step.get("if") != TRUSTED_CONDITION:
+            errors.append("checkout can run without the exact trusted-source condition")
+
+    # A run step executes repository-controlled content after checkout; require the
+    # trusted source guard on every normal run, not merely on the first such step.
+    for step in steps:
+        run = step.get("run")
+        if not run or step in reject_steps:
+            continue
+        if step.get("if") != TRUSTED_CONDITION:
+            errors.append(f"repository-code step is not bound to the trusted-source condition: {run!r}")
 
     return errors
 
 
 def run_self_test() -> int:
-    unsafe_workflow = """jobs:
-  tracked-artifacts:
-    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
-    steps:
-      - name: Checkout repository
+    trusted_steps = f"""      - name: Checkout repository
+        if: {TRUSTED_CONDITION}
         uses: actions/checkout@v4
-      - run: python3 scripts/guard-tracked-artifacts.py
+      - name: Validate source policy
+        if: {TRUSTED_CONDITION}
+        run: python3 scripts/ci/validate-artifact-guard-source.py
+      - name: Run artifact guard
+        if: {TRUSTED_CONDITION}
+        run: python3 scripts/guard-tracked-artifacts.py
 """
-    errors = validate(unsafe_workflow)
-    if not errors:
-        print("artifact-guard source validator self-test failed: unsafe fixture passed", file=sys.stderr)
+    unsafe_dynamic_fork_runner = f"""jobs:
+  tracked-artifacts:
+    runs-on: ${{{{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && '[\"self-hosted\",\"macOS\",\"ARM64\",\"xcode\",\"ios\",\"local-mac\"]' || '[\"self-hosted\",\"macOS\",\"ARM64\",\"xcode\",\"ios\",\"local-mac\"]') }}}}
+    steps:
+      - name: Reject untrusted fork without using the Mac runner
+        if: {FORK_CONDITION}
+        run: exit 1
+{trusted_steps}"""
+    unsafe_always_checkout = f"""jobs:
+  tracked-artifacts:
+    runs-on: {DYNAMIC_RUNNER}
+    steps:
+      - name: Reject untrusted fork without using the Mac runner
+        if: {FORK_CONDITION}
+        run: exit 1
+      - name: Checkout repository after fork rejection
+        if: always()
+        uses: actions/checkout@v4
+      - name: Run artifact guard
+        if: {TRUSTED_CONDITION}
+        run: python3 scripts/guard-tracked-artifacts.py
+"""
+    fixtures = {
+        "dynamic fork-to-self-hosted-Mac runner": unsafe_dynamic_fork_runner,
+        "later always() checkout": unsafe_always_checkout,
+    }
+    failures = [name for name, fixture in fixtures.items() if not validate(fixture)]
+    if failures:
+        print("artifact-guard source validator self-test failed: unsafe fixtures passed", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
         return 1
 
-    print(f"artifact-guard source validator self-test passed ({len(errors)} unsafe-policy violations detected).")
+    violations = sum(len(validate(fixture)) for fixture in fixtures.values())
+    print(
+        f"artifact-guard source validator self-test passed "
+        f"({len(fixtures)} unsafe fixtures, {violations} violations detected)."
+    )
     return 0
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--self-test", action="store_true", help="Verify that an unsafe workflow fixture is rejected.")
+    parser.add_argument("--self-test", action="store_true", help="Verify that unsafe workflow fixtures are rejected.")
     args = parser.parse_args()
 
     if args.self_test:

--- a/scripts/ci/validate-artifact-guard-source.py
+++ b/scripts/ci/validate-artifact-guard-source.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
-import re
+import subprocess
 import sys
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -25,88 +26,105 @@ DYNAMIC_RUNNER = (
     "'[\"ubuntu-latest\"]' || "
     "'[\"self-hosted\",\"macOS\",\"ARM64\",\"xcode\",\"ios\",\"local-mac\"]') }}"
 )
-STEP_START = re.compile(r"^      -(?:\s|$)")
-FIELD = re.compile(r"^        (?P<name>if|uses|run):\s*(?P<value>.*)$")
-NON_PLAIN_USES_PREFIXES = ("&", "*", "!", ">", "|")
+RUBY_STEP_PARSER = r"""
+require "json"
+require "psych"
+
+def walk(node, &block)
+  yield node
+  (node.respond_to?(:children) && node.children || []).each { |child| walk(child, &block) }
+end
+
+def anchors_for(document)
+  anchors = {}
+  walk(document) do |node|
+    if node.is_a?(Psych::Nodes::Scalar) && node.anchor
+      anchors[node.anchor] = node
+    end
+  end
+  anchors
+end
+
+def scalar_metadata(node, anchors)
+  case node
+  when Psych::Nodes::Scalar
+    { "kind" => "scalar", "value" => node.value, "style" => node.style,
+      "tag" => node.tag, "anchor" => node.anchor }
+  when Psych::Nodes::Alias
+    target = anchors[node.anchor]
+    { "kind" => "alias", "value" => target&.value, "style" => target&.style,
+      "tag" => target&.tag, "anchor" => node.anchor }
+  else
+    { "kind" => "unsupported", "value" => nil, "style" => nil,
+      "tag" => nil, "anchor" => nil }
+  end
+end
+
+def mapping_entries(mapping)
+  mapping.children.each_slice(2).each_with_object({}) do |(key, value), entries|
+    entries[key.value] = value if key.is_a?(Psych::Nodes::Scalar)
+  end
+end
+
+document = Psych.parse_stream(STDIN.read)
+anchors = anchors_for(document)
+steps = []
+walk(document) do |node|
+  next unless node.is_a?(Psych::Nodes::Mapping)
+  entries = mapping_entries(node)
+  step_list = entries["steps"]
+  next unless step_list.is_a?(Psych::Nodes::Sequence)
+  step_list.children.each do |step|
+    next unless step.is_a?(Psych::Nodes::Mapping)
+    step_entries = mapping_entries(step)
+    steps << %w[if uses run].each_with_object({}) do |field, result|
+      result[field] = scalar_metadata(step_entries[field], anchors) if step_entries.key?(field)
+    end
+  end
+end
+puts JSON.generate({ "steps" => steps })
+"""
+
+PLAIN_OR_QUOTED_YAML_STYLES = {1, 2, 3}
 
 
-def _steps(workflow: str) -> list[dict[str, str]]:
-    """Extract each workflow step's security-relevant fields without YAML coercion."""
-    steps: list[dict[str, str]] = []
-    current: dict[str, str] | None = None
-    for line in workflow.splitlines():
-        if STEP_START.match(line):
-            current = {}
-            steps.append(current)
-            continue
-        if current is None:
-            continue
-        match = FIELD.match(line)
-        if match:
-            current[match.group("name")] = match.group("value").strip()
-        elif line.startswith("          "):
-            for name in ("run", "uses"):
-                if current.get(name, "").startswith(("|", ">")):
-                    current[name] += f"\n{line.strip()}"
+def _steps(workflow: str) -> list[dict[str, dict[str, object]]]:
+    """Parse workflow steps structurally and preserve YAML scalar metadata.
+
+    Psych resolves the YAML tree rather than inferring fields from indentation, so
+    legal sequence styles such as ``- uses: ...`` cannot conceal an action. The
+    validator fails closed if the parser is unavailable or the workflow is invalid.
+    """
+    try:
+        result = subprocess.run(
+            ["ruby", "-e", RUBY_STEP_PARSER],
+            input=workflow,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        parsed = json.loads(result.stdout)
+    except (FileNotFoundError, subprocess.CalledProcessError, json.JSONDecodeError) as error:
+        raise ValueError(f"structural YAML parser failed: {error}") from error
+    steps = parsed.get("steps")
+    if not isinstance(steps, list):
+        raise ValueError("structural YAML parser did not return workflow steps")
     return steps
 
 
-def _strip_yaml_inline_comment(value: str) -> str:
-    """Remove a YAML comment while preserving hashes inside quoted scalars."""
-    quote: str | None = None
-    escaped = False
-    for index, character in enumerate(value):
-        if quote == '"' and character == "\\" and not escaped:
-            escaped = True
-            continue
-        if character == quote and not escaped:
-            quote = None
-        elif quote is None and character in {"'", '"'}:
-            quote = character
-        elif quote is None and character == "#" and (index == 0 or value[index - 1].isspace()):
-            return value[:index].rstrip()
-        escaped = False
-    return value.rstrip()
+def _value(step: dict[str, dict[str, object]], field: str) -> str:
+    value = step.get(field, {}).get("value")
+    return value if isinstance(value, str) else ""
 
 
-def _yaml_scalar(value: str) -> str:
-    """Extract a checkout candidate from a YAML scalar without trusting its syntax.
-
-    This is deliberately not a general YAML parser.  The policy rejects aliases,
-    anchors, tags, and block scalar syntax below, but still extracts their textual
-    checkout target so every semantic ``actions/checkout@*`` candidate receives the
-    trusted-source check before the unsupported syntax produces its fail-closed
-    violation.
-    """
-    value = _strip_yaml_inline_comment(value.strip())
-    if value.startswith((">", "|")):
-        return " ".join(
-            _strip_yaml_inline_comment(line.strip())
-            for line in value.splitlines()[1:]
-        ).strip()
-    if value.startswith("&") or value.startswith("!"):
-        parts = value.split(maxsplit=1)
-        return _yaml_scalar(parts[1]) if len(parts) == 2 else ""
-    if value.startswith("*"):
-        return ""
-    if len(value) < 2 or value[0] not in {"'", '"'}:
-        return value
-    if value[-1] != value[0]:
-        return ""
-    if value[0] == "'":
-        return value[1:-1].replace("''", "'")
-    return value[1:-1]
-
-
-def _is_non_plain_uses_scalar(value: str) -> bool:
-    """Reject YAML syntax that can hide a checkout action from this source guard.
-
-    The workflow deliberately uses plain or quoted scalar action references.  This
-    validator does not attempt a partial YAML implementation: anchors, aliases,
-    tags, and block scalars are rejected so they cannot resolve to a later
-    ``actions/checkout@*`` invocation outside the trusted-source condition.
-    """
-    return value.lstrip().startswith(NON_PLAIN_USES_PREFIXES)
+def _has_unsupported_uses_syntax(step: dict[str, dict[str, object]]) -> bool:
+    uses = step["uses"]
+    return (
+        uses.get("kind") != "scalar"
+        or uses.get("style") not in PLAIN_OR_QUOTED_YAML_STYLES
+        or uses.get("tag") is not None
+        or uses.get("anchor") is not None
+    )
 
 
 def validate(workflow: str) -> list[str]:
@@ -124,21 +142,19 @@ def validate(workflow: str) -> list[str]:
     if any("runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]" in line for line in lines):
         errors.append("workflow has an unconditional self-hosted runner assignment")
 
-    steps = _steps(workflow)
+    try:
+        steps = _steps(workflow)
+    except ValueError as error:
+        return [*errors, str(error)]
     reject_steps = [
         step
         for step in steps
-        if step.get("if") == FORK_CONDITION and "exit 1" in step.get("run", "")
+        if _value(step, "if") == FORK_CONDITION and "exit 1" in _value(step, "run")
     ]
     if not reject_steps:
         errors.append("fork rejection must be a fork-conditioned nonzero-exit run step")
 
-    non_plain_uses = [
-        step["uses"]
-        for step in steps
-        if "uses" in step and _is_non_plain_uses_scalar(step["uses"])
-    ]
-    if non_plain_uses:
+    if any("uses" in step and _has_unsupported_uses_syntax(step) for step in steps):
         errors.append(
             "uses fields must use plain or quoted scalars; aliases, tags, anchors, "
             "and block scalars are not allowed"
@@ -150,21 +166,21 @@ def validate(workflow: str) -> list[str]:
     checkout_steps = [
         step
         for step in steps
-        if _yaml_scalar(step.get("uses", "")).startswith("actions/checkout@")
+        if _value(step, "uses").startswith("actions/checkout@")
     ]
     if not checkout_steps:
         errors.append("workflow must have a trusted checkout step")
     for step in checkout_steps:
-        if step.get("if") != TRUSTED_CONDITION:
+        if _value(step, "if") != TRUSTED_CONDITION:
             errors.append("checkout can run without the exact trusted-source condition")
 
     # A run step executes repository-controlled content after checkout; require the
     # trusted source guard on every normal run, not merely on the first such step.
     for step in steps:
-        run = step.get("run")
+        run = _value(step, "run")
         if not run or step in reject_steps:
             continue
-        if step.get("if") != TRUSTED_CONDITION:
+        if _value(step, "if") != TRUSTED_CONDITION:
             errors.append(f"repository-code step is not bound to the trusted-source condition: {run!r}")
 
     return errors
@@ -212,6 +228,10 @@ def run_self_test() -> int:
     unsafe_always_quoted_inline_comment_checkout = unsafe_always_quoted_checkout.replace(
         'uses: "actions/checkout@v5"', 'uses: "actions/checkout@v5" # semantic checkout action'
     )
+    unsafe_always_inline_mapping_checkout = unsafe_always_quoted_checkout.replace(
+        "- name: Checkout repository after fork rejection\n        if: always()\n        uses: \"actions/checkout@v5\"",
+        "- uses: actions/checkout@v5\n        if: always()",
+    )
     unsafe_always_anchor_checkout = unsafe_always_quoted_checkout.replace(
         'uses: "actions/checkout@v5"', "uses: &checkout_v5 actions/checkout@v5"
     )
@@ -257,6 +277,7 @@ def run_self_test() -> int:
         "later always() double-quoted actions/checkout@v5 after trusted checkout": unsafe_always_quoted_checkout,
         "later always() single-quoted actions/checkout@v5 after trusted checkout": unsafe_always_single_quoted_checkout,
         "later always() quoted actions/checkout@v5 with inline comment after trusted checkout": unsafe_always_quoted_inline_comment_checkout,
+        "later always() inline-mapping actions/checkout@v5 after trusted checkout": unsafe_always_inline_mapping_checkout,
         "later always() anchored actions/checkout@v5 after trusted checkout": unsafe_always_anchor_checkout,
         "later always() explicitly tagged actions/checkout@v5 after trusted checkout": unsafe_always_tagged_checkout,
         "later always() folded actions/checkout@v5 after trusted checkout": unsafe_always_folded_checkout,

--- a/scripts/ci/validate-artifact-guard-source.py
+++ b/scripts/ci/validate-artifact-guard-source.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Fail when the artifact-guard workflow can run fork code on a private runner."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/artifact-guard.yml"
+
+FORK_RUNNER = '["ubuntu-latest"]'
+TRUSTED_RUNNER = '["self-hosted","macOS","ARM64","xcode","ios","local-mac"]'
+FORK_CONDITION = (
+    "github.event_name == 'pull_request' && "
+    "github.event.pull_request.head.repo.full_name != github.repository"
+)
+TRUSTED_CONDITION = (
+    "github.event_name != 'pull_request' || "
+    "github.event.pull_request.head.repo.full_name == github.repository"
+)
+
+
+def validate(workflow: str) -> list[str]:
+    """Return fail-closed policy violations for the workflow source."""
+    required_fragments = {
+        "fork jobs route to GitHub-hosted infrastructure": FORK_RUNNER,
+        "same-repository jobs retain the labeled Mac runner": TRUSTED_RUNNER,
+        "fork path is explicitly rejected": "Reject untrusted fork without using the Mac runner",
+        "fork rejection condition is present": FORK_CONDITION,
+        "fork rejection exits nonzero": "exit 1",
+        "checkout is limited to trusted PRs and pushes": f"if: {TRUSTED_CONDITION}\n        uses: actions/checkout@v4",
+        "source policy validation is limited to trusted PRs and pushes": (
+            f"if: {TRUSTED_CONDITION}\n"
+            "        run: python3 scripts/ci/validate-artifact-guard-source.py"
+        ),
+        "artifact guard self-test is limited to trusted PRs and pushes": (
+            f"if: {TRUSTED_CONDITION}\n"
+            "        run: python3 scripts/guard-tracked-artifacts.py --self-test"
+        ),
+        "artifact guard execution is limited to trusted PRs and pushes": (
+            f"if: {TRUSTED_CONDITION}\n"
+            "        run: python3 scripts/guard-tracked-artifacts.py"
+        ),
+    }
+    errors = [
+        f"workflow invariant missing: {description} ({fragment!r})"
+        for description, fragment in required_fragments.items()
+        if fragment not in workflow
+    ]
+
+    if "runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]" in workflow:
+        errors.append("workflow has an unconditional self-hosted runner assignment")
+    if "uses: actions/checkout@v4\n" in workflow and "if: " not in workflow.split(
+        "uses: actions/checkout@v4", maxsplit=1
+    )[0].rsplit("- name:", maxsplit=1)[-1]:
+        errors.append("checkout can run without a trusted-source condition")
+
+    return errors
+
+
+def run_self_test() -> int:
+    unsafe_workflow = """jobs:
+  tracked-artifacts:
+    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - run: python3 scripts/guard-tracked-artifacts.py
+"""
+    errors = validate(unsafe_workflow)
+    if not errors:
+        print("artifact-guard source validator self-test failed: unsafe fixture passed", file=sys.stderr)
+        return 1
+
+    print(f"artifact-guard source validator self-test passed ({len(errors)} unsafe-policy violations detected).")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true", help="Verify that an unsafe workflow fixture is rejected.")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return run_self_test()
+
+    errors = validate(WORKFLOW.read_text(encoding="utf-8"))
+    if errors:
+        print("Artifact-guard source validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("Artifact-guard source validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/validate-artifact-guard-source.py
+++ b/scripts/ci/validate-artifact-guard-source.py
@@ -44,16 +44,55 @@ def _steps(workflow: str) -> list[dict[str, str]]:
         match = FIELD.match(line)
         if match:
             current[match.group("name")] = match.group("value").strip()
-        elif current.get("run", "").startswith("|") and line.startswith("          "):
-            current["run"] += f"\n{line.strip()}"
+        elif line.startswith("          "):
+            for name in ("run", "uses"):
+                if current.get(name, "").startswith(("|", ">")):
+                    current[name] += f"\n{line.strip()}"
     return steps
 
 
+def _strip_yaml_inline_comment(value: str) -> str:
+    """Remove a YAML comment while preserving hashes inside quoted scalars."""
+    quote: str | None = None
+    escaped = False
+    for index, character in enumerate(value):
+        if quote == '"' and character == "\\" and not escaped:
+            escaped = True
+            continue
+        if character == quote and not escaped:
+            quote = None
+        elif quote is None and character in {"'", '"'}:
+            quote = character
+        elif quote is None and character == "#" and (index == 0 or value[index - 1].isspace()):
+            return value[:index].rstrip()
+        escaped = False
+    return value.rstrip()
+
+
 def _yaml_scalar(value: str) -> str:
-    """Normalize the single-line YAML scalar forms accepted for ``uses`` values."""
-    value = value.strip()
-    if len(value) < 2 or value[0] != value[-1] or value[0] not in {"'", '"'}:
+    """Extract a checkout candidate from a YAML scalar without trusting its syntax.
+
+    This is deliberately not a general YAML parser.  The policy rejects aliases,
+    anchors, tags, and block scalar syntax below, but still extracts their textual
+    checkout target so every semantic ``actions/checkout@*`` candidate receives the
+    trusted-source check before the unsupported syntax produces its fail-closed
+    violation.
+    """
+    value = _strip_yaml_inline_comment(value.strip())
+    if value.startswith((">", "|")):
+        return " ".join(
+            _strip_yaml_inline_comment(line.strip())
+            for line in value.splitlines()[1:]
+        ).strip()
+    if value.startswith("&") or value.startswith("!"):
+        parts = value.split(maxsplit=1)
+        return _yaml_scalar(parts[1]) if len(parts) == 2 else ""
+    if value.startswith("*"):
+        return ""
+    if len(value) < 2 or value[0] not in {"'", '"'}:
         return value
+    if value[-1] != value[0]:
+        return ""
     if value[0] == "'":
         return value[1:-1].replace("''", "'")
     return value[1:-1]
@@ -170,6 +209,9 @@ def run_self_test() -> int:
     unsafe_always_single_quoted_checkout = unsafe_always_quoted_checkout.replace(
         'uses: "actions/checkout@v5"', "uses: 'actions/checkout@v5'"
     )
+    unsafe_always_quoted_inline_comment_checkout = unsafe_always_quoted_checkout.replace(
+        'uses: "actions/checkout@v5"', 'uses: "actions/checkout@v5" # semantic checkout action'
+    )
     unsafe_always_anchor_checkout = unsafe_always_quoted_checkout.replace(
         'uses: "actions/checkout@v5"', "uses: &checkout_v5 actions/checkout@v5"
     )
@@ -206,11 +248,15 @@ def run_self_test() -> int:
         "single-quoted trusted checkout": trusted_steps.replace(
             "uses: actions/checkout@v4", "uses: 'actions/checkout@v4'"
         ),
+        "double-quoted trusted checkout with inline comment": trusted_steps.replace(
+            "uses: actions/checkout@v4", 'uses: "actions/checkout@v4" # trusted action'
+        ),
     }
     fixtures = {
         "dynamic fork-to-self-hosted-Mac runner": unsafe_dynamic_fork_runner,
         "later always() double-quoted actions/checkout@v5 after trusted checkout": unsafe_always_quoted_checkout,
         "later always() single-quoted actions/checkout@v5 after trusted checkout": unsafe_always_single_quoted_checkout,
+        "later always() quoted actions/checkout@v5 with inline comment after trusted checkout": unsafe_always_quoted_inline_comment_checkout,
         "later always() anchored actions/checkout@v5 after trusted checkout": unsafe_always_anchor_checkout,
         "later always() explicitly tagged actions/checkout@v5 after trusted checkout": unsafe_always_tagged_checkout,
         "later always() folded actions/checkout@v5 after trusted checkout": unsafe_always_folded_checkout,

--- a/scripts/ci/validate-artifact-guard-source.py
+++ b/scripts/ci/validate-artifact-guard-source.py
@@ -27,6 +27,7 @@ DYNAMIC_RUNNER = (
 )
 STEP_START = re.compile(r"^      -(?:\s|$)")
 FIELD = re.compile(r"^        (?P<name>if|uses|run):\s*(?P<value>.*)$")
+NON_PLAIN_USES_PREFIXES = ("&", "*", "!", ">", "|")
 
 
 def _steps(workflow: str) -> list[dict[str, str]]:
@@ -58,6 +59,17 @@ def _yaml_scalar(value: str) -> str:
     return value[1:-1]
 
 
+def _is_non_plain_uses_scalar(value: str) -> bool:
+    """Reject YAML syntax that can hide a checkout action from this source guard.
+
+    The workflow deliberately uses plain or quoted scalar action references.  This
+    validator does not attempt a partial YAML implementation: anchors, aliases,
+    tags, and block scalars are rejected so they cannot resolve to a later
+    ``actions/checkout@*`` invocation outside the trusted-source condition.
+    """
+    return value.lstrip().startswith(NON_PLAIN_USES_PREFIXES)
+
+
 def validate(workflow: str) -> list[str]:
     """Return fail-closed policy violations for the workflow source."""
     errors: list[str] = []
@@ -81,6 +93,17 @@ def validate(workflow: str) -> list[str]:
     ]
     if not reject_steps:
         errors.append("fork rejection must be a fork-conditioned nonzero-exit run step")
+
+    non_plain_uses = [
+        step["uses"]
+        for step in steps
+        if "uses" in step and _is_non_plain_uses_scalar(step["uses"])
+    ]
+    if non_plain_uses:
+        errors.append(
+            "uses fields must use plain or quoted scalars; aliases, tags, anchors, "
+            "and block scalars are not allowed"
+        )
 
     # Pinning a checkout version is a supply-chain choice, not a trust boundary.
     # Guard every actions/checkout@* invocation so a later version bump cannot
@@ -147,6 +170,22 @@ def run_self_test() -> int:
     unsafe_always_single_quoted_checkout = unsafe_always_quoted_checkout.replace(
         'uses: "actions/checkout@v5"', "uses: 'actions/checkout@v5'"
     )
+    unsafe_always_anchor_checkout = unsafe_always_quoted_checkout.replace(
+        'uses: "actions/checkout@v5"', "uses: &checkout_v5 actions/checkout@v5"
+    )
+    unsafe_always_tagged_checkout = unsafe_always_quoted_checkout.replace(
+        'uses: "actions/checkout@v5"', "uses: !!str actions/checkout@v5"
+    )
+    unsafe_always_folded_checkout = unsafe_always_quoted_checkout.replace(
+        'uses: "actions/checkout@v5"', "uses: >-\n          actions/checkout@v5"
+    )
+    unsafe_always_literal_checkout = unsafe_always_quoted_checkout.replace(
+        'uses: "actions/checkout@v5"', "uses: |-\n          actions/checkout@v5"
+    )
+    unsafe_always_aliased_checkout = unsafe_always_quoted_checkout.replace(
+        "- name: Checkout repository after fork rejection\n        if: always()\n        uses: \"actions/checkout@v5\"",
+        "- name: &checkout_v5 actions/checkout@v5\n        if: always()\n        uses: *checkout_v5",
+    )
     unsafe_unguarded_repository_code = f"""jobs:
   tracked-artifacts:
     runs-on: {DYNAMIC_RUNNER}
@@ -172,6 +211,11 @@ def run_self_test() -> int:
         "dynamic fork-to-self-hosted-Mac runner": unsafe_dynamic_fork_runner,
         "later always() double-quoted actions/checkout@v5 after trusted checkout": unsafe_always_quoted_checkout,
         "later always() single-quoted actions/checkout@v5 after trusted checkout": unsafe_always_single_quoted_checkout,
+        "later always() anchored actions/checkout@v5 after trusted checkout": unsafe_always_anchor_checkout,
+        "later always() explicitly tagged actions/checkout@v5 after trusted checkout": unsafe_always_tagged_checkout,
+        "later always() folded actions/checkout@v5 after trusted checkout": unsafe_always_folded_checkout,
+        "later always() literal actions/checkout@v5 after trusted checkout": unsafe_always_literal_checkout,
+        "later always() aliased actions/checkout@v5 after trusted checkout": unsafe_always_aliased_checkout,
         "unguarded repository-code step": unsafe_unguarded_repository_code,
     }
     valid_failures = {

--- a/scripts/ci/validate-artifact-guard-source.py
+++ b/scripts/ci/validate-artifact-guard-source.py
@@ -48,6 +48,16 @@ def _steps(workflow: str) -> list[dict[str, str]]:
     return steps
 
 
+def _yaml_scalar(value: str) -> str:
+    """Normalize the single-line YAML scalar forms accepted for ``uses`` values."""
+    value = value.strip()
+    if len(value) < 2 or value[0] != value[-1] or value[0] not in {"'", '"'}:
+        return value
+    if value[0] == "'":
+        return value[1:-1].replace("''", "'")
+    return value[1:-1]
+
+
 def validate(workflow: str) -> list[str]:
     """Return fail-closed policy violations for the workflow source."""
     errors: list[str] = []
@@ -78,7 +88,7 @@ def validate(workflow: str) -> list[str]:
     checkout_steps = [
         step
         for step in steps
-        if step.get("uses", "").startswith("actions/checkout@")
+        if _yaml_scalar(step.get("uses", "")).startswith("actions/checkout@")
     ]
     if not checkout_steps:
         errors.append("workflow must have a trusted checkout step")
@@ -117,7 +127,7 @@ def run_self_test() -> int:
         if: {FORK_CONDITION}
         run: exit 1
 {trusted_steps}"""
-    unsafe_always_checkout = f"""jobs:
+    unsafe_always_quoted_checkout = f"""jobs:
   tracked-artifacts:
     runs-on: {DYNAMIC_RUNNER}
     steps:
@@ -129,11 +139,14 @@ def run_self_test() -> int:
         uses: actions/checkout@v4
       - name: Checkout repository after fork rejection
         if: always()
-        uses: actions/checkout@v5
+        uses: "actions/checkout@v5"
       - name: Run artifact guard
         if: {TRUSTED_CONDITION}
         run: python3 scripts/guard-tracked-artifacts.py
 """
+    unsafe_always_single_quoted_checkout = unsafe_always_quoted_checkout.replace(
+        'uses: "actions/checkout@v5"', "uses: 'actions/checkout@v5'"
+    )
     unsafe_unguarded_repository_code = f"""jobs:
   tracked-artifacts:
     runs-on: {DYNAMIC_RUNNER}
@@ -147,11 +160,39 @@ def run_self_test() -> int:
       - name: Run repository-controlled command without source guard
         run: python3 scripts/guard-tracked-artifacts.py
 """
+    valid_quoted_checkouts = {
+        "double-quoted trusted checkout": trusted_steps.replace(
+            "uses: actions/checkout@v4", 'uses: "actions/checkout@v4"'
+        ),
+        "single-quoted trusted checkout": trusted_steps.replace(
+            "uses: actions/checkout@v4", "uses: 'actions/checkout@v4'"
+        ),
+    }
     fixtures = {
         "dynamic fork-to-self-hosted-Mac runner": unsafe_dynamic_fork_runner,
-        "later always() actions/checkout@v5 after trusted checkout": unsafe_always_checkout,
+        "later always() double-quoted actions/checkout@v5 after trusted checkout": unsafe_always_quoted_checkout,
+        "later always() single-quoted actions/checkout@v5 after trusted checkout": unsafe_always_single_quoted_checkout,
         "unguarded repository-code step": unsafe_unguarded_repository_code,
     }
+    valid_failures = {
+        name: validate(
+            f"""jobs:
+  tracked-artifacts:
+    runs-on: {DYNAMIC_RUNNER}
+    steps:
+      - name: Reject untrusted fork without using the Mac runner
+        if: {FORK_CONDITION}
+        run: exit 1
+{steps}"""
+        )
+        for name, steps in valid_quoted_checkouts.items()
+    }
+    valid_failures = {name: errors for name, errors in valid_failures.items() if errors}
+    if valid_failures:
+        print("artifact-guard source validator self-test failed: valid quoted checkout rejected", file=sys.stderr)
+        for name, errors in valid_failures.items():
+            print(f"- {name}: {errors}", file=sys.stderr)
+        return 1
     failures = [name for name, fixture in fixtures.items() if not validate(fixture)]
     if failures:
         print("artifact-guard source validator self-test failed: unsafe fixtures passed", file=sys.stderr)

--- a/scripts/ci/validate-artifact-guard-source.py
+++ b/scripts/ci/validate-artifact-guard-source.py
@@ -91,7 +91,16 @@ walk(document) do |node|
   step_list = entries["steps"]
   next unless step_list.is_a?(Psych::Nodes::Sequence)
   step_list.children.each do |step|
-    next unless step.is_a?(Psych::Nodes::Mapping)
+    # A sequence alias can materialize a complete step mapping without exposing
+    # its fields in this AST position. Reject it rather than silently omitting a
+    # semantic checkout from the policy scan.
+    unless step.is_a?(Psych::Nodes::Mapping)
+      error = step.is_a?(Psych::Nodes::Alias) ?
+        "workflow step contains a YAML alias" :
+        "workflow step must be a YAML mapping"
+      steps << { "syntax_errors" => [error] }
+      next
+    end
     step_entries = mapping_entries(step)
     steps << %w[if uses run].each_with_object({ "syntax_errors" => step_syntax_errors(step) }) do |field, result|
       result[field] = scalar_metadata(step_entries[field], anchors) if step_entries.key?(field)
@@ -270,6 +279,22 @@ def run_self_test() -> int:
         "- name: Checkout repository after fork rejection\n        if: always()\n        uses: \"actions/checkout@v5\"",
         f"- &trusted_checkout\n        name: Trusted checkout template\n        if: {TRUSTED_CONDITION}\n        uses: actions/checkout@v4\n      - <<: *trusted_checkout\n        name: Checkout repository after fork rejection\n        if: always()",
     )
+    unsafe_aliased_step_checkout = f"""jobs:
+  tracked-artifacts:
+    runs-on: {DYNAMIC_RUNNER}
+    steps:
+      - name: Reject untrusted fork without using the Mac runner
+        if: {FORK_CONDITION}
+        run: exit 1
+      - &trusted_checkout
+        name: Trusted checkout template
+        if: {TRUSTED_CONDITION}
+        uses: actions/checkout@v4
+      - *trusted_checkout
+      - name: Run artifact guard
+        if: {TRUSTED_CONDITION}
+        run: python3 scripts/guard-tracked-artifacts.py
+"""
     unsafe_unguarded_repository_code = f"""jobs:
   tracked-artifacts:
     runs-on: {DYNAMIC_RUNNER}
@@ -306,6 +331,7 @@ def run_self_test() -> int:
         "later always() literal actions/checkout@v5 after trusted checkout": unsafe_always_literal_checkout,
         "later always() aliased actions/checkout@v5 after trusted checkout": unsafe_always_aliased_checkout,
         "later always() merged actions/checkout@v4 after trusted checkout": unsafe_always_merged_checkout,
+        "aliased workflow-step checkout after trusted checkout": unsafe_aliased_step_checkout,
         "unguarded repository-code step": unsafe_unguarded_repository_code,
     }
     valid_failures = {


### PR DESCRIPTION
## Summary
- add exact-head iPhone and regular-width iPad Xcode gate jobs on WPR2 self-hosted Mac runners
- fail closed on low disk, missing runtime/device, timeout, zero tests, unexpected skips, Xcode failures, or evidence-log failures
- preserve unit/regression and deterministic UI-smoke xcresults, summaries, logs, and provenance metadata on success or failure
- document beta-gate operations and keep ordinary PRs separate from TestFlight archive/upload

## Validation
- `bash -n scripts/ci/run-ios-beta-gate.sh`
- Ruby/Psych parse of `.github/workflows/ios-beta-gate.yml`
- fail-closed checks: wrong SHA exit 1; forced disk threshold exit 1; bounded process exit 142
- focused independent Codex review: no remaining high/medium findings
- local iPhone canary compiled the app and executed/passed multiple UI tests before the broad manual UI catalog exposed an unbounded automation stall; the implementation now uses the maintained bounded Stage9 UI smoke plan plus all unit/regression tests
- PR Actions must supply final current-head iPhone + iPad evidence

Closes #1480
Tracked in WEI-5356

TestFlight/App Store Connect archive and upload are explicitly out of scope for this PR.