### PR TITLE
feat(panel): panel setup sheet + tappable builder header

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelRedesignBuilderView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelRedesignBuilderView.swift
@@ -15,10 +15,12 @@ struct PanelRedesignBuilderView: View {
     @State private var editorDraft: PanelEditorDraft?
     @State private var placementError: String?
     @State private var showWatts = false
+    @State private var showSetup = false
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 14) {
+                headerRow
                 layoutSwitcher
                 phaseBalanceCard
                 if let placementError {
@@ -34,6 +36,11 @@ struct PanelRedesignBuilderView: View {
                 }
             }
             .padding()
+        }
+        .sheet(isPresented: $showSetup) {
+            PanelSetupSheet(setup: panel.setup) { newSetup in
+                panel.setup = newSetup
+            }
         }
         .sheet(item: $editorDraft) { draft in
             PanelCircuitEditorSheet(draft: draft, voltageSystem: panel.setup.voltageSystem) { entry in
@@ -64,6 +71,29 @@ struct PanelRedesignBuilderView: View {
         } else {
             editorDraft = .defaults(kind: .full, anchorSpace: space)
         }
+    }
+
+    private var headerRow: some View {
+        Button { showSetup = true } label: {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\(panel.setup.brand) \(panel.setup.model)")
+                        .font(.headline)
+                    Text("\(panel.setup.voltageSystem.rawValue) · \(panel.setup.mainAmps)A \(panel.setup.panelKind.rawValue) · \(panel.setup.totalSpaces) sp\(panel.setup.ctlTandemsAnySlot ? "" : " · CTL")")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: "slider.horizontal.3")
+                    .foregroundStyle(Color.accentColor)
+                    .accessibilityHidden(true)
+            }
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Panel setup: \(panel.setup.brand) \(panel.setup.model), \(panel.setup.mainAmps) amp, \(panel.setup.totalSpaces) spaces. Double tap to change.")
+        .accessibilityIdentifier("panelSetupHeader")
     }
 
     // MARK: - Switcher + balance card

--- a/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelSetupSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Notebooks/PanelSetupSheet.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+import WiredPartCore
+
+/// Panel setup sheet (plan §2): brand, model, panel kind, voltage system,
+/// CTL tandem slotting, spaces (chips + custom stepper, even 4–200), and
+/// main rating. Edits a copy and commits on Save so Cancel is safe.
+struct PanelSetupSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var draft: DesignPanelSetup
+    let onSave: (DesignPanelSetup) -> Void
+
+    init(setup: DesignPanelSetup, onSave: @escaping (DesignPanelSetup) -> Void) {
+        _draft = State(initialValue: setup)
+        self.onSave = onSave
+    }
+
+    private static let spaceChips = [4, 8, 12, 16, 20, 24, 30, 40, 42, 60, 72]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Panel") {
+                    Picker("Brand", selection: $draft.brand) {
+                        ForEach(DesignPanelSetup.brandChoices, id: \.self) { Text($0).tag($0) }
+                    }
+                    TextField("Model (QO, BR, PON…)", text: $draft.model)
+                        .accessibilityIdentifier("panelSetupModel")
+                    Picker("Type", selection: $draft.panelKind) {
+                        ForEach(DesignPanelSetup.PanelKind.allCases, id: \.self) { Text($0.rawValue).tag($0) }
+                    }
+                }
+
+                Section("Voltage system") {
+                    Picker("System", selection: $draft.voltageSystem) {
+                        ForEach(PanelVoltageSystem.allCases, id: \.self) { Text($0.rawValue).tag($0) }
+                    }
+                    .pickerStyle(.inline)
+                    .labelsHidden()
+                    .accessibilityIdentifier("panelSetupVoltage")
+                }
+
+                Section {
+                    Toggle("Tandems in any slot (CTL)", isOn: $draft.ctlTandemsAnySlot)
+                        .accessibilityIdentifier("panelSetupCTL")
+                } footer: {
+                    Text(draft.ctlTandemsAnySlot
+                         ? "Twin breakers can go in any space."
+                         : "Twin breakers only in this panel's marked slots (e.g. a 40/40 listing). Mark slots by tapping them in the builder — unmarked slots reject tandems.")
+                }
+
+                Section("Spaces") {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(Self.spaceChips, id: \.self) { count in
+                                let selected = draft.totalSpaces == count
+                                Button("\(count)") {
+                                    draft.totalSpaces = DesignPanelSetup.clampSpaces(count)
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                                .frame(minWidth: 44, minHeight: 44)
+                                .background(selected ? Color.accentColor.opacity(0.18) : .clear, in: Capsule())
+                                .accessibilityIdentifier("panelSetupSpaces_\(count)")
+                                .accessibilityAddTraits(selected ? .isSelected : [])
+                            }
+                        }
+                    }
+                    Stepper(
+                        "Custom: \(draft.totalSpaces) spaces",
+                        value: Binding(
+                            get: { draft.totalSpaces },
+                            set: { draft.totalSpaces = DesignPanelSetup.clampSpaces($0) }
+                        ),
+                        in: 4...200,
+                        step: 2
+                    )
+                    .accessibilityIdentifier("panelSetupSpacesStepper")
+                }
+
+                Section("Main rating") {
+                    Picker("Main", selection: $draft.mainAmps) {
+                        ForEach(DesignPanelSetup.mainAmpChoices, id: \.self) { Text("\($0)A").tag($0) }
+                    }
+                    .pickerStyle(.segmented)
+                    .accessibilityIdentifier("panelSetupMain")
+                }
+            }
+            .navigationTitle("Panel Setup")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .accessibilityIdentifier("panelSetupCancel")
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        onSave(draft)
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                    .accessibilityIdentifier("panelSetupSave")
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PanelSetupSheet(setup: DesignPanelSetup()) { _ in }
+}


### PR DESCRIPTION
## What

The first of the three polish items (plan §2): the Panel Setup sheet — brand/model/kind, the four voltage systems, the CTL tandem-slotting toggle with a plain-language footer, space chips + clamped custom stepper, main rating — plus the builder's tappable header showing the panel meta line and opening setup, per the design's tune-icon affordance. Draft-edit with commit-on-Save.

## Verification

- Both files parse clean; clamping and CTL semantics are the already-tested core (`DesignPanelSetup.clampSpaces`, save-time enforcement).
- Gates run the full build.

## Remaining polish

Add-to-JPO action, iPad reference panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)