### PR TITLE
fix(sync): close the 22-table sync gap — allowlist + migration 119 + classification gate

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -154,6 +154,7 @@ extension AppDatabase {
         registerMigration114AIConversationRecency(&migrator)
         registerMigration115SyncReplayGuard(&migrator)
         registerMigration116TeamMutationAttribution(&migrator)
+        registerMigration119SyncGapTables(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -6175,5 +6176,63 @@ private func registerMigration116TeamMutationAttribution(_ migrator: inout Datab
         try addColumnIfMissing(db, table: "employee_teams", column: "deleted_by", type: .integer)
         try addColumnIfMissing(db, table: "employee_team_members", column: "added_by", type: .integer)
         try addColumnIfMissing(db, table: "employee_team_members", column: "removed_by", type: .integer)
+    }
+}
+
+private func registerMigration119SyncGapTables(_ migrator: inout DatabaseMigrator) {
+    migrator.registerMigration("119_sync_gap_tables") { db in
+        // 100%-sync gap closure (owner 2026-08-01; audit on issue #1417).
+        // Migration 112 installed change triggers for the tables in
+        // ConflictResolver.allowedSyncTables AS OF ITS RUN — devices that ran
+        // it before 2026-08-02 never got triggers for these 22 business
+        // tables, so their rows silently stayed device-local. This migration
+        // uses a FROZEN copy of the added set (a migration must not read the
+        // live allowlist — it drifts) and is idempotent (IF NOT EXISTS +
+        // backfill WHERE NOT EXISTS) for fresh installs where 112 already
+        // covered them.
+        let addedTables = [
+            "wishlist_items", "color_brand_skus", "color_supplier_costs", "part_change_log",
+            "job_stages", "job_stage_templates", "job_stage_category_map",
+            "job_return_intakes", "job_return_intake_items",
+            "shift_templates", "company_holidays", "overtime_settings",
+            "vehicle_issue_reports", "vehicle_location_logs",
+            "warehouse_zones", "warehouse_walking_paths", "warehouse_walking_path_stops",
+            "staging_box_contents",
+            "audit_session_events", "multi_user_audit_assignments",
+            "timesheet_correction_audits", "labor_entry_correction_audits",
+        ]
+        let existingTables = try Set(String.fetchAll(
+            db, sql: "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ))
+        for table in addedTables {
+            guard existingTables.contains(table) else { continue }
+            let columns = try String.fetchAll(
+                db, sql: "SELECT name FROM pragma_table_info(?)", arguments: [table]
+            )
+            guard columns.contains("id") else { continue }
+
+            for (op, rowRef) in [("INSERT", "NEW"), ("UPDATE", "NEW"), ("DELETE", "OLD")] {
+                try db.execute(sql: """
+                    CREATE TRIGGER IF NOT EXISTS trg_sync_\(table)_\(op.lowercased())
+                    AFTER \(op) ON [\(table)]
+                    WHEN (SELECT COUNT(*) FROM _sync_apply_guard) = 0
+                    BEGIN
+                        INSERT INTO _change_log (device_id, table_name, record_id, operation)
+                        VALUES ('', '\(table)', \(rowRef).id, '\(op)');
+                    END
+                    """)
+            }
+
+            // Backfill exactly as migration 112 did: pre-existing rows get one
+            // bootstrap INSERT entry so the next sync delivers them.
+            try db.execute(sql: """
+                INSERT INTO _change_log (device_id, table_name, record_id, operation, changed_fields)
+                SELECT '', '\(table)', id, 'INSERT', '{"__backfill__":1}' FROM [\(table)]
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM _change_log
+                    WHERE table_name = '\(table)' AND record_id = [\(table)].id
+                )
+                """)
+        }
     }
 }

--- a/core/Sources/WiredPartCore/Sync/ConflictResolver.swift
+++ b/core/Sources/WiredPartCore/Sync/ConflictResolver.swift
@@ -173,6 +173,18 @@ public enum ConflictResolver {
         "payment_records", "customer_communications", "contractor_notes", "contractor_ratings",
         // Work classification audit
         "classification_history",
+        // 100%-sync gap closure (owner directive 2026-08-01, audit on #1417):
+        // business tables that predated any classification gate. Their change
+        // triggers are installed by migration 119 (frozen copy of this list).
+        "wishlist_items", "color_brand_skus", "color_supplier_costs", "part_change_log",
+        "job_stages", "job_stage_templates", "job_stage_category_map",
+        "job_return_intakes", "job_return_intake_items",
+        "shift_templates", "company_holidays", "overtime_settings",
+        "vehicle_issue_reports", "vehicle_location_logs",
+        "warehouse_zones", "warehouse_walking_paths", "warehouse_walking_path_stops",
+        "staging_box_contents",
+        "audit_session_events", "multi_user_audit_assignments",
+        "timesheet_correction_audits", "labor_entry_correction_audits",
         // Estimation
         "estimation_questions", "estimation_responses", "estimation_results",
         "estimation_reviews", "estimation_question_rejections",
@@ -216,6 +228,30 @@ public enum ConflictResolver {
 
     /// Validate that a table name is in the whitelist.
     /// Returns false for unknown or potentially malicious table names.
+    /// Tables that intentionally NEVER sync — device-scoped by design.
+    /// Every table in the database must appear in exactly one of
+    /// `allowedSyncTables` or this set; `SyncTableClassificationTests`
+    /// fails the build when a new table is left unclassified (the gap that
+    /// silently accumulated 22 unsynced business tables until 2026-08-01).
+    static let deviceLocalTables: Set<String> = [
+        // Per-Mac AI agent keys and their audit trail — trust is per device.
+        "agent_links", "agent_link_calls",
+        // Per-device login sessions.
+        "auth_token_sessions",
+        // Local wizard/import scratch state.
+        "company_setup_draft", "part_import_sessions",
+        "part_import_row_evidence", "part_import_saved_mappings",
+        // Local operational logs and locks (lock semantics cannot survive
+        // asynchronous merge).
+        "background_task_log", "notebook_entry_edit_locks",
+        // On-device AI conversations (architecture: never leave the device).
+        "ai_conversation_messages",
+        // Regenerable ML derivatives.
+        "part_image_features",
+        // On-device estimation calibration.
+        "estimation_question_accuracy_reviews",
+    ]
+
     public static func isAllowedTable(_ name: String) -> Bool {
         allowedSyncTables.contains(name.lowercased())
     }

--- a/core/Tests/WiredPartCoreTests/SyncTableClassificationTests.swift
+++ b/core/Tests/WiredPartCoreTests/SyncTableClassificationTests.swift
@@ -80,4 +80,82 @@ struct SyncTableClassificationTests {
         }
         #expect(logged >= 1, "company_holidays INSERT was not change-tracked")
     }
+
+    @Test("Migration 119 upgrades pre-gap stores without echoing sync-applied writes")
+    func migration119BackfillsExistingRowsAndHonorsApplyGuard() throws {
+        var config = Configuration()
+        config.foreignKeysEnabled = true
+        let queue = try DatabaseQueue(configuration: config)
+
+        // Reproduce a store that ran the historical migration 112 before these
+        // tables were added to its allowlist: its schema and guard table exist,
+        // but company_holidays has no change triggers or bootstrap row.
+        var historicalMigrator = DatabaseMigrator()
+        AppDatabase.registerMigrations(&historicalMigrator)
+        try historicalMigrator.migrate(queue, upTo: "111_chat_attachment_storage_relative")
+        try queue.write { db in
+            try db.execute(sql: "CREATE TABLE _sync_apply_guard (id INTEGER PRIMARY KEY)")
+        }
+        var appliedHistorical112 = DatabaseMigrator()
+        appliedHistorical112.registerMigration("112_change_tracking_triggers") { _ in }
+        try appliedHistorical112.migrate(queue)
+        try queue.write { db in
+            try db.execute(sql: """
+                INSERT INTO company_holidays (name, date)
+                VALUES ('Pre-migration holiday', '2026-12-25')
+                """)
+        }
+
+        var currentMigrator = DatabaseMigrator()
+        AppDatabase.registerMigrations(&currentMigrator)
+        try currentMigrator.migrate(queue)
+
+        let upgraded = try queue.read { db -> (bootstrapRows: Int, triggers: Set<String>) in
+            let bootstrapRows = try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM _change_log
+                WHERE table_name = 'company_holidays'
+                  AND operation = 'INSERT'
+                  AND changed_fields = '{"__backfill__":1}'
+                """) ?? 0
+            let triggers = try Set(String.fetchAll(db, sql: """
+                SELECT name FROM sqlite_master
+                WHERE type = 'trigger' AND name IN (?, ?, ?)
+                """, arguments: [
+                    "trg_sync_company_holidays_insert",
+                    "trg_sync_company_holidays_update",
+                    "trg_sync_company_holidays_delete",
+                ]))
+            return (bootstrapRows, triggers)
+        }
+        #expect(upgraded.bootstrapRows == 1, "migration 119 must backfill one existing gap-table row")
+        #expect(upgraded.triggers == [
+            "trg_sync_company_holidays_insert",
+            "trg_sync_company_holidays_update",
+            "trg_sync_company_holidays_delete",
+        ])
+
+        try queue.write { db in
+            try db.execute(sql: "UPDATE company_holidays SET name = 'Local edit' WHERE id = 1")
+        }
+        let localUpdates = try queue.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM _change_log
+                WHERE table_name = 'company_holidays' AND operation = 'UPDATE'
+                """) ?? 0
+        }
+        #expect(localUpdates == 1, "normal gap-table writes must be change-tracked")
+
+        try queue.write { db in
+            try db.execute(sql: "INSERT INTO _sync_apply_guard (id) VALUES (1)")
+            try db.execute(sql: "UPDATE company_holidays SET name = 'Peer edit' WHERE id = 1")
+            try db.execute(sql: "DELETE FROM _sync_apply_guard WHERE id = 1")
+        }
+        let guardedUpdates = try queue.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM _change_log
+                WHERE table_name = 'company_holidays' AND operation = 'UPDATE'
+                """) ?? 0
+        }
+        #expect(guardedUpdates == localUpdates, "sync-applied writes must not echo into _change_log")
+    }
 }

--- a/core/Tests/WiredPartCoreTests/SyncTableClassificationTests.swift
+++ b/core/Tests/WiredPartCoreTests/SyncTableClassificationTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+import GRDB
+@testable import WiredPartCore
+
+/// The gate that closes the 100%-sync gap for good (owner directive
+/// 2026-08-01; audit on #1417): every table in the database must be
+/// explicitly classified as synced (`allowedSyncTables`) or device-local
+/// (`deviceLocalTables`). A new table without a classification fails here,
+/// so it can never silently join the 22 that accumulated before 2026-08-02.
+@Suite("Sync table classification")
+struct SyncTableClassificationTests {
+
+    private func allBusinessTables(_ db: AppDatabase) throws -> Set<String> {
+        try db.writer.read { dbc in
+            try Set(String.fetchAll(dbc, sql: """
+                SELECT name FROM sqlite_master
+                WHERE type = 'table'
+                  AND name NOT LIKE 'sqlite\\_%' ESCAPE '\\'
+                  AND name NOT LIKE '\\_%' ESCAPE '\\'
+                  AND name != 'grdb_migrations'
+                """))
+        }
+    }
+
+    @Test("Every table is classified as synced or device-local — no third bucket")
+    func everyTableClassified() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        let tables = try allBusinessTables(db)
+        let unclassified = tables
+            .subtracting(ConflictResolver.allowedSyncTables)
+            .subtracting(ConflictResolver.deviceLocalTables)
+        #expect(
+            unclassified.isEmpty,
+            "Unclassified tables (add to allowedSyncTables — plus a trigger migration — or to deviceLocalTables with a reason): \(unclassified.sorted())"
+        )
+    }
+
+    @Test("The two classifications never overlap")
+    func classificationsDisjoint() {
+        let overlap = ConflictResolver.allowedSyncTables
+            .intersection(ConflictResolver.deviceLocalTables)
+        #expect(overlap.isEmpty, "Tables in BOTH sets: \(overlap.sorted())")
+    }
+
+    @Test("Migration 119 installed change triggers for the gap tables")
+    func gapTableTriggersExist() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        // Spot-check one table per affected area, all three operations.
+        for table in ["wishlist_items", "job_stages", "company_holidays",
+                      "warehouse_zones", "timesheet_correction_audits"] {
+            for op in ["insert", "update", "delete"] {
+                let exists = try db.writer.read { dbc in
+                    try Bool.fetchOne(dbc, sql: """
+                        SELECT EXISTS(
+                            SELECT 1 FROM sqlite_master
+                            WHERE type = 'trigger' AND name = ?
+                        )
+                        """, arguments: ["trg_sync_\(table)_\(op)"]) ?? false
+                }
+                #expect(exists, "missing trigger trg_sync_\(table)_\(op)")
+            }
+        }
+    }
+
+    @Test("Gap-table writes now land in the change log")
+    func gapTableWriteIsTracked() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        try db.writer.write { dbc in
+            try dbc.execute(sql: """
+                INSERT INTO company_holidays (name, date)
+                VALUES ('Christmas', '2026-12-25')
+                """)
+        }
+        let logged = try db.writer.read { dbc in
+            try Int.fetchOne(dbc, sql: """
+                SELECT COUNT(*) FROM _change_log
+                WHERE table_name = 'company_holidays' AND operation = 'INSERT'
+                """) ?? 0
+        }
+        #expect(logged >= 1, "company_holidays INSERT was not change-tracked")
+    }
+}


### PR DESCRIPTION
## What (owner 100%-sync directive, audit posted on #1417)

22 business tables never synced between devices — they were missing from `ConflictResolver.allowedSyncTables`, which both gates sync application AND drove migration 112's trigger install. Anything added after 112 ran silently stayed device-local: wishlist items, color SKU pricing/supplier costs, job stages + templates, return intakes, shift templates, company holidays, overtime settings, vehicle issue reports + location logs, warehouse zones + walking paths, staging box contents, and the audit/correction trails.

## Fix

1. **Allowlist += 22** (documented gap-closure block).
2. **Migration 119** installs their AFTER INSERT/UPDATE/DELETE triggers + the same bootstrap backfill 112 used, from a **frozen** table list — migrations must not read the live allowlist, which is exactly how this drift happened. Idempotent (`IF NOT EXISTS` + `WHERE NOT EXISTS`) for fresh installs.
3. **`deviceLocalTables`** — the 12 intentional exemptions, each with its reason (per-Mac agent keys, per-device sessions, import scratch, edit locks, on-device AI, regenerable ML features).
4. **`SyncTableClassificationTests`** — the permanent gate: every table must appear in exactly one of the two sets, so a future migration adding an unclassified table FAILS CI instead of silently not syncing. Plus trigger spot-checks and a live write→change-log proof.

## Verification

Full core suite locally: **2554/2554**. Field effect: after this ships, edits in the 22 areas replicate between the owner's iPhone/iPad/Mac like everything else; pre-existing rows backfill on first sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Tracked in WEI-6768.