### PR TITLE
ci: allow curated media locations in artifact guard

### DIFF
--- a/scripts/guard-tracked-artifacts.py
+++ b/scripts/guard-tracked-artifacts.py
@@ -57,12 +57,25 @@ ALLOWED_EXAMPLES = [
 # screenshot/evidence dump that belongs in a GitHub issue or PR attachment
 # (see docs/testing/artifacts/README.md for the policy).
 IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".heic", ".webp"}
-IMAGE_ALLOWED_PREFIXES = ("docs/problems/",)
-IMAGE_ALLOWED_PATH_PARTS = {"Assets.xcassets"}
+IMAGE_ALLOWED_PREFIXES = (
+    "docs/problems/",
+    # Curated App Store listing screenshots (docs/app-store/description.md).
+    "docs/app-store/screenshots/",
+    # README showcase images governed by docs/readme-assets/README-ASSET-REVIEW.md.
+    "docs/readme-assets/",
+)
+# Asset catalogs and Icon Composer bundles ship real app imagery.
+IMAGE_ALLOWED_PATH_PARTS = {"Assets.xcassets", "AppIcon.icon"}
 
 # Any tracked file larger than this is presumed to be a build artifact or
 # media dump; raise the limit deliberately if a legitimate need appears.
 MAX_TRACKED_FILE_BYTES = 1_000_000
+
+# Deliberate per-file exceptions to the size cap (path -> max bytes).
+LARGE_FILE_EXCEPTIONS = {
+    # Owner's Icon Composer source artwork for the app icon (2.6 MB PNG).
+    "Weird Parts IOS/Weird Parts IOS/AppIcon.icon/Assets/Copilot_20260315_163221.png": 3_000_000,
+}
 
 
 BLOCKED_SUFFIXES = {
@@ -174,7 +187,8 @@ def main() -> int:
             size = os.path.getsize(path)
         except OSError:
             continue
-        if size > MAX_TRACKED_FILE_BYTES:
+        limit = LARGE_FILE_EXCEPTIONS.get(path, MAX_TRACKED_FILE_BYTES)
+        if size > limit:
             oversized.append(f"{path} ({size / 1_000_000:.1f} MB)")
 
     if blocked or oversized:


### PR DESCRIPTION
## Summary

The Tracked artifact guard correctly blocks stray media, but its allowlist predates having legitimate curated media in-repo. Three open PRs fail it: #1563 (App Store screenshots), #1565 (README showcase images), #1560 (Icon Composer bundle). This adds exactly those locations:

- `docs/app-store/screenshots/` — the store listing package (`docs/app-store/description.md`)
- `docs/readme-assets/` — governed by its asset-review register
- `AppIcon.icon` path component — Icon Composer bundles are app imagery like `Assets.xcassets`
- `LARGE_FILE_EXCEPTIONS`: one deliberate entry for the owner's 2.6 MB icon source PNG (cap mechanism stays for everything else)

Validation: `--self-test` passes; full guard run on this checkout passes. Merge this first, then #1560/#1563/#1565 rebase clean.

## CI

Required checks run on the local self-hosted Mac runner lane (`[self-hosted, macOS, ARM64, xcode, ios, local-mac]`). Diff reviewed pre-merge per the agent review-first policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)