### PR TITLE
canary: verify fork PR fails closed before checkout

### DIFF
--- a/.github/workflows/ios-beta-gate.yml
+++ b/.github/workflows/ios-beta-gate.yml
@@ -1,0 +1,71 @@
+name: iOS Beta Gate
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+
+# The gate is intentionally same-repository only because it runs trusted code on
+# WPR2's private Mac runners. Fork PRs remain fail-closed and require an owner-
+# approved validation path before merge.
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-beta-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  ios-beta-gate:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    name: iOS Beta Gate (${{ matrix.name }})
+    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: iPhone
+            device_class: iphone
+          - name: iPad
+            device_class: ipad
+    env:
+      EXPECTED_SHA: ${{ github.event.pull_request.head.sha }}
+      IOS_RUNTIME_VERSION: "26.5"
+      MINIMUM_FREE_GIB: "60"
+      SIMULATOR_BOOT_TIMEOUT_SECONDS: "900"
+      XCODE_PHASE_TIMEOUT_SECONDS: "3000"
+
+    steps:
+      - name: Checkout exact pull-request head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+          clean: true
+
+      - name: Run exact-head Xcode build and tests
+        run: bash scripts/ci/run-ios-beta-gate.sh "${{ matrix.device_class }}"
+
+      - name: Remove run-owned simulator after interruption
+        if: always()
+        shell: bash
+        run: |
+          metadata="artifacts/ios-beta-gate-${{ matrix.device_class }}/metadata.txt"
+          simulator_id=""
+          if [[ -f "$metadata" ]]; then
+            simulator_id="$(awk -F= '$1 == "simulator_id" {print $2}' "$metadata")"
+          fi
+          if [[ -n "$simulator_id" ]]; then
+            xcrun simctl shutdown "$simulator_id" >/dev/null 2>&1 || true
+            xcrun simctl delete "$simulator_id" >/dev/null 2>&1 || true
+          fi
+
+      - name: Upload Xcode evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-beta-gate-${{ matrix.device_class }}-${{ github.event.pull_request.head.sha }}
+          path: artifacts/ios-beta-gate-${{ matrix.device_class }}/
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/ios-beta-gate.yml
+++ b/.github/workflows/ios-beta-gate.yml
@@ -5,9 +5,10 @@ on:
     branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
 
-# The gate is intentionally same-repository only because it runs trusted code on
-# WPR2's private Mac runners. Fork PRs remain fail-closed and require an owner-
-# approved validation path before merge.
+# Trusted heads run on WPR2's private Mac runners. Fork heads run only on a
+# GitHub-hosted runner and deliberately fail the same required contexts before
+# checkout, so untrusted code never reaches the Mac and a skipped job cannot be
+# mistaken for successful device evidence.
 permissions:
   contents: read
 
@@ -17,9 +18,8 @@ concurrency:
 
 jobs:
   ios-beta-gate:
-    if: github.event.pull_request.head.repo.full_name == github.repository
     name: iOS Beta Gate (${{ matrix.name }})
-    runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.full_name == github.repository && '["self-hosted","macOS","ARM64","xcode","ios","local-mac"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -33,22 +33,37 @@ jobs:
       EXPECTED_SHA: ${{ github.event.pull_request.head.sha }}
       IOS_RUNTIME_VERSION: "26.5"
       MINIMUM_FREE_GIB: "60"
-      SIMULATOR_BOOT_TIMEOUT_SECONDS: "900"
-      XCODE_PHASE_TIMEOUT_SECONDS: "3000"
+      SIMULATOR_BOOT_COMMAND_TIMEOUT_SECONDS: "120"
+      SIMULATOR_BOOT_TIMEOUT_SECONDS: "600"
+      XCODE_PHASE_TIMEOUT_SECONDS: "2400"
+      JOB_TIMEOUT_SECONDS: "7200"
+      CLEANUP_UPLOAD_MARGIN_SECONDS: "1200"
 
     steps:
+      - name: Reject untrusted fork without using the Mac runner
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::error::Fork pull requests cannot execute untrusted code on WPR2's self-hosted Mac runners. A trusted maintainer must reproduce the head in a same-repository branch before either required device context can pass."
+          exit 1
+
       - name: Checkout exact pull-request head
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
           clean: true
 
+      - name: Validate fail-closed beta-gate source policy
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: python3 scripts/ci/validate-ios-beta-gate-source.py
+
       - name: Run exact-head Xcode build and tests
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: bash scripts/ci/run-ios-beta-gate.sh "${{ matrix.device_class }}"
 
       - name: Remove run-owned simulator after interruption
-        if: always()
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         shell: bash
         run: |
           metadata="artifacts/ios-beta-gate-${{ matrix.device_class }}/metadata.txt"
@@ -62,7 +77,7 @@ jobs:
           fi
 
       - name: Upload Xcode evidence
