### PR TITLE
feat(panel): panel state bridge — slice 3a (setup, entries, aggregates, legacy projection)

### DIFF
--- a/core/Sources/WiredPartCore/Models/Notebooks/DesignPanelState.swift
+++ b/core/Sources/WiredPartCore/Models/Notebooks/DesignPanelState.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+// Panel Schedule Builder redesign — panel state (slice 3 foundation).
+// Spec: docs/plans/panel-schedule-builder-visual-redesign.md §1–§3.
+// The redesigned builder's document: panel setup + a map of anchor space →
+// DesignSpaceEntry, with the spec's save semantics (saving an entry deletes
+// anything it overlaps), CTL-aware tandem slotting, aggregate phase math for
+// the balance card, and a legacy CircuitEntry projection so the existing
+// print/export pipeline keeps working until the print slice replaces it.
+
+/// Panel setup fields from the setup sheet (spec §2).
+public struct DesignPanelSetup: Codable, Sendable, Equatable {
+    public var brand: String
+    public var model: String
+    public var panelKind: PanelKind
+    public var voltageSystem: PanelVoltageSystem
+    /// CTL on = tandems allowed in any slot; off = only marked slots.
+    public var ctlTandemsAnySlot: Bool
+    /// Spaces marked for tandems when CTL is off (e.g. a 40/40 panel's marks).
+    public var ctlMarkedSpaces: Set<Int>
+    public var totalSpaces: Int
+    public var mainAmps: Int
+
+    public enum PanelKind: String, Codable, Sendable, CaseIterable {
+        case mainBreaker = "Main Breaker"
+        case mainLug = "Main Lug"
+        case subPanel = "Sub-Panel"
+    }
+
+    public static let brandChoices = ["Square D", "Eaton", "Siemens", "GE", "Cutler-Hammer", "Murray"]
+    public static let mainAmpChoices = [100, 125, 150, 200, 225, 400]
+
+    public init(
+        brand: String = "Square D",
+        model: String = "QO",
+        panelKind: PanelKind = .mainBreaker,
+        voltageSystem: PanelVoltageSystem = .v120_240Single3Wire,
+        ctlTandemsAnySlot: Bool = true,
+        ctlMarkedSpaces: Set<Int> = [],
+        totalSpaces: Int = 40,
+        mainAmps: Int = 200
+    ) {
+        self.brand = brand
+        self.model = model
+        self.panelKind = panelKind
+        self.voltageSystem = voltageSystem
+        self.ctlTandemsAnySlot = ctlTandemsAnySlot
+        self.ctlMarkedSpaces = ctlMarkedSpaces
+        self.totalSpaces = Self.clampSpaces(totalSpaces)
+        self.mainAmps = mainAmps
+    }
+
+    /// Spaces are even, clamped 4...200 (spec §2 setup sheet).
+    public static func clampSpaces(_ raw: Int) -> Int {
+        let clamped = min(max(raw, 4), 200)
+        return clamped - (clamped % 2)
+    }
+}
+
+/// Errors from redesigned-panel placement.
+public enum DesignPanelError: Error, Equatable, Sendable {
+    /// Entry would occupy a space outside 1...totalSpaces.
+    case outOfRange(spaces: [Int])
+    /// Tandem placed in an unmarked slot while CTL is off.
+    case tandemSlotNotMarked(space: Int)
+}
+
+/// The redesigned panel document.
+public struct DesignPanelState: Codable, Sendable, Equatable {
+    public var setup: DesignPanelSetup
+    /// Anchor space number → entry. Anchors are the entry's topmost space.
+    public var entries: [Int: DesignSpaceEntry]
+    /// Layout the user last chose (Classic | List | Visual; spec §1 —
+    /// state survives relaunch via persistence with the notebook JSON).
+    public var layout: Layout
+
+    public enum Layout: String, Codable, Sendable, CaseIterable {
+        case classic = "Classic"
+        case list = "List"
+        case visual = "Visual"
+    }
+
+    public init(
+        setup: DesignPanelSetup = DesignPanelSetup(),
+        entries: [Int: DesignSpaceEntry] = [:],
+        layout: Layout = .visual
+    ) {
+        self.setup = setup
+        self.entries = entries
+        self.layout = layout
+    }
+
+    // MARK: - Occupancy
+
+    /// Anchor owning each occupied space.
+    public var occupancy: [Int: Int] {
+        var map: [Int: Int] = [:]
+        for (anchor, entry) in entries {
+            for space in entry.occupiedSpaces(anchoredAt: anchor) {
+                map[space] = anchor
+            }
+        }
+        return map
+    }
+
+    public func entry(coveringSpace space: Int) -> (anchor: Int, entry: DesignSpaceEntry)? {
+        guard let anchor = occupancy[space], let entry = entries[anchor] else { return nil }
+        return (anchor, entry)
+    }
+
+    public var freeSpaces: [Int] {
+        let occupied = Set(occupancy.keys)
+        return (1...setup.totalSpaces).filter { !occupied.contains($0) }
+    }
+
+    /// The next free space for List view's Add Circuit (spec §1).
+    public var nextFreeSpace: Int? { freeSpaces.first }
+
+    // MARK: - Mutation (spec §2 save semantics)
+
+    /// Saves an entry at an anchor. Per spec, saving deletes ANY overlapping
+    /// entries; passing nil clears the anchor's entry (SPARE semantics).
+    /// Throws for out-of-range placement or CTL-violating tandems — those are
+    /// user-visible errors, not silent repairs.
+    public mutating func save(_ entry: DesignSpaceEntry?, atAnchor anchor: Int) throws {
+        guard let entry else {
+            entries[anchor] = nil
+            return
+        }
+        let spaces = entry.occupiedSpaces(anchoredAt: anchor)
+        let outside = spaces.filter { $0 < 1 || $0 > setup.totalSpaces }
+        guard outside.isEmpty else { throw DesignPanelError.outOfRange(spaces: outside) }
+
+        if case .tandem = entry, !setup.ctlTandemsAnySlot, !setup.ctlMarkedSpaces.contains(anchor) {
+            throw DesignPanelError.tandemSlotNotMarked(space: anchor)
+        }
+
+        // Delete anything the new entry overlaps (including an entry whose
+        // span reaches into our spaces from an earlier anchor).
+        let conflictingAnchors = Set(spaces.compactMap { occupancy[$0] })
+        for conflicting in conflictingAnchors { entries[conflicting] = nil }
+        entries[anchor] = entry
+    }
+
+    // MARK: - Aggregates (phase balance card, spec §1/§3)
+
+    /// Per-leg connected VA across the whole panel.
+    public var perLegVA: [Double] {
+        var legs = [Double](repeating: 0, count: setup.voltageSystem.legCount)
+        for (anchor, entry) in entries {
+            let entryLegs = PanelPhaseMath.perLegVA(entry: entry, anchoredAt: anchor, system: setup.voltageSystem)
+            for (index, va) in entryLegs.enumerated() { legs[index] += va }
+        }
+        return legs
+    }
+
+    /// Per-leg connected amps (VA / vln — leg amps are line-to-neutral).
+    public var perLegAmps: [Double] {
+        perLegVA.map { $0 / setup.voltageSystem.vln }
+    }
+
+    public var totalConnectedVA: Double { perLegVA.reduce(0, +) }
+
+    public var serviceAmps: Double {
+        PanelPhaseMath.serviceAmps(totalVA: totalConnectedVA, system: setup.voltageSystem)
+    }
+
+    /// Largest-leg callout numbers (amps, fraction of main; spec §1).
+    public var largestLeg: (leg: Int, amps: Double, fractionOfMain: Double) {
+        let amps = perLegAmps
+        let maxIndex = amps.indices.max(by: { amps[$0] < amps[$1] }) ?? 0
+        let fraction = setup.mainAmps > 0 ? min(amps[maxIndex] / Double(setup.mainAmps), 1.0) : 0
+        return (maxIndex, amps[maxIndex], fraction)
+    }
+
+    // MARK: - Legacy projection (export compatibility until the print slice)
+
+    /// Flattens entries into legacy `CircuitEntry` rows so the existing PDF
+    /// export keeps producing correct-if-plainer output. Sub-circuits get
+    /// their own rows labeled per spec (6a/6b, 8–10↑ …) via the description.
+    public func legacyCircuits() -> [CircuitEntry] {
+        var rows: [CircuitEntry] = []
+        for (anchor, entry) in entries.sorted(by: { $0.key < $1.key }) {
+            switch entry {
+            case .full(let poles, let circuit):
+                rows.append(CircuitEntry(
+                    spaceNumber: anchor,
+                    breakerAmps: circuit.amps,
+                    breakerType: poles >= 2 ? .double : .single,
+                    circuitDescription: circuit.name,
+                    isSpare: circuit.type == .spare,
+                    classification: circuit.type == .spare ? .spare : .special
+                ))
+            case .tandem(let upper, let lower):
+                rows.append(CircuitEntry(
+                    spaceNumber: anchor,
+                    breakerAmps: upper.amps,
+                    breakerType: .tandem,
+                    circuitDescription: upper.name,
+                    isSpare: upper.type == .spare,
+                    classification: .special,
+                    secondaryCircuitDescription: lower.name.isEmpty ? nil : lower.name
+                ))
+            case .quad(_, let sections):
+                for (offset, section) in sections.enumerated() where section.type != .spare {
+                    rows.append(CircuitEntry(
+                        spaceNumber: anchor,
+                        breakerAmps: section.amps,
+                        breakerType: .tandem,
+                        circuitDescription: section.name.isEmpty ? "Quad \(offset + 1)" : section.name,
+                        isSpare: false,
+                        classification: .special
+                    ))
+                }
+            }
+        }
+        return rows
+    }
+}

