### PR TITLE
[Warehouse][Bug] Restore Audit search on compact iPhone

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAuditPage.swift
@@ -134,7 +134,11 @@ struct IOSAuditPage: View {
             }
         }
         .navigationTitle("Warehouse Audit")
-        .searchable(text: $searchText, prompt: "Search parts...")
+        .searchable(
+            text: $searchText,
+            placement: .navigationBarDrawer(displayMode: .always),
+            prompt: "Search parts..."
+        )
         .onChange(of: searchText) { _, _ in postAIContext() }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {

--- a/Weird Parts IOS/Weird Parts IOSUITests/WarehouseAuditSearchUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/WarehouseAuditSearchUITests.swift
@@ -49,7 +49,7 @@ final class WarehouseAuditSearchUITests: XCTestCase {
         XCTAssertTrue(dashboardTab.waitForExistence(timeout: 5), "The adjacent Warehouse Dashboard tab should be reachable.")
         XCTAssertTrue(dashboardTab.isHittable, "The Dashboard tab should be tappable from Audit.")
         dashboardTab.tap()
-        XCTAssertTrue(searchField.waitForNonExistence(timeout: 5), "Leaving Audit should remove its search control and inactive page context.")
+        XCTAssertFalse(searchField.waitForExistence(timeout: 5), "Leaving Audit should remove its search control and inactive page context.")
 
         XCTAssertTrue(auditTab.waitForExistence(timeout: 5), "The Audit tab should remain reachable after the context transition.")
         auditTab.tap()

--- a/Weird Parts IOS/Weird Parts IOSUITests/WarehouseAuditSearchUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/WarehouseAuditSearchUITests.swift
@@ -1,0 +1,69 @@
+import XCTest
+
+final class WarehouseAuditSearchUITests: XCTestCase {
+    private static let uiTestingPIN = "8396"
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testCompactAuditSearchRevealFocusTypeClearAndTabRefresh() throws {
+        let app = XCUIApplication()
+        app.launchEnvironment["WEIRD_PARTS_UI_TEST_PIN"] = Self.uiTestingPIN
+        app.launchEnvironment["OS_ACTIVITY_MODE"] = "disable"
+        app.launchEnvironment["UITEST_DISABLE_ANIMATIONS"] = "1"
+        app.launchArguments += [
+            "-UITesting",
+            "-UITestingWEI936AutoLogin",
+            "-UITestingDispatchBoard",
+            "-UITestingWarehouseDashboard",
+        ]
+        app.launch()
+
+        let auditTab = app.descendants(matching: .any)["subtab_warehouse-audit"].firstMatch
+        XCTAssertTrue(auditTab.waitForExistence(timeout: 20), "The Warehouse Audit tab should be reachable from the Dashboard.")
+        XCTAssertTrue(auditTab.isHittable, "The adjacent Audit tab should be tappable in compact layout.")
+        auditTab.tap()
+        XCTAssertTrue(app.navigationBars["Warehouse Audit"].waitForExistence(timeout: 10), "Tapping Audit should open Warehouse Audit.")
+
+        let searchField = app.searchFields["Search parts..."]
+        if !searchField.waitForExistence(timeout: 3) {
+            app.swipeDown()
+        }
+        XCTAssertTrue(searchField.waitForExistence(timeout: 5), "Audit search must be user-reachable in compact iPhone layout.")
+        XCTAssertTrue(searchField.isHittable, "Audit search must be focusable without an inaccessible navigation gesture.")
+        attachScreenshot(named: "01-audit-search-revealed", app: app)
+
+        searchField.tap()
+        searchField.typeText("UITEST-MUV-001")
+        XCTAssertEqual(searchField.value as? String, "UITEST-MUV-001", "Audit search should accept part names or codes.")
+        attachScreenshot(named: "02-audit-search-typed", app: app)
+
+        let clearButton = app.buttons["Clear text"].firstMatch
+        XCTAssertTrue(clearButton.waitForExistence(timeout: 3), "Focused Audit search should expose the standard clear action.")
+        clearButton.tap()
+        XCTAssertEqual(searchField.value as? String, "Search parts...", "Clearing Audit search should restore the prompt and refresh empty-search context.")
+
+        let dashboardTab = app.descendants(matching: .any)["subtab_warehouse-dashboard"].firstMatch
+        XCTAssertTrue(dashboardTab.waitForExistence(timeout: 5), "The adjacent Warehouse Dashboard tab should be reachable.")
+        XCTAssertTrue(dashboardTab.isHittable, "The Dashboard tab should be tappable from Audit.")
+        dashboardTab.tap()
+        XCTAssertTrue(searchField.waitForNonExistence(timeout: 5), "Leaving Audit should remove its search control and inactive page context.")
+
+        XCTAssertTrue(auditTab.waitForExistence(timeout: 5), "The Audit tab should remain reachable after the context transition.")
+        auditTab.tap()
+        XCTAssertTrue(searchField.waitForExistence(timeout: 10), "Returning to Audit should recreate its search control and active page context.")
+        searchField.tap()
+        searchField.typeText("context-refresh")
+        XCTAssertEqual(searchField.value as? String, "context-refresh", "Search should remain interactive after Audit page-context reactivation.")
+        attachScreenshot(named: "03-audit-search-context-refreshed", app: app)
+    }
+
+    private func attachScreenshot(named name: String, app: XCUIApplication) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
## Summary

Repairs the current-main conflict in the superseding PR by rebuilding it from current `main` and replaying only the original Warehouse Audit search delta:

- makes the compact Audit search drawer always visible/reachable via `.navigationBarDrawer(displayMode: .always)`
- restores the iPhone/iPad user-flow regression for Dashboard → Audit → reveal/focus/type/clear → Dashboard → Audit → type
- includes the source branch’s UI-test API correction (`waitForExistence` negation)

The old 20-commit stacked page-context payload was intentionally not replayed: it conflicts with #1470, whose equivalent page-context infrastructure is now in `main`.

## Provenance

- Current base: `0e32726664b8730d25bccdcf7cb9a79cc685b55b`
- Successor head: `9bab4e244ac30cba51eac9afa1d4aea1abecf9a0`
- Refiles/replaces closed stacked PR #1474; source fix is #1473 / `b3e7661131a1512d16e87fe68111241f72c8990e`.
- Source test correction: `a52a365cae5a6491ccaf77a77034cc541c205742`.

## Verification

- `git diff --check origin/main...HEAD`
- Focused iPhone + iPad XCUITest in progress on this exact head; result bundles will be attached to the linked Paperclip repair record.
- iOS Beta Gate is expected to run on the trusted self-hosted Mac runner (`[self-hosted, macOS, ARM64, xcode, ios, local-mac]`) after this push.

Closes #1473
Refs #86
Refs #499
Tracked in WEI-6582
Parent: WEI-6077