### PR TITLE
feat(panel): wire redesigned builder into the Notebooks page — integration slice

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -23,6 +23,7 @@ struct IOSNotebookDetailPage: View {
     @State private var panelSchedule = PanelSchedule()
     @State private var designPanelState = DesignPanelState()
     @State private var designPanelEntryId: Int64?
+    @State private var hasUnreadableDesignPanelState = false
     @State private var designPanelAutosaveTask: Task<Void, Never>?
     @AppStorage("panelPrintConfigJSON") private var panelPrintConfigJSON = ""
     @State private var showPanelPrintPreview = false
@@ -1650,16 +1651,23 @@ struct IOSNotebookDetailPage: View {
 
     /// Loads the redesigned panel state from its own block entry; when absent
     /// but a legacy schedule exists, seeds it via the migration helper (the
-    /// legacy entry stays untouched until the user saves here).
+    /// legacy entry stays untouched until the user saves here). An existing
+    /// state that cannot decode is never replaced with migrated legacy data.
     private func loadDesignPanelState() {
-        if let entryId = findDesignPanelEntryId(),
-           let entry = blockEntry(withId: entryId),
-           let data = entry.blockData?.data(using: .utf8),
-           let state = try? JSONDecoder().decode(DesignPanelState.self, from: data) {
+        if let entryId = findDesignPanelEntryId() {
             designPanelEntryId = entryId
+            guard let entry = blockEntry(withId: entryId),
+                  let data = entry.blockData?.data(using: .utf8),
+                  let state = try? JSONDecoder().decode(DesignPanelState.self, from: data) else {
+                hasUnreadableDesignPanelState = true
+                loadError = "Saved redesigned panel data could not be read. It was not changed."
+                return
+            }
+            hasUnreadableDesignPanelState = false
             designPanelState = state
         } else {
             designPanelEntryId = nil
+            hasUnreadableDesignPanelState = false
             designPanelState = panelSchedule.circuits.isEmpty
                 ? DesignPanelState()
                 : .migrated(fromLegacy: panelSchedule)
@@ -1667,6 +1675,10 @@ struct IOSNotebookDetailPage: View {
     }
 
     private func persistDesignPanelState() {
+        guard !hasUnreadableDesignPanelState else {
+            loadError = "Saved redesigned panel data could not be read. It was not changed."
+            return
+        }
         guard let service = appCore.notebooksService,
               let userId = appCore.currentUser?.id,
               let notebookId = notebook?.id,

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -1692,7 +1692,7 @@ struct IOSNotebookDetailPage: View {
         findEntryId(blockType: "panel_design_state")
     }
 
-    private func blockEntry(withId id: Int64) -> NotebookBlockEntry? {
+    private func blockEntry(withId id: Int64) -> NotebooksService.NotebookEntryRow? {
         for group in hierarchy?.groups ?? [] {
             for section in group.sections {
                 if let entry = section.entries.first(where: { $0.id == id }) { return entry }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -22,6 +22,8 @@ struct IOSNotebookDetailPage: View {
     @State private var todosNeedingReview: [NotebooksService.NotebookEntryRow] = []
     @State private var panelSchedule = PanelSchedule()
     @State private var designPanelState = DesignPanelState()
+    @State private var designPanelEntryId: Int64?
+    @State private var designPanelAutosaveTask: Task<Void, Never>?
     @AppStorage("panelPrintConfigJSON") private var panelPrintConfigJSON = ""
     @State private var showPanelPrintPreview = false
     @State private var blockConflicts: [NotebookBlockConflict] = []
@@ -1358,6 +1360,7 @@ struct IOSNotebookDetailPage: View {
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
                             Button("Done") {
+                                designPanelAutosaveTask?.cancel()
                                 persistDesignPanelState()
                                 activeSheet = nil
                             }
@@ -1373,7 +1376,7 @@ struct IOSNotebookDetailPage: View {
                         }
                     }
                     .onChange(of: designPanelState) { _, _ in
-                        persistDesignPanelState()
+                        scheduleDesignPanelAutosave()
                     }
                     .sheet(isPresented: $showPanelPrintPreview) {
                         PanelPrintPreviewSheet(
@@ -1508,6 +1511,9 @@ struct IOSNotebookDetailPage: View {
 
             // Load panel schedule from first panel_schedule block entry
             loadPanelScheduleFromEntries(service: service)
+            // Redesigned schedules can be the only persisted panel state, so
+            // load them independently of the legacy schedule lookup.
+            loadDesignPanelState()
 
             // Check if this notebook belongs to a warranty job
             if let jobId = notebook?.jobId, let jobsService = appCore.jobsService {
@@ -1538,7 +1544,6 @@ struct IOSNotebookDetailPage: View {
                         // Clamp malformed/synced totalSpaces before rendering —
                         // a negative value traps range construction (#1239).
                         panelSchedule = schedule.clampingTotalSpacesToSupportedRange()
-                        loadDesignPanelState()
                         return
                     }
                 }
@@ -1551,7 +1556,6 @@ struct IOSNotebookDetailPage: View {
                     if let data = entry.blockData?.data(using: .utf8),
                        let schedule = try? JSONDecoder().decode(PanelSchedule.self, from: data) {
                         panelSchedule = schedule.clampingTotalSpacesToSupportedRange()
-                        loadDesignPanelState()
                         return
                     }
                 }
@@ -1652,9 +1656,13 @@ struct IOSNotebookDetailPage: View {
            let entry = blockEntry(withId: entryId),
            let data = entry.blockData?.data(using: .utf8),
            let state = try? JSONDecoder().decode(DesignPanelState.self, from: data) {
+            designPanelEntryId = entryId
             designPanelState = state
-        } else if !panelSchedule.circuits.isEmpty {
-            designPanelState = .migrated(fromLegacy: panelSchedule)
+        } else {
+            designPanelEntryId = nil
+            designPanelState = panelSchedule.circuits.isEmpty
+                ? DesignPanelState()
+                : .migrated(fromLegacy: panelSchedule)
         }
     }
 
@@ -1665,16 +1673,17 @@ struct IOSNotebookDetailPage: View {
               let json = try? JSONEncoder().encode(designPanelState),
               let jsonString = String(data: json, encoding: .utf8) else { return }
         do {
-            if let existingEntryId = findDesignPanelEntryId() {
+            if let existingEntryId = designPanelEntryId ?? findDesignPanelEntryId() {
                 try service.updateBlockEntry(
                     entryId: existingEntryId,
                     content: nil,
                     blockData: jsonString,
                     updatedBy: userId
                 )
+                designPanelEntryId = existingEntryId
             } else {
                 guard let sectionId = try findOrCreateDefaultSectionId(service: service, notebookId: notebookId) else { return }
-                _ = try service.createBlockEntry(
+                designPanelEntryId = try service.createBlockEntry(
                     sectionId: sectionId,
                     blockType: "panel_design_state",
                     title: "Panel Schedule (Redesign)",
@@ -1685,6 +1694,16 @@ struct IOSNotebookDetailPage: View {
             }
         } catch {
             loadError = userFriendlyError(error, context: "save panel design")
+        }
+    }
+
+    private func scheduleDesignPanelAutosave() {
+        designPanelAutosaveTask?.cancel()
+        designPanelAutosaveTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            guard !Task.isCancelled else { return }
+            persistDesignPanelState()
+            designPanelAutosaveTask = nil
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -21,6 +21,9 @@ struct IOSNotebookDetailPage: View {
     @State private var isWarrantyJob = false
     @State private var todosNeedingReview: [NotebooksService.NotebookEntryRow] = []
     @State private var panelSchedule = PanelSchedule()
+    @State private var designPanelState = DesignPanelState()
+    @AppStorage("panelPrintConfigJSON") private var panelPrintConfigJSON = ""
+    @State private var showPanelPrintPreview = false
     @State private var blockConflicts: [NotebookBlockConflict] = []
     @State private var activeEditLocks: [NotebookEntryEditLock] = []
     @State private var pendingDelete: PendingDelete?
@@ -69,6 +72,7 @@ struct IOSNotebookDetailPage: View {
         case editSection(sectionId: Int64, name: String)
         case editGroup(groupId: Int64, name: String)
         case panelScheduleEditor
+        case panelRedesignBuilder
         case conflictResolution
         case notebookSections
         case help
@@ -82,7 +86,42 @@ struct IOSNotebookDetailPage: View {
             case .editSection(let id, _): return "editSection-\(id)"
             case .editGroup(let id, _): return "editGroup-\(id)"
             case .panelScheduleEditor: return "panelSchedule"
-            case .conflictResolution: return "conflictResolution"
+            case .panelRedesignBuilder: return "panelRedesign"
+            case .panelRedesignBuilder:
+            NavigationStack {
+                PanelRedesignBuilderView(panel: $designPanelState)
+                    .navigationTitle("Panel Schedule")
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Done") {
+                                persistDesignPanelState()
+                                activeSheet = nil
+                            }
+                            .accessibilityIdentifier("panelRedesignDone")
+                        }
+                        ToolbarItem(placement: .primaryAction) {
+                            Button {
+                                showPanelPrintPreview = true
+                            } label: {
+                                Label("Print", systemImage: "printer")
+                            }
+                            .accessibilityIdentifier("panelRedesignPrint")
+                        }
+                    }
+                    .onChange(of: designPanelState) { _, _ in
+                        persistDesignPanelState()
+                    }
+                    .sheet(isPresented: $showPanelPrintPreview) {
+                        PanelPrintPreviewSheet(
+                            panelName: notebook?.title ?? "Panel",
+                            panel: designPanelState,
+                            config: panelPrintConfigBinding
+                        )
+                    }
+            }
+
+        case .conflictResolution: return "conflictResolution"
             case .notebookSections: return "notebookSections"
             case .help: return "help"
             }
@@ -711,6 +750,33 @@ struct IOSNotebookDetailPage: View {
                     .frame(minHeight: 44)
                 }
                 .buttonStyle(.plain)
+
+                Button {
+                    activeSheet = .panelRedesignBuilder
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: "sparkles")
+                            .foregroundStyle(.blue)
+                            .frame(width: 28)
+                            .accessibilityHidden(true)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("New Builder (redesign)")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            Text("Three layouts, tandem/quad breakers, pro print")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .accessibilityHidden(true)
+                    }
+                    .frame(minHeight: 44)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("openPanelRedesignBuilder")
             }
         }
     }
@@ -1472,6 +1538,7 @@ struct IOSNotebookDetailPage: View {
                         // Clamp malformed/synced totalSpaces before rendering —
                         // a negative value traps range construction (#1239).
                         panelSchedule = schedule.clampingTotalSpacesToSupportedRange()
+                        loadDesignPanelState()
                         return
                     }
                 }
@@ -1484,6 +1551,7 @@ struct IOSNotebookDetailPage: View {
                     if let data = entry.blockData?.data(using: .utf8),
                        let schedule = try? JSONDecoder().decode(PanelSchedule.self, from: data) {
                         panelSchedule = schedule.clampingTotalSpacesToSupportedRange()
+                        loadDesignPanelState()
                         return
                     }
                 }
@@ -1554,6 +1622,102 @@ struct IOSNotebookDetailPage: View {
         }
         // No sections exist — create a default one (throws on failure so caller can surface the error)
         return try service.createSection(notebookId: notebookId, groupId: nil, name: "General")
+    }
+
+    /// Print config persists app-wide (spec: set once, reused for every
+    /// schedule) as JSON in AppStorage.
+    private var panelPrintConfigBinding: Binding<PanelPrintConfig> {
+        Binding(
+            get: {
+                guard let data = panelPrintConfigJSON.data(using: .utf8),
+                      let config = try? JSONDecoder().decode(PanelPrintConfig.self, from: data) else {
+                    return PanelPrintConfig()
+                }
+                return config
+            },
+            set: { newValue in
+                if let data = try? JSONEncoder().encode(newValue),
+                   let json = String(data: data, encoding: .utf8) {
+                    panelPrintConfigJSON = json
+                }
+            }
+        )
+    }
+
+    /// Loads the redesigned panel state from its own block entry; when absent
+    /// but a legacy schedule exists, seeds it via the migration helper (the
+    /// legacy entry stays untouched until the user saves here).
+    private func loadDesignPanelState() {
+        if let entryId = findDesignPanelEntryId(),
+           let entry = blockEntry(withId: entryId),
+           let data = entry.blockData?.data(using: .utf8),
+           let state = try? JSONDecoder().decode(DesignPanelState.self, from: data) {
+            designPanelState = state
+        } else if !panelSchedule.circuits.isEmpty {
+            designPanelState = .migrated(fromLegacy: panelSchedule)
+        }
+    }
+
+    private func persistDesignPanelState() {
+        guard let service = appCore.notebooksService,
+              let userId = appCore.currentUser?.id,
+              let notebookId = notebook?.id,
+              let json = try? JSONEncoder().encode(designPanelState),
+              let jsonString = String(data: json, encoding: .utf8) else { return }
+        do {
+            if let existingEntryId = findDesignPanelEntryId() {
+                try service.updateBlockEntry(
+                    entryId: existingEntryId,
+                    content: nil,
+                    blockData: jsonString,
+                    updatedBy: userId
+                )
+            } else {
+                guard let sectionId = try findOrCreateDefaultSectionId(service: service, notebookId: notebookId) else { return }
+                _ = try service.createBlockEntry(
+                    sectionId: sectionId,
+                    blockType: "panel_design_state",
+                    title: "Panel Schedule (Redesign)",
+                    content: nil,
+                    blockData: jsonString,
+                    createdBy: userId
+                )
+            }
+        } catch {
+            loadError = userFriendlyError(error, context: "save panel design")
+        }
+    }
+
+    private func findDesignPanelEntryId() -> Int64? {
+        findEntryId(blockType: "panel_design_state")
+    }
+
+    private func blockEntry(withId id: Int64) -> NotebookBlockEntry? {
+        for group in hierarchy?.groups ?? [] {
+            for section in group.sections {
+                if let entry = section.entries.first(where: { $0.id == id }) { return entry }
+            }
+        }
+        for section in hierarchy?.ungroupedSections ?? [] {
+            if let entry = section.entries.first(where: { $0.id == id }) { return entry }
+        }
+        return nil
+    }
+
+    private func findEntryId(blockType: String) -> Int64? {
+        for group in hierarchy?.groups ?? [] {
+            for section in group.sections {
+                for entry in section.entries where entry.blockType == blockType {
+                    return entry.id
+                }
+            }
+        }
+        for section in hierarchy?.ungroupedSections ?? [] {
+            for entry in section.entries where entry.blockType == blockType {
+                return entry.id
+            }
+        }
+        return nil
     }
 
     private func findPanelScheduleEntryId() -> Int64? {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/IOSNotebookDetailPage.swift
@@ -87,41 +87,7 @@ struct IOSNotebookDetailPage: View {
             case .editGroup(let id, _): return "editGroup-\(id)"
             case .panelScheduleEditor: return "panelSchedule"
             case .panelRedesignBuilder: return "panelRedesign"
-            case .panelRedesignBuilder:
-            NavigationStack {
-                PanelRedesignBuilderView(panel: $designPanelState)
-                    .navigationTitle("Panel Schedule")
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbar {
-                        ToolbarItem(placement: .cancellationAction) {
-                            Button("Done") {
-                                persistDesignPanelState()
-                                activeSheet = nil
-                            }
-                            .accessibilityIdentifier("panelRedesignDone")
-                        }
-                        ToolbarItem(placement: .primaryAction) {
-                            Button {
-                                showPanelPrintPreview = true
-                            } label: {
-                                Label("Print", systemImage: "printer")
-                            }
-                            .accessibilityIdentifier("panelRedesignPrint")
-                        }
-                    }
-                    .onChange(of: designPanelState) { _, _ in
-                        persistDesignPanelState()
-                    }
-                    .sheet(isPresented: $showPanelPrintPreview) {
-                        PanelPrintPreviewSheet(
-                            panelName: notebook?.title ?? "Panel",
-                            panel: designPanelState,
-                            config: panelPrintConfigBinding
-                        )
-                    }
-            }
-
-        case .conflictResolution: return "conflictResolution"
+            case .conflictResolution: return "conflictResolution"
             case .notebookSections: return "notebookSections"
             case .help: return "help"
             }
@@ -1382,6 +1348,40 @@ struct IOSNotebookDetailPage: View {
                         Button("Done") { activeSheet = nil }
                     }
                 }
+            }
+
+        case .panelRedesignBuilder:
+            NavigationStack {
+                PanelRedesignBuilderView(panel: $designPanelState)
+                    .navigationTitle("Panel Schedule")
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Done") {
+                                persistDesignPanelState()
+                                activeSheet = nil
+                            }
+                            .accessibilityIdentifier("panelRedesignDone")
+                        }
+                        ToolbarItem(placement: .primaryAction) {
+                            Button {
+                                showPanelPrintPreview = true
+                            } label: {
+                                Label("Print", systemImage: "printer")
+                            }
+                            .accessibilityIdentifier("panelRedesignPrint")
+                        }
+                    }
+                    .onChange(of: designPanelState) { _, _ in
+                        persistDesignPanelState()
+                    }
+                    .sheet(isPresented: $showPanelPrintPreview) {
+                        PanelPrintPreviewSheet(
+                            panelName: notebook?.title ?? "Panel",
+                            panel: designPanelState,
+                            config: panelPrintConfigBinding
+                        )
+                    }
             }
 
         case .conflictResolution:

--- a/core/Sources/WiredPartCore/Models/Notebooks/DesignPanelState.swift
+++ b/core/Sources/WiredPartCore/Models/Notebooks/DesignPanelState.swift
@@ -217,3 +217,42 @@ public struct DesignPanelState: Codable, Sendable, Equatable {
         return rows
     }
 }
+
+// MARK: - Legacy migration (integration slice)
+
+extension DesignPanelState {
+    /// Best-effort seed from a legacy `PanelSchedule` so an existing panel
+    /// opens in the redesigned builder with its circuits in place. Singles
+    /// become 1-pole fulls, doubles 2-pole fulls, tandems twin entries;
+    /// spares are skipped (open spaces). Entries that no longer fit (overlap
+    /// or out of range) are dropped rather than corrupting the map — the
+    /// legacy entry remains untouched as the source of truth for exports
+    /// until the user saves from the new builder.
+    public static func migrated(fromLegacy legacy: PanelSchedule) -> DesignPanelState {
+        var state = DesignPanelState(setup: DesignPanelSetup(
+            totalSpaces: DesignPanelSetup.clampSpaces(legacy.totalSpaces),
+            mainAmps: legacy.mainBreakerAmps ?? 200
+        ))
+        for circuit in legacy.circuits where !circuit.isSpare {
+            let amps = circuit.breakerAmps ?? 20
+            let sub = DesignSubCircuit(amps: amps, name: circuit.circuitDescription)
+            let entry: DesignSpaceEntry
+            switch circuit.breakerType {
+            case .double:
+                entry = .full(poles: 2, circuit: sub)
+            case .tandem:
+                entry = .tandem(
+                    upper: sub,
+                    lower: DesignSubCircuit(
+                        amps: amps,
+                        name: circuit.secondaryCircuitDescription ?? ""
+                    )
+                )
+            default:
+                entry = .full(poles: 1, circuit: sub)
+            }
+            try? state.save(entry, atAnchor: circuit.spaceNumber)
+        }
+        return state
+    }
+}

--- a/core/Sources/WiredPartCore/Models/Notebooks/DesignPanelState.swift
+++ b/core/Sources/WiredPartCore/Models/Notebooks/DesignPanelState.swift
@@ -233,9 +233,16 @@ extension DesignPanelState {
             totalSpaces: DesignPanelSetup.clampSpaces(legacy.totalSpaces),
             mainAmps: legacy.mainBreakerAmps ?? 200
         ))
-        for circuit in legacy.circuits where !circuit.isSpare {
+        for circuit in legacy.circuits where !circuit.isSpare && circuit.breakerType != .spare && circuit.breakerType != .blank {
             let amps = circuit.breakerAmps ?? 20
-            let sub = DesignSubCircuit(amps: amps, name: circuit.circuitDescription)
+            let type: DesignBreakerType
+            switch circuit.breakerType {
+            case .gfci: type = .gfci
+            case .afci: type = .afci
+            case .dualFunction: type = .dualFunction
+            default: type = .standard
+            }
+            let sub = DesignSubCircuit(amps: amps, type: type, name: circuit.circuitDescription)
             let entry: DesignSpaceEntry
             switch circuit.breakerType {
             case .double:
@@ -245,6 +252,7 @@ extension DesignPanelState {
                     upper: sub,
                     lower: DesignSubCircuit(
                         amps: amps,
+                        type: type,
                         name: circuit.secondaryCircuitDescription ?? ""
                     )
                 )

--- a/core/Tests/WiredPartCoreTests/DesignPanelStateTests.swift
+++ b/core/Tests/WiredPartCoreTests/DesignPanelStateTests.swift
@@ -115,4 +115,22 @@ struct DesignPanelStateTests {
         let decoded = try JSONDecoder().decode(DesignPanelState.self, from: data)
         #expect(decoded == panel)
     }
+
+    @Test("Legacy migration seeds fulls, doubles, and tandems; skips spares")
+    func legacyMigration() {
+        let legacy = PanelSchedule(totalSpaces: 20, mainBreakerAmps: 100, circuits: [
+            CircuitEntry(spaceNumber: 1, breakerAmps: 20, breakerType: .single, circuitDescription: "Lights", isSpare: false),
+            CircuitEntry(spaceNumber: 2, breakerAmps: 30, breakerType: .double, circuitDescription: "Dryer", isSpare: false),
+            CircuitEntry(spaceNumber: 5, breakerAmps: 15, breakerType: .tandem, circuitDescription: "Hall", isSpare: false, secondaryCircuitDescription: "Bath"),
+            CircuitEntry(spaceNumber: 7, breakerType: .spare, isSpare: true),
+        ])
+        let state = DesignPanelState.migrated(fromLegacy: legacy)
+        #expect(state.setup.mainAmps == 100)
+        #expect(state.entries.count == 3)
+        if case .full(let poles, let c)? = state.entries[2] { #expect(poles == 2); #expect(c.name == "Dryer") }
+        else { Issue.record("expected 2P full at 2") }
+        if case .tandem(let up, let low)? = state.entries[5] { #expect(up.name == "Hall"); #expect(low.name == "Bath") }
+        else { Issue.record("expected tandem at 5") }
+        #expect(state.entries[7] == nil)
+    }
 }

--- a/core/Tests/WiredPartCoreTests/DesignPanelStateTests.swift
+++ b/core/Tests/WiredPartCoreTests/DesignPanelStateTests.swift
@@ -116,21 +116,32 @@ struct DesignPanelStateTests {
         #expect(decoded == panel)
     }
 
-    @Test("Legacy migration seeds fulls, doubles, and tandems; skips spares")
+    @Test("Legacy migration preserves breaker protection types and skips blank or spare circuits")
     func legacyMigration() {
         let legacy = PanelSchedule(totalSpaces: 20, mainBreakerAmps: 100, circuits: [
             CircuitEntry(spaceNumber: 1, breakerAmps: 20, breakerType: .single, circuitDescription: "Lights", isSpare: false),
             CircuitEntry(spaceNumber: 2, breakerAmps: 30, breakerType: .double, circuitDescription: "Dryer", isSpare: false),
             CircuitEntry(spaceNumber: 5, breakerAmps: 15, breakerType: .tandem, circuitDescription: "Hall", isSpare: false, secondaryCircuitDescription: "Bath"),
             CircuitEntry(spaceNumber: 7, breakerType: .spare, isSpare: true),
+            CircuitEntry(spaceNumber: 8, breakerType: .blank, circuitDescription: "Blank", isSpare: false),
+            CircuitEntry(spaceNumber: 9, breakerAmps: 20, breakerType: .gfci, circuitDescription: "Bath GFCI", isSpare: false),
+            CircuitEntry(spaceNumber: 10, breakerAmps: 20, breakerType: .afci, circuitDescription: "Bedroom AFCI", isSpare: false),
+            CircuitEntry(spaceNumber: 11, breakerAmps: 20, breakerType: .dualFunction, circuitDescription: "Kitchen DF", isSpare: false),
         ])
         let state = DesignPanelState.migrated(fromLegacy: legacy)
         #expect(state.setup.mainAmps == 100)
-        #expect(state.entries.count == 3)
+        #expect(state.entries.count == 6)
         if case .full(let poles, let c)? = state.entries[2] { #expect(poles == 2); #expect(c.name == "Dryer") }
         else { Issue.record("expected 2P full at 2") }
         if case .tandem(let up, let low)? = state.entries[5] { #expect(up.name == "Hall"); #expect(low.name == "Bath") }
         else { Issue.record("expected tandem at 5") }
         #expect(state.entries[7] == nil)
+        #expect(state.entries[8] == nil)
+        if case .full(_, let c)? = state.entries[9] { #expect(c.type == .gfci) }
+        else { Issue.record("expected GFCI at 9") }
+        if case .full(_, let c)? = state.entries[10] { #expect(c.type == .afci) }
+        else { Issue.record("expected AFCI at 10") }
+        if case .full(_, let c)? = state.entries[11] { #expect(c.type == .dualFunction) }
+        else { Issue.record("expected dual-function breaker at 11") }
     }
 }

--- a/scripts/ci/run-ios-beta-gate.sh
+++ b/scripts/ci/run-ios-beta-gate.sh
@@ -56,7 +56,15 @@ metadata_file="$artifact_dir/metadata.txt"
 derived_data=""
 simulator_id=""
 
-mkdir -p "$artifact_dir"
+# The self-hosted runner retains ignored artifacts between jobs. xcodebuild
+# refuses an already-existing -resultBundlePath, so every gate attempt must
+# begin with a clean device-scoped evidence directory.
+prepare_artifact_dir() {
+  rm -rf "$artifact_dir"
+  mkdir -p "$artifact_dir"
+}
+
+prepare_artifact_dir
 
 cleanup() {
   local status=$?
@@ -136,6 +144,10 @@ if [[ "${IOS_BETA_GATE_SELF_TEST:-}" == "1" ]]; then
   gate_name="iPhone"
   ui_log="$self_test_dir/ui-smokes.log"
   ui_result="$self_test_dir/ui-smokes.xcresult"
+
+  mkdir -p "$artifact_dir/stale-ui-smokes-iPhone.xcresult"
+  prepare_artifact_dir
+  [[ ! -e "$artifact_dir/stale-ui-smokes-iPhone.xcresult" ]] || exit 1
 
   prepare_first_ui_smoke_attempt() {
     rm -rf "$artifact_dir" "$ui_result"


### PR DESCRIPTION
## What

The redesign becomes reachable: the Panel Schedule section gets a **New Builder (redesign)** entry beside the legacy one (additive — old builder untouched until the new one is proven on device). The sheet hosts the three-layout builder with persist-on-change, Done, and **Print** (the full preview → PDF pipeline). State persists as its own `panel_design_state` block entry — zero risk to existing data — and first open migrates legacy circuits via a new tested core helper. Print config persists app-wide per the set-once spec.

## Verification

- Core migration helper: suite now 11/11 locally.
- swiftc parse clean on the page; gates run the full build + suites.

## After this

The whole redesign is user-reachable on TestFlight. Remaining polish: panel setup sheet UI, Add-to-JPO, iPad reference panel (final slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #1597
Tracked in WEI-6682.