### PR TITLE
test: salvage Stage 8 warehouse audit QA seed

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -1251,6 +1251,61 @@ final class AppCore: ObservableObject {
                 arguments: [partId, supplierId]
             )
 
+            var auditAreaId = try Int64.fetchOne(
+                dbConn,
+                sql: "SELECT id FROM warehouse_storage_areas WHERE full_location_code = 'WEI-3295-A1' AND deleted_at IS NULL LIMIT 1"
+            )
+            if auditAreaId == nil {
+                try dbConn.execute(
+                    sql: """
+                        INSERT INTO warehouse_floor_plans
+                        (name, width_inches, length_inches, is_active, created_at, updated_at, deleted_at)
+                        VALUES ('WEI-3295 Stage 8 QA Floor', 120, 120, 1, datetime('now'), datetime('now'), NULL)
+                        """
+                )
+                let floorPlanId = try Int64.fetchOne(
+                    dbConn,
+                    sql: "SELECT id FROM warehouse_floor_plans WHERE name = 'WEI-3295 Stage 8 QA Floor' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1"
+                )!
+                try dbConn.execute(
+                    sql: """
+                        INSERT INTO warehouse_storage_units
+                        (floor_plan_id, name, unit_type, unit_number, is_configured, created_at, updated_at, deleted_at)
+                        VALUES (?, 'WEI-3295 QA Shelf', 'shelf', 'WEI3295', 1, datetime('now'), datetime('now'), NULL)
+                        """,
+                    arguments: [floorPlanId]
+                )
+                let unitId = try Int64.fetchOne(
+                    dbConn,
+                    sql: "SELECT id FROM warehouse_storage_units WHERE name = 'WEI-3295 QA Shelf' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1"
+                )!
+                try dbConn.execute(
+                    sql: """
+                        INSERT INTO warehouse_storage_levels
+                        (unit_id, level_code, level_name, level_order, area_count, created_at, deleted_at)
+                        VALUES (?, 'A', 'QA Shelf Level A', 1, 1, datetime('now'), NULL)
+                        """,
+                    arguments: [unitId]
+                )
+                let levelId = try Int64.fetchOne(
+                    dbConn,
+                    sql: "SELECT id FROM warehouse_storage_levels WHERE unit_id = ? AND level_code = 'A' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1",
+                    arguments: [unitId]
+                )!
+                try dbConn.execute(
+                    sql: """
+                        INSERT INTO warehouse_storage_areas
+                        (level_id, area_code, area_number, width_inches, has_qr_code, has_sticker, full_location_code, created_at, deleted_at)
+                        VALUES (?, 'A1', 1, 24, 0, 0, 'WEI-3295-A1', datetime('now'), NULL)
+                        """,
+                    arguments: [levelId]
+                )
+                auditAreaId = try Int64.fetchOne(
+                    dbConn,
+                    sql: "SELECT id FROM warehouse_storage_areas WHERE full_location_code = 'WEI-3295-A1' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1"
+                )
+            }
+
             try dbConn.execute(
                 sql: """
                     DELETE FROM audit_sessions_v2
@@ -1265,6 +1320,26 @@ final class AppCore: ObservableObject {
                     VALUES ('count', ?, 'active', 1, 1, 'WEI-3295 Stage 8 reports viewport seed', datetime('now'), NULL)
                     """,
                 arguments: [userId]
+            )
+            let auditSessionId = try Int64.fetchOne(
+                dbConn,
+                sql: """
+                    SELECT id
+                    FROM audit_sessions_v2
+                    WHERE notes = 'WEI-3295 Stage 8 reports viewport seed'
+                      AND deleted_at IS NULL
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """
+            )!
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO audit_counts
+                    (session_id, part_id, area_id, system_count, user_count, variance,
+                     variance_dollars, variance_percent, result, counted_by, counted_at)
+                    VALUES (?, ?, ?, 12, 9, -3, 127.50, -25.0, 'variance', ?, datetime('now'))
+                    """,
+                arguments: [auditSessionId, partId, auditAreaId!, userId]
             )
         }
     }

--- a/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/Weird_Parts_IOSUITests.swift
@@ -127,7 +127,18 @@ final class Weird_Parts_IOSUITests: XCTestCase {
         if ProcessInfo.processInfo.environment["WEI_1185_LANDSCAPE"] == "1" {
             XCUIDevice.shared.orientation = .landscapeLeft
         }
+        if shouldDeferLaunchToTestBody {
+            return
+        }
         app.launch()
+    }
+
+    private var shouldDeferLaunchToTestBody: Bool {
+        [
+            "WEI3144JobMaterialsWalkthroughEvidence",
+            "WEI3295Stage8ReportsViewportHarness",
+            "WEI3988BackupRestoreSmokeEvidence",
+        ].contains { name.contains($0) }
     }
 
     private var shouldOpenPartsCategoriesOnLaunch: Bool {

--- a/core/Sources/WiredPartCore/Services/WarehouseService.swift
+++ b/core/Sources/WiredPartCore/Services/WarehouseService.swift
@@ -2640,6 +2640,7 @@ public final class WarehouseService: Sendable {
                           AND s.last_counted IS NOT NULL
                           AND date(s.last_counted) = date('now')
                           AND s.counted_qty IS NOT NULL
+                          AND s.counted_qty != s.qty
                         ORDER BY p.name
                         """
                 )

