### PR TITLE
[Tests][Bug] Isolate timezone date-boundary tests

### DIFF
--- a/core/Sources/WiredPartCore/Database/OperationalDay.swift
+++ b/core/Sources/WiredPartCore/Database/OperationalDay.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// Explicit local-day boundaries for services that persist timestamps in UTC.
+///
+/// SQLite's `localtime` modifier reads process-global timezone state. Computing
+/// UTC boundaries with an injected calendar keeps concurrent tests isolated and
+/// preserves device-local bucketing in production through the `.current` default.
+struct OperationalDay: Sendable {
+    let calendar: Calendar
+    let now: @Sendable () -> Date
+
+    init(
+        calendar: Calendar = .current,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.calendar = calendar
+        self.now = now
+    }
+
+    func interval(containing date: Date) -> OperationalDayInterval {
+        let start = calendar.startOfDay(for: date)
+        let end = calendar.date(byAdding: .day, value: 1, to: start)!
+        let localDate = dateString(from: start)
+        return OperationalDayInterval(
+            localStartDate: localDate,
+            localEndDate: localDate,
+            utcStart: utcTimestamp(start),
+            utcEnd: utcTimestamp(end)
+        )
+    }
+
+    func interval(startDate: String, endDate: String) -> OperationalDayInterval? {
+        guard let start = date(from: startDate), let endDay = date(from: endDate),
+              let end = calendar.date(byAdding: .day, value: 1, to: endDay),
+              start <= endDay else {
+            return nil
+        }
+        return OperationalDayInterval(
+            localStartDate: startDate,
+            localEndDate: endDate,
+            utcStart: utcTimestamp(start),
+            utcEnd: utcTimestamp(end)
+        )
+    }
+
+    func dateString(from date: Date) -> String {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(
+            format: "%04d-%02d-%02d",
+            components.year ?? 0,
+            components.month ?? 0,
+            components.day ?? 0
+        )
+    }
+
+    func dateString(fromPersistedTimestamp timestamp: String) -> String? {
+        if timestamp.count <= 10 {
+            return String(timestamp.prefix(10))
+        }
+        guard let date = CoreFormatters.parseDateTimeUTC(timestamp) else { return nil }
+        return dateString(from: date)
+    }
+
+    func utcTimestamp(_ date: Date) -> String {
+        Self.formatUTCTimestamp(date)
+    }
+
+    private func date(from value: String) -> Date? {
+        let parts = value.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              let year = Int(parts[0]),
+              let month = Int(parts[1]),
+              let day = Int(parts[2]) else {
+            return nil
+        }
+        return calendar.date(from: DateComponents(year: year, month: month, day: day))
+    }
+
+    private static func formatUTCTimestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter.string(from: date)
+    }
+}
+
+struct OperationalDayInterval: Sendable {
+    let localStartDate: String
+    let localEndDate: String
+    let utcStart: String
+    let utcEnd: String
+
+    func exactDayPredicate(_ expression: String) -> String {
+        """
+        ((length(\(expression)) <= 10 AND date(\(expression)) = date(?))
+          OR (length(\(expression)) > 10
+              AND julianday(\(expression)) >= julianday(?)
+              AND julianday(\(expression)) < julianday(?)))
+        """
+    }
+
+    func rangePredicate(_ expression: String) -> String {
+        """
+        ((length(\(expression)) <= 10
+          AND date(\(expression)) >= date(?)
+          AND date(\(expression)) <= date(?))
+         OR (length(\(expression)) > 10
+             AND julianday(\(expression)) >= julianday(?)
+             AND julianday(\(expression)) < julianday(?)))
+        """
+    }
+
+    func startsAtOrAfterPredicate(_ expression: String) -> String {
+        """
+        ((length(\(expression)) <= 10 AND date(\(expression)) >= date(?))
+         OR (length(\(expression)) > 10
+             AND julianday(\(expression)) >= julianday(?)))
+        """
+    }
+
+    var exactArguments: [String] { [localStartDate, utcStart, utcEnd] }
+    var rangeArguments: [String] { [localStartDate, localEndDate, utcStart, utcEnd] }
+    var startArguments: [String] { [localStartDate, utcStart] }
+}

--- a/core/Sources/WiredPartCore/Database/OperationalDay.swift
+++ b/core/Sources/WiredPartCore/Database/OperationalDay.swift
@@ -13,7 +13,12 @@ struct OperationalDay: Sendable {
         calendar: Calendar = .current,
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
-        self.calendar = calendar
+        // Persisted date-only values and SQLite timestamps use the proleptic
+        // Gregorian calendar. Preserve the injected/device time zone while
+        // avoiding user calendar preferences changing SQL boundary values.
+        var gregorianCalendar = Calendar(identifier: .gregorian)
+        gregorianCalendar.timeZone = calendar.timeZone
+        self.calendar = gregorianCalendar
         self.now = now
     }
 
