### PR TITLE
test: serialize SyncServerTests — one cause behind three intermittents (#1583)

### DIFF
--- a/core/Tests/WiredPartCoreTests/SyncServerTests.swift
+++ b/core/Tests/WiredPartCoreTests/SyncServerTests.swift
@@ -3,7 +3,16 @@ import Foundation
 import os
 @testable import WiredPartCore
 
-@Suite("LAN Sync Server Tests")
+// .serialized (#1583): three distinct intermittents in one day — an
+// unpaired-sender 400 answered 200, state.port read 0 after start, and an
+// .incorrectParameterSize decrypt — all fit one cause: parallel tests each
+// binding ephemeral-port servers can hit a port the kernel just rebound to a
+// SIBLING test's server, so requests land on the wrong server (wrong pairing
+// table, wrong keys, races on state publication). Serializing removes the
+// cross-test port/URLSession interleaving at negligible runtime cost for
+// this suite. If an intermittent recurs while serialized, it is a REAL
+// in-process race — investigate the server, not the tests.
+@Suite("LAN Sync Server Tests", .serialized)
 struct SyncServerTests {
 
     private var validPeerKey: String {


### PR DESCRIPTION
## What

`.serialized` on the LAN Sync Server suite, with the diagnosis documented in the header.

## The unifying cause

All three of yesterday's distinct flakes — an unpaired sender answered 200 instead of 400, `state.port` read 0 right after start, and an `.incorrectParameterSize` decrypt — fit one mechanism: parallel tests each bind ephemeral-port servers, and a request can land on a port the kernel just rebound to a sibling test's server (wrong pairing table → false 200; wrong keys → parameter-size error; port publication raced). This also explains why the iPad job always passed minutes later: different scheduling, no collision.

## Why serialize rather than isolate harder

The suite runs in 1.4 s serialized — the parallelism bought nothing. And the policy line matters: **any intermittent that recurs under serialization is a real in-process server race** and gets investigated as a product bug, not rerun.

## Verification

32/32 locally under `.serialized`; gates run the full suite. Closes the investigation lane of #1583 (the issue stays open until a week of gates confirms quiet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)