--- a/core/Tests/WiredPartCoreTests/E2EWarehouseTests.swift
+++ b/core/Tests/WiredPartCoreTests/E2EWarehouseTests.swift
@@ -570,6 +570,25 @@ struct E2EWarehouseTests {
                 "Soft-deleted part must degrade to 'Unknown Part' in getAuditDiscrepancies")
     }
 
+    @Test("getAuditDiscrepancies excludes matched physical counts")
+    func testGetAuditDiscrepanciesExcludesMatchedCounts() throws {
+        let env = try E2ETestHelpers.setUp()
+        let categoryId = try E2ETestHelpers.seedCategory(env, name: "Matched Audit Category")
+        let partId = try E2ETestHelpers.seedPart(env, name: "Matched Audit Part", categoryId: categoryId)
+        _ = try E2ETestHelpers.seedStock(env, partId: partId, qty: 10)
+        try env.db.writer.write { db in
+            try db.execute(sql: """
+                UPDATE stock
+                SET counted_qty = qty, last_counted = datetime('now')
+                WHERE part_id = ? AND location_type = 'warehouse'
+                """, arguments: [partId])
+        }
+
+        let discrepancies = try env.warehouse.getAuditDiscrepancies()
+        #expect(discrepancies.contains(where: { $0.partId == partId }) == false,
+                "A matched physical count is not a discrepancy")
+    }
+
     @Test("listTrailers and getTrailer show nil driver for soft-deleted user")
     func testTrailersHideDeletedDriverName() throws {
         let env = try E2ETestHelpers.setUp()


### PR DESCRIPTION
## Summary
- Salvage the valid Stage-8 QA seed delta from preserved WEI-4469 without altering that source worktree.
- Create a valid warehouse location hierarchy and `audit_counts` row for the Stage-8 audit-summary fixture.
- Defer initial app launch for tests that explicitly relaunch themselves, and exclude matching counts from the discrepancy query.

## Validation
- `swift test --filter 'WiredPartCoreTests.E2EWarehouseTests/testGetAuditDiscrepanciesExcludesMatchedCounts'` — Swift Testing test passed (1 test).
- iOS Simulator Debug build succeeded via XcodeBuildMCP (69.4s).
- Targeted UI-test invocation is currently blocked by the `Weird Parts` scheme/test plan: `Weird_Parts_IOSUITests` is not a scheme member.

Tracked in WEI-6048.

Refs #1522. Revalidation tracked in WEI-6175; merge gate tracked in WEI-6061.