@@ -62,7 +67,7 @@ struct OperationalDay: Sendable {
     }
 
     func utcTimestamp(_ date: Date) -> String {
-        Self.formatUTCTimestamp(date)
+        CoreFormatters.dateTimeSpaceUTC.string(from: date)
     }
 
     private func date(from value: String) -> Date? {
@@ -76,14 +81,6 @@ struct OperationalDay: Sendable {
         return calendar.date(from: DateComponents(year: year, month: month, day: day))
     }
 
-    private static func formatUTCTimestamp(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return formatter.string(from: date)
-    }
 }
 
 struct OperationalDayInterval: Sendable {

--- a/core/Sources/WiredPartCore/Database/OperationalDay.swift
+++ b/core/Sources/WiredPartCore/Database/OperationalDay.swift
@@ -71,14 +71,28 @@ struct OperationalDay: Sendable {
     }
 
     private func date(from value: String) -> Date? {
+        let bytes = Array(value.utf8)
+        guard bytes.count == 10,
+              bytes[4] == 45,
+              bytes[7] == 45,
+              [0, 1, 2, 3, 5, 6, 8, 9].allSatisfy({ (48...57).contains(bytes[$0]) }) else {
+            return nil
+        }
         let parts = value.split(separator: "-", omittingEmptySubsequences: false)
         guard parts.count == 3,
               let year = Int(parts[0]),
               let month = Int(parts[1]),
-              let day = Int(parts[2]) else {
+              let day = Int(parts[2]),
+              let date = calendar.date(from: DateComponents(year: year, month: month, day: day)) else {
             return nil
         }
-        return calendar.date(from: DateComponents(year: year, month: month, day: day))
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        guard components.year == year,
+              components.month == month,
+              components.day == day else {
+            return nil
+        }
+        return date
     }
 
 }

--- a/core/Sources/WiredPartCore/Services/DailyReportGenerator.swift
+++ b/core/Sources/WiredPartCore/Services/DailyReportGenerator.swift
@@ -62,6 +62,7 @@ public final class DailyReportGenerator: Sendable {
         let reportDate = date ?? operationalDay.now()
         let day = operationalDay.interval(containing: reportDate)
         let dateStr = day.localStartDate
+        let reportTimestamp = operationalDay.utcTimestamp(reportDate)
 
         do { return try db.writer.read { dbConn in
             let userName = try String.fetchOne(dbConn, sql: """
@@ -100,11 +101,11 @@ public final class DailyReportGenerator: Sendable {
             // Get break minutes from break_records table
             totalBreakMinutes = try Int.fetchOne(dbConn, sql: """
                 SELECT COALESCE(SUM(
-                    CAST((julianday(COALESCE(ended_at, datetime('now'))) - julianday(started_at)) * 1440 AS INTEGER)
+                    CAST((julianday(COALESCE(ended_at, ?)) - julianday(started_at)) * 1440 AS INTEGER)
                 ), 0)
                 FROM break_records
                 WHERE user_id = ? AND date(started_at) = ? AND deleted_at IS NULL
-                """, arguments: [userId, dateStr]) ?? 0
+                """, arguments: [reportTimestamp, userId, dateStr]) ?? 0
 
             let totalHours = max(0, (totalMinutes - Double(totalBreakMinutes))) / 60.0
 
@@ -205,14 +206,16 @@ public final class DailyReportGenerator: Sendable {
 
     /// Get today's jobs for a user to determine primary job.
     public func getTodaysJobs(userId: Int64, date: Date? = nil) throws -> [(jobId: Int64, jobName: String, hours: Double)] {
-        let day = operationalDay.interval(containing: date ?? operationalDay.now())
+        let reportDate = date ?? operationalDay.now()
+        let day = operationalDay.interval(containing: reportDate)
+        let reportTimestamp = operationalDay.utcTimestamp(reportDate)
         do {
             return try db.writer.read { dbConn in
                 let rows = try Row.fetchAll(dbConn, sql: """
                     SELECT le.job_id,
                            COALESCE(j.job_name, j.job_number, 'Unknown') as job_name,
                            SUM(
-                               (julianday(COALESCE(le.clock_out, datetime('now'))) - julianday(le.clock_in)) * 24
+                               (julianday(COALESCE(le.clock_out, ?)) - julianday(le.clock_in)) * 24
                            ) as total_hours
                     FROM labor_entries le
                     LEFT JOIN jobs j ON j.id = le.job_id AND j.deleted_at IS NULL
@@ -221,7 +224,7 @@ public final class DailyReportGenerator: Sendable {
                     GROUP BY le.job_id
                     ORDER BY total_hours DESC
                     """, arguments: [
-                        userId, day.localStartDate, day.utcStart, day.utcEnd
+                        reportTimestamp, userId, day.localStartDate, day.utcStart, day.utcEnd
                     ])
                 return rows.map { row in
                     (

--- a/core/Sources/WiredPartCore/Services/DailyReportGenerator.swift
+++ b/core/Sources/WiredPartCore/Services/DailyReportGenerator.swift
@@ -104,8 +104,12 @@ public final class DailyReportGenerator: Sendable {
                     CAST((julianday(COALESCE(ended_at, ?)) - julianday(started_at)) * 1440 AS INTEGER)
                 ), 0)
                 FROM break_records
-                WHERE user_id = ? AND date(started_at) = ? AND deleted_at IS NULL
-                """, arguments: [reportTimestamp, userId, dateStr]) ?? 0
+                WHERE user_id = ?
+                  AND \(day.exactDayPredicate("started_at"))
+                  AND deleted_at IS NULL
+                """, arguments: [
+                    reportTimestamp, userId, dateStr, day.utcStart, day.utcEnd
+                ]) ?? 0
 
             let totalHours = max(0, (totalMinutes - Double(totalBreakMinutes))) / 60.0
 

--- a/core/Sources/WiredPartCore/Services/DailyReportGenerator.swift
+++ b/core/Sources/WiredPartCore/Services/DailyReportGenerator.swift
@@ -4,9 +4,15 @@ import GRDB
 /// Auto-populates daily reports from system data (clock events, to-dos, parts, Q&A).
 public final class DailyReportGenerator: Sendable {
     private let db: AppDatabase
+    private let operationalDay: OperationalDay
 
-    public init(db: AppDatabase) {
+    public init(
+        db: AppDatabase,
+        calendar: Calendar = .current,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
         self.db = db
+        self.operationalDay = OperationalDay(calendar: calendar, now: now)
     }
 
     // MARK: - Report Data Models
@@ -52,8 +58,10 @@ public final class DailyReportGenerator: Sendable {
     // MARK: - Generate Report
 
     /// Generate daily report data from system records for a user on a job.
-    public func generateReport(userId: Int64, jobId: Int64, date: Date = Date()) throws -> DailyReportData {
-        let dateStr = formatDate(date)
+    public func generateReport(userId: Int64, jobId: Int64, date: Date? = nil) throws -> DailyReportData {
+        let reportDate = date ?? operationalDay.now()
+        let day = operationalDay.interval(containing: reportDate)
+        let dateStr = day.localStartDate
 
         do { return try db.writer.read { dbConn in
             let userName = try String.fetchOne(dbConn, sql: """
@@ -68,10 +76,12 @@ public final class DailyReportGenerator: Sendable {
             let clockRows = try Row.fetchAll(dbConn, sql: """
                 SELECT clock_in, clock_out, regular_hours, overtime_hours
                 FROM labor_entries
-                WHERE user_id = ? AND job_id = ? AND \(Self.localDateSQL("clock_in")) = ?
+                WHERE user_id = ? AND job_id = ? AND \(day.exactDayPredicate("clock_in"))
                   AND deleted_at IS NULL
                 ORDER BY clock_in ASC
-                """, arguments: [userId, jobId, dateStr])
+                """, arguments: [
+                    userId, jobId, day.localStartDate, day.utcStart, day.utcEnd
+                ])
 
             let clockIn = clockRows.first?["clock_in"] as String?
             let clockOut = clockRows.last?["clock_out"] as String?
@@ -82,7 +92,7 @@ public final class DailyReportGenerator: Sendable {
                 let cin: String = row["clock_in"] ?? ""
                 let cout: String? = row["clock_out"]
                 if let inDate = parseDateTime(cin) {
-                    let outDate = cout.flatMap { parseDateTime($0) } ?? date
+                    let outDate = cout.flatMap { parseDateTime($0) } ?? reportDate
                     totalMinutes += outDate.timeIntervalSince(inDate) / 60
                 }
             }
@@ -194,8 +204,8 @@ public final class DailyReportGenerator: Sendable {
     }
 
     /// Get today's jobs for a user to determine primary job.
-    public func getTodaysJobs(userId: Int64, date: Date = Date()) throws -> [(jobId: Int64, jobName: String, hours: Double)] {
-        let dateStr = formatDate(date)
+    public func getTodaysJobs(userId: Int64, date: Date? = nil) throws -> [(jobId: Int64, jobName: String, hours: Double)] {
+        let day = operationalDay.interval(containing: date ?? operationalDay.now())
         do {
             return try db.writer.read { dbConn in
                 let rows = try Row.fetchAll(dbConn, sql: """
@@ -206,11 +216,13 @@ public final class DailyReportGenerator: Sendable {
                            ) as total_hours
                     FROM labor_entries le
                     LEFT JOIN jobs j ON j.id = le.job_id AND j.deleted_at IS NULL
-                    WHERE le.user_id = ? AND \(Self.localDateSQL("le.clock_in")) = ?
+                    WHERE le.user_id = ? AND \(day.exactDayPredicate("le.clock_in"))
                       AND le.deleted_at IS NULL
                     GROUP BY le.job_id
                     ORDER BY total_hours DESC
-                    """, arguments: [userId, dateStr])
+                    """, arguments: [
+                        userId, day.localStartDate, day.utcStart, day.utcEnd
+                    ])
                 return rows.map { row in
                     (
                         jobId: row["job_id"] as Int64? ?? 0,
@@ -227,17 +239,7 @@ public final class DailyReportGenerator: Sendable {
 
     // MARK: - Helpers
 
-    private func formatDate(_ date: Date) -> String {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd"
-        return f.string(from: date)
-    }
-
-    private func parseDateTime(_ str: String) -> Date? { CoreFormatters.parseDateTime(str) }
-
-    private static func localDateSQL(_ expression: String) -> String {
-        "CASE WHEN length(\(expression)) <= 10 THEN date(\(expression)) ELSE date(\(expression), 'localtime') END"
-    }
+    private func parseDateTime(_ str: String) -> Date? { CoreFormatters.parseDateTimeUTC(str) }
 
     private func isTableNotFoundError(_ error: Error) -> Bool {
         let message = String(describing: error)

--- a/core/Sources/WiredPartCore/Services/DashboardService.swift
+++ b/core/Sources/WiredPartCore/Services/DashboardService.swift
@@ -14,9 +14,15 @@ import GRDB
 /// Ported from: `src/pages/DashboardPage.tsx` aggregate queries
 public final class DashboardService: Sendable {
     private let db: AppDatabase
+    private let operationalDay: OperationalDay
 
-    public init(db: AppDatabase) {
+    public init(
+        db: AppDatabase,
+        calendar: Calendar = .current,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
         self.db = db
+        self.operationalDay = OperationalDay(calendar: calendar, now: now)
     }
 
     // MARK: - Result Types
@@ -583,14 +589,19 @@ public final class DashboardService: Sendable {
 
     /// Fetch hours worked today for a specific user, including active clock session.
     public func getMyHoursToday(userId: Int64) throws -> MyHoursToday {
+        let now = operationalDay.now()
+        let nowTimestamp = operationalDay.utcTimestamp(now)
+        let day = operationalDay.interval(containing: now)
         do {
             return try db.writer.read { conn in
                 // Total completed hours today
                 var totalHours = try Double.fetchOne(conn, sql: """
                     SELECT COALESCE(SUM(regular_hours + overtime_hours), 0)
                     FROM labor_entries
-                    WHERE user_id = ? AND \(Self.localDateSQL("clock_in")) = date('now', 'localtime') AND deleted_at IS NULL
-                    """, arguments: [userId]) ?? 0
+                    WHERE user_id = ? AND \(day.exactDayPredicate("clock_in")) AND deleted_at IS NULL
+                    """, arguments: [
+                        userId, day.localStartDate, day.utcStart, day.utcEnd
+                    ]) ?? 0
 
                 // Active clock-in session
                 var clockInTime: String?
@@ -613,11 +624,11 @@ public final class DashboardService: Sendable {
 
                     // Add active session elapsed time
                     let activeHours = try Double.fetchOne(conn, sql: """
-                        SELECT (julianday('now') - julianday(clock_in)) * 24
+                        SELECT (julianday(?) - MAX(julianday(clock_in), julianday(?))) * 24
                         FROM labor_entries
                         WHERE user_id = ? AND clock_out IS NULL AND deleted_at IS NULL
                         ORDER BY clock_in DESC LIMIT 1
-                        """, arguments: [userId]) ?? 0
+                        """, arguments: [nowTimestamp, day.utcStart, userId]) ?? 0
                     totalHours += max(0, activeHours)
                 }
 
@@ -626,15 +637,20 @@ public final class DashboardService: Sendable {
                     SELECT COALESCE(j.job_name, 'Shop / Warehouse') AS job_name,
                            SUM(
                              CASE WHEN le.clock_out IS NOT NULL THEN le.regular_hours + le.overtime_hours
-                                  ELSE (julianday('now') - julianday(le.clock_in)) * 24
+                                  ELSE (julianday(?) - MAX(julianday(le.clock_in), julianday(?))) * 24
                              END
                            ) AS total_hours
                     FROM labor_entries le
                     LEFT JOIN jobs j ON j.id = le.job_id AND j.deleted_at IS NULL
-                    WHERE le.user_id = ? AND \(Self.localDateSQL("le.clock_in")) = date('now', 'localtime') AND le.deleted_at IS NULL
+                    WHERE le.user_id = ?
+                      AND (le.clock_out IS NULL OR \(day.exactDayPredicate("le.clock_in")))
+                      AND le.deleted_at IS NULL
                     GROUP BY le.job_id
                     ORDER BY total_hours DESC
-                    """, arguments: [userId])
+                    """, arguments: [
+                        nowTimestamp, day.utcStart, userId,
+                        day.localStartDate, day.utcStart, day.utcEnd
+                    ])
                 let jobBreakdown = breakdownRows.map { row in
                     JobTimeBreakdown(
                         jobName: row["job_name"] ?? "Shop / Warehouse",
@@ -652,14 +668,16 @@ public final class DashboardService: Sendable {
                                     CAST((julianday(ended_at) - julianday(started_at)) * 1440 AS INTEGER)
                                 )
                             ELSE
-                                CAST((julianday('now') - julianday(started_at)) * 1440 AS INTEGER)
+                                CAST((julianday(?) - julianday(started_at)) * 1440 AS INTEGER)
                         END
                     ), 0)
                     FROM break_records
                     WHERE user_id = ?
-                      AND \(Self.localDateSQL("started_at")) = date('now', 'localtime')
+                      AND \(day.exactDayPredicate("started_at"))
                       AND deleted_at IS NULL
-                    """, arguments: [userId]) ?? 0
+                    """, arguments: [
+                        nowTimestamp, userId, day.localStartDate, day.utcStart, day.utcEnd
+                    ]) ?? 0
 
                 return MyHoursToday(
                     totalHours: totalHours,
@@ -793,24 +811,28 @@ public final class DashboardService: Sendable {
 
     /// Fetch labor hours for the past 7 days.
     public func getLaborChartData() throws -> [LaborDayRow] {
+        let referenceDate = operationalDay.now()
         do {
             return try db.writer.read { conn in
-                let isoFormatter = DateFormatter()
-                isoFormatter.dateFormat = "yyyy-MM-dd"
-
                 var results: [LaborDayRow] = []
                 for i in (0..<7).reversed() {
-                    let date = Calendar.current.date(byAdding: .day, value: -i, to: Date()) ?? Date()
-                    let dateStr = isoFormatter.string(from: date)
-                    let regular = try Double.fetchOne(conn, sql: """
-                        SELECT COALESCE(SUM(regular_hours), 0) FROM labor_entries
-                        WHERE \(Self.localDateSQL("clock_in")) = ? AND deleted_at IS NULL
-                        """, arguments: [dateStr]) ?? 0
-                    let overtime = try Double.fetchOne(conn, sql: """
-                        SELECT COALESCE(SUM(overtime_hours), 0) FROM labor_entries
-                        WHERE \(Self.localDateSQL("clock_in")) = ? AND deleted_at IS NULL
-                        """, arguments: [dateStr]) ?? 0
-                    results.append(LaborDayRow(dateString: dateStr, regularHours: regular, overtimeHours: overtime))
+                    let date = operationalDay.calendar.date(
+                        byAdding: .day,
+                        value: -i,
+                        to: referenceDate
+                    ) ?? referenceDate
+                    let day = operationalDay.interval(containing: date)
+                    let row = try Row.fetchOne(conn, sql: """
+                        SELECT COALESCE(SUM(regular_hours), 0) AS regular_hours,
+                               COALESCE(SUM(overtime_hours), 0) AS overtime_hours
+                        FROM labor_entries
+                        WHERE \(day.exactDayPredicate("clock_in")) AND deleted_at IS NULL
+                        """, arguments: StatementArguments(day.exactArguments))
+                    results.append(LaborDayRow(
+                        dateString: day.localStartDate,
+                        regularHours: row?["regular_hours"] ?? 0,
+                        overtimeHours: row?["overtime_hours"] ?? 0
+                    ))
                 }
                 return results
             }

--- a/core/Sources/WiredPartCore/Services/JobEstimationService.swift
+++ b/core/Sources/WiredPartCore/Services/JobEstimationService.swift
@@ -4,9 +4,15 @@ import GRDB
 /// Service for job estimation: questions, responses, calculation, reviews, and AI learning.
 public final class JobEstimationService: Sendable {
     private let db: AppDatabase
+    private let operationalDay: OperationalDay
 
-    public init(db: AppDatabase) {
+    public init(
+        db: AppDatabase,
+        calendar: Calendar = .current,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
         self.db = db
+        self.operationalDay = OperationalDay(calendar: calendar, now: now)
     }
 
     // =========================================================================
@@ -872,24 +878,35 @@ public final class JobEstimationService: Sendable {
                 SELECT COUNT(*) FROM users WHERE deleted_at IS NULL
                 """) ?? 1
 
-            // Average productive hours per worker per day from last 6 months
-            let sixMonthsAgo = Calendar.current.date(byAdding: .month, value: -6, to: Date()) ?? Date()
-            let f = DateFormatter()
-            f.dateFormat = "yyyy-MM-dd"
-            let sinceDate = f.string(from: sixMonthsAgo)
-
-            let avgHoursPerDay = try Double.fetchOne(dbConn, sql: """
-                SELECT AVG(daily_hours) FROM (
-                    SELECT \(Self.localDateSQL("clock_in")) as work_date, SUM(regular_hours + overtime_hours) as daily_hours
-                    FROM labor_entries
-                    WHERE clock_in >= ? AND deleted_at IS NULL AND (regular_hours + overtime_hours) > 0
-                    GROUP BY user_id, \(Self.localDateSQL("clock_in"))
-                )
-                """, arguments: [sinceDate]) ?? 8.0
+            let now = operationalDay.now()
+            let sixMonthsAgo = operationalDay.calendar.date(
+                byAdding: .month,
+                value: -6,
+                to: now
+            ) ?? now
+            let historyStart = operationalDay.interval(containing: sixMonthsAgo)
+            let laborRows = try Row.fetchAll(dbConn, sql: """
+                SELECT user_id, clock_in, regular_hours + overtime_hours AS hours
+                FROM labor_entries
+                WHERE \(historyStart.startsAtOrAfterPredicate("clock_in"))
+                  AND deleted_at IS NULL
+                  AND (regular_hours + overtime_hours) > 0
+                """, arguments: StatementArguments(historyStart.startArguments))
+            var dailyHours: [String: Double] = [:]
+            for row in laborRows {
+                let userId: Int64 = row["user_id"] ?? 0
+                let clockIn: String = row["clock_in"] ?? ""
+                guard let localDate = operationalDay.dateString(fromPersistedTimestamp: clockIn) else {
+                    continue
+                }
+                dailyHours["\(userId):\(localDate)", default: 0] += row["hours"] ?? 0.0
+            }
+            let avgHoursPerDay = dailyHours.isEmpty
+                ? 8.0
+                : dailyHours.values.reduce(0, +) / Double(dailyHours.count)
 
             // Working days in current month (approx 22)
-            let calendar = Calendar.current
-            let now = Date()
+            let calendar = operationalDay.calendar
             let range = calendar.range(of: .day, in: .month, for: now) ?? 1..<31
             let weekdays = (range).reduce(0) { count, day in
                 var comps = calendar.dateComponents([.year, .month], from: now)
@@ -913,9 +930,6 @@ public final class JobEstimationService: Sendable {
 
     private static func nowString() -> String { CoreFormatters.nowISO() }
 
-    private static func localDateSQL(_ expression: String) -> String {
-        "CASE WHEN length(\(expression)) <= 10 THEN date(\(expression)) ELSE date(\(expression), 'localtime') END"
-    }
 
     private func isTableNotFoundError(_ error: Error) -> Bool {
         let message = String(describing: error)

--- a/core/Sources/WiredPartCore/Services/ReportsService.swift
+++ b/core/Sources/WiredPartCore/Services/ReportsService.swift
@@ -14,9 +14,15 @@ import GRDB
 /// Ported from: Reports & Pre-Billing feature area (Phase 8/11)
 public final class ReportsService: Sendable {
     private let db: AppDatabase
+    private let operationalDay: OperationalDay
 
-    public init(db: AppDatabase) {
+    public init(
+        db: AppDatabase,
+        calendar: Calendar = .current,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
         self.db = db
+        self.operationalDay = OperationalDay(calendar: calendar, now: now)
     }
 
     // =========================================================================
@@ -277,6 +283,9 @@ public final class ReportsService: Sendable {
     ///   - endDate: End date in ISO-8601 format (e.g., "2026-03-15").
     /// - Returns: An array of `TimesheetRow` sorted by user name ascending.
     public func getTimesheetData(startDate: String, endDate: String) throws -> [TimesheetRow] {
+        guard let interval = operationalDay.interval(startDate: startDate, endDate: endDate) else {
+            return []
+        }
         do {
             return try db.writer.read { dbConn -> [TimesheetRow] in
                 let sql = """
@@ -284,18 +293,34 @@ public final class ReportsService: Sendable {
                            COALESCE(u.display_name, u.email, 'Unknown') AS user_name,
                            COALESCE(SUM(le.regular_hours), 0) AS regular_hours,
                            COALESCE(SUM(le.overtime_hours), 0) AS overtime_hours,
-                           COALESCE(SUM(le.regular_hours), 0) + COALESCE(SUM(le.overtime_hours), 0) AS total_hours,
-                           COUNT(DISTINCT \(Self.localDateSQL("le.clock_in"))) AS days_worked
+                           COALESCE(SUM(le.regular_hours), 0) + COALESCE(SUM(le.overtime_hours), 0) AS total_hours
                     FROM labor_entries le
                     LEFT JOIN users u ON u.id = le.user_id AND u.deleted_at IS NULL
                     WHERE le.deleted_at IS NULL
-                      AND \(Self.localDateSQL("le.clock_in")) >= date(?)
-                      AND \(Self.localDateSQL("le.clock_in")) <= date(?)
+                      AND \(interval.rangePredicate("le.clock_in"))
                     GROUP BY le.user_id
                     ORDER BY user_name ASC
                     """
 
-                let rows = try Row.fetchAll(dbConn, sql: sql, arguments: [startDate, endDate])
+                let rows = try Row.fetchAll(
+                    dbConn,
+                    sql: sql,
+                    arguments: StatementArguments(interval.rangeArguments)
+                )
+                let workDayRows = try Row.fetchAll(dbConn, sql: """
+                    SELECT le.user_id, le.clock_in
+                    FROM labor_entries le
+                    WHERE le.deleted_at IS NULL
+                      AND \(interval.rangePredicate("le.clock_in"))
+                    """, arguments: StatementArguments(interval.rangeArguments))
+                var workDaysByUser: [Int64: Set<String>] = [:]
+                for row in workDayRows {
+                    let userId: Int64 = row["user_id"] ?? 0
+                    let timestamp: String = row["clock_in"] ?? ""
+                    if let localDate = operationalDay.dateString(fromPersistedTimestamp: timestamp) {
+                        workDaysByUser[userId, default: []].insert(localDate)
+                    }
+                }
                 return rows.enumerated().map { index, row in
                     let userId: Int64 = row["user_id"] ?? 0
                     return TimesheetRow(
@@ -305,7 +330,7 @@ public final class ReportsService: Sendable {
                         regularHours: row["regular_hours"] ?? 0.0,
                         overtimeHours: row["overtime_hours"] ?? 0.0,
                         totalHours: row["total_hours"] ?? 0.0,
-                        daysWorked: row["days_worked"] ?? 0
+                        daysWorked: workDaysByUser[userId]?.count ?? 0
                     )
                 }
             }
@@ -561,6 +586,9 @@ public final class ReportsService: Sendable {
     /// - Parameter date: The date in ISO-8601 format (e.g., "2026-03-15").
     /// - Returns: An array of `DailyReportSummaryRow` sorted by job name ascending.
     public func getDailyReportSummary(date: String) throws -> [DailyReportSummaryRow] {
+        guard let interval = operationalDay.interval(startDate: date, endDate: date) else {
+            return []
+        }
         do {
             return try db.writer.read { dbConn -> [DailyReportSummaryRow] in
                 let sql = """
@@ -571,12 +599,16 @@ public final class ReportsService: Sendable {
                     JOIN jobs j ON j.id = le.job_id
                     WHERE le.deleted_at IS NULL
                       AND j.deleted_at IS NULL
-                      AND \(Self.localDateSQL("le.clock_in")) = date(?)
+                      AND \(interval.exactDayPredicate("le.clock_in"))
                     GROUP BY j.id
                     ORDER BY j.job_name ASC
                     """
 
-                let rows = try Row.fetchAll(dbConn, sql: sql, arguments: [date])
+                let rows = try Row.fetchAll(
+                    dbConn,
+                    sql: sql,
+                    arguments: StatementArguments(interval.exactArguments)
+                )
                 return rows.map { row in
                     DailyReportSummaryRow(
                         id: row["id"] ?? 0,

--- a/core/Tests/WiredPartCoreTests/DailyReportGeneratorTests.swift
+++ b/core/Tests/WiredPartCoreTests/DailyReportGeneratorTests.swift
@@ -203,8 +203,10 @@ struct DailyReportGeneratorTests {
 
     @Test("Historical report instant controls active labor and break durations")
     func testGenerateReportUsesExplicitInstantForActiveRows() throws {
-        let injectedNow = try Date("2026-07-21T10:30:00Z", strategy: .iso8601)
-        let reportDate = try Date("2026-07-20T10:30:00Z", strategy: .iso8601)
+        // 09:45 UTC is 23:45 on July 20 in Honolulu. The UTC date differs from
+        // the operational date, so SQLite date(started_at) would miss this break.
+        let injectedNow = try Date("2026-07-22T09:45:00Z", strategy: .iso8601)
+        let reportDate = try Date("2026-07-21T09:45:00Z", strategy: .iso8601)
         let (env, gen) = try freshEnv(calendar: Self.honoluluCalendar, now: { injectedNow })
         let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-HIST-DRG", name: "Historical Report")
 
@@ -212,13 +214,13 @@ struct DailyReportGeneratorTests {
             try db.execute(sql: """
                 INSERT INTO labor_entries
                     (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
-                VALUES (?, ?, '2026-07-20 10:00:00', NULL, 0, 0, 'active', '2026-07-20 10:00:00')
+                VALUES (?, ?, '2026-07-21 09:00:00', NULL, 0, 0, 'active', '2026-07-21 09:00:00')
                 """, arguments: [env.adminUserId, jobId])
             let laborEntryId = db.lastInsertedRowID
             try db.execute(sql: """
                 INSERT INTO break_records
                     (user_id, labor_entry_id, break_type, started_at, ended_at, duration_minutes, is_paid, auto_filled)
-                VALUES (?, ?, 'break', '2026-07-20 10:10:00', NULL, NULL, 1, 0)
+                VALUES (?, ?, 'break', '2026-07-21 09:30:00', NULL, NULL, 1, 0)
                 """, arguments: [env.adminUserId, laborEntryId])
         }
 
@@ -229,8 +231,8 @@ struct DailyReportGeneratorTests {
         )
         let breakMinutes = try #require(report.breaksTaken.first?.durationMinutes)
 
-        #expect((19...20).contains(breakMinutes))
-        #expect(abs(report.totalHours - (30.0 - Double(breakMinutes)) / 60.0) < 0.001)
+        #expect((14...15).contains(breakMinutes))
+        #expect(abs(report.totalHours - (45.0 - Double(breakMinutes)) / 60.0) < 0.001)
     }
 
     @Test("Local-midnight active labor uses the requested instant instead of wall clock")

--- a/core/Tests/WiredPartCoreTests/DailyReportGeneratorTests.swift
+++ b/core/Tests/WiredPartCoreTests/DailyReportGeneratorTests.swift
@@ -1,9 +1,4 @@
 import Foundation
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
 import Testing
 import GRDB
 @testable import WiredPartCore
@@ -11,9 +6,11 @@ import GRDB
 @Suite("DailyReportGenerator Tests", .serialized)
 struct DailyReportGeneratorTests {
 
-    private func freshEnv() throws -> (E2ETestHelpers.TestEnvironment, DailyReportGenerator) {
+    private func freshEnv(
+        calendar: Calendar = .current
+    ) throws -> (E2ETestHelpers.TestEnvironment, DailyReportGenerator) {
         let env = try E2ETestHelpers.setUp()
-        let generator = DailyReportGenerator(db: env.db)
+        let generator = DailyReportGenerator(db: env.db, calendar: calendar)
         return (env, generator)
     }
 
@@ -106,7 +103,7 @@ struct DailyReportGeneratorTests {
         try env.db.writer.write { db in
             try db.execute(sql: """
                 INSERT INTO labor_entries (user_id, job_id, clock_in, deleted_at)
-                VALUES (?, ?, '\(fixedDate) 08:00:00', NULL)
+                VALUES (?, ?, '\(fixedDate) 12:00:00', NULL)
                 """, arguments: [env.adminUserId, jobId])
             try db.execute(sql: "UPDATE jobs SET deleted_at = datetime('now') WHERE id = ?", arguments: [jobId])
         }
@@ -162,68 +159,50 @@ struct DailyReportGeneratorTests {
 
     @Test("Generate report buckets UTC end-of-day labor into local report date")
     func testGenerateReportUsesLocalClockInDateBucket() throws {
-        try withMountainTimeZone {
-            let (env, gen) = try freshEnv()
-            let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-DRG", name: "Local Daily Report")
+        let (env, gen) = try freshEnv(calendar: Self.mountainCalendar)
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-DRG", name: "Local Daily Report")
 
-            try env.db.writer.write { db in
-                try db.execute(sql: """
-                    INSERT INTO labor_entries
-                        (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
-                    VALUES (?, ?, '2026-02-01 02:30:00', '2026-02-01 04:30:00', 2.0, 0.0, 'completed', datetime('now'))
-                    """, arguments: [env.adminUserId, jobId])
-            }
-
-            let date = try #require(Self.dayFormatter.date(from: "2026-01-31"))
-            let report = try gen.generateReport(userId: env.adminUserId, jobId: jobId, date: date)
-
-            #expect(report.clockIn == "2026-02-01 02:30:00")
-            #expect(report.totalHours == 2.0)
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, '2026-02-01 02:30:00', '2026-02-01 04:30:00', 2.0, 0.0, 'completed', datetime('now'))
+                """, arguments: [env.adminUserId, jobId])
         }
+
+        let date = try #require(Self.mountainCalendar.date(
+            from: DateComponents(year: 2026, month: 1, day: 31, hour: 12)
+        ))
+        let report = try gen.generateReport(userId: env.adminUserId, jobId: jobId, date: date)
+
+        #expect(report.clockIn == "2026-02-01 02:30:00")
+        #expect(report.totalHours == 2.0)
     }
 
     @Test("Today's jobs buckets UTC end-of-day labor into local work date")
     func testTodaysJobsUsesLocalClockInDateBucket() throws {
-        try withMountainTimeZone {
-            let (env, gen) = try freshEnv()
-            let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-JOBS", name: "Local Jobs")
+        let (env, gen) = try freshEnv(calendar: Self.mountainCalendar)
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-JOBS", name: "Local Jobs")
 
-            try env.db.writer.write { db in
-                try db.execute(sql: """
-                    INSERT INTO labor_entries
-                        (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
-                    VALUES (?, ?, '2026-02-01 02:30:00', '2026-02-01 04:30:00', 2.0, 0.0, 'completed', datetime('now'))
-                    """, arguments: [env.adminUserId, jobId])
-            }
-
-            let date = try #require(Self.dayFormatter.date(from: "2026-01-31"))
-            let jobs = try gen.getTodaysJobs(userId: env.adminUserId, date: date)
-
-            #expect(jobs.contains { $0.jobId == jobId && abs($0.hours - 2.0) < 0.001 })
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, '2026-02-01 02:30:00', '2026-02-01 04:30:00', 2.0, 0.0, 'completed', datetime('now'))
+                """, arguments: [env.adminUserId, jobId])
         }
+
+        let date = try #require(Self.mountainCalendar.date(
+            from: DateComponents(year: 2026, month: 1, day: 31, hour: 12)
+        ))
+        let jobs = try gen.getTodaysJobs(userId: env.adminUserId, date: date)
+
+        #expect(jobs.contains { $0.jobId == jobId && abs($0.hours - 2.0) < 0.001 })
     }
 
-    private static let dayFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = TimeZone(identifier: "America/Denver")
-        return formatter
+    private static let mountainCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/Denver")!
+        return calendar
     }()
-
-    private func withMountainTimeZone<T>(_ body: () throws -> T) rethrows -> T {
-        #if canImport(Darwin) || canImport(Glibc)
-        let originalTZ = getenv("TZ").map { String(cString: $0) }
-        setenv("TZ", "America/Denver", 1)
-        tzset()
-        defer {
-            if let originalTZ {
-                setenv("TZ", originalTZ, 1)
-            } else {
-                unsetenv("TZ")
-            }
-            tzset()
-        }
-        #endif
-        return try body()
-    }
 }

--- a/core/Tests/WiredPartCoreTests/DailyReportGeneratorTests.swift
+++ b/core/Tests/WiredPartCoreTests/DailyReportGeneratorTests.swift
@@ -256,13 +256,13 @@ struct DailyReportGeneratorTests {
 
     private static let mountainCalendar: Calendar = {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "America/Denver")!
+        calendar.timeZone = TimeZone(identifier: "America/Denver") ?? .gmt
         return calendar
     }()
 
     private static let honoluluCalendar: Calendar = {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "Pacific/Honolulu")!
+        calendar.timeZone = TimeZone(identifier: "Pacific/Honolulu") ?? .gmt
         return calendar
     }()
 }

--- a/core/Tests/WiredPartCoreTests/DailyReportGeneratorTests.swift
+++ b/core/Tests/WiredPartCoreTests/DailyReportGeneratorTests.swift
@@ -7,10 +7,11 @@ import GRDB
 struct DailyReportGeneratorTests {
 
     private func freshEnv(
-        calendar: Calendar = .current
+        calendar: Calendar = .current,
+        now: @escaping @Sendable () -> Date = { Date() }
     ) throws -> (E2ETestHelpers.TestEnvironment, DailyReportGenerator) {
         let env = try E2ETestHelpers.setUp()
-        let generator = DailyReportGenerator(db: env.db, calendar: calendar)
+        let generator = DailyReportGenerator(db: env.db, calendar: calendar, now: now)
         return (env, generator)
     }
 
@@ -200,9 +201,68 @@ struct DailyReportGeneratorTests {
         #expect(jobs.contains { $0.jobId == jobId && abs($0.hours - 2.0) < 0.001 })
     }
 
+    @Test("Historical report instant controls active labor and break durations")
+    func testGenerateReportUsesExplicitInstantForActiveRows() throws {
+        let injectedNow = try Date("2026-07-21T10:30:00Z", strategy: .iso8601)
+        let reportDate = try Date("2026-07-20T10:30:00Z", strategy: .iso8601)
+        let (env, gen) = try freshEnv(calendar: Self.honoluluCalendar, now: { injectedNow })
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-HIST-DRG", name: "Historical Report")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, '2026-07-20 10:00:00', NULL, 0, 0, 'active', '2026-07-20 10:00:00')
+                """, arguments: [env.adminUserId, jobId])
+            let laborEntryId = db.lastInsertedRowID
+            try db.execute(sql: """
+                INSERT INTO break_records
+                    (user_id, labor_entry_id, break_type, started_at, ended_at, duration_minutes, is_paid, auto_filled)
+                VALUES (?, ?, 'break', '2026-07-20 10:10:00', NULL, NULL, 1, 0)
+                """, arguments: [env.adminUserId, laborEntryId])
+        }
+
+        let report = try gen.generateReport(
+            userId: env.adminUserId,
+            jobId: jobId,
+            date: reportDate
+        )
+        let breakMinutes = try #require(report.breaksTaken.first?.durationMinutes)
+
+        #expect((19...20).contains(breakMinutes))
+        #expect(abs(report.totalHours - (30.0 - Double(breakMinutes)) / 60.0) < 0.001)
+    }
+
+    @Test("Local-midnight active labor uses the requested instant instead of wall clock")
+    func testTodaysJobsUsesExplicitInstantForActiveLabor() throws {
+        let injectedNow = try Date("2026-07-21T10:30:00Z", strategy: .iso8601)
+        let reportDate = try Date("2026-07-20T10:30:00Z", strategy: .iso8601)
+        let (env, gen) = try freshEnv(calendar: Self.honoluluCalendar, now: { injectedNow })
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-MIDNIGHT-DRG", name: "Midnight Report")
+
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, '2026-07-20 10:00:00', NULL, 0, 0, 'active', '2026-07-20 10:00:00')
+                """, arguments: [env.adminUserId, jobId])
+        }
+
+        let jobs = try gen.getTodaysJobs(userId: env.adminUserId, date: reportDate)
+        let hours = try #require(jobs.first(where: { $0.jobId == jobId })?.hours)
+
+        #expect(abs(hours - 0.5) < 0.001)
+    }
+
     private static let mountainCalendar: Calendar = {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "America/Denver")!
+        return calendar
+    }()
+
+    private static let honoluluCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Pacific/Honolulu")!
         return calendar
     }()
 }

--- a/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
@@ -1,33 +1,16 @@
 import Foundation
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
 import Testing
 import GRDB
 @testable import WiredPartCore
 
 @Suite("DashboardService Tests", .serialized)
 struct DashboardServiceTests {
-    private func withDenverTimeZone(_ work: () throws -> Void) throws {
-        let originalTZ = getenv("TZ").map { String(cString: $0) }
-        setenv("TZ", "America/Denver", 1)
-        tzset()
-        defer {
-            if let originalTZ {
-                setenv("TZ", originalTZ, 1)
-            } else {
-                unsetenv("TZ")
-            }
-            tzset()
-        }
-        try work()
-    }
-
-    private func freshEnv() throws -> (E2ETestHelpers.TestEnvironment, DashboardService) {
+    private func freshEnv(
+        calendar: Calendar = .current,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) throws -> (E2ETestHelpers.TestEnvironment, DashboardService) {
         let env = try E2ETestHelpers.setUp()
-        let dashboard = DashboardService(db: env.db)
+        let dashboard = DashboardService(db: env.db, calendar: calendar, now: now)
         return (env, dashboard)
     }
 
@@ -118,45 +101,47 @@ struct DashboardServiceTests {
 
     @Test("Labor chart buckets UTC evening clock-in into local work day")
     func testLaborChartUsesLocalOperationalDayForUtcClockIn() throws {
-        try withDenverTimeZone {
-            let (env, dash) = try freshEnv()
-            let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-DASH", name: "Local Dashboard Job")
+        let fixedNow = try Date("2026-03-06T06:55:00Z", strategy: .iso8601)
+        let (env, dash) = try freshEnv(calendar: Self.denverCalendar, now: { fixedNow })
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-DASH", name: "Local Dashboard Job")
 
-            var localCalendar = Calendar(identifier: .gregorian)
-            localCalendar.timeZone = TimeZone(identifier: "America/Denver")!
-            let localStartOfDay = localCalendar.startOfDay(for: Date())
-            let localEvening = localCalendar.date(bySettingHour: 21, minute: 30, second: 0, of: localStartOfDay)!
+        let localStartOfDay = Self.denverCalendar.startOfDay(for: fixedNow)
+        let localEvening = Self.denverCalendar.date(
+            bySettingHour: 21,
+            minute: 30,
+            second: 0,
+            of: localStartOfDay
+        )!
 
-            let utcFormatter = DateFormatter()
-            utcFormatter.calendar = Calendar(identifier: .gregorian)
-            utcFormatter.locale = Locale(identifier: "en_US_POSIX")
-            utcFormatter.timeZone = TimeZone(identifier: "UTC")
-            utcFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        let utcFormatter = DateFormatter()
+        utcFormatter.calendar = Calendar(identifier: .gregorian)
+        utcFormatter.locale = Locale(identifier: "en_US_POSIX")
+        utcFormatter.timeZone = TimeZone(identifier: "UTC")
+        utcFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
 
-            let localDayFormatter = DateFormatter()
-            localDayFormatter.calendar = Calendar(identifier: .gregorian)
-            localDayFormatter.locale = Locale(identifier: "en_US_POSIX")
-            localDayFormatter.timeZone = TimeZone(identifier: "America/Denver")
-            localDayFormatter.dateFormat = "yyyy-MM-dd"
+        let localDayFormatter = DateFormatter()
+        localDayFormatter.calendar = Calendar(identifier: .gregorian)
+        localDayFormatter.locale = Locale(identifier: "en_US_POSIX")
+        localDayFormatter.timeZone = TimeZone(identifier: "America/Denver")
+        localDayFormatter.dateFormat = "yyyy-MM-dd"
 
-            let clockIn = utcFormatter.string(from: localEvening)
-            let clockOut = utcFormatter.string(from: localEvening.addingTimeInterval(2 * 60 * 60))
-            let localDay = localDayFormatter.string(from: localEvening)
+        let clockIn = utcFormatter.string(from: localEvening)
+        let clockOut = utcFormatter.string(from: localEvening.addingTimeInterval(2 * 60 * 60))
+        let localDay = localDayFormatter.string(from: localEvening)
 
-            try env.db.writer.write { db in
-                try db.execute(sql: """
-                    INSERT INTO labor_entries
-                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
-                    VALUES (?, ?, ?, ?, 2.0, 0.0, 'completed', datetime('now'))
-                    """, arguments: [env.adminUserId, jobId, clockIn, clockOut])
-            }
-
-            let chartRows = try dash.getLaborChartData()
-            let localDayRow = chartRows.first(where: { $0.dateString == localDay })
-
-            #expect(localDayRow != nil)
-            #expect(abs((localDayRow?.regularHours ?? 0) - 2.0) < 0.01)
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, ?, ?, 2.0, 0.0, 'completed', datetime('now'))
+                """, arguments: [env.adminUserId, jobId, clockIn, clockOut])
         }
+
+        let chartRows = try dash.getLaborChartData()
+        let localDayRow = chartRows.first(where: { $0.dateString == localDay })
+
+        #expect(localDayRow != nil)
+        #expect(abs((localDayRow?.regularHours ?? 0) - 2.0) < 0.01)
     }
 
     // MARK: - Delivery & Budget
@@ -268,13 +253,16 @@ struct DashboardServiceTests {
 
     @Test("My hours today includes elapsed minutes for active same-day break record")
     func testMyHoursTodayIncludesActiveBreakElapsedMinutes() throws {
-        let (env, dash) = try freshEnv()
+        // 00:30 in Honolulu: a wall-clock `now - 20 minutes` fixture can cross
+        // the local-day boundary depending on the machine running the suite.
+        let fixedNow = try Date("2026-07-20T10:30:00Z", strategy: .iso8601)
+        let (env, dash) = try freshEnv(calendar: Self.honoluluCalendar, now: { fixedNow })
         try env.db.writer.write { db in
             try db.execute(sql: """
                 INSERT INTO break_records
                     (user_id, break_type, started_at, ended_at, duration_minutes, is_paid, auto_filled)
                 VALUES
-                    (?, 'break', datetime('now','-20 minutes'), NULL, NULL, 1, 0)
+                    (?, 'break', '2026-07-20 10:10:00', NULL, NULL, 1, 0)
                 """, arguments: [env.adminUserId])
         }
 
@@ -283,6 +271,42 @@ struct DashboardServiceTests {
         #expect(hours.breakMinutes >= 19)
         #expect(hours.breakMinutes <= 21)
     }
+
+    @Test("My hours today clamps an overnight active session to local midnight")
+    func testMyHoursTodayClampsActiveSessionAtOperationalDayStart() throws {
+        let fixedNow = try Date("2026-07-20T10:30:00Z", strategy: .iso8601)
+        let (env, dash) = try freshEnv(calendar: Self.honoluluCalendar, now: { fixedNow })
+        let jobId = try E2ETestHelpers.seedJob(
+            env,
+            jobNumber: "J-OVERNIGHT-01",
+            name: "Overnight Job"
+        )
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO labor_entries (user_id, job_id, clock_in, clock_out, status)
+                VALUES (?, ?, '2026-07-20T09:30:00Z', NULL, 'active')
+                """, arguments: [env.adminUserId, jobId])
+        }
+
+        let hours = try dash.getMyHoursToday(userId: env.adminUserId)
+
+        #expect(abs(hours.totalHours - 0.5) < 0.001)
+        #expect(hours.jobBreakdown.count == 1)
+        #expect(hours.jobBreakdown.first?.jobName == "Overnight Job")
+        #expect(abs((hours.jobBreakdown.first?.hours ?? 0) - 0.5) < 0.001)
+    }
+
+    private static let denverCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/Denver")!
+        return calendar
+    }()
+
+    private static let honoluluCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Pacific/Honolulu")!
+        return calendar
+    }()
 
     @Test("Team clocked in status reflects active clock entry")
     func testTeamClockedIn() throws {

--- a/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/DashboardServiceTests.swift
@@ -298,13 +298,13 @@ struct DashboardServiceTests {
 
     private static let denverCalendar: Calendar = {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "America/Denver")!
+        calendar.timeZone = TimeZone(identifier: "America/Denver") ?? .gmt
         return calendar
     }()
 
     private static let honoluluCalendar: Calendar = {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "Pacific/Honolulu")!
+        calendar.timeZone = TimeZone(identifier: "Pacific/Honolulu") ?? .gmt
         return calendar
     }()
 

--- a/core/Tests/WiredPartCoreTests/JobEstimationServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobEstimationServiceTests.swift
@@ -1,9 +1,4 @@
 import Foundation
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
 import Testing
 import GRDB
 @testable import WiredPartCore
@@ -11,9 +6,12 @@ import GRDB
 @Suite("JobEstimationService Tests", .serialized)
 struct JobEstimationServiceTests {
 
-    private func freshEnv() throws -> (E2ETestHelpers.TestEnvironment, JobEstimationService) {
+    private func freshEnv(
+        calendar: Calendar = .current,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) throws -> (E2ETestHelpers.TestEnvironment, JobEstimationService) {
         let env = try E2ETestHelpers.setUp()
-        let estimation = JobEstimationService(db: env.db)
+        let estimation = JobEstimationService(db: env.db, calendar: calendar, now: now)
         return (env, estimation)
     }
 
@@ -376,13 +374,17 @@ struct JobEstimationServiceTests {
 
     @Test("Monthly capacity groups UTC-split labor by local work date")
     func testMonthlyCapacityUsesLocalClockInDateBucket() throws {
-        try withMountainTimeZone {
-            let (env, est) = try freshEnv()
+            let fixedNow = try Date("2026-07-20T12:00:00Z", strategy: .iso8601)
+            let (env, est) = try freshEnv(calendar: Self.denverCalendar, now: { fixedNow })
             let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-CAP-LOCAL", name: "Local Capacity")
             let utcFormatter = Self.utcTimestampFormatter
 
-            let firstClockIn = utcFormatter.string(from: try Self.localToday(hour: 16, minute: 30))
-            let secondClockIn = utcFormatter.string(from: try Self.localToday(hour: 18, minute: 30))
+            let firstClockIn = utcFormatter.string(from: try Self.localToday(
+                hour: 16, minute: 30, referenceDate: fixedNow
+            ))
+            let secondClockIn = utcFormatter.string(from: try Self.localToday(
+                hour: 18, minute: 30, referenceDate: fixedNow
+            ))
 
             try env.db.writer.write { db in
                 try db.execute(sql: "DELETE FROM labor_entries")
@@ -403,10 +405,38 @@ struct JobEstimationServiceTests {
             }
 
             let capacity = try est.calculateMonthlyCapacity()
-            let expected = Double(workerCount * Self.weekdaysInCurrentMonth())
+            let expected = Double(workerCount * Self.weekdaysInCurrentMonth(referenceDate: fixedNow))
 
             #expect(abs(capacity - expected) < 0.001)
+    }
+
+    @Test("Monthly capacity includes date-only labor on the first historical local day")
+    func testMonthlyCapacityIncludesDateOnlyHistoryBoundary() throws {
+        let fixedNow = try Date("2026-07-20T12:00:00Z", strategy: .iso8601)
+        let (env, est) = try freshEnv(calendar: Self.denverCalendar, now: { fixedNow })
+        let jobId = try E2ETestHelpers.seedJob(
+            env,
+            jobNumber: "J-CAP-DATE-ONLY",
+            name: "Date-Only Capacity"
+        )
+        try env.db.writer.write { db in
+            try db.execute(sql: "DELETE FROM labor_entries")
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, '2026-01-20', '2026-01-20', 4.0, 0.0, 'completed', datetime('now'))
+                """, arguments: [env.adminUserId, jobId])
         }
+        let workerCount = try env.db.writer.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM users WHERE deleted_at IS NULL") ?? 1
+        }
+
+        let capacity = try est.calculateMonthlyCapacity()
+        let expected = 0.5 * Double(
+            workerCount * Self.weekdaysInCurrentMonth(referenceDate: fixedNow)
+        )
+
+        #expect(abs(capacity - expected) < 0.001)
     }
 
     @Test("Historical average query")
@@ -424,19 +454,17 @@ struct JobEstimationServiceTests {
         return formatter
     }()
 
-    private static func localToday(hour: Int, minute: Int) throws -> Date {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = try #require(TimeZone(identifier: "America/Denver"))
-        var components = calendar.dateComponents([.year, .month, .day], from: Date())
+    private static func localToday(hour: Int, minute: Int, referenceDate: Date) throws -> Date {
+        var components = denverCalendar.dateComponents([.year, .month, .day], from: referenceDate)
         components.hour = hour
         components.minute = minute
         components.second = 0
-        return try #require(calendar.date(from: components))
+        return try #require(denverCalendar.date(from: components))
     }
 
-    private static func weekdaysInCurrentMonth() -> Int {
-        let calendar = Calendar.current
-        let now = Date()
+    private static func weekdaysInCurrentMonth(referenceDate: Date) -> Int {
+        let calendar = denverCalendar
+        let now = referenceDate
         let range = calendar.range(of: .day, in: .month, for: now) ?? 1..<31
         return range.reduce(0) { count, day in
             var components = calendar.dateComponents([.year, .month], from: now)
@@ -447,22 +475,12 @@ struct JobEstimationServiceTests {
         }
     }
 
-    private func withMountainTimeZone<T>(_ body: () throws -> T) rethrows -> T {
-        #if canImport(Darwin) || canImport(Glibc)
-        let originalTZ = getenv("TZ").map { String(cString: $0) }
-        setenv("TZ", "America/Denver", 1)
-        tzset()
-        defer {
-            if let originalTZ {
-                setenv("TZ", originalTZ, 1)
-            } else {
-                unsetenv("TZ")
-            }
-            tzset()
-        }
-        #endif
-        return try body()
-    }
+    private static let denverCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/Denver")!
+        return calendar
+    }()
+
 
     @Test("Regression: getHistoricalAverage finds jobs with status 'completed' (not 'complete')")
     func testHistoricalAverage_findsCompletedJobs() throws {

--- a/core/Tests/WiredPartCoreTests/JobEstimationServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobEstimationServiceTests.swift
@@ -477,7 +477,7 @@ struct JobEstimationServiceTests {
 
     private static let denverCalendar: Calendar = {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "America/Denver")!
+        calendar.timeZone = TimeZone(identifier: "America/Denver") ?? .gmt
         return calendar
     }()
 

--- a/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/JobsServiceTests.swift
@@ -1,9 +1,4 @@
 import Foundation
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
 import Testing
 import GRDB
 @testable import WiredPartCore
@@ -481,7 +476,6 @@ struct JobsServiceTests {
 
     @Test("Daily overtime threshold spans multiple labor entries")
     func testDailyOvertimeThresholdSpansMultipleLaborEntries() throws {
-        try withMountainTimeZone {
             let env = try E2ETestHelpers.setUp()
             let firstJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-OT-1", name: "First OT Job")
             let secondJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-OT-2", name: "Second OT Job")
@@ -516,12 +510,10 @@ struct JobsServiceTests {
 
             #expect(secondEntry?["regular_hours"] as Double? == 2.0)
             #expect(secondEntry?["overtime_hours"] as Double? == 2.0)
-        }
     }
 
     @Test("Weekly overtime settings split hours after configured threshold")
     func testWeeklyOvertimeSettingsSplitHoursAfterThreshold() throws {
-        try withMountainTimeZone {
             let env = try E2ETestHelpers.setUp()
             let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-WEEKLY-OT", name: "Weekly OT")
             _ = try env.jobs.updateOvertimeSettings(
@@ -564,12 +556,10 @@ struct JobsServiceTests {
 
             #expect(saturdayEntry?["regular_hours"] as Double? == 0.0)
             #expect(saturdayEntry?["overtime_hours"] as Double? == 4.0)
-        }
     }
 
     @Test("Labor correction persists actor reason and before after hours")
     func testLaborCorrectionPersistsAudit() throws {
-        try withMountainTimeZone {
             let env = try E2ETestHelpers.setUp()
             let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-CORRECT", name: "Correction Audit")
             let entryId = try env.jobs.clockIn(
@@ -608,12 +598,10 @@ struct JobsServiceTests {
             #expect(corrected?["regular_hours"] as Double? == 8.0)
             #expect(corrected?["overtime_hours"] as Double? == 1.0)
             #expect(corrected?["edited_by"] as Int64? == env.adminUserId)
-        }
     }
 
     @Test("Switching jobs closes current entry and starts next entry at the same instant")
     func testSwitchClockedInJobIsAtomicAndDeterministic() throws {
-        try withMountainTimeZone {
             let env = try E2ETestHelpers.setUp()
             let firstJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-SW-1", name: "Switch From")
             let secondJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-SW-2", name: "Switch To")
@@ -641,12 +629,10 @@ struct JobsServiceTests {
             #expect(secondEntry.status == "clocked_in")
             #expect(active?.id == secondEntryId)
             #expect(active?.jobId == secondJobId)
-        }
     }
 
     @Test("Switching jobs keeps current entry active when target job is not clockable")
     func testSwitchClockedInJobRollsBackWhenTargetIsNotClockable() throws {
-        try withMountainTimeZone {
             let env = try E2ETestHelpers.setUp()
             let firstJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-SW-STAY", name: "Switch Stays Active")
             let closedJobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-SW-CLOSED", name: "Closed Switch Target")
@@ -675,12 +661,10 @@ struct JobsServiceTests {
             #expect(originalEntry.clockOut == nil)
             #expect(active?.id == firstEntryId)
             #expect(active?.jobId == firstJobId)
-        }
     }
 
     @Test("Clock out subtracts unpaid breaks but keeps paid breaks compensable")
     func testClockOutBreakPayTreatmentIsDeterministic() throws {
-        try withMountainTimeZone {
             let env = try E2ETestHelpers.setUp()
             let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-BREAK-PAY", name: "Break Pay Job")
             let laborEntryId = try env.jobs.clockIn(
@@ -721,7 +705,6 @@ struct JobsServiceTests {
 
             #expect(entry?["regular_hours"] as Double? == 8.0)
             #expect(entry?["overtime_hours"] as Double? == 0.5)
-        }
     }
 
     // MARK: - Team Members
@@ -971,7 +954,6 @@ struct JobsServiceTests {
 
     @Test("Today's clock entries use local-day completed labor")
     func testGetTodaysClockEntriesUsesLocalOperationalDayForCompletedLabor() throws {
-        try withMountainTimeZone {
             let env = try E2ETestHelpers.setUp()
             let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-CLOCK-LOCAL", name: "Local Clock Job")
             let clockIn = Self.utcTimestampFormatter.string(from: try Self.localToday(hour: 22, minute: 30))
@@ -992,7 +974,6 @@ struct JobsServiceTests {
             #expect(group.jobName == "Local Clock Job")
             #expect(group.entries.count == 1)
             #expect(abs(group.totalDuration - 3600) < 1)
-        }
     }
 
     @Test("Today's clock entries reject malformed clock-in timestamps")
@@ -1276,7 +1257,6 @@ struct JobsServiceTests {
 
     @Test("Jobs dashboard KPIs bucket UTC end-of-day labor into local today")
     func testJobsDashboardKPIsUseLocalClockInDateBucket() throws {
-        try withMountainTimeZone {
             let env = try E2ETestHelpers.setUp()
             let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-KPI-LOCAL", name: "Local KPI")
             let clockIn = Self.utcTimestampFormatter.string(from: try Self.localToday(hour: 23, minute: 30))
@@ -1293,7 +1273,6 @@ struct JobsServiceTests {
             let kpis = try env.jobs.getJobsDashboardKPIs()
 
             #expect(kpis.todayLaborHours == 3.0)
-        }
     }
 
     // MARK: - Supply Run Toggle & Labor Notes
@@ -1324,8 +1303,7 @@ struct JobsServiceTests {
     }()
 
     private static func localToday(hour: Int, minute: Int) throws -> Date {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = try #require(TimeZone(identifier: "America/Denver"))
+        let calendar = Calendar.current
         var components = calendar.dateComponents([.year, .month, .day], from: Date())
         components.hour = hour
         components.minute = minute
@@ -1334,8 +1312,7 @@ struct JobsServiceTests {
     }
 
     private static func localWeekday(dayOffset: Int, hour: Int, minute: Int) throws -> Date {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = try #require(TimeZone(identifier: "America/Denver"))
+        var calendar = Calendar.current
         calendar.firstWeekday = 2
         let todayStart = calendar.startOfDay(for: Date())
         let weekday = calendar.component(.weekday, from: todayStart)
@@ -1349,22 +1326,6 @@ struct JobsServiceTests {
         return try #require(calendar.date(from: components))
     }
 
-    private func withMountainTimeZone<T>(_ body: () throws -> T) rethrows -> T {
-        #if canImport(Darwin) || canImport(Glibc)
-        let originalTZ = getenv("TZ").map { String(cString: $0) }
-        setenv("TZ", "America/Denver", 1)
-        tzset()
-        defer {
-            if let originalTZ {
-                setenv("TZ", originalTZ, 1)
-            } else {
-                unsetenv("TZ")
-            }
-            tzset()
-        }
-        #endif
-        return try body()
-    }
 
     // MARK: - Jobs for Customer
 

--- a/core/Tests/WiredPartCoreTests/OperationalDayTests.swift
+++ b/core/Tests/WiredPartCoreTests/OperationalDayTests.swift
@@ -17,4 +17,13 @@ struct OperationalDayTests {
         #expect(interval.utcStart == "2026-07-20 10:00:00")
         #expect(interval.utcEnd == "2026-07-21 10:00:00")
     }
+
+    @Test("Date intervals reject malformed ISO components instead of normalizing them")
+    func intervalRejectsMalformedISODateComponents() throws {
+        let operationalDay = OperationalDay(calendar: Calendar(identifier: .gregorian))
+
+        #expect(operationalDay.interval(startDate: "2026-02-30", endDate: "2026-02-30") == nil)
+        #expect(operationalDay.interval(startDate: "2026-02-28", endDate: "2026-02-30") == nil)
+        #expect(operationalDay.interval(startDate: "2026-2-28", endDate: "2026-02-28") == nil)
+    }
 }

--- a/core/Tests/WiredPartCoreTests/OperationalDayTests.swift
+++ b/core/Tests/WiredPartCoreTests/OperationalDayTests.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Testing
+@testable import WiredPartCore
+
+@Suite("OperationalDay")
+struct OperationalDayTests {
+    @Test("User calendar preference cannot change Gregorian persistence boundaries")
+    func nonGregorianCalendarUsesGregorianDateBoundaries() throws {
+        var buddhistCalendar = Calendar(identifier: .buddhist)
+        buddhistCalendar.timeZone = try #require(TimeZone(identifier: "Pacific/Honolulu"))
+        let date = try Date("2026-07-20T10:30:00Z", strategy: .iso8601)
+
+        let interval = OperationalDay(calendar: buddhistCalendar).interval(containing: date)
+
+        #expect(interval.localStartDate == "2026-07-20")
+        #expect(interval.localEndDate == "2026-07-20")
+        #expect(interval.utcStart == "2026-07-20 10:00:00")
+        #expect(interval.utcEnd == "2026-07-21 10:00:00")
+    }
+}

--- a/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
@@ -7,7 +7,7 @@ import GRDB
 struct ReportsServiceTests {
     private static let denverCalendar: Calendar = {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "America/Denver")!
+        calendar.timeZone = TimeZone(identifier: "America/Denver") ?? .gmt
         return calendar
     }()
 

--- a/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
@@ -117,6 +117,25 @@ struct ReportsServiceTests {
         #expect(abs((localDayRows.first?.totalHours ?? 0) - 1.0) < 0.01)
     }
 
+    @Test("Report exact-day and range paths reject malformed dates instead of querying normalized days")
+    func testReportsRejectMalformedOperationalDayInputs() throws {
+        let env = try E2ETestHelpers.setUp()
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-BAD-RANGE", name: "Malformed Range Job")
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, '2026-03-02 12:00:00', '2026-03-02 20:00:00', 8.0, 0.0, 'completed', datetime('now'))
+                """, arguments: [env.adminUserId, jobId])
+        }
+
+        let exactDayRows = try env.reports.getDailyReportSummary(date: "2026-02-30")
+        let rangeRows = try env.reports.getTimesheetData(startDate: "2026-02-28", endDate: "2026-02-30")
+
+        #expect(exactDayRows.isEmpty)
+        #expect(rangeRows.isEmpty)
+    }
+
     @Test("Timesheet correction persists audit row and updates labor entry")
     func testTimesheetCorrectionPersistsAuditAndUpdatesEntry() throws {
         let env = try E2ETestHelpers.setUp()

--- a/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/ReportsServiceTests.swift
@@ -1,29 +1,15 @@
 import Foundation
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
 import Testing
 import GRDB
 @testable import WiredPartCore
 
 @Suite("ReportsService Tests", .serialized)
 struct ReportsServiceTests {
-    private func withDenverTimeZone(_ work: () throws -> Void) throws {
-        let originalTZ = getenv("TZ").map { String(cString: $0) }
-        setenv("TZ", "America/Denver", 1)
-        tzset()
-        defer {
-            if let originalTZ {
-                setenv("TZ", originalTZ, 1)
-            } else {
-                unsetenv("TZ")
-            }
-            tzset()
-        }
-        try work()
-    }
+    private static let denverCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/Denver")!
+        return calendar
+    }()
 
     // MARK: - Timesheet
 
@@ -53,8 +39,8 @@ struct ReportsServiceTests {
         let env = try E2ETestHelpers.setUp()
         let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-ACTIVE-BREAK", name: "Active Break Summary Job")
         let breakService = BreakService(db: env.db)
-        let clockIn = try Date("2026-03-05T08:00:00Z", strategy: .iso8601)
-        let clockOut = try Date("2026-03-05T17:00:00Z", strategy: .iso8601)
+        let clockIn = try Date("2026-03-05T12:00:00Z", strategy: .iso8601)
+        let clockOut = try Date("2026-03-05T21:00:00Z", strategy: .iso8601)
         let laborEntryId = try env.jobs.clockIn(userId: env.adminUserId, jobId: jobId, at: clockIn)
 
         let breakRecord = try breakService.startBreak(
@@ -65,8 +51,8 @@ struct ReportsServiceTests {
         try env.db.writer.write { db in
             try db.execute(sql: """
                 UPDATE break_records
-                SET started_at = '2026-03-05T12:00:00Z',
-                    ended_at = '2026-03-05T12:30:00Z',
+                SET started_at = '2026-03-05T16:00:00Z',
+                    ended_at = '2026-03-05T16:30:00Z',
                     duration_minutes = 30
                 WHERE id = ?
                 """, arguments: [breakRecord.id])
@@ -88,13 +74,13 @@ struct ReportsServiceTests {
             try db.execute(sql: """
                 INSERT INTO labor_entries
                     (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
-                VALUES (?, ?, '2026-03-05T08:00:00Z', '2026-03-05T16:00:00Z', 7.5, 0.0, 'completed', datetime('now'))
+                VALUES (?, ?, '2026-03-05T12:00:00Z', '2026-03-05T20:00:00Z', 7.5, 0.0, 'completed', datetime('now'))
                 """, arguments: [env.adminUserId, jobId])
             let entryId = db.lastInsertedRowID
             try db.execute(sql: """
                 INSERT INTO break_records
                     (user_id, labor_entry_id, break_type, started_at, ended_at, duration_minutes, is_paid, auto_filled)
-                VALUES (?, ?, 'break', '2026-03-05T12:00:00Z', '2026-03-05T12:30:00Z', 30, 0, 0)
+                VALUES (?, ?, 'break', '2026-03-05T16:00:00Z', '2026-03-05T16:30:00Z', 30, 0, 0)
                 """, arguments: [env.adminUserId, entryId])
             return entryId
         }
@@ -113,23 +99,22 @@ struct ReportsServiceTests {
 
     @Test("Timesheet data buckets UTC evening clock-in into local work day")
     func testTimesheetUsesLocalOperationalDayForUtcClockIn() throws {
-        try withDenverTimeZone {
-            let env = try E2ETestHelpers.setUp()
-            let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-TS", name: "Local Timesheet Job")
-            try env.db.writer.write { db in
-                try db.execute(sql: """
-                    INSERT INTO labor_entries
-                    (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
-                    VALUES (?, ?, '2026-03-06 03:30:00', '2026-03-06 04:30:00', 1.0, 0.0, 'completed', datetime('now'))
-                    """, arguments: [env.adminUserId, jobId])
-            }
-
-            let localDayRows = try env.reports.getTimesheetData(startDate: "2026-03-05", endDate: "2026-03-05")
-
-            #expect(localDayRows.count == 1)
-            #expect(localDayRows.first?.daysWorked == 1)
-            #expect(abs((localDayRows.first?.totalHours ?? 0) - 1.0) < 0.01)
+        let env = try E2ETestHelpers.setUp()
+        let reports = ReportsService(db: env.db, calendar: Self.denverCalendar)
+        let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-TS", name: "Local Timesheet Job")
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                INSERT INTO labor_entries
+                (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
+                VALUES (?, ?, '2026-03-06 03:30:00', '2026-03-06 04:30:00', 1.0, 0.0, 'completed', datetime('now'))
+                """, arguments: [env.adminUserId, jobId])
         }
+
+        let localDayRows = try reports.getTimesheetData(startDate: "2026-03-05", endDate: "2026-03-05")
+
+        #expect(localDayRows.count == 1)
+        #expect(localDayRows.first?.daysWorked == 1)
+        #expect(abs((localDayRows.first?.totalHours ?? 0) - 1.0) < 0.01)
     }
 
     @Test("Timesheet correction persists audit row and updates labor entry")
@@ -236,7 +221,6 @@ struct ReportsServiceTests {
 
     @Test("Timesheet correction allocates weekly overtime from current settings instead of request buckets")
     func testTimesheetCorrectionUsesOvertimeSettingsForAdjustedHours() throws {
-        try withDenverTimeZone {
             let env = try E2ETestHelpers.setUp()
             let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-CORR-OT", name: "Correction Overtime Job")
             _ = try env.jobs.updateOvertimeSettings(
@@ -279,7 +263,6 @@ struct ReportsServiceTests {
             }
             #expect(updated?["regular_hours"] as Double? == 2.0)
             #expect(updated?["overtime_hours"] as Double? == 2.0)
-        }
     }
 
     @Test("Timesheet correction history loads by reviewed work period")
@@ -290,7 +273,7 @@ struct ReportsServiceTests {
             try db.execute(sql: """
                 INSERT INTO labor_entries
                     (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
-                VALUES (?, ?, '2026-04-10T08:00:00Z', '2026-04-10T12:00:00Z', 4.0, 0.0, 'completed', datetime('now'))
+                VALUES (?, ?, '2026-04-10T12:00:00Z', '2026-04-10T16:00:00Z', 4.0, 0.0, 'completed', datetime('now'))
                 """, arguments: [env.adminUserId, jobId])
             return db.lastInsertedRowID
         }
@@ -298,8 +281,8 @@ struct ReportsServiceTests {
         _ = try env.reports.saveTimesheetCorrection(
             ReportsService.TimesheetCorrectionRequest(
                 laborEntryId: laborEntryId,
-                adjustedClockIn: "2026-04-10T08:00:00Z",
-                adjustedClockOut: "2026-04-10T13:00:00Z",
+                adjustedClockIn: "2026-04-10T12:00:00Z",
+                adjustedClockOut: "2026-04-10T17:00:00Z",
                 clientPreviewRegularHours: 5.0,
                 clientPreviewOvertimeHours: 0.0,
                 reason: "Verified against supervisor note.",
@@ -322,7 +305,6 @@ struct ReportsServiceTests {
 
     @Test("Timesheet correction history survives entry moving into reviewed period")
     func testTimesheetCorrectionHistorySurvivesMoveIntoReviewedPeriod() throws {
-        try withDenverTimeZone {
             let env = try E2ETestHelpers.setUp()
             let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-HIST-MOVE", name: "History Move Job")
             // Entry originally worked on 2026-04-09 (15:00Z-19:00Z = 09:00-13:00 Denver).
@@ -376,7 +358,6 @@ struct ReportsServiceTests {
                 endDate: "2026-04-11"
             )
             #expect(!unrelatedHistory.contains { $0.segmentId == laborEntryId })
-        }
     }
 
     // MARK: - Daily Report Summary
@@ -390,8 +371,8 @@ struct ReportsServiceTests {
 
     @Test("Daily report summary buckets UTC evening clock-in into local work day")
     func testDailyReportSummaryUsesLocalOperationalDayForUtcClockIn() throws {
-        try withDenverTimeZone {
             let env = try E2ETestHelpers.setUp()
+            let reports = ReportsService(db: env.db, calendar: Self.denverCalendar)
             let jobId = try E2ETestHelpers.seedJob(env, jobNumber: "J-LOCAL-DR", name: "Local Daily Report Job")
             try env.db.writer.write { db in
                 try db.execute(sql: """
@@ -401,13 +382,12 @@ struct ReportsServiceTests {
                     """, arguments: [env.adminUserId, jobId])
             }
 
-            let rows = try env.reports.getDailyReportSummary(date: "2026-03-05")
+            let rows = try reports.getDailyReportSummary(date: "2026-03-05")
             let row = rows.first(where: { $0.id == jobId })
 
             #expect(row != nil)
             #expect(row?.workerCount == 1)
             #expect(abs((row?.totalHours ?? 0) - 1.5) < 0.01)
-        }
     }
 
     // MARK: - Spending
@@ -925,7 +905,7 @@ struct ReportsServiceTests {
             try db.execute(sql: """
                 INSERT INTO labor_entries
                 (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
-                VALUES (?, ?, '2026-02-01 07:00:00', '2026-02-01 11:00:00', 4.0, 0.0, 'completed', datetime('now'))
+                VALUES (?, ?, '2026-02-01 12:00:00', '2026-02-01 16:00:00', 4.0, 0.0, 'completed', datetime('now'))
                 """, arguments: [env.adminUserId, jobId])
         }
         let rows = try env.reports.getPreBillingData(startDate: "2026-02-01", endDate: "2026-02-01")
@@ -947,7 +927,7 @@ struct ReportsServiceTests {
             try db.execute(sql: """
                 INSERT INTO labor_entries
                 (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
-                VALUES (?, ?, '2026-06-01 07:00:00', '2026-06-01 17:00:00', 8.0, 2.0, 'completed', datetime('now'))
+                VALUES (?, ?, '2026-06-01 12:00:00', '2026-06-01 22:00:00', 8.0, 2.0, 'completed', datetime('now'))
                 """, arguments: [env.adminUserId, jobId])
             try db.execute(sql: """
                 INSERT INTO job_parts
@@ -1048,8 +1028,8 @@ struct ReportsServiceTests {
                 INSERT INTO labor_entries
                 (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
                 VALUES
-                    (?, ?, '2026-06-04 07:00:00', '2026-06-04 11:00:00', 4.0, 0.0, 'completed', datetime('now')),
-                    (?, ?, '2026-06-04 12:00:00', '2026-06-04 16:00:00', 4.0, 0.0, 'completed', datetime('now'))
+                    (?, ?, '2026-06-04 12:00:00', '2026-06-04 16:00:00', 4.0, 0.0, 'completed', datetime('now')),
+                    (?, ?, '2026-06-04 17:00:00', '2026-06-04 21:00:00', 4.0, 0.0, 'completed', datetime('now'))
                 """, arguments: [env.adminUserId, firstJobId, env.adminUserId, secondJobId])
             try db.execute(sql: """
                 INSERT INTO stock_movements
@@ -1156,7 +1136,7 @@ struct ReportsServiceTests {
             try db.execute(sql: """
                 INSERT INTO labor_entries
                 (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
-                VALUES (?, ?, '2026-06-02 07:00:00', '2026-06-02 18:00:00', 8.0, 2.0, 'completed', datetime('now'))
+                VALUES (?, ?, '2026-06-02 12:00:00', '2026-06-02 23:00:00', 8.0, 2.0, 'completed', datetime('now'))
                 """, arguments: [env.adminUserId, jobId])
         }
 
@@ -1184,8 +1164,8 @@ struct ReportsServiceTests {
                 INSERT INTO labor_entries
                 (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
                 VALUES
-                    (?, ?, '2026-06-02 07:00:00', '2026-06-02 18:00:00', 8.0, 2.0, 'completed', datetime('now')),
-                    (?, ?, '2026-06-02 08:00:00', '2026-06-02 12:00:00', 4.0, 1.0, 'completed', datetime('now'))
+                    (?, ?, '2026-06-02 12:00:00', '2026-06-02 23:00:00', 8.0, 2.0, 'completed', datetime('now')),
+                    (?, ?, '2026-06-02 13:00:00', '2026-06-02 17:00:00', 4.0, 1.0, 'completed', datetime('now'))
                 """, arguments: [env.adminUserId, jobId, userId, jobId])
             return userId
         }
@@ -1321,7 +1301,7 @@ struct ReportsServiceTests {
             try db.execute(sql: """
                 INSERT INTO labor_entries
                 (user_id, job_id, clock_in, clock_out, regular_hours, overtime_hours, status, created_at)
-                VALUES (?, ?, '2026-03-05 07:00:00', '2026-03-05 15:00:00', 8.0, 0.0, 'completed', datetime('now'))
+                VALUES (?, ?, '2026-03-05 12:00:00', '2026-03-05 20:00:00', 8.0, 0.0, 'completed', datetime('now'))
                 """, arguments: [env.adminUserId, jobId])
         }
         let rows = try env.reports.getDailyReportSummary(date: "2026-03-05")


### PR DESCRIPTION
## Summary
- add an injected `OperationalDay` boundary model for UTC persistence and local operational-day queries
- migrate DailyReportGenerator, DashboardService, ReportsService, and monthly capacity calculations away from process-global SQLite `localtime` behavior on affected paths
- remove test-time `TZ` mutation and replace wall-clock-sensitive fixtures with explicit UTC, Denver, and Honolulu calendars/clocks
- clamp overnight active dashboard sessions to local midnight and preserve date-only historical labor boundaries

## Verification
- `TZ=UTC swift test` — 2400 tests in 72 suites passed
- `TZ=Pacific/Honolulu swift test` — 2400 tests in 72 suites passed
- focused DailyReportGenerator, DashboardService, ReportsService, JobsService, and JobEstimationService suites passed
- `git diff --check` passed
- final Codex read-only review: no findings

## Local Apple validation path
This Swift-core-only change was compiled and tested locally on the repository Mac/Xcode toolchain. PR CI jobs requiring macOS/Xcode should use the trusted local runner labels `[self-hosted, macOS, ARM64, xcode, ios, local-mac]`. No UI or device behavior changed.

Closes #1479

Paperclip: WEI-5673

Merge tracked in WEI-5693.