### PR TITLE
fix(auth): Mac sessions survive relaunch — sandbox fallback for the signing key

### DIFF
--- a/.github/workflows/ios-beta-gate.yml
+++ b/.github/workflows/ios-beta-gate.yml
@@ -37,6 +37,10 @@ jobs:
       SIMULATOR_BOOT_TIMEOUT_SECONDS: "600"
       SIMULATOR_BOOT_RECOVERY_TIMEOUT_SECONDS: "600"
       XCODE_PHASE_TIMEOUT_SECONDS: "2400"
+      # The iPad UI-smoke plan exceeded the prior 15-minute allowance after
+      # its unit phase passed. Keep the phase bounded while allowing the full
+      # deterministic plan to finalize a valid result bundle.
+      UI_SMOKE_PHASE_TIMEOUT_SECONDS: "1200"
       JOB_TIMEOUT_SECONDS: "7200"
       CLEANUP_UPLOAD_MARGIN_SECONDS: "1080"
 

--- a/core/Sources/WiredPartCore/Services/AuthService.swift
+++ b/core/Sources/WiredPartCore/Services/AuthService.swift
@@ -1290,6 +1290,14 @@ public final class AuthService: Sendable {
             _ = SecItemUpdate(migrateQuery as CFDictionary, migrateAttrs as CFDictionary)
             return SymmetricKey(data: data)
         }
+        // Keychain-less environments (iPad binary on Apple Silicon Macs —
+        // errSecMissingEntitlement, the #1622 class): reuse the sandbox
+        // fallback key so sessions survive relaunch there too. A working
+        // keychain always wins the read above, so real iPhones/iPads never
+        // reach this.
+        if let fallback = AuthService.readFallbackSigningKey() {
+            return SymmetricKey(data: fallback)
+        }
         // Generate a new 256-bit key and persist it.
         var keyBytes = [UInt8](repeating: 0, count: 32)
         _ = SecRandomCopyBytes(kSecRandomDefault, 32, &keyBytes)
@@ -1304,12 +1312,50 @@ public final class AuthService: Sendable {
         ]
         let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
         if addStatus != errSecSuccess && addStatus != errSecDuplicateItem {
-            // Key generated but not persisted — tokens will invalidate on next app launch.
-            // errSecDuplicateItem is benign (item was added between our read and write).
-            AuthService.logger.warning("SecItemAdd failed (OSStatus \(addStatus)) — signing key in memory only. Tokens will not survive app restart.")
+            if addStatus == errSecMissingEntitlement || addStatus == errSecNotAvailable {
+                // Keychain unusable in THIS environment (not merely locked) —
+                // persist to the sandbox fallback so Mac sessions survive
+                // relaunch (issue: re-login every launch on iPad-on-Mac).
+                AuthService.logger.warning("SecItemAdd failed (OSStatus \(addStatus)) — persisting signing key to sandbox fallback (keychain-less environment).")
+                AuthService.writeFallbackSigningKey(keyData)
+            } else {
+                // Key generated but not persisted — tokens will invalidate on next app launch.
+                // errSecDuplicateItem is benign (item was added between our read and write).
+                AuthService.logger.warning("SecItemAdd failed (OSStatus \(addStatus)) — signing key in memory only. Tokens will not survive app restart.")
+            }
         }
         return SymmetricKey(data: keyData)
     }()
