### PR TITLE
feat: commit per-channel release version files (App verison trigger)

### DIFF
--- a/App verison/INTERNAL-BETA.md
+++ b/App verison/INTERNAL-BETA.md
@@ -1,0 +1,7 @@
+channel: internal-beta
+group: Home Base
+version: 1.0.0
+build: auto (Xcode Cloud manages build numbers)
+last-updated: 2026-08-01
+notes-file: docs/app-store/testflight-notes/
+review: none

--- a/App verison/PUBLIC-BETA.md
+++ b/App verison/PUBLIC-BETA.md
@@ -1,0 +1,8 @@
+channel: public-beta
+group: Camp 1
+version: 0.0.0
+build: none-yet
+last-updated: 2026-08-01
+notes-file: docs/app-store/testflight-notes/
+review: apple-beta-review
+cadence-cap: one push per 5-9 days, owner-gated

--- a/App verison/PUBLIC-RELEASE.md
+++ b/App verison/PUBLIC-RELEASE.md
@@ -1,0 +1,7 @@
+channel: public-release
+version: 0.0.0
+build: none-yet
+last-updated: 2026-08-01
+notes-file: docs/app-store/testflight-notes/
+review: apple-app-review
+gate: owner-only

--- a/App verison/README.md
+++ b/App verison/README.md
@@ -1,0 +1,18 @@
+# App verison/ — release channel triggers
+
+One machine-parseable file per release channel. **The folder name's spelling is
+load-bearing** — Xcode Cloud Branch-Changes conditions reference it URL-encoded
+(`App%20verison`); do not rename. NOTE: until 2026-08-01 this folder existed
+only as an untracked local file on the shared Mac, so cloud conditions watching
+it could never fire — this commit makes the trigger real.
+
+- `INTERNAL-BETA.md` — Home Base group. Bumping it produces an internal build
+  automatically (no Apple review).
+- `PUBLIC-BETA.md` — Camp 1 external group (public link). Full Xcode Cloud
+  workflow + Apple beta review. HARD CAP: one push per 5–9 days, owner-gated.
+- `PUBLIC-RELEASE.md` — App Store. Owner-gated.
+
+Rules (owner spec, 2026-07-31): bump a channel file ONLY in the same commit/PR
+as everything its build needs (notes written, fixes merged). Strict `key: value`
+format so any agent or bot can parse and bump. Replaces the original single
+`Version File.md`.


### PR DESCRIPTION
## What

Implements the owner's spec from the local `App verison/Version File.md` ("one file for each to replace this… do it right for me"): `INTERNAL-BETA.md`, `PUBLIC-BETA.md`, `PUBLIC-RELEASE.md` in strict key:value form + a README covering trigger mechanics, the external 5–9-day cadence cap, and the bump-with-everything rule.

## Notable discovery

The `App verison/` folder was **never committed** — it existed only as an untracked local file on the shared Mac, so the Xcode Cloud Branch-Changes condition pointing at it (`App%20verison`) could never fire. This PR makes that trigger real for the first time. (Recent internal builds came from other workflow conditions.)

## Owner follow-up (Xcode Cloud UI, can't be done from here)

Point each channel's workflow at its own file: internal → `INTERNAL-BETA.md`, the external Camp 1 workflow → `PUBLIC-BETA.md` — so bumping one channel never triggers another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)