-        if: always()
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/upload-artifact@v4
         with:
           name: ios-beta-gate-${{ matrix.device_class }}-${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ios-beta-gate.yml
+++ b/.github/workflows/ios-beta-gate.yml
@@ -3,7 +3,7 @@ name: iOS Beta Gate
 on:
   pull_request:
     branches: ["main"]
-    types: [opened, synchronize, reopened, ready_for_review, edited]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 # The gate is intentionally same-repository only because it runs trusted code on
 # WPR2's private Mac runners. Fork PRs remain fail-closed and require an owner-

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ token.json
 
 # Temporary files
 .tmp/
+/artifacts/
 __pycache__/
 **/__pycache__/
 *.py[cod]

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -569,10 +569,19 @@ final class Weird_Parts_IOSUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Database Size"].waitForExistence(timeout: 5), "Backup page should show database size")
         captureWEI3988("01-backups-before-create")
 
-        let createBackup = app.buttons["Create Backup Now"].firstMatch
+        let createBackup = app.descendants(matching: .any)["settings-backups-create-backup-button"].firstMatch
         XCTAssertTrue(createBackup.waitForExistence(timeout: 10), "Create Backup Now action should be available")
+        XCTAssertEqual(createBackup.label, "Create backup now", "Backup action should expose its stable accessible name")
         createBackup.tap()
-        XCTAssertTrue(app.buttons["Backup Created!"].waitForExistence(timeout: 15), "Manual backup action should complete with visible success state")
+        let backupCreated = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "value == %@", "Backup created"),
+            object: createBackup
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [backupCreated], timeout: 15),
+            .completed,
+            "Manual backup action should complete with visible and accessible success state"
+        )
         XCTAssertTrue(app.staticTexts["Stored Backups"].waitForExistence(timeout: 5), "Backup count row should remain visible after backup creation")
         captureWEI3988("02-backups-created")
 

--- a/docs/plans/ios-beta-pr-gate.md
+++ b/docs/plans/ios-beta-pr-gate.md
@@ -1,0 +1,86 @@
+# iOS Beta PR Gate
+
+Status: Approved owner requirement captured in WEI-5356 / GitHub #1480
+Owner: CTO
+Repository: `xXKillerNoobYT/Weird-Part-Run-2`
+
+## Purpose
+
+`main` is the TestFlight beta integration branch. A pull request must not merge based on the echo-only `Analyze (swift)` compatibility context. Same-repository pull requests targeting `main` require real Xcode build/test evidence for both compact iPhone and regular-width iPad simulator classes at the exact pull-request head.
+
+This PR gate does not archive, export, upload, or submit to App Store Connect. TestFlight archive/upload remains a separate post-merge `main` operation that requires an authenticated App Store Connect session.
+
+## Design
+
+### Workflow
+
+Add `.github/workflows/ios-beta-gate.yml` with a two-entry matrix:
+
+- `iPhone`: iPhone 16 Pro simulator on iOS 26.5
+- `iPad`: iPad Air 13-inch (M2) simulator on iOS 26.5
+
+Each matrix entry runs on the repo's self-hosted Mac labels:
+
+`[self-hosted, macOS, ARM64, xcode, ios, local-mac]`
+
+The workflow is limited to trusted same-repository pull requests targeting `main`. A pull request head update cancels stale in-flight work. Each lane checks out `github.event.pull_request.head.sha` explicitly and verifies `HEAD` equals that SHA before invoking Xcode.
+
+### Deterministic runner
+
+Add `scripts/ci/run-ios-beta-gate.sh` as the execution layer. It:
+
+1. Records expected SHA, actual SHA, runner, Xcode, runtime, and device-class metadata.
+2. Requires at least 60 GiB free on the volume backing `RUNNER_TEMP`; insufficient capacity fails before Xcode.
+3. Verifies the requested iOS runtime and simulator device type exist.
+4. Creates a run-owned temporary simulator and DerivedData directory; simulator boot is bounded at 15 minutes so runtime failures return control for cleanup/evidence upload.
+5. Runs all app/core unit and regression tests from `WiredPart-iOS`, excluding the broad UI-test target from that phase.
+6. Runs the bounded `WiredPart-iOS-Stage9-Smokes` deterministic UI plan on the same simulator; this includes the maintained viewport harness without invoking manual screenshot catalogs.
+7. Writes an `.xcresult`, Xcode log, and machine-readable summary for both phases in every lane.
+8. Bounds each Xcode phase at 50 minutes so the script can package partial evidence before the 120-minute job timeout.
+9. Fails if Xcode fails or times out, the result bundle is missing, zero tests execute, any test fails, or any executed test is skipped.
+10. Shuts down/deletes the run-owned simulator and removes DerivedData on exit; an `always()` cleanup step repeats simulator removal after an interrupted script.
+
+### Evidence and retention
+
+Each lane uploads its log, summary, metadata, and zipped `.xcresult` even when the gate fails. Artifacts are retained for seven days. GitHub Actions run/check URLs remain the durable audit index.
+
+### Required checks
+
+After the workflow has produced check runs on its own PR head, require both stable contexts on protected `main` with strict/current-head enforcement:
+
+- `iOS Beta Gate (iPhone)`
+- `iOS Beta Gate (iPad)`
+
+Keep required conversation resolution enabled. Do not remove `Analyze (swift)` as part of this change; CodeQL policy changes are separate.
+
+Paperclip PR disposition must classify missing, queued, cancelled, stale-head, or failed device contexts as not merge-ready.
+
+## Dependencies
+
+- Self-hosted runner online with labels `self-hosted`, `macOS`, `ARM64`, `xcode`, `ios`, `local-mac`.
+- Xcode with iOS 26.5 simulator runtime.
+- At least 60 GiB free on the runner temp volume.
+- GitHub branch-administration permission to add required contexts after canary evidence exists.
+
+Runner unavailability, simulator-runtime drift, disk pressure, or GitHub Actions outage are infrastructure failures. They remain red/pending; no echo-only substitute is permitted.
+
+## Acceptance criteria
+
+- A same-repository PR to `main` produces distinct phone and tablet checks at its exact head SHA.
+- Both checks execute non-empty unit/regression and deterministic UI-smoke phases with zero failures and zero unexpected skips.
+- Insufficient disk, absent runtime/device type, Xcode failure, missing/invalid result, timeout, cancellation, or runner outage cannot report success.
+- `.xcresult`, log, summary, and provenance metadata are available on both success and failure.
+- Branch protection requires both current-head contexts after the canary run.
+- Ordinary PRs perform no archive, export, TestFlight upload, or App Store Connect operation.
+
+## Validation
+
+- Shell syntax: `bash -n scripts/ci/run-ios-beta-gate.sh`
+- Workflow parse: Ruby/Psych or `actionlint` when available
+- Source assertions: trusted-PR guard, exact SHA checkout, two device contexts, local runner labels, artifact upload under `if: always()`
+- Local runner canary: execute one phone and one tablet lane with the current repository SHA and inspect `xcresulttool` summaries
+- GitHub readback: PR check runs show both contexts on the current head; branch protection API lists both with `strict: true`
+
+## Rollback
+
+Revert the workflow and script only if the gate itself is defective. While repairing it, keep merges fail-closed. Do not replace it with an echo/status-only success path. Removing required contexts requires explicit owner approval because it weakens the beta gate.

