### PR TITLE
fix(sync): fall back from Wi-Fi to Bluetooth on initial join — field P0

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -1242,9 +1242,14 @@ final class IOSSyncManager {
 
         let deviceId = DeviceIdentity.current
 
-        // Prefer Wi-Fi/LAN when a shop server address is known (faster full download);
-        // otherwise fall back to the Bluetooth initial sync for a device that paired
-        // over Bluetooth (no server address).
+        // Prefer Wi-Fi/LAN when a shop server address is known (faster full
+        // download) — but a failed HTTP attempt must FALL THROUGH to the
+        // Bluetooth/Multipeer snapshot when this device paired over Bluetooth.
+        // Field-confirmed 2026-08-01 (#1417): a stale discovered address made
+        // the HTTP branch fail in ~2-3s (connection refused) and the old
+        // if/else THREW without ever trying the authorized Multipeer path,
+        // bricking every tablet join despite both radios being ready.
+        var wifiFailure: String?
         if let engine = syncEngine, let server = serverAddress {
             syncProgressMessage = "Downloading database from shop..."
             syncProgressPercent = 0.2
@@ -1254,8 +1259,6 @@ final class IOSSyncManager {
                 shopUrl: server
             )
 
-            syncProgressPercent = 0.8
-
             if success {
                 syncProgressMessage = "Initial sync complete."
                 syncProgressPercent = 1.0
@@ -1263,30 +1266,41 @@ final class IOSSyncManager {
                 lastSyncDate = Formatters.iso8601Basic.string(from: Date())
             } else {
                 let state = await engine.getState()
-                syncProgressMessage = nil
-                syncStatus = .error
-                errorMessage = state.error ?? "Initial sync failed."
-                throw SyncError.syncFailed(state.error ?? "Unknown error")
+                wifiFailure = state.error ?? "Wi-Fi download failed."
             }
-        } else if let hostDeviceId = pairedBluetoothHostDeviceId(), let pm = peerManager {
+        }
+
+        if syncStatus != .synced, let hostDeviceId = pairedBluetoothHostDeviceId(), let pm = peerManager {
             // Bluetooth: ask the paired host to replay the whole company over the
             // live Multipeer session — no Wi-Fi/server needed.
-            syncProgressMessage = "Downloading data over Bluetooth…"
+            syncProgressMessage = wifiFailure == nil
+                ? "Downloading data over Bluetooth…"
+                : "Wi-Fi didn't work — downloading over Bluetooth instead…"
             syncProgressPercent = 0.3
             do {
                 try await pm.requestFullSyncOverMultipeer(hostDeviceId: hostDeviceId)
             } catch {
                 syncProgressMessage = nil
                 syncStatus = .error
-                errorMessage = "Bluetooth sync failed. Keep both devices close with Bluetooth on and try again."
-                throw error
+                errorMessage = Self.initialSyncFailureMessage(
+                    wifiFailure: wifiFailure,
+                    bluetoothError: error
+                )
+                throw SyncError.syncFailed(errorMessage ?? "Initial sync failed.")
             }
             syncProgressMessage = "Initial sync complete."
             syncProgressPercent = 1.0
             syncStatus = .synced
             lastSyncDate = Formatters.iso8601Basic.string(from: Date())
-        } else {
+        } else if syncStatus != .synced {
             syncProgressMessage = nil
+            syncStatus = .error
+            if let wifiFailure {
+                // HTTP was attempted and failed, and no Bluetooth pairing exists
+                // to fall back on — surface the real reason, not a generic line.
+                errorMessage = "Couldn't download from the shop over Wi-Fi (\(wifiFailure)) and this device has no Bluetooth pairing to fall back on. Re-pair the device and try again."
+                throw SyncError.syncFailed(errorMessage ?? wifiFailure)
+            }
             throw SyncError.noServerConfigured
         }
 
@@ -1378,6 +1392,31 @@ final class IOSSyncManager {
         case .offline:
             return pendingChanges > 0 ? "Offline — \(pendingChanges) changes queued" : "Offline"
         }
+    }
+
+    /// Compose an honest initial-sync failure covering every transport tried.
+    /// The generic "Couldn't sync data" hid the real cause in the 2026-08-01
+    /// field failure — never collapse distinct transport failures again.
+    static func initialSyncFailureMessage(
+        wifiFailure: String?,
+        bluetoothError: Error
+    ) -> String {
+        let bluetoothReason: String
+        switch bluetoothError {
+        case MultipeerPairingError.rejected:
+            bluetoothReason = "the shop device didn't recognize this pairing — generate a NEW code on the shop device and pair again"
+        case MultipeerPairingError.connectionTimeout:
+            bluetoothReason = "the devices lost their connection — keep both unlocked, close together, with the shop device's Add-a-Device screen open, and retry"
+        case MultipeerPairingError.requestAlreadyInProgress:
+            bluetoothReason = "a previous attempt is still finishing — wait a few seconds and retry"
+        default:
+            bluetoothReason = (bluetoothError as? LocalizedError)?.errorDescription
+                ?? "Bluetooth transfer failed — keep both devices close and retry"
+        }
+        if let wifiFailure {
+            return "Wi-Fi download failed (\(wifiFailure)), then Bluetooth also failed: \(bluetoothReason)."
+        }
+        return "Bluetooth sync failed: \(bluetoothReason)."
     }
 
     // MARK: - Sync Errors


### PR DESCRIPTION
## The field failure (owner, 2026-08-01 evening, build 39)

iPad join failed **2–3 seconds** after entering the code, every attempt, with generic "Couldn't sync data" — while Bluetooth + Local Network were ON and discovery worked on both devices (owner-verified). Host iPhone even showed "Sent 9 records" (incremental push), never a snapshot.

## Root cause

`IOSSyncManager.performInitialSync` prefers the Wi-Fi/HTTP engine when any `serverAddress` is known — and on failure it **threw from an if/else**, so the fully-authorized Multipeer snapshot path (token minted at pairing, peer trusted, session connected) was never attempted. A stale discovered address → connection refused (~2-3 s) → total join failure. One dead branch killed the whole flow.

## Fix

- HTTP branch records its failure instead of throwing; the flow **falls through to the Bluetooth snapshot** whenever a Bluetooth pairing exists.
- Only both-transports-failed (or none available) errors out — with **transport-specific messages** (`initialSyncFailureMessage`): rejected pairing → "generate a NEW code", dropped session → "keep both unlocked, close together", Wi-Fi-only failure with no BT pairing → says exactly that. The generic message that hid this bug is gone from the join path.
- Progress line says "Wi-Fi didn't work — downloading over Bluetooth instead…" so the field can SEE the fallback.

## Verification

iOS Simulator build clean locally; gates run the suites. **Owner field test on the next internal build**: retry the same iPhone↔iPad join — expected: fallback line, then completion. Remaining #1417 hardening (progress-based timeout instead of the 60s cap, batch-count progress UI, host suppressing incremental pushes to unsnapshotted peers) follows in a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)