### PR TITLE
feat(panel): redesign domain layer — slice 1 (voltage systems, catalog, entries, math)

### DIFF
--- a/core/Sources/WiredPartCore/Models/Notebooks/PanelScheduleDesign.swift
+++ b/core/Sources/WiredPartCore/Models/Notebooks/PanelScheduleDesign.swift
@@ -1,0 +1,310 @@
+import Foundation
+
+// Panel Schedule Builder visual redesign — domain layer (slice 1).
+// Spec: docs/plans/panel-schedule-builder-visual-redesign.md §2–§3.
+// Additive alongside PanelScheduleModels.swift: `CircuitEntry` and the
+// #1514/#1515 validation invariants stay authoritative for persisted
+// schedules; this layer models the redesigned builder's richer space
+// entries and electrical math. UI colors are hex strings here — core is
+// UI-framework-free.
+
+// MARK: - Voltage systems
+
+/// The service voltage systems the panel setup sheet offers.
+public enum PanelVoltageSystem: String, Codable, Sendable, CaseIterable {
+    case v120Single2Wire = "120V 1Ø 2-wire"
+    case v120_240Single3Wire = "120/240V 1Ø 3-wire"
+    case v120_208Three = "120/208V 3Ø"
+    case v277_480Three = "277/480V 3Ø"
+
+    /// Line-to-neutral volts (single-pole circuits).
+    public var vln: Double {
+        switch self {
+        case .v120Single2Wire, .v120_240Single3Wire, .v120_208Three: return 120
+        case .v277_480Three: return 277
+        }
+    }
+
+    /// Line-to-line volts (2/3-pole circuits).
+    public var vll: Double {
+        switch self {
+        case .v120Single2Wire: return 120
+        case .v120_240Single3Wire: return 240
+        case .v120_208Three: return 208
+        case .v277_480Three: return 480
+        }
+    }
+
+    /// Number of phase legs feeding the panel.
+    public var legCount: Int {
+        switch self {
+        case .v120Single2Wire: return 1
+        case .v120_240Single3Wire: return 2
+        case .v120_208Three, .v277_480Three: return 3
+        }
+    }
+
+    /// Leg (0-based) serving a given space number.
+    /// `phaseFor(space) = legs[(ceil(space/2) - 1) % legCount]` per spec §2.
+    public func legIndex(forSpace space: Int) -> Int {
+        let row = (space + 1) / 2 // ceil(space/2) for positive ints
+        return (row - 1).quotientAndRemainder(dividingBy: legCount).remainder
+    }
+}
+
+/// Phase-leg display metadata (letters + hex colors per spec §2).
+public enum PanelPhaseLeg: Int, CaseIterable, Sendable {
+    case a = 0, b = 1, c = 2
+
+    public var letter: String { ["A", "B", "C"][rawValue] }
+    public var colorHex: String { ["#0A84FF", "#FF9F0A", "#BF5AF2"][rawValue] }
+    /// Tie accent for 240V pairs inside quads (spec §2).
+    public static let tieColorHex = "#5E5CE6"
+}
+
+// MARK: - Breaker type catalog
+
+/// The redesigned color-coded breaker type catalog (spec §2 table).
+/// Distinct from the legacy `BreakerType` persistence enum — a design entry
+/// describes protection function; the space entry's kind describes form.
+public enum DesignBreakerType: String, Codable, Sendable, CaseIterable {
+    case standard = "STD"
+    case gfci = "GFCI"
+    case afci = "AFCI"
+    case dualFunction = "DF"
+    case gfpe = "GFPE"
+    case hacr = "HACR"
+    case general = "GEN"
+    case spare = "SPARE"
+
+    public var displayName: String {
+        switch self {
+        case .standard: return "Standard"
+        case .gfci: return "GFCI"
+        case .afci: return "AFCI"
+        case .dualFunction: return "Dual-Fn"
+        case .gfpe: return "GFPE"
+        case .hacr: return "HACR"
+        case .general: return "General"
+        case .spare: return "Spare"
+        }
+    }
+
+    /// Short code printed on schedules (spec: AFCI prints "CAFI").
+    public var shortCode: String {
+        switch self {
+        case .afci: return "CAFI"
+        case .spare: return "—"
+        default: return rawValue
+        }
+    }
+
+    public var colorHex: String {
+        switch self {
+        case .standard: return "#0A84FF"
+        case .gfci: return "#00B0A6"
+        case .afci: return "#FF9F0A"
+        case .dualFunction: return "#BF5AF2"
+        case .gfpe: return "#FF375F"
+        case .hacr: return "#30D158"
+        case .general: return "#8E8E93"
+        case .spare: return "#C7C7CC"
+        }
+    }
+
+    /// Types offered for tandem halves (spec §2 amp/type constraints).
+    public static let tandemAllowed: [DesignBreakerType] = [.standard, .gfci, .afci, .dualFunction]
+    /// Types offered for quad 2-pole sections.
+    public static let quadTwoPoleAllowed: [DesignBreakerType] = [.standard, .hacr, .gfpe, .gfci]
+
+    /// Amp choices per context (spec §2).
+    public static let fullAmpChoices = [15, 20, 25, 30, 40, 50, 60, 70, 90, 100]
+    public static let tandemHalfAmpChoices = [15, 20, 30]
+    public static let quadTwoPoleAmpChoices = [15, 20, 30, 40, 50, 60]
+}
+
+// MARK: - Space entries
+
+/// One sub-circuit inside a space entry (a tandem half, a quad section, or
+/// the single circuit of a full entry).
+public struct DesignSubCircuit: Codable, Sendable, Equatable {
+    public var amps: Int
+    public var type: DesignBreakerType
+    /// Connected ("used") amps for load math — the value behind the A/W toggle.
+    public var usedAmps: Double
+    public var name: String
+    public var note: String
+
+    public init(amps: Int, type: DesignBreakerType = .standard, usedAmps: Double = 0, name: String = "", note: String = "") {
+        self.amps = amps
+        self.type = type
+        self.usedAmps = usedAmps
+        self.name = name
+        self.note = note
+    }
+}
+
+/// Quad occupancy modes (spec §2).
+public enum QuadMode: String, Codable, Sendable, CaseIterable {
+    /// Four independent 120V singles (labels 8a, 8b, 10a, 10b).
+    case four
+    /// Outer singles + tied inner 2-pole 240V (e.g. 20·30·20; label 8–10).
+    case center
+    /// Two independent 2-pole breakers (e.g. 30/50; labels 8–10↑, 8–10↓).
+    case double
+}
+
+/// A redesigned panel space entry. A panel maps space numbers to entries;
+/// entries with poles > 1 or quad kinds span additional same-side spaces.
+public enum DesignSpaceEntry: Codable, Sendable, Equatable {
+    /// Standard breaker: 1/2/3 poles spanning s, s+2, s+4 on one side.
+    case full(poles: Int, circuit: DesignSubCircuit)
+    /// Twin — two half-width circuits in ONE space, both on that space's leg.
+    case tandem(upper: DesignSubCircuit, lower: DesignSubCircuit)
+    /// Quad — occupies s and s+2, contents per mode. `sections` are ordered
+    /// top-to-bottom (four: 4 singles; center: [outerTop, inner2P, outerBottom];
+    /// double: [upper2P, lower2P]).
+    case quad(mode: QuadMode, sections: [DesignSubCircuit])
+
+    /// Spaces this entry occupies when anchored at `space`.
+    public func occupiedSpaces(anchoredAt space: Int) -> [Int] {
+        switch self {
+        case .full(let poles, _):
+            return (0..<max(poles, 1)).map { space + $0 * 2 }
+        case .tandem:
+            return [space]
+        case .quad:
+            return [space, space + 2]
+        }
+    }
+
+    /// Sub-circuits with the leg offset (in same-side steps) each one loads.
+    /// Offsets feed `PanelVoltageSystem.legIndex(forSpace: space + 2*offset)`.
+    /// Multi-pole circuits appear once per spanned leg with their VA split
+    /// handled by the math layer (spec §3).
+    public var sections: [DesignSubCircuit] {
+        switch self {
+        case .full(_, let circuit): return [circuit]
+        case .tandem(let upper, let lower): return [upper, lower]
+        case .quad(_, let sections): return sections
+        }
+    }
+}
+
+// MARK: - Electrical math (spec §3)
+
+public enum PanelPhaseMath {
+    /// Volts seen by a circuit of the given pole count.
+    public static func circuitVolts(poles: Int, system: PanelVoltageSystem) -> Double {
+        poles >= 2 ? system.vll : system.vln
+    }
+
+    /// Connected VA for a circuit (spec: 3-pole uses vll·√3).
+    public static func watts(amps: Double, poles: Int, system: PanelVoltageSystem) -> Double {
+        guard amps > 0 else { return 0 }
+        if poles >= 3 { return amps * system.vll * 3.0.squareRoot() }
+        return amps * circuitVolts(poles: poles, system: system)
+    }
+
+    /// Per-leg connected VA for one anchored entry (spec §3 splitting rules).
+    /// Returns a `legCount`-sized array.
+    public static func perLegVA(
+        entry: DesignSpaceEntry,
+        anchoredAt space: Int,
+        system: PanelVoltageSystem
+    ) -> [Double] {
+        var legs = [Double](repeating: 0, count: system.legCount)
+        func add(_ va: Double, toLegOfSpace s: Int) {
+            legs[system.legIndex(forSpace: s)] += va
+        }
+        switch entry {
+        case .full(let poles, let circuit):
+            guard circuit.type != .spare else { break }
+            let total = watts(amps: circuit.usedAmps, poles: poles, system: system)
+            let spanned = entry.occupiedSpaces(anchoredAt: space)
+            for s in spanned { add(total / Double(spanned.count), toLegOfSpace: s) }
+        case .tandem(let upper, let lower):
+            for half in [upper, lower] where half.type != .spare {
+                add(watts(amps: half.usedAmps, poles: 1, system: system), toLegOfSpace: space)
+            }
+        case .quad(let mode, let sections):
+            switch mode {
+            case .four:
+                // Top two on leg(space); bottom two on leg(space+2).
+                for (index, section) in sections.prefix(4).enumerated() where section.type != .spare {
+                    let s = index < 2 ? space : space + 2
+                    add(watts(amps: section.usedAmps, poles: 1, system: system), toLegOfSpace: s)
+                }
+            case .center:
+                // [outerTop(1P @space), inner 2P (split across both), outerBottom(1P @space+2)]
+                if sections.indices.contains(0), sections[0].type != .spare {
+                    add(watts(amps: sections[0].usedAmps, poles: 1, system: system), toLegOfSpace: space)
+                }
+                if sections.indices.contains(1), sections[1].type != .spare {
+                    let inner = watts(amps: sections[1].usedAmps, poles: 2, system: system)
+                    add(inner / 2, toLegOfSpace: space)
+                    add(inner / 2, toLegOfSpace: space + 2)
+                }
+                if sections.indices.contains(2), sections[2].type != .spare {
+                    add(watts(amps: sections[2].usedAmps, poles: 1, system: system), toLegOfSpace: space + 2)
+                }
+            case .double:
+                // Two independent 2-pole breakers; each splits across both legs.
+                for section in sections.prefix(2) where section.type != .spare {
+                    let va = watts(amps: section.usedAmps, poles: 2, system: system)
+                    add(va / 2, toLegOfSpace: space)
+                    add(va / 2, toLegOfSpace: space + 2)
+                }
+            }
+        }
+        return legs
+    }
+
+    /// Balanced service amps from a total connected VA (spec §3).
+    public static func serviceAmps(totalVA: Double, system: PanelVoltageSystem) -> Double {
+        guard totalVA > 0 else { return 0 }
+        switch system {
+        case .v120_208Three, .v277_480Three:
+            return totalVA / (3.0.squareRoot() * system.vll)
+        case .v120_240Single3Wire:
+            return totalVA / system.vll
+        case .v120Single2Wire:
+            return totalVA / system.vln
+        }
+    }
+
+    /// Editor "Estimate" helper: 80% of breaker size (spec §3).
+    public static func estimatedUsedAmps(forBreakerAmps amps: Int) -> Double {
+        Double(amps) * 0.8
+    }
+
+    /// Standard service/OCPD sizes for the "Min. service" print field (§5).
+    public static let standardServiceSizes = [
+        60, 100, 125, 150, 175, 200, 225, 250, 300, 350, 400,
+        450, 500, 600, 700, 800, 1000, 1200,
+    ]
+
+    /// Next standard size at or above `amps` (caps at the largest listed).
+    public static func nextStandardServiceSize(atLeast amps: Double) -> Int {
+        standardServiceSizes.first { Double($0) >= amps } ?? standardServiceSizes[standardServiceSizes.count - 1]
+    }
+
+    /// Copper THHN wire-size auto-column (spec §5 table).
+    public static func wireSize(forBreakerAmps amps: Int) -> String? {
+        switch amps {
+        case ...0: return nil
+        case ...15: return "#14 Cu"
+        case ...20: return "#12 Cu"
+        case ...30: return "#10 Cu"
+        case ...50: return "#8 Cu"
+        case ...60: return "#6 Cu"
+        case ...70: return "#4 Cu"
+        case ...100: return "#3 Cu"
+        case ...125: return "#1 Cu"
+        case ...150: return "#1/0 Cu"
+        case ...175: return "#2/0 Cu"
+        case ...200: return "#3/0 Cu"
+        default: return nil
+        }
+    }
+}