--- a/docs/plans/ios-beta-pr-gate.md
+++ b/docs/plans/ios-beta-pr-gate.md
@@ -23,7 +23,7 @@ Each matrix entry runs on the repo's self-hosted Mac labels:
 
 `[self-hosted, macOS, ARM64, xcode, ios, local-mac]`
 
-The workflow is limited to trusted same-repository pull requests targeting `main`. A pull request head update cancels stale in-flight work. Each lane checks out `github.event.pull_request.head.sha` explicitly and verifies `HEAD` equals that SHA before invoking Xcode.
+Trusted same-repository pull requests targeting `main` run on the self-hosted Mac. Fork pull requests route the same stable iPhone/iPad contexts to `ubuntu-latest`, fail explicitly before checkout, and never execute untrusted code on the Mac. This prevents GitHub's skipped-job success semantics from satisfying either required context. A pull request head update cancels stale in-flight work. Each trusted lane checks out `github.event.pull_request.head.sha` explicitly and verifies `HEAD` equals that SHA before invoking Xcode.
 
 ### Deterministic runner
 
@@ -32,11 +32,11 @@ Add `scripts/ci/run-ios-beta-gate.sh` as the execution layer. It:
 1. Records expected SHA, actual SHA, runner, Xcode, runtime, and device-class metadata.
 2. Requires at least 60 GiB free on the volume backing `RUNNER_TEMP`; insufficient capacity fails before Xcode.
 3. Verifies the requested iOS runtime and simulator device type exist.
-4. Creates a run-owned temporary simulator and DerivedData directory; simulator boot is bounded at 15 minutes so runtime failures return control for cleanup/evidence upload.
+4. Creates a run-owned temporary simulator and DerivedData directory; the boot command is bounded at 2 minutes and boot readiness at 10 minutes so runtime failures return control for cleanup/evidence upload.
 5. Runs all app/core unit and regression tests from `WiredPart-iOS`, excluding the broad UI-test target from that phase.
 6. Runs the bounded `WiredPart-iOS-Stage9-Smokes` deterministic UI plan on the same simulator; this includes the maintained viewport harness without invoking manual screenshot catalogs.
 7. Writes an `.xcresult`, Xcode log, and machine-readable summary for both phases in every lane.
-8. Bounds each Xcode phase at 50 minutes so the script can package partial evidence before the 120-minute job timeout.
+8. Bounds each Xcode phase at 40 minutes. A source-validated runtime assertion caps the two Xcode phases plus simulator boot at 92 minutes, reserving 20 minutes of the 120-minute job envelope for result packaging, cleanup, and artifact upload.
 9. Fails if Xcode fails or times out, the result bundle is missing, zero tests execute, any test fails, or any executed test is skipped.
 10. Shuts down/deletes the run-owned simulator and removes DerivedData on exit; an `always()` cleanup step repeats simulator removal after an interrupted script.
 
@@ -67,6 +67,7 @@ Runner unavailability, simulator-runtime drift, disk pressure, or GitHub Actions
 ## Acceptance criteria
 
 - A same-repository PR to `main` produces distinct phone and tablet checks at its exact head SHA.
