### PR TITLE
feat: wire panel settings validation UI

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
@@ -13,7 +13,7 @@ struct WiredPartIOSApp: App {
     @State private var showLaunchErrorReport = false
     @State private var uiTestingPanelSchedule = PanelSchedule(
         panelName: "QA Panel A",
-        panelType: .loadCenter,
+        panelType: .smallPanel,
         totalSpaces: 8,
         mainBreakerAmps: 200,
         voltage: 240,

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelScheduleBuilder.swift
@@ -708,6 +708,8 @@ private struct PanelSettingsSheet: View {
                             Text(type.rawValue).tag(type)
                         }
                     }
+                    .accessibilityIdentifier("panelSettingsTypePicker")
+                    .accessibilityHint("Changing the panel type updates the available total spaces choices.")
                     TextField("Location", text: Binding(
                         get: { schedule.location ?? "" },
                         set: { schedule.location = $0.isEmpty ? nil : $0 }
@@ -719,6 +721,8 @@ private struct PanelSettingsSheet: View {
                             Text("\(size) spaces").tag(size)
                         }
                     }
+                    .accessibilityIdentifier("panelSettingsTotalSpacesPicker")
+                    .accessibilityHint("Choose a total space count supported by the selected panel type.")
                     if !circuitOriginSpacesThatWouldBeHidden.isEmpty {
                         Label(
                             "The selected settings would hide circuit\(circuitOriginSpacesThatWouldBeHidden.count == 1 ? "" : "s") at space\(circuitOriginSpacesThatWouldBeHidden.count == 1 ? "" : "s") \(circuitOriginSpacesThatWouldBeHidden.map(String.init).joined(separator: ", ")). Move or remove \(circuitOriginSpacesThatWouldBeHidden.count == 1 ? "it" : "them") before saving.",
@@ -755,28 +759,31 @@ private struct PanelSettingsSheet: View {
             }
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") {
-                        do {
-                            try schedule.updatePanelSettings(
-                                panelType: draftPanelType,
-                                totalSpaces: draftTotalSpaces
-                            )
-                            dismiss()
-                        } catch {
-                            settingsValidationMessage = error.localizedDescription
-                        }
-                    }
+                    Button("Done") { savePanelSettings() }
                         .fontWeight(.semibold)
+                        .accessibilityIdentifier("panelSettingsSaveButton")
                 }
             }
-            .alert("Panel settings issue", isPresented: Binding(
-                get: { settingsValidationMessage != nil },
-                set: { if !$0 { settingsValidationMessage = nil } }
-            )) {
-                Button("OK", role: .cancel) { settingsValidationMessage = nil }
-            } message: {
-                Text(settingsValidationMessage ?? "")
-            }
+        }
+        .alert("Unable to Save Panel Settings", isPresented: Binding(
+            get: { settingsValidationMessage != nil },
+            set: { if !$0 { settingsValidationMessage = nil } }
+        )) {
+            Button("Keep Editing", role: .cancel) { settingsValidationMessage = nil }
+        } message: {
+            Text(settingsValidationMessage ?? "")
+        }
+    }
+
+    private func savePanelSettings() {
+        do {
+            try schedule.updatePanelSettings(
+                panelType: draftPanelType,
+                totalSpaces: draftTotalSpaces
+            )
+            dismiss()
+        } catch {
+            settingsValidationMessage = error.localizedDescription
         }
     }
 }

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -229,6 +229,61 @@ final class Weird_Parts_IOSUITests: XCTestCase {
         )
     }
 
+    @MainActor
+    func testPanelSettingsRequireTypeSupportedSpaceBeforeSaving() throws {
+        relaunchForPanelScheduleBuilderFixture()
+
+        let settings = app.buttons["Settings"]
+        XCTAssertTrue(settings.waitForExistence(timeout: 10))
+        settings.tap()
+
+        let typePicker = app.descendants(matching: .any)["panelSettingsTypePicker"]
+        let totalSpacesPicker = app.descendants(matching: .any)["panelSettingsTotalSpacesPicker"]
+        let save = app.buttons["panelSettingsSaveButton"]
+        XCTAssertTrue(typePicker.waitForExistence(timeout: 5), "Panel type picker should be visible in Settings.")
+        XCTAssertTrue(totalSpacesPicker.exists, "Total spaces picker should be visible in Settings.")
+        XCTAssertTrue(save.exists, "Settings must expose a save action.")
+
+        typePicker.tap()
+        let disconnect = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label == %@", "Disconnect"))
+            .firstMatch
+        XCTAssertTrue(disconnect.waitForExistence(timeout: 5))
+        disconnect.tap()
+
+        save.tap()
+        XCTAssertTrue(
+            app.alerts["Unable to Save Panel Settings"].waitForExistence(timeout: 5),
+            "A panel-size change that would hide a double breaker's second occupied space should stay in Settings and present the shared-core validation error."
+        )
+        XCTAssertTrue(
+            app.staticTexts["Disconnect with 2 spaces would hide circuits at spaces 2. Move or remove those circuits before changing panel settings."].exists,
+            "The alert should identify the circuit origin that must be moved or removed before saving."
+        )
+        XCTAssertTrue(app.buttons["Keep Editing"].exists, "The alert must leave a correction path in the settings sheet.")
+        app.buttons["Keep Editing"].tap()
+
+        typePicker.tap()
+        let smallPanel = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label == %@", "Small Panel"))
+            .firstMatch
+        XCTAssertTrue(smallPanel.waitForExistence(timeout: 5))
+        smallPanel.tap()
+        save.tap()
+
+        XCTAssertFalse(
+            app.navigationBars["Panel Settings"].waitForExistence(timeout: 2),
+            "A supported type/size correction should save and dismiss the settings sheet."
+        )
+        XCTAssertTrue(app.staticTexts["Small Panel"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["8 Spaces"].exists)
+
+        let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+        attachment.name = "WEI-6008 panel settings no-loss correction saved"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
     private func relaunchForPanelScheduleBuilderFixture() {
         app?.terminate()
         app = XCUIApplication()


### PR DESCRIPTION
## Summary
- restrict Panel Settings total-space choices to the selected panel type via `allowedTotalSpaces`
- submit panel type and size only through atomic `updatePanelSettings`, preserving schedule/circuits on rejection
- provide an accessible validation alert and correction path, plus phone/tablet UI coverage

## Tests
- `cd core && swift test --filter PanelScheduleTests`
- iPhone 17 (390×844-class): `Weird_Parts_IOSUITests/testPanelSettingsRequireTypeSupportedSpaceBeforeSaving`
- iPad Air 11-inch: `Weird_Parts_IOSUITests/testPanelSettingsRequireTypeSupportedSpaceBeforeSaving`

Closes #1513
Tracked in WEI-6008
Stacked on #1514, which now correctly uses `Refs #1513`; close occurs only when this frontend PR merges after the backend contract.