### PR TITLE
fix(ci): fail closed on incomplete current-head reviews

### DIFF
--- a/.github/workflows/pr-merge-maintenance.yml
+++ b/.github/workflows/pr-merge-maintenance.yml
@@ -44,7 +44,6 @@ jobs:
       GH_TOKEN: ${{ secrets.PR_MAINTENANCE_PAT || github.token }}
       PR_MAINTENANCE_BASE: main
       PR_MAINTENANCE_TRUSTED_PR_AUTHORS: "xXKillerNoobYT"
-      PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW: "0"
       PR_MAINTENANCE_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true && '1' || '0' }}
 
     steps:

--- a/scripts/pr-merge-maintenance.sh
+++ b/scripts/pr-merge-maintenance.sh
@@ -78,6 +78,41 @@ run_or_log() {
   "$@"
 }
 
+# The paginated list is only a queue-discovery snapshot. Never make a rebase or
+# merge decision from it: a force-push can change the review/check target after
+# the list request returns. Every candidate is re-read before eligibility and
+# the merge path verifies that exact head again immediately before invoking gh.
+fetch_current_pr() {
+  local number="$1"
+  gh api "repos/$REPO/pulls/$number" | jq -ce '{
+    number:           .number,
+    title:            (.title // ""),
+    isDraft:          (.draft // false),
+    labels:           [(.labels // [])[].name],
+    author:           (.user.login // ""),
+    headOwner:        (.head.repo.owner.login // ""),
+    mergeable:        (if .mergeable == true then "MERGEABLE"
+                       elif .mergeable == false then "CONFLICTING"
+                       else "UNKNOWN" end),
+    mergeStateStatus: ((.mergeable_state // "unknown") | ascii_upcase),
+    autoMerge:        (.auto_merge != null),
+    headSha:          (.head.sha // "")
+  }'
+}
+
+load_pr_snapshot() {
+  local snapshot="$1"
+  title="$(jq -r     '.title'                            <<<"$snapshot")"
+  is_draft="$(jq -r  '.isDraft'                          <<<"$snapshot")"
+  merge_state="$(jq -r '.mergeStateStatus // "UNKNOWN"'  <<<"$snapshot")"
+  mergeable="$(jq -r   '.mergeable // "UNKNOWN"'         <<<"$snapshot")"
+  auto_merge="$(jq -r  '.autoMerge'                      <<<"$snapshot")"
+  labels_json="$(jq -c '.labels'                         <<<"$snapshot")"
+  author="$(jq -r      '.author // ""'                   <<<"$snapshot")"
+  head_owner="$(jq -r  '.headOwner'                      <<<"$snapshot")"
+  head_sha="$(jq -r    '.headSha'                        <<<"$snapshot")"
+}
+
 if [[ -n "$MAX_PRS" && ! "$MAX_PRS" =~ ^[0-9]+$ ]]; then
   echo "error: PR_MAINTENANCE_MAX_PRS must be a positive integer when set, got '$MAX_PRS'" >&2
   exit 1
@@ -139,21 +174,19 @@ repo_name="${REPO##*/}"
 # Pick the FIRST one we can act on and do exactly that one action, then exit.
 while IFS= read -r pr; do
   number="$(jq -r    '.number'                           <<<"$pr")"
-  title="$(jq -r     '.title'                            <<<"$pr")"
-  is_draft="$(jq -r  '.isDraft'                          <<<"$pr")"
-  merge_state="$(jq -r '.mergeStateStatus // "UNKNOWN"'  <<<"$pr")"
-  mergeable="$(jq -r   '.mergeable // "UNKNOWN"'         <<<"$pr")"
-  auto_merge="$(jq -r  '.autoMerge'                      <<<"$pr")"
-  labels_json="$(jq -c '.labels'                         <<<"$pr")"
-  author="$(jq -r      '.author // ""'                     <<<"$pr")"
-  head_owner="$(jq -r  '.headOwner'                      <<<"$pr")"
-  head_sha="$(jq -r    '.headSha'                        <<<"$pr")"
+  # The list record is deliberately not used to choose an action. Refetch first
+  # so every eligibility check below is bound to one current PR snapshot.
+  if ! current_pr="$(fetch_current_pr "$number")"; then
+    echo "    skip: could not refresh current PR state — not acting on stale queue data"
+    continue
+  fi
+  load_pr_snapshot "$current_pr"
 
   echo ""
   echo "--- PR #$number: $title"
-  echo "    author=${author:-<unknown>} state=$merge_state mergeable=$mergeable autoMerge=$auto_merge draft=$is_draft"
+  echo "    refreshed head=${head_sha:0:8} author=${author:-<unknown>} state=$merge_state mergeable=$mergeable autoMerge=$auto_merge draft=$is_draft"
 
-  # --- Skip conditions ---
+  # --- Skip conditions, evaluated from the fresh PR snapshot ---
   if [[ "$is_draft" == "true" ]]; then
     echo "    skip: draft"; continue; fi
 
@@ -170,21 +203,21 @@ while IFS= read -r pr; do
     echo "    skip: has merge conflicts — engineer must resolve first"; continue; fi
 
   # --- Resolve UNKNOWN mergeability before acting ---
-  # The list endpoint returns mergeable_state only when GitHub has it cached;
-  # treating UNKNOWN as BEHIND made the train "rebase" an up-to-date branch
-  # forever (update-branch no-ops, the state never changes, nothing merges).
-  # A single-PR GET forces GitHub to compute mergeability; poll briefly.
+  # Refresh the full PR rather than only mergeable_state so a head change while
+  # GitHub computes mergeability cannot carry stale review/check evidence forward.
   if [[ "$merge_state" == "UNKNOWN" ]]; then
     for _attempt in 1 2 3 4 5; do
-      merge_state="$(gh api "repos/$REPO/pulls/$number" \
-        --jq '(.mergeable_state // "unknown") | ascii_upcase' 2>/dev/null || echo "UNKNOWN")"
+      if ! current_pr="$(fetch_current_pr "$number")"; then
+        break
+      fi
+      load_pr_snapshot "$current_pr"
       [[ "$merge_state" != "UNKNOWN" ]] && break
       sleep 3
     done
     echo "    resolved mergeability: state=$merge_state"
     if [[ "$merge_state" == "UNKNOWN" ]]; then
-      echo "    skip: mergeability still computing — next run retries"; continue; fi
-    if [[ "$merge_state" == "DIRTY" ]]; then
+      echo "    skip: mergeability still computing or refresh failed — next run retries"; continue; fi
+    if [[ "$mergeable" == "CONFLICTING" || "$merge_state" == "DIRTY" ]]; then
       echo "    skip: has merge conflicts — engineer must resolve first"; continue; fi
   fi
 
@@ -203,19 +236,29 @@ while IFS= read -r pr; do
   fi
 
   # --- Check if all required status checks are passing ---
-  if [[ -n "$head_sha" ]]; then
-    failing_checks="$(gh api "repos/$REPO/commits/$head_sha/check-runs" \
-      --jq '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null and .status == "completed")] | length' 2>/dev/null || echo "0")"
-    pending_checks="$(gh api "repos/$REPO/commits/$head_sha/check-runs" \
-      --jq '[.check_runs[] | select(.status == "in_progress" or .status == "queued")] | length' 2>/dev/null || echo "0")"
+  if [[ -z "$head_sha" ]]; then
+    echo "    skip: refreshed PR has no head SHA — cannot verify checks"
+    continue
+  fi
+  if ! check_runs="$(gh api "repos/$REPO/commits/$head_sha/check-runs")"; then
+    echo "    skip: could not read checks for refreshed head ${head_sha:0:8} — not merging on unknown check state"
+    continue
+  fi
+  if ! failing_checks="$(jq -er '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null and .status == "completed")] | length' <<<"$check_runs")"; then
+    echo "    skip: malformed check response for refreshed head ${head_sha:0:8} — not merging"
+    continue
+  fi
+  if ! pending_checks="$(jq -er '[.check_runs[] | select(.status == "in_progress" or .status == "queued")] | length' <<<"$check_runs")"; then
+    echo "    skip: malformed check response for refreshed head ${head_sha:0:8} — not merging"
+    continue
+  fi
 
-    if [[ "$pending_checks" -gt 0 ]]; then
-      echo "    skip: $pending_checks check(s) still running — waiting for scan to complete"; continue; fi
+  if [[ "$pending_checks" -gt 0 ]]; then
+    echo "    skip: $pending_checks check(s) still running — waiting for scan to complete"; continue; fi
 
-    if [[ "$failing_checks" -gt 0 ]]; then
+  if [[ "$failing_checks" -gt 0 ]]; then
       # Summarise failures and comment once (avoid spamming)
-      failures="$(gh api "repos/$REPO/commits/$head_sha/check-runs" \
-        --jq '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null and .status == "completed") | "- \(.name): \(.conclusion)"] | join("\n")' 2>/dev/null || echo "unknown")"
+      failures="$(jq -r '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null and .status == "completed") | "- \(.name): \(.conclusion)"] | join("\n")' <<<"$check_runs")"
       echo "    SCAN FAILED — $failing_checks check(s) failing:"
       echo "$failures"
       # Only comment if not already commented recently
@@ -223,7 +266,6 @@ while IFS= read -r pr; do
         --body "🔴 **Merge blocked — required checks failing.**\n\nFailing checks on \`${head_sha:0:8}\`:\n${failures}\n\nPlease fix the issues above and push. The pipeline will retry automatically." 2>/dev/null || true
       echo "    Commented on PR. Skipping — engineer must fix scan failures."
       continue
-    fi
   fi
 
   # Legacy Copilot-only review gate is disabled: this repository uses the
@@ -237,10 +279,13 @@ while IFS= read -r pr; do
     # cannot satisfy the gate.
     # reviews(last: 100) — the MOST RECENT reviews, so a Copilot review is
     # never missed on PRs whose total review history exceeds one page.
-    review_state="$(gh api graphql -f query="query { repository(owner: \"$repo_owner\", name: \"$repo_name\") { pullRequest(number: $number) { latestReviews: reviews(last: 100) { nodes { author { login } state } } reviewThreads(first: 100) { totalCount nodes { isResolved } } } } }" 2>/dev/null || echo "")"
-
-    if [[ -z "$review_state" ]]; then
+    if ! review_state="$(gh api graphql -f query="query { repository(owner: \"$repo_owner\", name: \"$repo_name\") { pullRequest(number: $number) { headRefOid latestReviews: reviews(last: 100) { nodes { author { login } state } } reviewThreads(first: 100) { totalCount nodes { isResolved } } } } }")"; then
       echo "    skip: could not read review state (API failure) — not merging on unknown review status"
+      continue
+    fi
+    review_head="$(jq -r '.data.repository.pullRequest.headRefOid // empty' <<<"$review_state" 2>/dev/null || true)"
+    if [[ "$review_head" != "$head_sha" ]]; then
+      echo "    skip: PR head changed during review verification (${head_sha:0:8} -> ${review_head:0:8}) — deferring"
       continue
     fi
 
@@ -296,11 +341,27 @@ while IFS= read -r pr; do
 
   # --- Ready to merge ---
   if [[ "$merge_state" == "CLEAN" || "$merge_state" == "HAS_HOOKS" ]]; then
-    echo "==> PR #$number is $merge_state with required checks green — merging now (squash)"
-    if run_or_log gh pr merge "$number" --repo "$REPO" --squash --delete-branch --auto; then
+    # A second fresh snapshot closes the list→verify→merge TOCTOU window. The
+    # server-side match guard covers the remaining race after this GET.
+    if ! final_pr="$(fetch_current_pr "$number")"; then
+      echo "    skip: could not refresh final PR state — not invoking merge"
+      continue
+    fi
+    final_head="$(jq -r '.headSha' <<<"$final_pr")"
+    final_state="$(jq -r '.mergeStateStatus // "UNKNOWN"' <<<"$final_pr")"
+    if [[ "$final_head" != "$head_sha" ]]; then
+      echo "    skip: PR head changed during final verification (${head_sha:0:8} -> ${final_head:0:8}) — deferring without merge"
+      continue
+    fi
+    if [[ "$final_state" != "CLEAN" && "$final_state" != "HAS_HOOKS" ]]; then
+      echo "    skip: merge state changed during final verification ($merge_state -> $final_state) — deferring without merge"
+      continue
+    fi
+    echo "==> PR #$number is $final_state at verified head ${head_sha:0:8} — merging now (squash)"
+    if run_or_log gh pr merge "$number" --repo "$REPO" --squash --delete-branch --auto --match-head-commit "$head_sha"; then
       echo "    Merged (or auto-merge queued). Push to $BASE will trigger next run."
     else
-      echo "    Merge failed — may need manual review."
+      echo "    Merge failed — the head may have changed or manual review is needed."
     fi
     exit 0   # ONE action per run — stop here
   fi

--- a/scripts/pr-merge-maintenance.sh
+++ b/scripts/pr-merge-maintenance.sh
@@ -78,43 +78,124 @@ run_or_log() {
   "$@"
 }
 
-# Historical GitHub reviews survive a rebase or force-push. Require a positive
-# review from every mandatory lane whose commit ID is the exact head being
-# merged, and fail closed if API or thread-resolution evidence is unavailable.
-require_current_head_review_lanes() {
-  local number="$1" head_sha="$2" reviews_json thread_state
-  local localfirst_count gpt_count claude_count copilot_count thread_total unresolved
+# The paginated list is only a queue-discovery snapshot. Never make a rebase or
+# merge decision from it: a force-push can change the review/check target after
+# the list request returns. Every candidate is re-read before eligibility and
+# the merge path verifies that exact head again immediately before invoking gh.
+fetch_current_pr() {
+  local number="$1"
+  gh api "repos/$REPO/pulls/$number" | jq -ce '{
+    number:           .number,
+    title:            (.title // ""),
+    isDraft:          (.draft // false),
+    labels:           [(.labels // [])[].name],
+    author:           (.user.login // ""),
+    headOwner:        (.head.repo.owner.login // ""),
+    mergeable:        (if .mergeable == true then "MERGEABLE"
+                       elif .mergeable == false then "CONFLICTING"
+                       else "UNKNOWN" end),
+    mergeStateStatus: ((.mergeable_state // "unknown") | ascii_upcase),
+    autoMerge:        (.auto_merge != null),
+    headSha:          (.head.sha // "")
+  }'
+}
 
-  reviews_json="$(gh api --paginate --slurp "repos/$REPO/pulls/$number/reviews?per_page=100" 2>/dev/null || echo "")"
-  if [[ -z "$reviews_json" ]] || ! jq -e 'type == "array"' <<<"$reviews_json" >/dev/null 2>&1; then
+load_pr_snapshot() {
+  local snapshot="$1"
+  title="$(jq -r     '.title'                            <<<"$snapshot")"
+  is_draft="$(jq -r  '.isDraft'                          <<<"$snapshot")"
+  merge_state="$(jq -r '.mergeStateStatus // "UNKNOWN"'  <<<"$snapshot")"
+  mergeable="$(jq -r   '.mergeable // "UNKNOWN"'         <<<"$snapshot")"
+  auto_merge="$(jq -r  '.autoMerge'                      <<<"$snapshot")"
+  labels_json="$(jq -c '.labels'                         <<<"$snapshot")"
+  author="$(jq -r      '.author // ""'                   <<<"$snapshot")"
+  head_owner="$(jq -r  '.headOwner'                      <<<"$snapshot")"
+  head_sha="$(jq -r    '.headSha'                        <<<"$snapshot")"
+}
+
+# Historical reviews survive rebases and force-pushes. For every named
+# non-Copilot lane, GitHub's submitted_at timestamp is the primary ordering key
+# and numeric review id breaks equal timestamps. The last exact-head submitted
+# decision is authoritative: only an explicit Accept/Pass is eligible; Revise,
+# missing verdicts, and malformed ordering data fail closed.
+latest_current_head_lane_verdict() {
+  local lane="$1" lane_pattern="$2" verified_head="$3" reviews_json="$4" verdict
+
+  if ! verdict="$(jq -er --arg sha "$verified_head" --arg lane "$lane_pattern" '
+    [ .[][]?
+      | select(type == "object")
+      | select(.commit_id == $sha)
+      | select(.state == "APPROVED" or .state == "COMMENTED")
+      | select((.body | type) == "string")
+      | select(.body | test($lane; "i"))
+      | select((.submitted_at | type) == "string")
+      | select((.id | type) == "number")
+      | {
+          submittedAt: .submitted_at,
+          submittedEpoch: (.submitted_at | fromdateiso8601),
+          id: .id,
+          body: .body
+        }
+    ]
+    | if length == 0 then error("missing exact-head lane review") else
+        sort_by(.submittedEpoch, .id) | last | .body
+        | if test("(?im)\\bVerdict:\\s*Revise\\b") then "REVISE"
+          elif test("(?im)\\bVerdict:\\s*(Accept|Pass)\\b") then "PASS"
+          else error("latest lane review lacks an explicit verdict")
+          end
+      end
+  ' <<<"$reviews_json" 2>/dev/null)"; then
+    echo "    skip: current-head $lane review evidence was malformed or incomplete — failing closed"
+    return 1
+  fi
+
+  printf '%s' "$verdict"
+}
+
+# Every required lane must have accepted evidence for the current head, and
+# thread evidence must come from that same current pull request state.
+require_current_head_review_lanes() {
+  local number="$1" verified_head="$2" reviews_json thread_state review_head
+  local localfirst_verdict gpt_verdict claude_verdict copilot_count thread_total unresolved
+
+  if ! reviews_json="$(gh api --paginate --slurp "repos/$REPO/pulls/$number/reviews?per_page=100")"; then
     echo "    skip: could not read review evidence — failing closed"
     return 1
   fi
-
-  localfirst_count="$(jq --arg sha "$head_sha" '[.[][]? | select(.commit_id == $sha) | select(.state == "APPROVED" or .state == "COMMENTED") | select((.body // "") | test("(?i)LocalFirst(?:Reviewer)?")) | select((.body // "") | test("(?im)\\bVerdict:\\s*(Accept|Pass)\\b")) | select(((.body // "") | test("(?im)\\bVerdict:\\s*Revise\\b")) | not)] | length' <<<"$reviews_json" 2>/dev/null || echo "0")"
-  gpt_count="$(jq --arg sha "$head_sha" '[.[][]? | select(.commit_id == $sha) | select(.state == "APPROVED" or .state == "COMMENTED") | select((.body // "") | test("(?i)GPTReviewer")) | select((.body // "") | test("(?im)\\bVerdict:\\s*(Accept|Pass)\\b")) | select(((.body // "") | test("(?im)\\bVerdict:\\s*Revise\\b")) | not)] | length' <<<"$reviews_json" 2>/dev/null || echo "0")"
-  claude_count="$(jq --arg sha "$head_sha" '[.[][]? | select(.commit_id == $sha) | select(.state == "APPROVED" or .state == "COMMENTED") | select((.body // "") | test("(?i)ClaudeReviewer")) | select((.body // "") | test("(?im)\\bVerdict:\\s*(Accept|Pass)\\b")) | select(((.body // "") | test("(?im)\\bVerdict:\\s*Revise\\b")) | not)] | length' <<<"$reviews_json" 2>/dev/null || echo "0")"
-  copilot_count="$(jq --arg sha "$head_sha" '[.[][]? | select(.commit_id == $sha) | select(.state == "APPROVED" or .state == "COMMENTED") | select((.user.login // "") == "copilot-pull-request-reviewer" or (.user.login // "") == "copilot-pull-request-reviewer[bot]")] | length' <<<"$reviews_json" 2>/dev/null || echo "0")"
-
-  if [[ ! "$localfirst_count" =~ ^[0-9]+$ || ! "$gpt_count" =~ ^[0-9]+$ || ! "$claude_count" =~ ^[0-9]+$ || ! "$copilot_count" =~ ^[0-9]+$ ]]; then
+  if ! jq -e 'type == "array"' <<<"$reviews_json" >/dev/null 2>&1; then
     echo "    skip: review evidence was malformed — failing closed"
     return 1
   fi
-  if [[ "$localfirst_count" -eq 0 || "$gpt_count" -eq 0 || "$claude_count" -eq 0 || "$copilot_count" -eq 0 ]]; then
-    echo "    skip: current-head review lane incomplete (LocalFirst=$localfirst_count GPT=$gpt_count Claude=$claude_count Copilot=$copilot_count)"
+
+  if ! localfirst_verdict="$(latest_current_head_lane_verdict "LocalFirst" "LocalFirst(?:Reviewer)?" "$verified_head" "$reviews_json")" ||
+     ! gpt_verdict="$(latest_current_head_lane_verdict "GPTReviewer" "GPTReviewer" "$verified_head" "$reviews_json")" ||
+     ! claude_verdict="$(latest_current_head_lane_verdict "ClaudeReviewer" "ClaudeReviewer" "$verified_head" "$reviews_json")"; then
+    return 1
+  fi
+  copilot_count="$(jq --arg sha "$verified_head" '[.[][]? | select(.commit_id == $sha) | select(.state == "APPROVED" or .state == "COMMENTED") | select((.user.login // "") == "copilot-pull-request-reviewer" or (.user.login // "") == "copilot-pull-request-reviewer[bot]")] | length' <<<"$reviews_json" 2>/dev/null || true)"
+
+  if [[ ! "$copilot_count" =~ ^[0-9]+$ ]]; then
+    echo "    skip: review evidence was malformed — failing closed"
+    return 1
+  fi
+  if [[ "$localfirst_verdict" != "PASS" || "$gpt_verdict" != "PASS" || "$claude_verdict" != "PASS" || "$copilot_count" -eq 0 ]]; then
+    echo "    skip: latest current-head review lane rejected (LocalFirst=$localfirst_verdict GPT=$gpt_verdict Claude=$claude_verdict Copilot=$copilot_count)"
     return 1
   fi
 
-  thread_state="$(gh api graphql -f query="query { repository(owner: \"$repo_owner\", name: \"$repo_name\") { pullRequest(number: $number) { reviewThreads(first: 100) { totalCount nodes { isResolved } } } } }" 2>/dev/null || echo "")"
-  thread_total="$(jq '.data.repository.pullRequest.reviewThreads.totalCount // -1' <<<"$thread_state" 2>/dev/null || echo "-1")"
-  unresolved="$(jq '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved == false)] | length' <<<"$thread_state" 2>/dev/null || echo "-1")"
-  if [[ ! "$thread_total" =~ ^[0-9]+$ || ! "$unresolved" =~ ^[0-9]+$ || "$thread_total" -gt 100 || "$unresolved" -gt 0 ]]; then
-    echo "    skip: review threads are unresolved or cannot be fully verified (total=$thread_total unresolved=$unresolved)"
+  if ! thread_state="$(gh api graphql -f query="query { repository(owner: \"$repo_owner\", name: \"$repo_name\") { pullRequest(number: $number) { headRefOid reviewThreads(first: 100) { totalCount nodes { isResolved } } } } }")"; then
+    echo "    skip: could not read review thread state — failing closed"
+    return 1
+  fi
+  review_head="$(jq -r '.data.repository.pullRequest.headRefOid // empty' <<<"$thread_state" 2>/dev/null || true)"
+  thread_total="$(jq -r '.data.repository.pullRequest.reviewThreads.totalCount // empty' <<<"$thread_state" 2>/dev/null || true)"
+  unresolved="$(jq '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved == false)] | length' <<<"$thread_state" 2>/dev/null || true)"
+  if [[ "$review_head" != "$verified_head" || ! "$thread_total" =~ ^[0-9]+$ || ! "$unresolved" =~ ^[0-9]+$ || "$thread_total" -gt 100 || "$unresolved" -gt 0 ]]; then
+    echo "    skip: review threads are unresolved or cannot be fully verified for current head (head=${review_head:0:8} total=${thread_total:-unknown} unresolved=${unresolved:-unknown})"
     return 1
   fi
 
   echo "    current-head review lanes satisfied (LocalFirst, GPT, Claude, Copilot; threads resolved)"
-  return 0
 }
 
 if [[ -n "$MAX_PRS" && ! "$MAX_PRS" =~ ^[0-9]+$ ]]; then
@@ -178,21 +259,19 @@ repo_name="${REPO##*/}"
 # Pick the FIRST one we can act on and do exactly that one action, then exit.
 while IFS= read -r pr; do
   number="$(jq -r    '.number'                           <<<"$pr")"
-  title="$(jq -r     '.title'                            <<<"$pr")"
-  is_draft="$(jq -r  '.isDraft'                          <<<"$pr")"
-  merge_state="$(jq -r '.mergeStateStatus // "UNKNOWN"'  <<<"$pr")"
-  mergeable="$(jq -r   '.mergeable // "UNKNOWN"'         <<<"$pr")"
-  auto_merge="$(jq -r  '.autoMerge'                      <<<"$pr")"
-  labels_json="$(jq -c '.labels'                         <<<"$pr")"
-  author="$(jq -r      '.author // ""'                     <<<"$pr")"
-  head_owner="$(jq -r  '.headOwner'                      <<<"$pr")"
-  head_sha="$(jq -r    '.headSha'                        <<<"$pr")"
+  # The list record is deliberately not used to choose an action. Refetch first
+  # so every eligibility check below is bound to one current PR snapshot.
+  if ! current_pr="$(fetch_current_pr "$number")"; then
+    echo "    skip: could not refresh current PR state — not acting on stale queue data"
+    continue
+  fi
+  load_pr_snapshot "$current_pr"
 
   echo ""
   echo "--- PR #$number: $title"
-  echo "    author=${author:-<unknown>} state=$merge_state mergeable=$mergeable autoMerge=$auto_merge draft=$is_draft"
+  echo "    refreshed head=${head_sha:0:8} author=${author:-<unknown>} state=$merge_state mergeable=$mergeable autoMerge=$auto_merge draft=$is_draft"
 
-  # --- Skip conditions ---
+  # --- Skip conditions, evaluated from the fresh PR snapshot ---
   if [[ "$is_draft" == "true" ]]; then
     echo "    skip: draft"; continue; fi
 
@@ -209,21 +288,21 @@ while IFS= read -r pr; do
     echo "    skip: has merge conflicts — engineer must resolve first"; continue; fi
 
   # --- Resolve UNKNOWN mergeability before acting ---
-  # The list endpoint returns mergeable_state only when GitHub has it cached;
-  # treating UNKNOWN as BEHIND made the train "rebase" an up-to-date branch
-  # forever (update-branch no-ops, the state never changes, nothing merges).
-  # A single-PR GET forces GitHub to compute mergeability; poll briefly.
+  # Refresh the full PR rather than only mergeable_state so a head change while
+  # GitHub computes mergeability cannot carry stale review/check evidence forward.
   if [[ "$merge_state" == "UNKNOWN" ]]; then
     for _attempt in 1 2 3 4 5; do
-      merge_state="$(gh api "repos/$REPO/pulls/$number" \
-        --jq '(.mergeable_state // "unknown") | ascii_upcase' 2>/dev/null || echo "UNKNOWN")"
+      if ! current_pr="$(fetch_current_pr "$number")"; then
+        break
+      fi
+      load_pr_snapshot "$current_pr"
       [[ "$merge_state" != "UNKNOWN" ]] && break
       sleep 3
     done
     echo "    resolved mergeability: state=$merge_state"
     if [[ "$merge_state" == "UNKNOWN" ]]; then
-      echo "    skip: mergeability still computing — next run retries"; continue; fi
-    if [[ "$merge_state" == "DIRTY" ]]; then
+      echo "    skip: mergeability still computing or refresh failed — next run retries"; continue; fi
+    if [[ "$mergeable" == "CONFLICTING" || "$merge_state" == "DIRTY" ]]; then
       echo "    skip: has merge conflicts — engineer must resolve first"; continue; fi
   fi
 
@@ -242,19 +321,29 @@ while IFS= read -r pr; do
   fi
 
   # --- Check if all required status checks are passing ---
-  if [[ -n "$head_sha" ]]; then
-    failing_checks="$(gh api "repos/$REPO/commits/$head_sha/check-runs" \
-      --jq '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null and .status == "completed")] | length' 2>/dev/null || echo "0")"
-    pending_checks="$(gh api "repos/$REPO/commits/$head_sha/check-runs" \
-      --jq '[.check_runs[] | select(.status == "in_progress" or .status == "queued")] | length' 2>/dev/null || echo "0")"
+  if [[ -z "$head_sha" ]]; then
+    echo "    skip: refreshed PR has no head SHA — cannot verify checks"
+    continue
+  fi
+  if ! check_runs="$(gh api "repos/$REPO/commits/$head_sha/check-runs")"; then
+    echo "    skip: could not read checks for refreshed head ${head_sha:0:8} — not merging on unknown check state"
+    continue
+  fi
+  if ! failing_checks="$(jq -er '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null and .status == "completed")] | length' <<<"$check_runs")"; then
+    echo "    skip: malformed check response for refreshed head ${head_sha:0:8} — not merging"
+    continue
+  fi
+  if ! pending_checks="$(jq -er '[.check_runs[] | select(.status == "in_progress" or .status == "queued")] | length' <<<"$check_runs")"; then
+    echo "    skip: malformed check response for refreshed head ${head_sha:0:8} — not merging"
+    continue
+  fi
 
-    if [[ "$pending_checks" -gt 0 ]]; then
-      echo "    skip: $pending_checks check(s) still running — waiting for scan to complete"; continue; fi
+  if [[ "$pending_checks" -gt 0 ]]; then
+    echo "    skip: $pending_checks check(s) still running — waiting for scan to complete"; continue; fi
 
-    if [[ "$failing_checks" -gt 0 ]]; then
+  if [[ "$failing_checks" -gt 0 ]]; then
       # Summarise failures and comment once (avoid spamming)
-      failures="$(gh api "repos/$REPO/commits/$head_sha/check-runs" \
-        --jq '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null and .status == "completed") | "- \(.name): \(.conclusion)"] | join("\n")' 2>/dev/null || echo "unknown")"
+      failures="$(jq -r '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null and .status == "completed") | "- \(.name): \(.conclusion)"] | join("\n")' <<<"$check_runs")"
       echo "    SCAN FAILED — $failing_checks check(s) failing:"
       echo "$failures"
       # Only comment if not already commented recently
@@ -262,23 +351,37 @@ while IFS= read -r pr; do
         --body "🔴 **Merge blocked — required checks failing.**\n\nFailing checks on \`${head_sha:0:8}\`:\n${failures}\n\nPlease fix the issues above and push. The pipeline will retry automatically." 2>/dev/null || true
       echo "    Commented on PR. Skipping — engineer must fix scan failures."
       continue
-    fi
   fi
 
   # This is intentionally unconditional: workflow/environment configuration
   # cannot downgrade the mandatory LocalFirst → GPT → Claude → Copilot chain.
-  # Each accepted lane is bound to head_sha, so a changed head resets readiness.
   if ! require_current_head_review_lanes "$number" "$head_sha"; then
     continue
   fi
 
   # --- Ready to merge ---
   if [[ "$merge_state" == "CLEAN" || "$merge_state" == "HAS_HOOKS" ]]; then
-    echo "==> PR #$number is $merge_state with required checks green — merging now (squash)"
-    if run_or_log gh pr merge "$number" --repo "$REPO" --squash --delete-branch --auto; then
+    # A second fresh snapshot closes the list→verify→merge TOCTOU window. The
+    # server-side match guard covers the remaining race after this GET.
+    if ! final_pr="$(fetch_current_pr "$number")"; then
+      echo "    skip: could not refresh final PR state — not invoking merge"
+      continue
+    fi
+    final_head="$(jq -r '.headSha' <<<"$final_pr")"
+    final_state="$(jq -r '.mergeStateStatus // "UNKNOWN"' <<<"$final_pr")"
+    if [[ "$final_head" != "$head_sha" ]]; then
+      echo "    skip: PR head changed during final verification (${head_sha:0:8} -> ${final_head:0:8}) — deferring without merge"
+      continue
+    fi
+    if [[ "$final_state" != "CLEAN" && "$final_state" != "HAS_HOOKS" ]]; then
+      echo "    skip: merge state changed during final verification ($merge_state -> $final_state) — deferring without merge"
+      continue
+    fi
+    echo "==> PR #$number is $final_state at verified head ${head_sha:0:8} — merging now (squash)"
+    if run_or_log gh pr merge "$number" --repo "$REPO" --squash --delete-branch --auto --match-head-commit "$head_sha"; then
       echo "    Merged (or auto-merge queued). Push to $BASE will trigger next run."
     else
-      echo "    Merge failed — may need manual review."
+      echo "    Merge failed — the head may have changed or manual review is needed."
     fi
     exit 0   # ONE action per run — stop here
   fi

--- a/scripts/pr-merge-maintenance.sh
+++ b/scripts/pr-merge-maintenance.sh
@@ -78,39 +78,43 @@ run_or_log() {
   "$@"
 }
 
-# The paginated list is only a queue-discovery snapshot. Never make a rebase or
-# merge decision from it: a force-push can change the review/check target after
-# the list request returns. Every candidate is re-read before eligibility and
-# the merge path verifies that exact head again immediately before invoking gh.
-fetch_current_pr() {
-  local number="$1"
-  gh api "repos/$REPO/pulls/$number" | jq -ce '{
-    number:           .number,
-    title:            (.title // ""),
-    isDraft:          (.draft // false),
-    labels:           [(.labels // [])[].name],
-    author:           (.user.login // ""),
-    headOwner:        (.head.repo.owner.login // ""),
-    mergeable:        (if .mergeable == true then "MERGEABLE"
-                       elif .mergeable == false then "CONFLICTING"
-                       else "UNKNOWN" end),
-    mergeStateStatus: ((.mergeable_state // "unknown") | ascii_upcase),
-    autoMerge:        (.auto_merge != null),
-    headSha:          (.head.sha // "")
-  }'
-}
+# Historical GitHub reviews survive a rebase or force-push. Require a positive
+# review from every mandatory lane whose commit ID is the exact head being
+# merged, and fail closed if API or thread-resolution evidence is unavailable.
+require_current_head_review_lanes() {
+  local number="$1" head_sha="$2" reviews_json thread_state
+  local localfirst_count gpt_count claude_count copilot_count thread_total unresolved
 
-load_pr_snapshot() {
-  local snapshot="$1"
-  title="$(jq -r     '.title'                            <<<"$snapshot")"
-  is_draft="$(jq -r  '.isDraft'                          <<<"$snapshot")"
-  merge_state="$(jq -r '.mergeStateStatus // "UNKNOWN"'  <<<"$snapshot")"
-  mergeable="$(jq -r   '.mergeable // "UNKNOWN"'         <<<"$snapshot")"
-  auto_merge="$(jq -r  '.autoMerge'                      <<<"$snapshot")"
-  labels_json="$(jq -c '.labels'                         <<<"$snapshot")"
-  author="$(jq -r      '.author // ""'                   <<<"$snapshot")"
-  head_owner="$(jq -r  '.headOwner'                      <<<"$snapshot")"
-  head_sha="$(jq -r    '.headSha'                        <<<"$snapshot")"
+  reviews_json="$(gh api --paginate --slurp "repos/$REPO/pulls/$number/reviews?per_page=100" 2>/dev/null || echo "")"
+  if [[ -z "$reviews_json" ]] || ! jq -e 'type == "array"' <<<"$reviews_json" >/dev/null 2>&1; then
+    echo "    skip: could not read review evidence — failing closed"
+    return 1
+  fi
+
+  localfirst_count="$(jq --arg sha "$head_sha" '[.[][]? | select(.commit_id == $sha) | select(.state == "APPROVED" or .state == "COMMENTED") | select((.body // "") | test("(?i)LocalFirst(?:Reviewer)?")) | select((.body // "") | test("(?im)\\bVerdict:\\s*(Accept|Pass)\\b")) | select(((.body // "") | test("(?im)\\bVerdict:\\s*Revise\\b")) | not)] | length' <<<"$reviews_json" 2>/dev/null || echo "0")"
+  gpt_count="$(jq --arg sha "$head_sha" '[.[][]? | select(.commit_id == $sha) | select(.state == "APPROVED" or .state == "COMMENTED") | select((.body // "") | test("(?i)GPTReviewer")) | select((.body // "") | test("(?im)\\bVerdict:\\s*(Accept|Pass)\\b")) | select(((.body // "") | test("(?im)\\bVerdict:\\s*Revise\\b")) | not)] | length' <<<"$reviews_json" 2>/dev/null || echo "0")"
+  claude_count="$(jq --arg sha "$head_sha" '[.[][]? | select(.commit_id == $sha) | select(.state == "APPROVED" or .state == "COMMENTED") | select((.body // "") | test("(?i)ClaudeReviewer")) | select((.body // "") | test("(?im)\\bVerdict:\\s*(Accept|Pass)\\b")) | select(((.body // "") | test("(?im)\\bVerdict:\\s*Revise\\b")) | not)] | length' <<<"$reviews_json" 2>/dev/null || echo "0")"
+  copilot_count="$(jq --arg sha "$head_sha" '[.[][]? | select(.commit_id == $sha) | select(.state == "APPROVED" or .state == "COMMENTED") | select((.user.login // "") == "copilot-pull-request-reviewer" or (.user.login // "") == "copilot-pull-request-reviewer[bot]")] | length' <<<"$reviews_json" 2>/dev/null || echo "0")"
+
+  if [[ ! "$localfirst_count" =~ ^[0-9]+$ || ! "$gpt_count" =~ ^[0-9]+$ || ! "$claude_count" =~ ^[0-9]+$ || ! "$copilot_count" =~ ^[0-9]+$ ]]; then
+    echo "    skip: review evidence was malformed — failing closed"
+    return 1
+  fi
+  if [[ "$localfirst_count" -eq 0 || "$gpt_count" -eq 0 || "$claude_count" -eq 0 || "$copilot_count" -eq 0 ]]; then
+    echo "    skip: current-head review lane incomplete (LocalFirst=$localfirst_count GPT=$gpt_count Claude=$claude_count Copilot=$copilot_count)"
+    return 1
+  fi
+
+  thread_state="$(gh api graphql -f query="query { repository(owner: \"$repo_owner\", name: \"$repo_name\") { pullRequest(number: $number) { reviewThreads(first: 100) { totalCount nodes { isResolved } } } } }" 2>/dev/null || echo "")"
+  thread_total="$(jq '.data.repository.pullRequest.reviewThreads.totalCount // -1' <<<"$thread_state" 2>/dev/null || echo "-1")"
+  unresolved="$(jq '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved == false)] | length' <<<"$thread_state" 2>/dev/null || echo "-1")"
+  if [[ ! "$thread_total" =~ ^[0-9]+$ || ! "$unresolved" =~ ^[0-9]+$ || "$thread_total" -gt 100 || "$unresolved" -gt 0 ]]; then
+    echo "    skip: review threads are unresolved or cannot be fully verified (total=$thread_total unresolved=$unresolved)"
+    return 1
+  fi
+
+  echo "    current-head review lanes satisfied (LocalFirst, GPT, Claude, Copilot; threads resolved)"
+  return 0
 }
 
 if [[ -n "$MAX_PRS" && ! "$MAX_PRS" =~ ^[0-9]+$ ]]; then
@@ -174,19 +178,21 @@ repo_name="${REPO##*/}"
 # Pick the FIRST one we can act on and do exactly that one action, then exit.
 while IFS= read -r pr; do
   number="$(jq -r    '.number'                           <<<"$pr")"
-  # The list record is deliberately not used to choose an action. Refetch first
-  # so every eligibility check below is bound to one current PR snapshot.
-  if ! current_pr="$(fetch_current_pr "$number")"; then
-    echo "    skip: could not refresh current PR state — not acting on stale queue data"
-    continue
-  fi
-  load_pr_snapshot "$current_pr"
+  title="$(jq -r     '.title'                            <<<"$pr")"
+  is_draft="$(jq -r  '.isDraft'                          <<<"$pr")"
+  merge_state="$(jq -r '.mergeStateStatus // "UNKNOWN"'  <<<"$pr")"
+  mergeable="$(jq -r   '.mergeable // "UNKNOWN"'         <<<"$pr")"
+  auto_merge="$(jq -r  '.autoMerge'                      <<<"$pr")"
+  labels_json="$(jq -c '.labels'                         <<<"$pr")"
+  author="$(jq -r      '.author // ""'                     <<<"$pr")"
+  head_owner="$(jq -r  '.headOwner'                      <<<"$pr")"
+  head_sha="$(jq -r    '.headSha'                        <<<"$pr")"
 
   echo ""
   echo "--- PR #$number: $title"
-  echo "    refreshed head=${head_sha:0:8} author=${author:-<unknown>} state=$merge_state mergeable=$mergeable autoMerge=$auto_merge draft=$is_draft"
+  echo "    author=${author:-<unknown>} state=$merge_state mergeable=$mergeable autoMerge=$auto_merge draft=$is_draft"
 
-  # --- Skip conditions, evaluated from the fresh PR snapshot ---
+  # --- Skip conditions ---
   if [[ "$is_draft" == "true" ]]; then
     echo "    skip: draft"; continue; fi
 
@@ -203,21 +209,21 @@ while IFS= read -r pr; do
     echo "    skip: has merge conflicts — engineer must resolve first"; continue; fi
 
   # --- Resolve UNKNOWN mergeability before acting ---
-  # Refresh the full PR rather than only mergeable_state so a head change while
-  # GitHub computes mergeability cannot carry stale review/check evidence forward.
+  # The list endpoint returns mergeable_state only when GitHub has it cached;
+  # treating UNKNOWN as BEHIND made the train "rebase" an up-to-date branch
+  # forever (update-branch no-ops, the state never changes, nothing merges).
+  # A single-PR GET forces GitHub to compute mergeability; poll briefly.
   if [[ "$merge_state" == "UNKNOWN" ]]; then
     for _attempt in 1 2 3 4 5; do
-      if ! current_pr="$(fetch_current_pr "$number")"; then
-        break
-      fi
-      load_pr_snapshot "$current_pr"
+      merge_state="$(gh api "repos/$REPO/pulls/$number" \
+        --jq '(.mergeable_state // "unknown") | ascii_upcase' 2>/dev/null || echo "UNKNOWN")"
       [[ "$merge_state" != "UNKNOWN" ]] && break
       sleep 3
     done
     echo "    resolved mergeability: state=$merge_state"
     if [[ "$merge_state" == "UNKNOWN" ]]; then
-      echo "    skip: mergeability still computing or refresh failed — next run retries"; continue; fi
-    if [[ "$mergeable" == "CONFLICTING" || "$merge_state" == "DIRTY" ]]; then
+      echo "    skip: mergeability still computing — next run retries"; continue; fi
+    if [[ "$merge_state" == "DIRTY" ]]; then
       echo "    skip: has merge conflicts — engineer must resolve first"; continue; fi
   fi
 
@@ -236,29 +242,19 @@ while IFS= read -r pr; do
   fi
 
   # --- Check if all required status checks are passing ---
-  if [[ -z "$head_sha" ]]; then
-    echo "    skip: refreshed PR has no head SHA — cannot verify checks"
-    continue
-  fi
-  if ! check_runs="$(gh api "repos/$REPO/commits/$head_sha/check-runs")"; then
-    echo "    skip: could not read checks for refreshed head ${head_sha:0:8} — not merging on unknown check state"
-    continue
-  fi
-  if ! failing_checks="$(jq -er '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null and .status == "completed")] | length' <<<"$check_runs")"; then
-    echo "    skip: malformed check response for refreshed head ${head_sha:0:8} — not merging"
-    continue
-  fi
-  if ! pending_checks="$(jq -er '[.check_runs[] | select(.status == "in_progress" or .status == "queued")] | length' <<<"$check_runs")"; then
-    echo "    skip: malformed check response for refreshed head ${head_sha:0:8} — not merging"
-    continue
-  fi
+  if [[ -n "$head_sha" ]]; then
+    failing_checks="$(gh api "repos/$REPO/commits/$head_sha/check-runs" \
+      --jq '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null and .status == "completed")] | length' 2>/dev/null || echo "0")"
+    pending_checks="$(gh api "repos/$REPO/commits/$head_sha/check-runs" \
+      --jq '[.check_runs[] | select(.status == "in_progress" or .status == "queued")] | length' 2>/dev/null || echo "0")"
 
-  if [[ "$pending_checks" -gt 0 ]]; then
-    echo "    skip: $pending_checks check(s) still running — waiting for scan to complete"; continue; fi
+    if [[ "$pending_checks" -gt 0 ]]; then
+      echo "    skip: $pending_checks check(s) still running — waiting for scan to complete"; continue; fi
 
-  if [[ "$failing_checks" -gt 0 ]]; then
+    if [[ "$failing_checks" -gt 0 ]]; then
       # Summarise failures and comment once (avoid spamming)
-      failures="$(jq -r '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null and .status == "completed") | "- \(.name): \(.conclusion)"] | join("\n")' <<<"$check_runs")"
+      failures="$(gh api "repos/$REPO/commits/$head_sha/check-runs" \
+        --jq '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null and .status == "completed") | "- \(.name): \(.conclusion)"] | join("\n")' 2>/dev/null || echo "unknown")"
       echo "    SCAN FAILED — $failing_checks check(s) failing:"
       echo "$failures"
       # Only comment if not already commented recently
@@ -266,102 +262,23 @@ while IFS= read -r pr; do
         --body "🔴 **Merge blocked — required checks failing.**\n\nFailing checks on \`${head_sha:0:8}\`:\n${failures}\n\nPlease fix the issues above and push. The pipeline will retry automatically." 2>/dev/null || true
       echo "    Commented on PR. Skipping — engineer must fix scan failures."
       continue
+    fi
   fi
 
-  # Legacy Copilot-only review gate is disabled: this repository uses the
-  # trusted first-party Codex path plus exact-head checks instead.
-  # It may be explicitly re-enabled only for a deliberately configured legacy
-  # migration, never as the default merge requirement.
-  if [[ "${PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW:-0}" == "1" ]]; then
-    # A GraphQL API failure must FAIL CLOSED (never merge on unknown review
-    # state). We probe once and treat empty/failed output as "not satisfied".
-    # Review nodes carry author login + state so a PENDING/DISMISSED review
-    # cannot satisfy the gate.
-    # reviews(last: 100) — the MOST RECENT reviews, so a Copilot review is
-    # never missed on PRs whose total review history exceeds one page.
-    if ! review_state="$(gh api graphql -f query="query { repository(owner: \"$repo_owner\", name: \"$repo_name\") { pullRequest(number: $number) { headRefOid latestReviews: reviews(last: 100) { nodes { author { login } state } } reviewThreads(first: 100) { totalCount nodes { isResolved } } } } }")"; then
-      echo "    skip: could not read review state (API failure) — not merging on unknown review status"
-      continue
-    fi
-    review_head="$(jq -r '.data.repository.pullRequest.headRefOid // empty' <<<"$review_state" 2>/dev/null || true)"
-    if [[ "$review_head" != "$head_sha" ]]; then
-      echo "    skip: PR head changed during review verification (${head_sha:0:8} -> ${review_head:0:8}) — deferring"
-      continue
-    fi
-
-    # A satisfying Copilot review is an EXACT bot login (no prefix spoofing by a
-    # 'copilot*' human account) whose state is a real submitted review
-    # (COMMENTED/APPROVED/CHANGES_REQUESTED — never PENDING/DISMISSED).
-    copilot_reviews="$(jq '[.data.repository.pullRequest.latestReviews.nodes[]?
-      | select((.author.login // "") == "copilot-pull-request-reviewer[bot]")
-      | select(.state == "COMMENTED" or .state == "APPROVED" or .state == "CHANGES_REQUESTED")] | length' <<<"$review_state" 2>/dev/null || echo "0")"
-    if [[ ! "$copilot_reviews" =~ ^[0-9]+$ ]]; then copilot_reviews="0"; fi
-
-    if [[ "$copilot_reviews" -eq 0 ]]; then
-      # Request the review only if the Copilot bot is not already a requested
-      # reviewer. Match the two exact logins GitHub uses for this bot across
-      # API surfaces ('Copilot' in requested_reviewers,
-      # 'copilot-pull-request-reviewer[bot]' in reviews) — no prefix match, so a
-      # similarly-named human can't suppress the request.
-      already_requested="$(gh api "repos/$REPO/pulls/$number" \
-        --jq '[.requested_reviewers[]?.login | select(. == "Copilot" or . == "copilot-pull-request-reviewer[bot]")] | length' 2>/dev/null || echo "0")"
-      if [[ ! "$already_requested" =~ ^[0-9]+$ ]]; then already_requested="0"; fi
-      if [[ "$already_requested" -eq 0 ]]; then
-        # Surface request failures honestly — a silently failed request would
-        # stall the train with a log line claiming the review was requested.
-        if run_or_log gh api -X POST "repos/$REPO/pulls/$number/requested_reviewers" \
-          -f 'reviewers[]=copilot-pull-request-reviewer[bot]' >/dev/null; then
-          echo "    skip: requested Copilot review — waiting for it before merge"
-        else
-          echo "    skip: FAILED to request Copilot review (API error above) — PR needs a manual review request"
-        fi
-      else
-        echo "    skip: Copilot review pending — waiting before merge"
-      fi
-      continue
-    fi
-
-    # Copilot has reviewed — block on any unresolved review thread (from any
-    # reviewer) so findings are addressed and resolved before the merge, not
-    # after. If the thread count exceeds the page we fetched, fail closed
-    # (can't prove resolution).
-    thread_total="$(jq '.data.repository.pullRequest.reviewThreads.totalCount // 0' <<<"$review_state" 2>/dev/null || echo "0")"
-    if [[ ! "$thread_total" =~ ^[0-9]+$ ]]; then thread_total="0"; fi
-    if [[ "$thread_total" -gt 100 ]]; then
-      echo "    skip: $thread_total review threads exceed the 100 fetched — cannot confirm resolution, not merging"
-      continue
-    fi
-    unresolved="$(jq '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved == false)] | length' <<<"$review_state" 2>/dev/null || echo "1")"
-    if [[ ! "$unresolved" =~ ^[0-9]+$ ]]; then unresolved="1"; fi
-    if [[ "$unresolved" -gt 0 ]]; then
-      echo "    skip: $unresolved unresolved review thread(s) (any reviewer) — must be resolved before merge"
-      continue
-    fi
+  # This is intentionally unconditional: workflow/environment configuration
+  # cannot downgrade the mandatory LocalFirst → GPT → Claude → Copilot chain.
+  # Each accepted lane is bound to head_sha, so a changed head resets readiness.
+  if ! require_current_head_review_lanes "$number" "$head_sha"; then
+    continue
   fi
 
   # --- Ready to merge ---
   if [[ "$merge_state" == "CLEAN" || "$merge_state" == "HAS_HOOKS" ]]; then
-    # A second fresh snapshot closes the list→verify→merge TOCTOU window. The
-    # server-side match guard covers the remaining race after this GET.
-    if ! final_pr="$(fetch_current_pr "$number")"; then
-      echo "    skip: could not refresh final PR state — not invoking merge"
-      continue
-    fi
-    final_head="$(jq -r '.headSha' <<<"$final_pr")"
-    final_state="$(jq -r '.mergeStateStatus // "UNKNOWN"' <<<"$final_pr")"
-    if [[ "$final_head" != "$head_sha" ]]; then
-      echo "    skip: PR head changed during final verification (${head_sha:0:8} -> ${final_head:0:8}) — deferring without merge"
-      continue
-    fi
-    if [[ "$final_state" != "CLEAN" && "$final_state" != "HAS_HOOKS" ]]; then
-      echo "    skip: merge state changed during final verification ($merge_state -> $final_state) — deferring without merge"
-      continue
-    fi
-    echo "==> PR #$number is $final_state at verified head ${head_sha:0:8} — merging now (squash)"
-    if run_or_log gh pr merge "$number" --repo "$REPO" --squash --delete-branch --auto --match-head-commit "$head_sha"; then
+    echo "==> PR #$number is $merge_state with required checks green — merging now (squash)"
+    if run_or_log gh pr merge "$number" --repo "$REPO" --squash --delete-branch --auto; then
       echo "    Merged (or auto-merge queued). Push to $BASE will trigger next run."
     else
-      echo "    Merge failed — the head may have changed or manual review is needed."
+      echo "    Merge failed — may need manual review."
     fi
     exit 0   # ONE action per run — stop here
   fi

--- a/scripts/pr-merge-maintenance.sh
+++ b/scripts/pr-merge-maintenance.sh
@@ -145,7 +145,10 @@ latest_current_head_lane_verdict() {
           end
       end
   ' <<<"$reviews_json" 2>/dev/null)"; then
-    echo "    skip: current-head $lane review evidence was malformed or incomplete — failing closed"
+    # This helper runs inside command substitution; write diagnostics to stderr so
+    # a missing lane remains visible to the merge-maintenance log while the caller
+    # can still capture only a PASS/REVISE verdict on stdout.
+    echo "    skip: current-head $lane review evidence was malformed or incomplete — failing closed" >&2
     return 1
   fi
 

--- a/scripts/test-pr-merge-maintenance-pagination.sh
+++ b/scripts/test-pr-merge-maintenance-pagination.sh
@@ -23,6 +23,25 @@ if [[ "${1:-}" == "api" ]]; then
       repos/*) endpoint="$arg" ;;
     esac
   done
+  if [[ "$endpoint" =~ ^repos/xXKillerNoobYT/Weird-Part-Run-2/pulls/[0-9]+$ ]]; then
+    number="${endpoint##*/}"
+    python3 - "$number" <<'PY'
+import json, sys
+n = int(sys.argv[1])
+print(json.dumps({
+    "number": n,
+    "title": f"Mock PR {n}",
+    "draft": True,
+    "labels": [],
+    "user": {"login": "xXKillerNoobYT"},
+    "head": {"repo": {"owner": {"login": "xXKillerNoobYT"}}, "sha": ""},
+    "mergeable": None,
+    "mergeable_state": "unknown",
+    "auto_merge": None,
+}))
+PY
+    exit 0
+  fi
   if [[ "$has_paginate" -ne 1 || "$has_slurp" -ne 1 ]]; then
     echo "expected gh api invocation to include --paginate and --slurp: $*" >&2
     exit 1

--- a/scripts/test-pr-merge-maintenance-review-gate.sh
+++ b/scripts/test-pr-merge-maintenance-review-gate.sh
@@ -15,12 +15,17 @@ pr_json() {
   jq -nc --arg sha "$1" '{number:1,title:"Safe merge fixture",draft:false,labels:[],user:{login:"xXKillerNoobYT"},head:{repo:{owner:{login:"xXKillerNoobYT"}},sha:$sha},mergeable:true,mergeable_state:"clean",auto_merge:null}'
 }
 reviews_json() {
-  jq -nc --arg sha "$1" '[[
-    {commit_id:$sha,state:"APPROVED",body:"LocalFirst\nVerdict: Pass",user:{login:"xXKillerNoobYT"}},
-    {commit_id:$sha,state:"APPROVED",body:"GPTReviewer\nVerdict: Accept",user:{login:"xXKillerNoobYT"}},
-    {commit_id:$sha,state:"APPROVED",body:"ClaudeReviewer\nVerdict: Accept",user:{login:"xXKillerNoobYT"}},
-    {commit_id:$sha,state:"APPROVED",body:"Copilot review",user:{login:"copilot-pull-request-reviewer[bot]"}}
-  ]]'
+  jq -nc --arg sha "$1" --arg mode "$FIXTURE_MODE" '[
+    [
+      {id:101,submitted_at:"2026-07-28T10:00:00Z",commit_id:$sha,state:"APPROVED",body:"LocalFirst\nVerdict: Pass",user:{login:"xXKillerNoobYT"}},
+      {id:102,submitted_at:"2026-07-28T10:01:00Z",commit_id:$sha,state:"APPROVED",body:"GPTReviewer\nVerdict: Accept",user:{login:"xXKillerNoobYT"}},
+      {id:103,submitted_at:"2026-07-28T10:02:00Z",commit_id:$sha,state:"APPROVED",body:"ClaudeReviewer\nVerdict: Accept",user:{login:"xXKillerNoobYT"}},
+      {id:104,submitted_at:"2026-07-28T10:03:00Z",commit_id:$sha,state:"APPROVED",body:"Copilot review",user:{login:"copilot-pull-request-reviewer[bot]"}}
+    ] +
+    (if $mode == "later-gpt-revise" then
+      [{id:105,submitted_at:"2026-07-28T10:04:00Z",commit_id:$sha,state:"COMMENTED",body:"GPTReviewer\nVerdict: Revise",user:{login:"xXKillerNoobYT"}}]
+     else [] end)
+  ]'
 }
 
 if [[ "${1:-}" == "api" ]]; then
@@ -77,6 +82,8 @@ run_rejection_case "head-change-after-listing" "head changed during final verifi
 run_rejection_case "review-api-failure" "could not read review evidence"
 run_rejection_case "review-thread-api-failure" "could not read review thread state"
 run_rejection_case "unresolved-review-thread" "review threads are unresolved"
+# The newer submitted GPTReviewer Revise must supersede its earlier valid pass.
+run_rejection_case "later-gpt-revise" "latest current-head review lane rejected (LocalFirst=PASS GPT=REVISE Claude=PASS Copilot=1)"
 
 fixture_dir="$TMPDIR/merge-eligible"; mkdir -p "$fixture_dir"
 PATH="$TMPDIR:$PATH" FIXTURE_MODE="merge-eligible" FIXTURE_DIR="$fixture_dir" "$ROOT/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 >/dev/null

--- a/scripts/test-pr-merge-maintenance-review-gate.sh
+++ b/scripts/test-pr-merge-maintenance-review-gate.sh
@@ -15,17 +15,24 @@ pr_json() {
   jq -nc --arg sha "$1" '{number:1,title:"Safe merge fixture",draft:false,labels:[],user:{login:"xXKillerNoobYT"},head:{repo:{owner:{login:"xXKillerNoobYT"}},sha:$sha},mergeable:true,mergeable_state:"clean",auto_merge:null}'
 }
 reviews_json() {
-  jq -nc --arg sha "$1" --arg mode "$FIXTURE_MODE" '[
+  jq -nc --arg sha "$1" --arg mode "$FIXTURE_MODE" '
     [
       {id:101,submitted_at:"2026-07-28T10:00:00Z",commit_id:$sha,state:"APPROVED",body:"LocalFirst\nVerdict: Pass",user:{login:"xXKillerNoobYT"}},
       {id:102,submitted_at:"2026-07-28T10:01:00Z",commit_id:$sha,state:"APPROVED",body:"GPTReviewer\nVerdict: Accept",user:{login:"xXKillerNoobYT"}},
       {id:103,submitted_at:"2026-07-28T10:02:00Z",commit_id:$sha,state:"APPROVED",body:"ClaudeReviewer\nVerdict: Accept",user:{login:"xXKillerNoobYT"}},
       {id:104,submitted_at:"2026-07-28T10:03:00Z",commit_id:$sha,state:"APPROVED",body:"Copilot review",user:{login:"copilot-pull-request-reviewer[bot]"}}
-    ] +
-    (if $mode == "later-gpt-revise" then
-      [{id:105,submitted_at:"2026-07-28T10:04:00Z",commit_id:$sha,state:"COMMENTED",body:"GPTReviewer\nVerdict: Revise",user:{login:"xXKillerNoobYT"}}]
-     else [] end)
-  ]'
+    ]
+    | if $mode == "missing-localfirst" then map(select(.id != 101))
+      elif $mode == "missing-gpt" then map(select(.id != 102))
+      elif $mode == "missing-claude" then map(select(.id != 103))
+      elif $mode == "missing-copilot" then map(select(.id != 104))
+      else .
+      end
+    | [.] +
+      (if $mode == "later-gpt-revise" then
+        [[{id:105,submitted_at:"2026-07-28T10:04:00Z",commit_id:$sha,state:"COMMENTED",body:"GPTReviewer\nVerdict: Revise",user:{login:"xXKillerNoobYT"}}]]
+       else [] end)
+  '
 }
 
 if [[ "${1:-}" == "api" ]]; then
@@ -55,7 +62,9 @@ if [[ "${1:-}" == "api" ]]; then
       jq -nc '{check_runs:[]}' ;;
     "repos/xXKillerNoobYT/Weird-Part-Run-2/pulls/1/reviews?per_page=100")
       [[ "$FIXTURE_MODE" == "review-api-failure" ]] && exit 1
-      reviews_json "head-a" ;;
+      review_head="head-a"
+      [[ "$FIXTURE_MODE" == "stale-review-evidence" ]] && review_head="head-old"
+      reviews_json "$review_head" ;;
     *) echo "unexpected gh api endpoint: $endpoint ($*)" >&2; exit 1 ;;
   esac
   exit 0
@@ -82,6 +91,19 @@ run_rejection_case "head-change-after-listing" "head changed during final verifi
 run_rejection_case "review-api-failure" "could not read review evidence"
 run_rejection_case "review-thread-api-failure" "could not read review thread state"
 run_rejection_case "unresolved-review-thread" "review threads are unresolved"
+# Table-driven lane omissions: a valid current-head review set with exactly one
+# required lane removed must fail closed before the merge command is reachable.
+while IFS='|' read -r mode expected; do
+  run_rejection_case "$mode" "$expected"
+done <<'CASES'
+missing-localfirst|current-head LocalFirst review evidence was malformed or incomplete — failing closed
+missing-gpt|current-head GPTReviewer review evidence was malformed or incomplete — failing closed
+missing-claude|current-head ClaudeReviewer review evidence was malformed or incomplete — failing closed
+missing-copilot|latest current-head review lane rejected (LocalFirst=PASS GPT=PASS Claude=PASS Copilot=0)
+CASES
+# Reviews that look complete but belong to a previous SHA cannot satisfy the
+# refreshed head-a predicate and must not reach gh pr merge.
+run_rejection_case "stale-review-evidence" "current-head LocalFirst review evidence was malformed or incomplete — failing closed"
 # The newer submitted GPTReviewer Revise must supersede its earlier valid pass.
 run_rejection_case "later-gpt-revise" "latest current-head review lane rejected (LocalFirst=PASS GPT=REVISE Claude=PASS Copilot=1)"
 

--- a/scripts/test-pr-merge-maintenance-review-gate.sh
+++ b/scripts/test-pr-merge-maintenance-review-gate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Regression: the merge train must fail closed until every reviewer has an
-# accepted review bound to the PR's exact current head.
+# Regression coverage for exact-head review/merge verification. Every rejection
+# fixture records attempted merges and asserts that no gh pr merge path is taken.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -11,56 +11,75 @@ cat >"$TMPDIR/gh" <<'GH'
 #!/usr/bin/env bash
 set -euo pipefail
 
+pr_json() {
+  jq -nc --arg sha "$1" '{number:1,title:"Safe merge fixture",draft:false,labels:[],user:{login:"xXKillerNoobYT"},head:{repo:{owner:{login:"xXKillerNoobYT"}},sha:$sha},mergeable:true,mergeable_state:"clean",auto_merge:null}'
+}
+reviews_json() {
+  jq -nc --arg sha "$1" '[[
+    {commit_id:$sha,state:"APPROVED",body:"LocalFirst\nVerdict: Pass",user:{login:"xXKillerNoobYT"}},
+    {commit_id:$sha,state:"APPROVED",body:"GPTReviewer\nVerdict: Accept",user:{login:"xXKillerNoobYT"}},
+    {commit_id:$sha,state:"APPROVED",body:"ClaudeReviewer\nVerdict: Accept",user:{login:"xXKillerNoobYT"}},
+    {commit_id:$sha,state:"APPROVED",body:"Copilot review",user:{login:"copilot-pull-request-reviewer[bot]"}}
+  ]]'
+}
+
 if [[ "${1:-}" == "api" ]]; then
   shift
-  if [[ " $* " == *" repos/xXKillerNoobYT/Weird-Part-Run-2/pulls?state=open&base=main&per_page=100 "* ]]; then
-    cat <<'JSON'
-[[{"number":42,"title":"Mock PR","draft":false,"labels":[],"user":{"login":"xXKillerNoobYT"},"head":{"repo":{"owner":{"login":"xXKillerNoobYT"}},"sha":"deadbeef"},"mergeable":true,"mergeable_state":"clean","auto_merge":null}]]
-JSON
+  if [[ "${1:-}" == "graphql" ]]; then
+    if [[ "$FIXTURE_MODE" == "review-thread-api-failure" ]]; then
+      exit 1
+    elif [[ "$FIXTURE_MODE" == "unresolved-review-thread" ]]; then
+      jq -nc '{data:{repository:{pullRequest:{headRefOid:"head-a",reviewThreads:{totalCount:1,nodes:[{isResolved:false}]}}}}}'
+    else
+      jq -nc '{data:{repository:{pullRequest:{headRefOid:"head-a",reviewThreads:{totalCount:0,nodes:[]}}}}}'
+    fi
     exit 0
   fi
-  if [[ " $* " == *" repos/xXKillerNoobYT/Weird-Part-Run-2/commits/deadbeef/check-runs "* ]]; then
-    printf '%s\n' '{"check_runs":[]}'
-    exit 0
-  fi
-  if [[ " $* " == *" repos/xXKillerNoobYT/Weird-Part-Run-2/pulls/42/reviews?per_page=100 "* ]]; then
-    printf '[%s]\n' "$MOCK_REVIEWS"
-    exit 0
-  fi
-  if [[ " $* " == *" graphql "* ]]; then
-    printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":0,"nodes":[]}}}}}'
-    exit 0
-  fi
+
+  endpoint=""
+  for arg in "$@"; do case "$arg" in repos/*) endpoint="$arg" ;; esac; done
+  case "$endpoint" in
+    *"/pulls?state=open&base=main&per_page=100")
+      pr_json "head-listed" | jq -s '[.]' ;;
+    "repos/xXKillerNoobYT/Weird-Part-Run-2/pulls/1")
+      count_file="$FIXTURE_DIR/current-pr-count"; count=0
+      [[ -f "$count_file" ]] && count="$(cat "$count_file")"
+      count=$((count + 1)); printf '%s' "$count" >"$count_file"
+      if [[ "$FIXTURE_MODE" == "head-change-after-listing" && "$count" -ge 2 ]]; then pr_json "head-b"; else pr_json "head-a"; fi ;;
+    "repos/xXKillerNoobYT/Weird-Part-Run-2/commits/head-a/check-runs"|"repos/xXKillerNoobYT/Weird-Part-Run-2/commits/head-b/check-runs")
+      jq -nc '{check_runs:[]}' ;;
+    "repos/xXKillerNoobYT/Weird-Part-Run-2/pulls/1/reviews?per_page=100")
+      [[ "$FIXTURE_MODE" == "review-api-failure" ]] && exit 1
+      reviews_json "head-a" ;;
+    *) echo "unexpected gh api endpoint: $endpoint ($*)" >&2; exit 1 ;;
+  esac
+  exit 0
 fi
 
-echo "unexpected gh invocation: $*" >&2
-exit 1
+if [[ "${1:-}" == "pr" && "${2:-}" == "merge" ]]; then
+  printf '%q ' "$@" >>"$FIXTURE_DIR/merge.log"; printf '\n' >>"$FIXTURE_DIR/merge.log"; exit 0
+fi
+echo "unexpected gh invocation: $*" >&2; exit 1
 GH
 chmod +x "$TMPDIR/gh"
 
-export PATH="$TMPDIR:$PATH"
-export PR_MAINTENANCE_DRY_RUN=1
+run_rejection_case() {
+  local mode="$1" expected="$2" fixture_dir="$TMPDIR/$1" output
+  mkdir -p "$fixture_dir"
+  output="$(PATH="$TMPDIR:$PATH" FIXTURE_MODE="$mode" FIXTURE_DIR="$fixture_dir" "$ROOT/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 2>&1)"
+  printf '%s\n' "$output" | grep -Fq "$expected"
+  test ! -s "$fixture_dir/merge.log"
+}
 
-missing_reviews='[{"commit_id":"deadbeef","state":"COMMENTED","body":"## LocalFirst exact-head review\nVerdict: Pass","user":{"login":"xXKillerNoobYT"}}]'
-stale_reviews='[{"commit_id":"oldhead","state":"COMMENTED","body":"## LocalFirst exact-head review\nVerdict: Pass","user":{"login":"xXKillerNoobYT"}},{"commit_id":"oldhead","state":"COMMENTED","body":"## GPTReviewer exact-head review\nVerdict: Accept","user":{"login":"xXKillerNoobYT"}},{"commit_id":"oldhead","state":"COMMENTED","body":"## ClaudeReviewer final exact-head review\nVerdict: Accept","user":{"login":"xXKillerNoobYT"}},{"commit_id":"oldhead","state":"COMMENTED","body":"Copilot review","user":{"login":"copilot-pull-request-reviewer[bot]"}}]'
-complete_reviews='[{"commit_id":"deadbeef","state":"COMMENTED","body":"## LocalFirst exact-head review\nVerdict: Pass","user":{"login":"xXKillerNoobYT"}},{"commit_id":"deadbeef","state":"COMMENTED","body":"## GPTReviewer exact-head review\nVerdict: Accept","user":{"login":"xXKillerNoobYT"}},{"commit_id":"deadbeef","state":"COMMENTED","body":"## ClaudeReviewer final exact-head review\nVerdict: Accept","user":{"login":"xXKillerNoobYT"}},{"commit_id":"deadbeef","state":"COMMENTED","body":"Copilot review","user":{"login":"copilot-pull-request-reviewer[bot]"}}]'
+# List data says head-listed; first fresh read binds head-a. The final read sees
+# head-b and must defer before an invocation is offered.
+run_rejection_case "head-change-after-listing" "head changed during final verification"
+run_rejection_case "review-api-failure" "could not read review evidence"
+run_rejection_case "review-thread-api-failure" "could not read review thread state"
+run_rejection_case "unresolved-review-thread" "review threads are unresolved"
 
-MOCK_REVIEWS="$missing_reviews" "$ROOT/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 >"$TMPDIR/missing.log" 2>&1
-grep -q 'current-head review lane incomplete' "$TMPDIR/missing.log"
-if grep -q 'dry-run: gh pr merge' "$TMPDIR/missing.log"; then
-  echo "merge was offered despite missing exact-head review lanes" >&2
-  exit 1
-fi
-
-MOCK_REVIEWS="$stale_reviews" "$ROOT/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 >"$TMPDIR/stale.log" 2>&1
-grep -q 'current-head review lane incomplete' "$TMPDIR/stale.log"
-if grep -q 'dry-run: gh pr merge' "$TMPDIR/stale.log"; then
-  echo "merge was offered using review evidence from an older head" >&2
-  exit 1
-fi
-
-MOCK_REVIEWS="$complete_reviews" "$ROOT/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 >"$TMPDIR/complete.log" 2>&1
-grep -q 'current-head review lanes satisfied' "$TMPDIR/complete.log"
-grep -q 'dry-run: gh pr merge' "$TMPDIR/complete.log"
+fixture_dir="$TMPDIR/merge-eligible"; mkdir -p "$fixture_dir"
+PATH="$TMPDIR:$PATH" FIXTURE_MODE="merge-eligible" FIXTURE_DIR="$fixture_dir" "$ROOT/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 >/dev/null
+grep -Fq -- '--match-head-commit head-a' "$fixture_dir/merge.log"
 
 echo "pr-merge-maintenance review-gate regression passed"

--- a/scripts/test-pr-merge-maintenance-review-gate.sh
+++ b/scripts/test-pr-merge-maintenance-review-gate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Regression coverage for exact-head review/merge verification. The fake gh
-# records every merge request so each rejection path proves it never reaches gh pr merge.
+# Regression: the merge train must fail closed until every reviewer has an
+# accepted review bound to the PR's exact current head.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -11,68 +11,26 @@ cat >"$TMPDIR/gh" <<'GH'
 #!/usr/bin/env bash
 set -euo pipefail
 
-pr_json() {
-  local sha="$1"
-  jq -nc --arg sha "$sha" '{
-    number: 1,
-    title: "Safe merge fixture",
-    draft: false,
-    labels: [],
-    user: {login: "xXKillerNoobYT"},
-    head: {repo: {owner: {login: "xXKillerNoobYT"}}, sha: $sha},
-    mergeable: true,
-    mergeable_state: "clean",
-    auto_merge: null
-  }'
-}
-
 if [[ "${1:-}" == "api" ]]; then
   shift
-  if [[ "${1:-}" == "graphql" ]]; then
-    case "${FIXTURE_MODE:?}" in
-      review-api-failure) exit 1 ;;
-      unresolved-review-thread)
-        jq -nc '{data:{repository:{pullRequest:{headRefOid:"head-a",latestReviews:{nodes:[{author:{login:"copilot-pull-request-reviewer[bot]"},state:"APPROVED"}]},reviewThreads:{totalCount:1,nodes:[{isResolved:false}]}}}}}'
-        exit 0 ;;
-      merge-eligible)
-        jq -nc '{data:{repository:{pullRequest:{headRefOid:"head-a",latestReviews:{nodes:[{author:{login:"copilot-pull-request-reviewer[bot]"},state:"APPROVED"}]},reviewThreads:{totalCount:0,nodes:[]}}}}}'
-        exit 0 ;;
-      *) echo "unexpected graphql fixture mode: $FIXTURE_MODE" >&2; exit 1 ;;
-    esac
+  if [[ " $* " == *" repos/xXKillerNoobYT/Weird-Part-Run-2/pulls?state=open&base=main&per_page=100 "* ]]; then
+    cat <<'JSON'
+[[{"number":42,"title":"Mock PR","draft":false,"labels":[],"user":{"login":"xXKillerNoobYT"},"head":{"repo":{"owner":{"login":"xXKillerNoobYT"}},"sha":"deadbeef"},"mergeable":true,"mergeable_state":"clean","auto_merge":null}]]
+JSON
+    exit 0
   fi
-
-  endpoint=""
-  for arg in "$@"; do
-    case "$arg" in repos/*) endpoint="$arg" ;; esac
-  done
-  case "$endpoint" in
-    *"/pulls?state=open&base=main&per_page=100")
-      # gh api --paginate --slurp returns an array of pages. The list head is
-      # intentionally stale; the script must not use it for eligibility.
-      pr_json "head-listed" | jq -s '[.]'
-      ;;
-    "repos/xXKillerNoobYT/Weird-Part-Run-2/pulls/1")
-      count_file="$FIXTURE_DIR/current-pr-count"
-      count=0; [[ -f "$count_file" ]] && count="$(cat "$count_file")"
-      count=$((count + 1)); printf '%s' "$count" >"$count_file"
-      if [[ "$FIXTURE_MODE" == "head-change-after-listing" && "$count" -ge 2 ]]; then
-        pr_json "head-b"
-      else
-        pr_json "head-a"
-      fi
-      ;;
-    "repos/xXKillerNoobYT/Weird-Part-Run-2/commits/head-a/check-runs"|"repos/xXKillerNoobYT/Weird-Part-Run-2/commits/head-b/check-runs")
-      jq -nc '{check_runs:[]}'
-      ;;
-    *) echo "unexpected gh api endpoint: $endpoint ($*)" >&2; exit 1 ;;
-  esac
-  exit 0
-fi
-
-if [[ "${1:-}" == "pr" && "${2:-}" == "merge" ]]; then
-  printf '%q ' "$@" >>"$FIXTURE_DIR/merge.log"
-  printf '\n' >>"$FIXTURE_DIR/merge.log"
-  exit 0
+  if [[ " $* " == *" repos/xXKillerNoobYT/Weird-Part-Run-2/commits/deadbeef/check-runs "* ]]; then
+    printf '%s\n' '{"check_runs":[]}'
+    exit 0
+  fi
+  if [[ " $* " == *" repos/xXKillerNoobYT/Weird-Part-Run-2/pulls/42/reviews?per_page=100 "* ]]; then
+    printf '[%s]\n' "$MOCK_REVIEWS"
+    exit 0
+  fi
+  if [[ " $* " == *" graphql "* ]]; then
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":0,"nodes":[]}}}}}'
+    exit 0
+  fi
 fi
 
 echo "unexpected gh invocation: $*" >&2
@@ -80,31 +38,29 @@ exit 1
 GH
 chmod +x "$TMPDIR/gh"
 
-run_case() {
-  local mode="$1" require_review="$2" expected="$3"
-  local fixture_dir="$TMPDIR/$mode"
-  local output
-  mkdir -p "$fixture_dir"
-  output="$(PATH="$TMPDIR:$PATH" FIXTURE_MODE="$mode" FIXTURE_DIR="$fixture_dir" \
-    PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW="$require_review" \
-    "$ROOT/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 2>&1)"
-  printf '%s\n' "$output" | grep -Fq "$expected"
-  test ! -s "$fixture_dir/merge.log"
-}
+export PATH="$TMPDIR:$PATH"
+export PR_MAINTENANCE_DRY_RUN=1
 
-# Fresh list validation succeeds on head-a; the final fresh read sees head-b and
-# must defer before invoking a merge.
-run_case "head-change-after-listing" 0 "head changed during final verification"
-run_case "review-api-failure" 1 "could not read review state (API failure)"
-run_case "unresolved-review-thread" 1 "1 unresolved review thread(s)"
+missing_reviews='[{"commit_id":"deadbeef","state":"COMMENTED","body":"## LocalFirst exact-head review\nVerdict: Pass","user":{"login":"xXKillerNoobYT"}}]'
+stale_reviews='[{"commit_id":"oldhead","state":"COMMENTED","body":"## LocalFirst exact-head review\nVerdict: Pass","user":{"login":"xXKillerNoobYT"}},{"commit_id":"oldhead","state":"COMMENTED","body":"## GPTReviewer exact-head review\nVerdict: Accept","user":{"login":"xXKillerNoobYT"}},{"commit_id":"oldhead","state":"COMMENTED","body":"## ClaudeReviewer final exact-head review\nVerdict: Accept","user":{"login":"xXKillerNoobYT"}},{"commit_id":"oldhead","state":"COMMENTED","body":"Copilot review","user":{"login":"copilot-pull-request-reviewer[bot]"}}]'
+complete_reviews='[{"commit_id":"deadbeef","state":"COMMENTED","body":"## LocalFirst exact-head review\nVerdict: Pass","user":{"login":"xXKillerNoobYT"}},{"commit_id":"deadbeef","state":"COMMENTED","body":"## GPTReviewer exact-head review\nVerdict: Accept","user":{"login":"xXKillerNoobYT"}},{"commit_id":"deadbeef","state":"COMMENTED","body":"## ClaudeReviewer final exact-head review\nVerdict: Accept","user":{"login":"xXKillerNoobYT"}},{"commit_id":"deadbeef","state":"COMMENTED","body":"Copilot review","user":{"login":"copilot-pull-request-reviewer[bot]"}}]'
 
-# A green exact-head review may reach the merge command only with the server-side
-# match guard that rejects a post-verification force-push.
-fixture_dir="$TMPDIR/merge-eligible"
-mkdir -p "$fixture_dir"
-PATH="$TMPDIR:$PATH" FIXTURE_MODE="merge-eligible" FIXTURE_DIR="$fixture_dir" \
-  PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW=1 \
-  "$ROOT/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 >/dev/null
-grep -Fq -- '--match-head-commit head-a' "$fixture_dir/merge.log"
+MOCK_REVIEWS="$missing_reviews" "$ROOT/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 >"$TMPDIR/missing.log" 2>&1
+grep -q 'current-head review lane incomplete' "$TMPDIR/missing.log"
+if grep -q 'dry-run: gh pr merge' "$TMPDIR/missing.log"; then
+  echo "merge was offered despite missing exact-head review lanes" >&2
+  exit 1
+fi
+
+MOCK_REVIEWS="$stale_reviews" "$ROOT/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 >"$TMPDIR/stale.log" 2>&1
+grep -q 'current-head review lane incomplete' "$TMPDIR/stale.log"
+if grep -q 'dry-run: gh pr merge' "$TMPDIR/stale.log"; then
+  echo "merge was offered using review evidence from an older head" >&2
+  exit 1
+fi
+
+MOCK_REVIEWS="$complete_reviews" "$ROOT/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 >"$TMPDIR/complete.log" 2>&1
+grep -q 'current-head review lanes satisfied' "$TMPDIR/complete.log"
+grep -q 'dry-run: gh pr merge' "$TMPDIR/complete.log"
 
 echo "pr-merge-maintenance review-gate regression passed"

--- a/scripts/test-pr-merge-maintenance-review-gate.sh
+++ b/scripts/test-pr-merge-maintenance-review-gate.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Regression coverage for exact-head review/merge verification. The fake gh
+# records every merge request so each rejection path proves it never reaches gh pr merge.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+pr_json() {
+  local sha="$1"
+  jq -nc --arg sha "$sha" '{
+    number: 1,
+    title: "Safe merge fixture",
+    draft: false,
+    labels: [],
+    user: {login: "xXKillerNoobYT"},
+    head: {repo: {owner: {login: "xXKillerNoobYT"}}, sha: $sha},
+    mergeable: true,
+    mergeable_state: "clean",
+    auto_merge: null
+  }'
+}
+
+if [[ "${1:-}" == "api" ]]; then
+  shift
+  if [[ "${1:-}" == "graphql" ]]; then
+    case "${FIXTURE_MODE:?}" in
+      review-api-failure) exit 1 ;;
+      unresolved-review-thread)
+        jq -nc '{data:{repository:{pullRequest:{headRefOid:"head-a",latestReviews:{nodes:[{author:{login:"copilot-pull-request-reviewer[bot]"},state:"APPROVED"}]},reviewThreads:{totalCount:1,nodes:[{isResolved:false}]}}}}}'
+        exit 0 ;;
+      merge-eligible)
+        jq -nc '{data:{repository:{pullRequest:{headRefOid:"head-a",latestReviews:{nodes:[{author:{login:"copilot-pull-request-reviewer[bot]"},state:"APPROVED"}]},reviewThreads:{totalCount:0,nodes:[]}}}}}'
+        exit 0 ;;
+      *) echo "unexpected graphql fixture mode: $FIXTURE_MODE" >&2; exit 1 ;;
+    esac
+  fi
+
+  endpoint=""
+  for arg in "$@"; do
+    case "$arg" in repos/*) endpoint="$arg" ;; esac
+  done
+  case "$endpoint" in
+    *"/pulls?state=open&base=main&per_page=100")
+      # gh api --paginate --slurp returns an array of pages. The list head is
+      # intentionally stale; the script must not use it for eligibility.
+      pr_json "head-listed" | jq -s '[.]'
+      ;;
+    "repos/xXKillerNoobYT/Weird-Part-Run-2/pulls/1")
+      count_file="$FIXTURE_DIR/current-pr-count"
+      count=0; [[ -f "$count_file" ]] && count="$(cat "$count_file")"
+      count=$((count + 1)); printf '%s' "$count" >"$count_file"
+      if [[ "$FIXTURE_MODE" == "head-change-after-listing" && "$count" -ge 2 ]]; then
+        pr_json "head-b"
+      else
+        pr_json "head-a"
+      fi
+      ;;
+    "repos/xXKillerNoobYT/Weird-Part-Run-2/commits/head-a/check-runs"|"repos/xXKillerNoobYT/Weird-Part-Run-2/commits/head-b/check-runs")
+      jq -nc '{check_runs:[]}'
+      ;;
+    *) echo "unexpected gh api endpoint: $endpoint ($*)" >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "merge" ]]; then
+  printf '%q ' "$@" >>"$FIXTURE_DIR/merge.log"
+  printf '\n' >>"$FIXTURE_DIR/merge.log"
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+GH
+chmod +x "$TMPDIR/gh"
+
+run_case() {
+  local mode="$1" require_review="$2" expected="$3"
+  local fixture_dir="$TMPDIR/$mode"
+  local output
+  mkdir -p "$fixture_dir"
+  output="$(PATH="$TMPDIR:$PATH" FIXTURE_MODE="$mode" FIXTURE_DIR="$fixture_dir" \
+    PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW="$require_review" \
+    "$ROOT/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 2>&1)"
+  printf '%s\n' "$output" | grep -Fq "$expected"
+  test ! -s "$fixture_dir/merge.log"
+}
+
+# Fresh list validation succeeds on head-a; the final fresh read sees head-b and
+# must defer before invoking a merge.
+run_case "head-change-after-listing" 0 "head changed during final verification"
+run_case "review-api-failure" 1 "could not read review state (API failure)"
+run_case "unresolved-review-thread" 1 "1 unresolved review thread(s)"
+
+# A green exact-head review may reach the merge command only with the server-side
+# match guard that rejects a post-verification force-push.
+fixture_dir="$TMPDIR/merge-eligible"
+mkdir -p "$fixture_dir"
+PATH="$TMPDIR:$PATH" FIXTURE_MODE="merge-eligible" FIXTURE_DIR="$fixture_dir" \
+  PR_MAINTENANCE_REQUIRE_COPILOT_REVIEW=1 \
+  "$ROOT/scripts/pr-merge-maintenance.sh" xXKillerNoobYT/Weird-Part-Run-2 >/dev/null
+grep -Fq -- '--match-head-commit head-a' "$fixture_dir/merge.log"
+
+echo "pr-merge-maintenance review-gate regression passed"


### PR DESCRIPTION
## Summary
- make the serialized merge predicate fail closed unless LocalFirst, GPT, Claude, and Copilot each have valid evidence at the exact current PR head
- reject unresolved or uninspectable review threads, and reset readiness automatically when a head changes
- add a fixture proving missing and stale review evidence never reaches `gh pr merge`

## Validation
- `bash -n scripts/pr-merge-maintenance.sh`
- `scripts/test-pr-merge-maintenance-pagination.sh`
- `scripts/test-pr-merge-maintenance-review-gate.sh`
- `git diff --check`

## Governance evidence
PR #1465 was merged by scheduled `PR Merge Maintenance` run 30381614862 at 17:09:50Z before its exact-head LocalFirst review (17:11:29Z). This PR repairs that predicate.

Closes #1541
Tracked in WEI-6480.