+- A fork PR produces the same two required contexts as explicit failures on `ubuntu-latest`; it cannot run on the self-hosted Mac or pass through skipped-job semantics.
 - Both checks execute non-empty unit/regression and deterministic UI-smoke phases with zero failures and zero unexpected skips.
 - Insufficient disk, absent runtime/device type, Xcode failure, missing/invalid result, timeout, cancellation, or runner outage cannot report success.
 - `.xcresult`, log, summary, and provenance metadata are available on both success and failure.

--- a/docs/runbooks/local-mac-actions-runner.md
+++ b/docs/runbooks/local-mac-actions-runner.md
@@ -43,6 +43,33 @@ runs-on: [self-hosted, macOS, ARM64, xcode, ios, local-mac]
 
 Keep cloud runners only for intentionally minimal jobs that do not need the Mac runner and are not contributing to PR blockages.
 
+## iOS beta PR gate
+
+Tracking: GitHub #1480 / Paperclip WEI-5356. Design: `docs/plans/ios-beta-pr-gate.md`.
+
+Every same-repository PR targeting `main` must produce both current-head checks:
+
+- `iOS Beta Gate (iPhone)`
+- `iOS Beta Gate (iPad)`
+
+The workflow is `.github/workflows/ios-beta-gate.yml`; deterministic execution is in `scripts/ci/run-ios-beta-gate.sh`. Each lane verifies the checked-out SHA, requires at least 60 GiB free on the runner temp volume, creates a run-owned iOS 26.5 simulator, runs the `WiredPart-iOS` unit/regression phase plus the bounded `WiredPart-iOS-Stage9-Smokes` UI plan, and uploads logs, summaries, metadata, and `.xcresult` evidence even on failure.
+
+Missing, queued, cancelled, stale-head, skipped-test, zero-test, disk-capacity, simulator-runtime, timeout, and runner-offline outcomes are non-mergeable. Do not substitute `Analyze (swift)` or another echo/status-only check for either device lane.
+
+Ordinary PR gates never archive or upload to App Store Connect. TestFlight upload is a separate post-merge `main` operation and requires an authenticated App Store Connect session.
+
+### Disk-capacity response
+
+If either lane reports less than 60 GiB free:
+
+1. Keep the check red and the PR out of the merge queue.
+2. Inspect the runner volume and generated caches/artifacts without deleting live worktrees or unique work.
+3. Perform only evidence-backed safe cleanup; route uncertain or broad deletion through a bounded cleanup issue.
+4. Rerun both device lanes at the unchanged PR head and use the new check/artifact URLs as evidence.
+5. Recheck free space after the run because a successful build can still expose a capacity trend.
+
+Review the gate on every PR. A repeated capacity failure, missing runtime, malformed result bundle, or unavailable runner creates/updates a Paperclip CI blocker after the first reproducible occurrence; do not wait for a merge attempt.
+
 ## Paperclip communication
 
 PR-info, merge, review, and blocker issues should mention this local-runner path whenever CI status is discussed. Do not repeatedly ask Isaac to correct cloud Actions/billing blockers without first checking the local Mac runner.

--- a/scripts/ci/run-ios-beta-gate.sh
+++ b/scripts/ci/run-ios-beta-gate.sh
@@ -22,7 +22,18 @@ case "$1" in
 esac
 
 expected_sha="${EXPECTED_SHA:-}"
-workspace="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}"
+if [[ -n "${GITHUB_WORKSPACE:-}" ]]; then
+  workspace="$GITHUB_WORKSPACE"
+else
+  workspace="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "ERROR: cannot resolve the repository root" >&2
+    exit 1
+  }
+fi
+[[ -n "$workspace" && -d "$workspace" ]] || {
+  echo "ERROR: repository root is not a directory: $workspace" >&2
+  exit 1
+}
 runner_temp="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
 runtime_version="${IOS_RUNTIME_VERSION:-26.5}"
 runtime_id="com.apple.CoreSimulator.SimRuntime.iOS-${runtime_version//./-}"
@@ -95,7 +106,12 @@ simulator_name="WPR2-CI-${gate_name}-${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEM
 simulator_id="$(xcrun simctl create "$simulator_name" "$device_type" "$runtime_id")" || fail "cannot create $gate_name simulator"
 echo "simulator_id=$simulator_id" >> "$metadata_file"
 
-xcrun simctl boot "$simulator_id" || fail "cannot boot $gate_name simulator"
+/usr/bin/perl -e 'alarm shift; exec @ARGV' "$simulator_boot_timeout_seconds" \
+  xcrun simctl boot "$simulator_id" \
+  2>&1 | tee -a "$artifact_dir/gate.log"
+boot_command_status=("${PIPESTATUS[@]}")
+[[ "${boot_command_status[0]}" == "0" ]] || fail "cannot boot $gate_name simulator before the timeout"
+[[ "${boot_command_status[1]}" == "0" ]] || fail "$gate_name simulator boot-command log could not be preserved"
 /usr/bin/perl -e 'alarm shift; exec @ARGV' "$simulator_boot_timeout_seconds" \
   xcrun simctl bootstatus "$simulator_id" -b \
   2>&1 | tee -a "$artifact_dir/gate.log"