+
+    /// Sandbox fallback for the session signing key — used ONLY where the
+    /// keychain reports missing-entitlement/not-available (same tradeoff and
+    /// storage envelope as CipherKeyManager's salt fallback from #1622).
+    private static func fallbackSigningKeyURL() -> URL? {
+        guard let supportURL = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask
+        ).first else { return nil }
+        let dir = supportURL.appendingPathComponent("WiredPart", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("session-signing-key.bin")
+    }
+
+    private static func readFallbackSigningKey() -> Data? {
+        guard let url = fallbackSigningKeyURL(),
+              let data = try? Data(contentsOf: url), data.count == 32 else { return nil }
+        return data
+    }
+
+    private static func writeFallbackSigningKey(_ key: Data) {
+        guard var url = fallbackSigningKeyURL() else { return }
+        do {
+            try key.write(to: url, options: .atomic)
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            try? url.setResourceValues(values)
+        } catch {
+            AuthService.logger.warning("Could not persist fallback signing key: \(error.localizedDescription)")
+        }
+    }
 
     /// Generate a signed local session token (base64 payload + HMAC-SHA256 signature).
     static func generateLocalToken(userId: Int64) -> String? {

--- a/core/Sources/WiredPartCore/Services/AuthService.swift
+++ b/core/Sources/WiredPartCore/Services/AuthService.swift
@@ -1292,10 +1292,10 @@ public final class AuthService: Sendable {
         }
         // Keychain-less environments (iPad binary on Apple Silicon Macs —
         // errSecMissingEntitlement, the #1622 class): reuse the sandbox
-        // fallback key so sessions survive relaunch there too. A working
-        // keychain always wins the read above, so real iPhones/iPads never
-        // reach this.
-        if let fallback = AuthService.readFallbackSigningKey() {
+        // fallback key so sessions survive relaunch there too. Locked and
+        // other Keychain failures must not use the fallback.
+        if AuthService.canUseSigningKeyFallback(for: status),
+           let fallback = AuthService.readFallbackSigningKey() {
             return SymmetricKey(data: fallback)
         }
         // Generate a new 256-bit key and persist it.
@@ -1312,7 +1312,7 @@ public final class AuthService: Sendable {
         ]
         let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
         if addStatus != errSecSuccess && addStatus != errSecDuplicateItem {
-            if addStatus == errSecMissingEntitlement || addStatus == errSecNotAvailable {
+            if AuthService.canUseSigningKeyFallback(for: addStatus) {
                 // Keychain unusable in THIS environment (not merely locked) —
                 // persist to the sandbox fallback so Mac sessions survive
                 // relaunch (issue: re-login every launch on iPad-on-Mac).
@@ -1330,6 +1330,10 @@ public final class AuthService: Sendable {
     /// Sandbox fallback for the session signing key — used ONLY where the
     /// keychain reports missing-entitlement/not-available (same tradeoff and
     /// storage envelope as CipherKeyManager's salt fallback from #1622).
+    static func canUseSigningKeyFallback(for status: OSStatus) -> Bool {
+        status == errSecMissingEntitlement || status == errSecNotAvailable
+    }
+
     private static func fallbackSigningKeyURL() -> URL? {
         guard let supportURL = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask

--- a/core/Tests/WiredPartCoreTests/AuthServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/AuthServiceTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 import GRDB
 import CryptoKit
+import Security
 @testable import WiredPartCore
 
 @Suite("AuthService Tests", .serialized)
@@ -88,6 +89,14 @@ struct AuthServiceTests {
     }
 
     // MARK: - Token Generation & Parsing
+
+    @Test("session signing-key fallback is limited to unavailable Keychain states")
+    func testSigningKeyFallbackStatesStayNarrow() {
+        #expect(AuthService.canUseSigningKeyFallback(for: errSecMissingEntitlement))
+        #expect(AuthService.canUseSigningKeyFallback(for: errSecNotAvailable))
+        #expect(!AuthService.canUseSigningKeyFallback(for: errSecInteractionNotAllowed))
+        #expect(!AuthService.canUseSigningKeyFallback(for: errSecAuthFailed))
+    }
 
     @Test("generateLocalToken produces signed payload.signature format")
     func testGenerateToken() throws {

--- a/scripts/ci/validate-ios-beta-gate-source.py
+++ b/scripts/ci/validate-ios-beta-gate-source.py
@@ -24,6 +24,7 @@ required_workflow_fragments = {
     "iPad required context remains stable": "- name: iPad",
     "job timeout is declared": "timeout-minutes: 120",
     "script receives the job timeout": 'JOB_TIMEOUT_SECONDS: "7200"',
+    "UI-smoke phase retains its bounded timeout": 'UI_SMOKE_PHASE_TIMEOUT_SECONDS: "1200"',
     "cleanup and upload margin is reserved": 'CLEANUP_UPLOAD_MARGIN_SECONDS: "1080"',
 }
 


### PR DESCRIPTION
## What

Follow-up to #1622, same root environment: on Apple Silicon Macs the iPad binary gets `errSecMissingEntitlement` from every SecItem call, so the **session-token signing key** never persisted — a fresh key each launch invalidated all tokens, forcing the owner to **log in every time the app opened on the Mac** (the known-issue line shipped in build 41's notes).

Fix mirrors #1622 exactly: when `SecItemAdd` reports missing-entitlement/not-available, the key persists to an atomic, backup-excluded sandbox file; the keychain read always wins where it works, so iPhones/iPads never touch the fallback and locked-keychain semantics are unchanged.

## Verification

AuthService suites 89/89 locally. Owner field check once shipped: log in on the Mac, quit, reopen — still signed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Tracked in WEI-6769