### PR TITLE
feat(feedback): known-issues tracker + Reset This Device on Device Management

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDeviceManagementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDeviceManagementPage.swift
@@ -48,7 +48,7 @@ struct IOSDeviceManagementPage: View {
                 )
             }
 
-            Section("Start Over") {
+            Section {
                 NavigationLink {
                     IOSDatabaseResetPage()
                 } label: {
@@ -61,6 +61,8 @@ struct IOSDeviceManagementPage: View {
                     hint: "Wipes this device's data and starts setup over. Requires admin approval. The app stays installed.",
                     id: "settings-device-mgmt-reset-link"
                 )
+            } header: {
+                Text("Start Over")
             } footer: {
                 Text("Wipes this device's company data and returns to setup — no need to delete and reinstall the app. Admin PIN required.")
             }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDeviceManagementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDeviceManagementPage.swift
@@ -48,6 +48,23 @@ struct IOSDeviceManagementPage: View {
                 )
             }
 
+            Section("Start Over") {
+                NavigationLink {
+                    IOSDatabaseResetPage()
+                } label: {
+                    Label("Reset This Device", systemImage: "arrow.counterclockwise.circle")
+                        .foregroundStyle(.red)
+                        .frame(minHeight: 44)
+                }
+                .rowAccessibility(
+                    label: "Reset this device",
+                    hint: "Wipes this device's data and starts setup over. Requires admin approval. The app stays installed.",
+                    id: "settings-device-mgmt-reset-link"
+                )
+            } footer: {
+                Text("Wipes this device's company data and returns to setup — no need to delete and reinstall the app. Admin PIN required.")
+            }
+
             Section("Actions") {
                 Button {
                     issuePairingCode()

--- a/docs/app-store/testflight-notes/KNOWN-ISSUES.md
+++ b/docs/app-store/testflight-notes/KNOWN-ISSUES.md
@@ -1,0 +1,33 @@
+# Known Issues — reported by testers, tracked until CONFIRMED fixed
+
+> Owner process (2026-08-01): every reported bug stays on this list, with a
+> fix-confidence rating, until the tester who reported it confirms it works.
+> Every build's What-to-Test notes carry the OPEN + AWAITING-CONFIRMATION
+> sections verbatim. Confirmed items move to the Confirmed log below (never
+> deleted). Behavior CHANGES (not bugs) are announced in the notes the build
+> they ship. New feedback is checked daily.
+>
+> Confidence scale: **High** = root cause found and fix verified locally;
+> **Medium** = fix shipped but root cause inferred, not proven; **Low** = not
+> reproducible or fix speculative.
+
+## Awaiting tester confirmation
+
+| Issue | Reported | Fix | Confidence | Please test |
+|---|---|---|---|---|
+| Tablet can't join the company — fails ~2-3s after entering code (P0) | 2026-08-01, build 39, iPad | PR #1616 → first build ≥ 40 | **High** — root cause matched your exact 2-3s timing: Wi-Fi attempt failed and the app never fell back to Bluetooth; now it does, visibly | Fresh code on the iPhone, keep its Add-a-Device screen open, retry the join on the iPad. Expect "Wi-Fi didn't work — downloading over Bluetooth instead…" then completion |
+| Mac pairing failed with Wi-Fi off guidance confusion | 2026-07-31, build 5, Mac | build 6 | **High** — guidance now detects the Wi-Fi radio and says exactly what to turn on | Retry Mac↔iPhone pairing with Wi-Fi ON on both |
+| Notebooks page won't load from More menu | 2026-07-31, build 2, iPhone | rebuilt since; not reproducible on current builds | **Medium** — couldn't reproduce on drained main; may already be fixed | Open More → Notebooks on the current build; screenshot if it still fails |
+
+## Open (not fixed yet — you'll see these)
+
+| Issue | Reported | Priority | Plan |
+|---|---|---|---|
+| Permissions page shows Local Network as "pending" even after you allow it in Settings | 2026-08-01, build 39, iPad | P2 | Re-probe on return from Settings; issue filed |
+| Host says "Sent 9 records" like a success while the new device is still empty | 2026-08-01, build 39, iPhone | P1 | Part of the #1417 sync hardening (progress + honest status, both screens) |
+
+## Confirmed fixed (log — never deleted)
+
+| Issue | Reported | Fixed | Confirmed |
+|---|---|---|---|
+| _(none yet — items land here when the reporting tester confirms)_ | | | |

--- a/docs/runbooks/testflight-upload.md
+++ b/docs/runbooks/testflight-upload.md
@@ -88,6 +88,17 @@ If CLI upload fails on App Store Connect authentication, fall back to the
 Organizer path: copy the archive into `~/Library/Developer/Xcode/Archives/` so
 it appears in Organizer, then upload from there.
 
+## What-to-Test notes — known-issues process (owner 2026-08-01)
+
+Every build's notes include the OPEN and AWAITING-CONFIRMATION sections of
+`docs/app-store/testflight-notes/KNOWN-ISSUES.md` — reported bugs stay listed
+with a fix-confidence rating until the reporting tester confirms the fix, then
+move to the confirmed log (never deleted). Behavior changes are announced in
+the notes the build they ship. Feedback is swept daily; tester follow-up
+questions may be sent from weirdnow@icloud.com (owner-authorized, report each
+send). Kevin's and external testers' reports are never interpreted by guess —
+ask the owner.
+
 ## Release channels (owner directive 2026-07-31)
 
 Two TestFlight channels with very different costs and cadences:


### PR DESCRIPTION
## What (owner directives, 2026-08-01)

1. **`docs/app-store/testflight-notes/KNOWN-ISSUES.md`** — canonical known-issues list: every reported bug, its fix-confidence rating (High/Medium/Low with the reason), and the exact re-test ask. Items stay until the reporting tester confirms, then move to a never-deleted confirmed log. Seeded with all five current items. Build notes will carry the open + awaiting-confirmation sections every build; behavior changes get announced the build they ship.
2. **Device Management → "Start Over"** — a red **Reset This Device** row linking the existing `IOSDatabaseResetPage` (admin-PIN approval → full teardown: device deactivated in the registry, database + defaults wiped, back to onboarding — app stays installed). The whole flow existed; it just wasn't reachable from the Devices page where the owner looked for it.
3. Runbook section documenting the loop: daily feedback sweeps, confidence-rated notes, tester follow-ups from weirdnow@icloud.com (owner-authorized), and the no-guessing rule for Kevin's/external testers' reports.

iOS Simulator build clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)