@@ -159,6 +175,7 @@ validate_phase() {
   local passed
   local failed
   local skipped
+  local summary_status=0
 
   [[ -f "$status_file" ]] || fail "missing Xcode status for $phase"
   [[ -f "$tee_status_file" ]] || fail "missing log-preservation status for $phase"
@@ -169,13 +186,14 @@ validate_phase() {
     phase_failure=1
     return
   fi
-  if ! xcrun xcresulttool get test-results summary --path "$result_bundle" --compact > "$summary_json"; then
-    echo "ERROR: $phase xcresult summary could not be read" | tee -a "$artifact_dir/gate.log" >&2
+  xcrun xcresulttool get test-results summary --path "$result_bundle" --compact > "$summary_json" || summary_status=$?
+  ditto -c -k --sequesterRsrc --keepParent "$result_bundle" "$archive" || fail "$phase xcresult archive could not be created"
+  rm -rf "$result_bundle"
+  if (( summary_status != 0 )); then
+    echo "ERROR: $phase xcresult summary could not be read; raw result was preserved in $archive" | tee -a "$artifact_dir/gate.log" >&2
     phase_failure=1
     return
   fi
-  ditto -c -k --sequesterRsrc --keepParent "$result_bundle" "$archive" || fail "$phase xcresult archive could not be created"
-  rm -rf "$result_bundle"
 
   result="$(jq -r '.result // "unknown"' "$summary_json")" || fail "cannot read $phase result"
   total="$(jq -r '.totalTestCount // 0' "$summary_json")" || fail "cannot read $phase test count"

--- a/scripts/ci/run-ios-beta-gate.sh
+++ b/scripts/ci/run-ios-beta-gate.sh
@@ -38,8 +38,11 @@ runner_temp="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
 runtime_version="${IOS_RUNTIME_VERSION:-26.5}"
 runtime_id="com.apple.CoreSimulator.SimRuntime.iOS-${runtime_version//./-}"
 minimum_free_gib="${MINIMUM_FREE_GIB:-60}"
-simulator_boot_timeout_seconds="${SIMULATOR_BOOT_TIMEOUT_SECONDS:-900}"
-xcode_phase_timeout_seconds="${XCODE_PHASE_TIMEOUT_SECONDS:-3000}"
+simulator_boot_command_timeout_seconds="${SIMULATOR_BOOT_COMMAND_TIMEOUT_SECONDS:-120}"
+simulator_boot_timeout_seconds="${SIMULATOR_BOOT_TIMEOUT_SECONDS:-600}"
+xcode_phase_timeout_seconds="${XCODE_PHASE_TIMEOUT_SECONDS:-2400}"
+job_timeout_seconds="${JOB_TIMEOUT_SECONDS:-7200}"
+cleanup_upload_margin_seconds="${CLEANUP_UPLOAD_MARGIN_SECONDS:-1200}"
 artifact_dir="$workspace/artifacts/ios-beta-gate-$device_key"
 metadata_file="$artifact_dir/metadata.txt"
 derived_data=""
@@ -67,6 +70,26 @@ fail() {
   exit 1
 }
 
+for timeout_value in \
+  "$simulator_boot_command_timeout_seconds" \
+  "$simulator_boot_timeout_seconds" \
+  "$xcode_phase_timeout_seconds" \
+  "$job_timeout_seconds" \
+  "$cleanup_upload_margin_seconds"; do
+  [[ "$timeout_value" =~ ^[0-9]+$ ]] && (( timeout_value > 0 )) || \
+    fail "all timeout budgets must be positive integer seconds"
+done
+(( cleanup_upload_margin_seconds < job_timeout_seconds )) || \
+  fail "cleanup/upload margin must be smaller than the job timeout"
+internal_budget_seconds=$((
+  simulator_boot_command_timeout_seconds +
+  simulator_boot_timeout_seconds +
+  (2 * xcode_phase_timeout_seconds)
+))
+available_internal_budget_seconds=$((job_timeout_seconds - cleanup_upload_margin_seconds))
+(( internal_budget_seconds <= available_internal_budget_seconds )) || \
+  fail "internal timeout budget ${internal_budget_seconds}s exceeds ${available_internal_budget_seconds}s after reserving cleanup/upload margin"
+
 actual_sha="$(git -C "$workspace" rev-parse HEAD)" || fail "cannot resolve repository HEAD"
 {
   echo "gate=$gate_name"
@@ -78,6 +101,12 @@ actual_sha="$(git -C "$workspace" rev-parse HEAD)" || fail "cannot resolve repos
   echo "runtime=$runtime_id"
   echo "device_type=$device_type"
   echo "minimum_free_gib=$minimum_free_gib"
+  echo "simulator_boot_command_timeout_seconds=$simulator_boot_command_timeout_seconds"
+  echo "simulator_boot_timeout_seconds=$simulator_boot_timeout_seconds"
+  echo "xcode_phase_timeout_seconds=$xcode_phase_timeout_seconds"
+  echo "job_timeout_seconds=$job_timeout_seconds"
+  echo "cleanup_upload_margin_seconds=$cleanup_upload_margin_seconds"
+  echo "internal_budget_seconds=$internal_budget_seconds"
   xcodebuild -version | tr '\n' ' '
   echo
 } > "$metadata_file"
@@ -106,7 +135,7 @@ simulator_name="WPR2-CI-${gate_name}-${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEM
 simulator_id="$(xcrun simctl create "$simulator_name" "$device_type" "$runtime_id")" || fail "cannot create $gate_name simulator"
 echo "simulator_id=$simulator_id" >> "$metadata_file"
 
-/usr/bin/perl -e 'alarm shift; exec @ARGV' "$simulator_boot_timeout_seconds" \
+/usr/bin/perl -e 'alarm shift; exec @ARGV' "$simulator_boot_command_timeout_seconds" \
   xcrun simctl boot "$simulator_id" \
   2>&1 | tee -a "$artifact_dir/gate.log"
 boot_command_status=("${PIPESTATUS[@]}")

--- a/scripts/ci/run-ios-beta-gate.sh
+++ b/scripts/ci/run-ios-beta-gate.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+usage() {
+  echo "usage: $0 <iphone|ipad>" >&2
+  exit 64
+}
+
+[[ $# -eq 1 ]] || usage
+case "$1" in
+  iphone)
+    gate_name="iPhone"
+    device_key="iphone"
+    device_type="com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro"
+    ;;
+  ipad)
+    gate_name="iPad"
+    device_key="ipad"
+    device_type="com.apple.CoreSimulator.SimDeviceType.iPad-Air-13-inch-M2"
+    ;;
+  *) usage ;;
+esac
+
+expected_sha="${EXPECTED_SHA:-}"
+workspace="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}"
+runner_temp="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+runtime_version="${IOS_RUNTIME_VERSION:-26.5}"
+runtime_id="com.apple.CoreSimulator.SimRuntime.iOS-${runtime_version//./-}"
+minimum_free_gib="${MINIMUM_FREE_GIB:-60}"
+simulator_boot_timeout_seconds="${SIMULATOR_BOOT_TIMEOUT_SECONDS:-900}"
+xcode_phase_timeout_seconds="${XCODE_PHASE_TIMEOUT_SECONDS:-3000}"
+artifact_dir="$workspace/artifacts/ios-beta-gate-$device_key"
+metadata_file="$artifact_dir/metadata.txt"
+derived_data=""
+simulator_id=""
+
+mkdir -p "$artifact_dir"
+
+cleanup() {
+  local status=$?
+  if [[ -n "$simulator_id" ]]; then
+    xcrun simctl shutdown "$simulator_id" >/dev/null 2>&1 || true
+    xcrun simctl delete "$simulator_id" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$derived_data" && -d "$derived_data" ]]; then
+    rm -rf "$derived_data"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+fail() {
+  echo "ERROR: $*" | tee -a "$artifact_dir/gate.log" >&2
+  exit 1
+}
+
+actual_sha="$(git -C "$workspace" rev-parse HEAD)" || fail "cannot resolve repository HEAD"
+{
+  echo "gate=$gate_name"
+  echo "expected_sha=$expected_sha"
+  echo "actual_sha=$actual_sha"
+  echo "runner_name=${RUNNER_NAME:-local-manual}"
+  echo "runner_os=${RUNNER_OS:-$(uname -s)}"
+  echo "runner_arch=${RUNNER_ARCH:-$(uname -m)}"
+  echo "runtime=$runtime_id"
+  echo "device_type=$device_type"
+  echo "minimum_free_gib=$minimum_free_gib"
+  xcodebuild -version | tr '\n' ' '
+  echo
+} > "$metadata_file"
+
+[[ -n "$expected_sha" ]] || fail "EXPECTED_SHA is required"
+[[ "$actual_sha" == "$expected_sha" ]] || fail "checked out HEAD $actual_sha does not match expected PR head $expected_sha"
+[[ "${RUNNER_OS:-macOS}" == "macOS" ]] || fail "gate requires a macOS runner"
+[[ "$(uname -s)" == "Darwin" ]] || fail "gate requires Darwin"
+command -v jq >/dev/null || fail "jq is required to validate xcresult evidence"
+command -v xcodebuild >/dev/null || fail "xcodebuild is required"
+command -v xcrun >/dev/null || fail "xcrun is required"
+[[ -x /usr/bin/perl ]] || fail "/usr/bin/perl is required for bounded Xcode phases"
+
+available_kib="$(df -Pk "$runner_temp" | awk 'NR == 2 {print $4}')"
+[[ "$available_kib" =~ ^[0-9]+$ ]] || fail "could not determine free disk space for $runner_temp"
+required_kib=$((minimum_free_gib * 1024 * 1024))
+available_gib=$((available_kib / 1024 / 1024))
+echo "available_free_gib=$available_gib" >> "$metadata_file"
+(( available_kib >= required_kib )) || fail "runner has ${available_gib} GiB free; ${minimum_free_gib} GiB is required"
+
+xcrun simctl list runtimes | grep -Fq "$runtime_id" || fail "required simulator runtime is unavailable: $runtime_id"
+xcrun simctl list devicetypes | grep -Fq "$device_type" || fail "required simulator device type is unavailable: $device_type"
+
+derived_data="$(mktemp -d "$runner_temp/wpr2-ios-beta-${1}.derived.XXXXXX")" || fail "cannot create temporary DerivedData directory"
+simulator_name="WPR2-CI-${gate_name}-${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEMPT:-1}"
+simulator_id="$(xcrun simctl create "$simulator_name" "$device_type" "$runtime_id")" || fail "cannot create $gate_name simulator"
+echo "simulator_id=$simulator_id" >> "$metadata_file"
+
+xcrun simctl boot "$simulator_id" || fail "cannot boot $gate_name simulator"
+/usr/bin/perl -e 'alarm shift; exec @ARGV' "$simulator_boot_timeout_seconds" \
+  xcrun simctl bootstatus "$simulator_id" -b \
+  2>&1 | tee -a "$artifact_dir/gate.log"
+boot_pipeline_status=("${PIPESTATUS[@]}")
+[[ "${boot_pipeline_status[0]}" == "0" ]] || fail "$gate_name simulator did not finish booting before the timeout"
+[[ "${boot_pipeline_status[1]}" == "0" ]] || fail "$gate_name simulator boot log could not be preserved"
+
+run_xcode_phase() {
+  local phase="$1"
+  local scheme="$2"
+  local result_bundle="$3"
+  local xcode_log="$4"
+  shift 4
+
+  /usr/bin/perl -e 'alarm shift; exec @ARGV' "$xcode_phase_timeout_seconds" xcodebuild test \
+    -workspace "$workspace/Weird Parts.xcworkspace" \
+    -scheme "$scheme" \
+    -destination "platform=iOS Simulator,id=$simulator_id" \
+    -derivedDataPath "$derived_data" \
+    -resultBundlePath "$result_bundle" \
+    -parallel-testing-enabled NO \
+    "$@" \
+    CODE_SIGNING_ALLOWED=NO \
+    2>&1 | tee "$xcode_log"
+  local pipeline_status=("${PIPESTATUS[@]}")
+  echo "${pipeline_status[0]}" > "$artifact_dir/${phase}-xcode-status.txt"
+  echo "${pipeline_status[1]}" > "$artifact_dir/${phase}-tee-status.txt"
+}
+
+unit_result="$artifact_dir/unit-regression-${gate_name}.xcresult"
+unit_log="$artifact_dir/unit-regression-xcodebuild.log"
+ui_result="$artifact_dir/ui-smokes-${gate_name}.xcresult"
+ui_log="$artifact_dir/ui-smokes-xcodebuild.log"
+
+# Run all app/core unit and regression tests while excluding the broad manual
+# UI catalog. The second phase executes the repo's bounded deterministic UI
+# smoke plan, including its viewport harness, on this same device class.
+run_xcode_phase \
+  "unit-regression" "WiredPart-iOS" "$unit_result" "$unit_log" \
+  -skip-testing:"Weird PartsUITests"
+run_xcode_phase \
+  "ui-smokes" "WiredPart-iOS-Stage9-Smokes" "$ui_result" "$ui_log"
+
+phase_failure=0
+aggregate_total=0
+aggregate_passed=0
+aggregate_failed=0
+aggregate_skipped=0
+
+validate_phase() {
+  local phase="$1"
+  local result_bundle="$2"
+  local status_file="$3"
+  local tee_status_file="$4"
+  local summary_json="$artifact_dir/${phase}-summary.json"
+  local archive="$artifact_dir/${phase}-${gate_name}.xcresult.zip"
+  local xcode_status
+  local tee_status
+  local result
+  local total
+  local passed
+  local failed
+  local skipped
+
+  [[ -f "$status_file" ]] || fail "missing Xcode status for $phase"
+  [[ -f "$tee_status_file" ]] || fail "missing log-preservation status for $phase"
+  xcode_status="$(<"$status_file")"
+  tee_status="$(<"$tee_status_file")"
+  if [[ ! -d "$result_bundle" ]]; then
+    echo "ERROR: $phase produced no xcresult bundle" | tee -a "$artifact_dir/gate.log" >&2
+    phase_failure=1
+    return
+  fi
+  if ! xcrun xcresulttool get test-results summary --path "$result_bundle" --compact > "$summary_json"; then
+    echo "ERROR: $phase xcresult summary could not be read" | tee -a "$artifact_dir/gate.log" >&2
+    phase_failure=1
+    return
+  fi
+  ditto -c -k --sequesterRsrc --keepParent "$result_bundle" "$archive" || fail "$phase xcresult archive could not be created"
+  rm -rf "$result_bundle"
+
+  result="$(jq -r '.result // "unknown"' "$summary_json")" || fail "cannot read $phase result"
+  total="$(jq -r '.totalTestCount // 0' "$summary_json")" || fail "cannot read $phase test count"
+  passed="$(jq -r '.passedTests // 0' "$summary_json")" || fail "cannot read $phase pass count"
+  failed="$(jq -r '.failedTests // 0' "$summary_json")" || fail "cannot read $phase failure count"
+  skipped="$(jq -r '.skippedTests // 0' "$summary_json")" || fail "cannot read $phase skip count"
+
+  {
+    echo "${phase}_result=$result"
+    echo "${phase}_total_tests=$total"
+    echo "${phase}_passed_tests=$passed"
+    echo "${phase}_failed_tests=$failed"
+    echo "${phase}_skipped_tests=$skipped"
+    echo "${phase}_xcode_status=$xcode_status"
+    echo "${phase}_tee_status=$tee_status"
+  } | tee -a "$metadata_file"
+
+  aggregate_total=$((aggregate_total + total))
+  aggregate_passed=$((aggregate_passed + passed))
+  aggregate_failed=$((aggregate_failed + failed))
+  aggregate_skipped=$((aggregate_skipped + skipped))
+
+  [[ "$xcode_status" == "0" ]] || phase_failure=1
+  [[ "$tee_status" == "0" ]] || phase_failure=1
+  [[ "$result" == "Passed" ]] || phase_failure=1
+  (( total > 0 )) || phase_failure=1
+  (( failed == 0 )) || phase_failure=1
+  (( skipped == 0 )) || phase_failure=1
+}
+
+validate_phase \
+  "unit-regression" "$unit_result" \
+  "$artifact_dir/unit-regression-xcode-status.txt" "$artifact_dir/unit-regression-tee-status.txt"
+validate_phase \
+  "ui-smokes" "$ui_result" \
+  "$artifact_dir/ui-smokes-xcode-status.txt" "$artifact_dir/ui-smokes-tee-status.txt"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## iOS Beta Gate — $gate_name"
+    echo
+    echo "- PR head: \`$actual_sha\`"
+    echo "- Tests: $aggregate_total total, $aggregate_passed passed, $aggregate_failed failed, $aggregate_skipped skipped"
+    echo "- Simulator: $simulator_name ($runtime_version)"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+(( phase_failure == 0 )) || fail "one or more $gate_name test phases failed, skipped tests, or produced invalid evidence"
+
+echo "iOS Beta Gate passed for $gate_name at $actual_sha"

--- a/scripts/ci/validate-ios-beta-gate-source.py
+++ b/scripts/ci/validate-ios-beta-gate-source.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Fail when the iOS beta-gate source weakens required fail-closed invariants."""
+
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/ios-beta-gate.yml"
+RUNNER = ROOT / "scripts/ci/run-ios-beta-gate.sh"
+
+workflow = WORKFLOW.read_text(encoding="utf-8")
+runner = RUNNER.read_text(encoding="utf-8")
+
+required_workflow_fragments = {
+    "fork jobs route to a GitHub-hosted runner": '["ubuntu-latest"]',
+    "trusted jobs route to the labeled Mac runners": '["self-hosted","macOS","ARM64","xcode","ios","local-mac"]',
+    "fork path is explicitly rejected": "Reject untrusted fork without using the Mac runner",
+    "fork rejection exits nonzero": "exit 1",
+    "exact PR head is checked out": "ref: ${{ github.event.pull_request.head.sha }}",
+    "iPhone required context remains stable": "- name: iPhone",
+    "iPad required context remains stable": "- name: iPad",
+    "job timeout is declared": "timeout-minutes: 120",
+    "script receives the job timeout": 'JOB_TIMEOUT_SECONDS: "7200"',
+    "cleanup and upload margin is reserved": 'CLEANUP_UPLOAD_MARGIN_SECONDS: "1200"',
+}
+
+required_runner_fragments = {
+    "expected and actual SHAs are compared": '[[ "$actual_sha" == "$expected_sha" ]]',
+    "internal timeout budget is calculated": "internal_budget_seconds=$((",
+    "job cleanup/upload margin is enforced": "available_internal_budget_seconds=$((job_timeout_seconds - cleanup_upload_margin_seconds))",
+    "zero tests fail closed": "(( total > 0 )) || phase_failure=1",
+    "skipped tests fail closed": "(( skipped == 0 )) || phase_failure=1",
+}
+
+errors: list[str] = []
+for description, fragment in required_workflow_fragments.items():
+    if fragment not in workflow:
+        errors.append(f"workflow invariant missing: {description} ({fragment!r})")
+for description, fragment in required_runner_fragments.items():
+    if fragment not in runner:
+        errors.append(f"runner invariant missing: {description} ({fragment!r})")
+
+legacy_skip_guard = r"(?m)^ {4}if:\s*github\.event\.pull_request\.head\.repo\.full_name == github\.repository\s*$"
+if re.search(legacy_skip_guard, workflow):
+    errors.append("workflow still has the job-level fork skip guard that can report a successful required context")
+
+if errors:
+    print("iOS beta-gate source validation failed:", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+print("iOS beta-gate source validation passed")


### PR DESCRIPTION
Temporary validation canary for PR #1495 / WEI-5663.

Expected: both stable iOS Beta Gate contexts run on ubuntu-latest, fail at the untrusted-fork rejection step, and execute neither checkout nor Xcode. This PR will be closed and its fork branch deleted after evidence capture.

Refs #1480
Tracked in WEI-5663