--- a/core/Tests/WiredPartCoreTests/PanelScheduleDesignTests.swift
+++ b/core/Tests/WiredPartCoreTests/PanelScheduleDesignTests.swift
@@ -1,0 +1,185 @@
+import Testing
+@testable import WiredPartCore
+
+// Slice-1 test matrix for the panel redesign domain layer
+// (docs/plans/panel-schedule-builder-visual-redesign.md §7.8):
+// phase-total math across entry kinds × quad modes × voltage systems,
+// occupancy, next-standard-size, and the wire-size table.
+@Suite("Panel redesign domain math")
+struct PanelScheduleDesignTests {
+
+    // MARK: Voltage systems + leg mapping
+
+    @Test("Voltage systems expose spec vln/vll/legCount")
+    func voltageSystems() {
+        #expect(PanelVoltageSystem.v120Single2Wire.legCount == 1)
+        #expect(PanelVoltageSystem.v120_240Single3Wire.vll == 240)
+        #expect(PanelVoltageSystem.v120_208Three.vln == 120)
+        #expect(PanelVoltageSystem.v120_208Three.vll == 208)
+        #expect(PanelVoltageSystem.v277_480Three.vln == 277)
+        #expect(PanelVoltageSystem.v277_480Three.legCount == 3)
+    }
+
+    @Test("Leg mapping follows ceil(space/2) rotation")
+    func legMapping() {
+        let three = PanelVoltageSystem.v120_208Three
+        // Rows: (1,2)→A, (3,4)→B, (5,6)→C, (7,8)→A …
+        #expect(three.legIndex(forSpace: 1) == 0)
+        #expect(three.legIndex(forSpace: 2) == 0)
+        #expect(three.legIndex(forSpace: 3) == 1)
+        #expect(three.legIndex(forSpace: 6) == 2)
+        #expect(three.legIndex(forSpace: 7) == 0)
+        let split = PanelVoltageSystem.v120_240Single3Wire
+        #expect(split.legIndex(forSpace: 1) == 0)
+        #expect(split.legIndex(forSpace: 3) == 1)
+        #expect(split.legIndex(forSpace: 5) == 0)
+    }
+
+    // MARK: Watts
+
+    @Test("Watts: 1P uses vln, 2P uses vll, 3P uses vll×√3")
+    func wattsByPoles() {
+        let sys = PanelVoltageSystem.v120_208Three
+        #expect(PanelPhaseMath.watts(amps: 10, poles: 1, system: sys) == 1200)
+        #expect(PanelPhaseMath.watts(amps: 10, poles: 2, system: sys) == 2080)
+        let threePole = PanelPhaseMath.watts(amps: 10, poles: 3, system: sys)
+        #expect(abs(threePole - 208 * 10 * 3.0.squareRoot()) < 0.001)
+    }
+
+    // MARK: Per-leg splits — full entries
+
+    @Test("Full 2-pole splits VA evenly across its two legs")
+    func fullTwoPoleSplit() {
+        let sys = PanelVoltageSystem.v120_240Single3Wire
+        let entry = DesignSpaceEntry.full(poles: 2, circuit: .init(amps: 30, usedAmps: 20))
+        let legs = PanelPhaseMath.perLegVA(entry: entry, anchoredAt: 1, system: sys)
+        // 20A @240V = 4800 VA, split 2400/2400 across legs of spaces 1 and 3.
+        #expect(legs == [2400, 2400])
+    }
+
+    @Test("Full 3-pole on 3Ø splits √3 VA across all three legs")
+    func fullThreePoleSplit() {
+        let sys = PanelVoltageSystem.v120_208Three
+        let entry = DesignSpaceEntry.full(poles: 3, circuit: .init(amps: 30, usedAmps: 30))
+        let legs = PanelPhaseMath.perLegVA(entry: entry, anchoredAt: 1, system: sys)
+        let total = 30.0 * 208 * 3.0.squareRoot()
+        #expect(legs.count == 3)
+        for leg in legs { #expect(abs(leg - total / 3) < 0.001) }
+    }
+
+    @Test("Spare full entries contribute nothing")
+    func spareExcluded() {
+        let sys = PanelVoltageSystem.v120_240Single3Wire
+        let entry = DesignSpaceEntry.full(poles: 1, circuit: .init(amps: 20, type: .spare, usedAmps: 15))
+        #expect(PanelPhaseMath.perLegVA(entry: entry, anchoredAt: 1, system: sys) == [0, 0])
+    }
+
+    // MARK: Per-leg splits — tandem
+
+    @Test("Tandem halves both load the single space's leg")
+    func tandemSingleLeg() {
+        let sys = PanelVoltageSystem.v120_240Single3Wire
+        let entry = DesignSpaceEntry.tandem(
+            upper: .init(amps: 15, usedAmps: 10),
+            lower: .init(amps: 20, usedAmps: 5)
+        )
+        let legs = PanelPhaseMath.perLegVA(entry: entry, anchoredAt: 3, system: sys)
+        // Space 3 → leg B; (10+5)A @120V = 1800 VA all on leg B.
+        #expect(legs == [0, 1800])
+    }
+
+    // MARK: Per-leg splits — quad modes
+
+    @Test("Quad four-mode: top pair on anchor leg, bottom pair two spaces down")
+    func quadFour() {
+        let sys = PanelVoltageSystem.v120_240Single3Wire
+        let entry = DesignSpaceEntry.quad(mode: .four, sections: [
+            .init(amps: 15, usedAmps: 10), .init(amps: 15, usedAmps: 10),
+            .init(amps: 20, usedAmps: 5), .init(amps: 20, usedAmps: 5),
+        ])
+        let legs = PanelPhaseMath.perLegVA(entry: entry, anchoredAt: 1, system: sys)
+        // Top two: 20A@120 = 2400 on leg(1)=A; bottom two: 10A@120 = 1200 on leg(3)=B.
+        #expect(legs == [2400, 1200])
+    }
+
+    @Test("Quad center-mode: outers on own legs, tied inner 2P split across both")
+    func quadCenter() {
+        let sys = PanelVoltageSystem.v120_240Single3Wire
+        let entry = DesignSpaceEntry.quad(mode: .center, sections: [
+            .init(amps: 20, usedAmps: 10),          // outer top → leg A
+            .init(amps: 30, usedAmps: 20),          // inner 2P → split A/B
+            .init(amps: 20, usedAmps: 10),          // outer bottom → leg B
+        ])
+        let legs = PanelPhaseMath.perLegVA(entry: entry, anchoredAt: 1, system: sys)
+        // Outer: 10A@120=1200 each. Inner: 20A@240=4800 → 2400/leg.
+        #expect(legs == [3600, 3600])
+    }
+
+    @Test("Quad double-mode: each independent 2P splits across both legs")
+    func quadDouble() {
+        let sys = PanelVoltageSystem.v120_240Single3Wire
+        let entry = DesignSpaceEntry.quad(mode: .double, sections: [
+            .init(amps: 30, usedAmps: 24),  // dryer
+            .init(amps: 50, usedAmps: 40),  // range
+        ])
+        let legs = PanelPhaseMath.perLegVA(entry: entry, anchoredAt: 5, system: sys)
+        // 24A@240=5760 + 40A@240=9600 → 15360 total, half per leg = 7680.
+        #expect(legs == [7680, 7680])
+    }
+
+    // MARK: Occupancy
+
+    @Test("Occupancy: full spans s+2 per extra pole; tandem one space; quad two")
+    func occupancy() {
+        #expect(DesignSpaceEntry.full(poles: 1, circuit: .init(amps: 20)).occupiedSpaces(anchoredAt: 4) == [4])
+        #expect(DesignSpaceEntry.full(poles: 3, circuit: .init(amps: 30)).occupiedSpaces(anchoredAt: 1) == [1, 3, 5])
+        #expect(DesignSpaceEntry.tandem(upper: .init(amps: 15), lower: .init(amps: 15)).occupiedSpaces(anchoredAt: 6) == [6])
+        #expect(DesignSpaceEntry.quad(mode: .four, sections: []).occupiedSpaces(anchoredAt: 8) == [8, 10])
+    }
+
+    // MARK: Service sizing + wire table
+
+    @Test("Service amps per system")
+    func serviceAmps() {
+        #expect(abs(PanelPhaseMath.serviceAmps(totalVA: 41600 * 3.0.squareRoot(), system: .v120_208Three) - 200) < 0.001)
+        #expect(PanelPhaseMath.serviceAmps(totalVA: 48000, system: .v120_240Single3Wire) == 200)
+        #expect(PanelPhaseMath.serviceAmps(totalVA: 12000, system: .v120Single2Wire) == 100)
+    }
+
+    @Test("Next standard service size rounds up and caps")
+    func nextStandardSize() {
+        #expect(PanelPhaseMath.nextStandardServiceSize(atLeast: 57) == 60)
+        #expect(PanelPhaseMath.nextStandardServiceSize(atLeast: 60) == 60)
+        #expect(PanelPhaseMath.nextStandardServiceSize(atLeast: 61) == 100)
+        #expect(PanelPhaseMath.nextStandardServiceSize(atLeast: 187) == 200)
+        #expect(PanelPhaseMath.nextStandardServiceSize(atLeast: 5000) == 1200)
+    }
+
+    @Test("Wire-size table matches spec breakpoints")
+    func wireTable() {
+        #expect(PanelPhaseMath.wireSize(forBreakerAmps: 15) == "#14 Cu")
+        #expect(PanelPhaseMath.wireSize(forBreakerAmps: 20) == "#12 Cu")
+        #expect(PanelPhaseMath.wireSize(forBreakerAmps: 30) == "#10 Cu")
+        #expect(PanelPhaseMath.wireSize(forBreakerAmps: 40) == "#8 Cu")
+        #expect(PanelPhaseMath.wireSize(forBreakerAmps: 50) == "#8 Cu")
+        #expect(PanelPhaseMath.wireSize(forBreakerAmps: 60) == "#6 Cu")
+        #expect(PanelPhaseMath.wireSize(forBreakerAmps: 100) == "#3 Cu")
+        #expect(PanelPhaseMath.wireSize(forBreakerAmps: 200) == "#3/0 Cu")
+        #expect(PanelPhaseMath.wireSize(forBreakerAmps: 0) == nil)
+    }
+
+    @Test("Estimate button is 80% of breaker size")
+    func estimate() {
+        #expect(PanelPhaseMath.estimatedUsedAmps(forBreakerAmps: 20) == 16)
+    }
+
+    @Test("Catalog: short codes, colors, and constrained choices")
+    func catalog() {
+        #expect(DesignBreakerType.afci.shortCode == "CAFI")
+        #expect(DesignBreakerType.standard.colorHex == "#0A84FF")
+        #expect(DesignBreakerType.tandemAllowed.contains(.gfci))
+        #expect(!DesignBreakerType.tandemAllowed.contains(.hacr))
+        #expect(DesignBreakerType.quadTwoPoleAllowed.contains(.hacr))
+        #expect(DesignBreakerType.fullAmpChoices.last == 100)
+    }
+}


### PR DESCRIPTION
## What

Slice 1 of the Panel Schedule Builder visual redesign (plan: `docs/plans/panel-schedule-builder-visual-redesign.md`, §2–§3): the pure-Swift domain layer in WiredPartCore. Voltage systems (4, with leg rotation), the 8-type color-coded breaker catalog with per-context constraints, the three space-entry kinds (full/tandem/quad — all three quad modes), and the complete electrical math (per-leg VA splits with √3 3-pole handling, service amps per system, estimate rule, next-standard-size, wire table).

**Additive**: `CircuitEntry` and the #1514/#1515 validation invariants are untouched; UI colors are hex strings (core stays UI-free).

## Verification

- 16 swift-testing cases covering the plan's §7.8 matrix (phase totals across every kind × mode × system, occupancy spans, service sizing, wire breakpoints) — all pass locally.
- Beta gates on this PR run the full suite.

## Next slices

2: circuit editor sheet (form factors + presets) · 3: Classic/List/Visual layouts + phase balance card · 4: print system · 5: Add-to-JPO + iPad reference panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)