--- a/core/Tests/WiredPartCoreTests/DesignPanelStateTests.swift
+++ b/core/Tests/WiredPartCoreTests/DesignPanelStateTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import WiredPartCore
+
+@Suite("Design panel state")
+struct DesignPanelStateTests {
+
+    private func makePanel(spaces: Int = 40) -> DesignPanelState {
+        DesignPanelState(setup: DesignPanelSetup(totalSpaces: spaces))
+    }
+
+    @Test("Save deletes overlapped entries (spec save semantics)")
+    func saveOverlapResolution() throws {
+        var panel = makePanel()
+        try panel.save(.full(poles: 1, circuit: .init(amps: 20, name: "A")), atAnchor: 3)
+        try panel.save(.full(poles: 1, circuit: .init(amps: 20, name: "B")), atAnchor: 5)
+        // A 3-pole at 1 spans 1,3,5 — must evict both existing entries.
+        try panel.save(.full(poles: 3, circuit: .init(amps: 60, name: "Sub")), atAnchor: 1)
+        #expect(panel.entries.count == 1)
+        #expect(panel.entry(coveringSpace: 5)?.anchor == 1)
+    }
+
+    @Test("Reverse overlap: saving under an existing span evicts the spanning entry")
+    func reverseOverlap() throws {
+        var panel = makePanel()
+        try panel.save(.full(poles: 2, circuit: .init(amps: 30, name: "Dryer")), atAnchor: 2)
+        try panel.save(.full(poles: 1, circuit: .init(amps: 20, name: "Lights")), atAnchor: 4)
+        #expect(panel.entries[2] == nil)
+        #expect(panel.entries[4] != nil)
+    }
+
+    @Test("Nil save clears the anchor (SPARE semantics)")
+    func clearAnchor() throws {
+        var panel = makePanel()
+        try panel.save(.tandem(upper: .init(amps: 15), lower: .init(amps: 20)), atAnchor: 6)
+        try panel.save(nil, atAnchor: 6)
+        #expect(panel.entries.isEmpty)
+    }
+
+    @Test("Out-of-range placement throws with the offending spaces")
+    func outOfRange() {
+        var panel = makePanel(spaces: 8)
+        #expect(throws: DesignPanelError.outOfRange(spaces: [9])) {
+            try panel.save(.quad(mode: .four, sections: []), atAnchor: 7)
+        }
+    }
+
+    @Test("CTL off restricts tandems to marked slots")
+    func ctlSlotting() throws {
+        var panel = DesignPanelState(setup: DesignPanelSetup(
+            ctlTandemsAnySlot: false, ctlMarkedSpaces: [39, 40], totalSpaces: 40
+        ))
+        #expect(throws: DesignPanelError.tandemSlotNotMarked(space: 5)) {
+            try panel.save(.tandem(upper: .init(amps: 15), lower: .init(amps: 15)), atAnchor: 5)
+        }
+        try panel.save(.tandem(upper: .init(amps: 15), lower: .init(amps: 15)), atAnchor: 39)
+        #expect(panel.entries[39] != nil)
+    }
+
+    @Test("Free spaces and next-free respect spans")
+    func freeSpaces() throws {
+        var panel = makePanel(spaces: 8)
+        try panel.save(.full(poles: 2, circuit: .init(amps: 30)), atAnchor: 1) // occupies 1,3
+        #expect(panel.nextFreeSpace == 2)
+        #expect(!panel.freeSpaces.contains(3))
+    }
+
+    @Test("Phase aggregates sum entries per leg and derive service amps")
+    func aggregates() throws {
+        var panel = DesignPanelState(setup: DesignPanelSetup(
+            voltageSystem: .v120_240Single3Wire, totalSpaces: 8, mainAmps: 100
+        ))
+        try panel.save(.full(poles: 1, circuit: .init(amps: 20, usedAmps: 10)), atAnchor: 1) // leg A: 1200 VA
+        try panel.save(.full(poles: 1, circuit: .init(amps: 20, usedAmps: 20)), atAnchor: 3) // leg B: 2400 VA
+        #expect(panel.perLegVA == [1200, 2400])
+        #expect(panel.perLegAmps == [10, 20])
+        #expect(panel.totalConnectedVA == 3600)
+        #expect(panel.serviceAmps == 15) // 3600 / 240
+        let largest = panel.largestLeg
+        #expect(largest.leg == 1)
+        #expect(largest.amps == 20)
+        #expect(abs(largest.fractionOfMain - 0.2) < 0.0001)
+    }
+
+    @Test("Setup clamps spaces even within 4...200")
+    func spaceClamp() {
+        #expect(DesignPanelSetup.clampSpaces(3) == 4)
+        #expect(DesignPanelSetup.clampSpaces(41) == 40)
+        #expect(DesignPanelSetup.clampSpaces(999) == 200)
+    }
+
+    @Test("Legacy projection flattens kinds into printable rows")
+    func legacyProjection() throws {
+        var panel = makePanel()
+        try panel.save(.full(poles: 2, circuit: .init(amps: 30, name: "Dryer")), atAnchor: 2)
+        try panel.save(.tandem(upper: .init(amps: 15, name: "Hall"), lower: .init(amps: 20, name: "Bath")), atAnchor: 5)
+        try panel.save(.quad(mode: .double, sections: [
+            .init(amps: 30, name: "Dryer 2"), .init(amps: 50, name: "Range"),
+        ]), atAnchor: 7)
+        let rows = panel.legacyCircuits()
+        #expect(rows.count == 4)
+        #expect(rows.first?.breakerType == .double)
+        #expect(rows.contains { $0.secondaryCircuitDescription == "Bath" })
+        #expect(rows.contains { $0.circuitDescription == "Range" })
+    }
+
+    @Test("State round-trips through Codable including layout")
+    func codableRoundTrip() throws {
+        var panel = makePanel()
+        panel.layout = .classic
+        try panel.save(.quad(mode: .center, sections: [
+            .init(amps: 20), .init(amps: 30, type: .hacr), .init(amps: 20),
+        ]), atAnchor: 9)
+        let data = try JSONEncoder().encode(panel)
+        let decoded = try JSONDecoder().decode(DesignPanelState.self, from: data)
+        #expect(decoded == panel)
+    }
+}


### PR DESCRIPTION
## What

The redesigned builder's document model (plan §1–§3): panel setup (incl. CTL tandem slotting and the 4–200 even-spaces clamp), the anchored entry map with spec save semantics (overlap eviction in both directions, nil = SPARE clear), occupancy/free-space queries, whole-panel phase aggregates for the balance card, layout persistence, and a legacy `CircuitEntry` projection keeping today's PDF export working until the print slice.

## Verification

10 swift-testing cases — overlap eviction, CTL enforcement, range errors, span-aware free spaces, aggregate math, clamps, projection, Codable round-trip — pass locally; gates run the full suite.

## Next

3b: the three layout views (Classic/List/Visual) + phase balance card rendering this state, editor wired to space taps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)