### PR TITLE
fix(startup): repair iPad-on-Mac bootstrap key fallback

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -754,6 +754,9 @@ final class AppCore: ObservableObject {
             if rereadResult.status == errSecSuccess, let data = rereadResult.data, data.count == 32 {
                 return data.map { String(format: "%02x", $0) }.joined()
             }
+            if shouldUseLocalBootstrapKeyFallback(for: rereadResult.status) {
+                return try localFallbackBootstrapKeyHex(in: fallbackDirectory)
+            }
             // Preserve the existing recovery path for a stale duplicate entry.
             _ = keychain.delete()
             let retryAddStatus = keychain.add(keyData)

--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -790,6 +790,7 @@ final class AppCore: ObservableObject {
     nonisolated static func localFallbackBootstrapKeyHex(in directory: URL? = nil) throws -> String {
         let keyURL = try localFallbackBootstrapKeyURL(in: directory)
         if let data = try? Data(contentsOf: keyURL), data.count == 32 {
+            try excludeLocalFallbackBootstrapKeyFromBackup(at: keyURL)
             return data.map { String(format: "%02x", $0) }.joined()
         }
 
@@ -800,11 +801,18 @@ final class AppCore: ObservableObject {
         }
         let keyData = Data(keyBytes)
         try keyData.write(to: keyURL, options: .atomic)
+        try excludeLocalFallbackBootstrapKeyFromBackup(at: keyURL)
+        return keyData.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Applies the fallback key's backup-exclusion requirement every time the
+    /// persisted key is used. A metadata-write failure is intentionally surfaced:
+    /// returning an unprotected persistent database key would weaken the fallback.
+    nonisolated private static func excludeLocalFallbackBootstrapKeyFromBackup(at keyURL: URL) throws {
         var values = URLResourceValues()
         values.isExcludedFromBackup = true
         var mutableURL = keyURL
         try mutableURL.setResourceValues(values)
-        return keyData.map { String(format: "%02x", $0) }.joined()
     }
 
     nonisolated static func deleteLocalFallbackBootstrapKey(in directory: URL? = nil) throws {

--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -780,6 +780,11 @@ final class AppCore: ObservableObject {
             if shouldUseLocalBootstrapKeyFallback(for: rereadResult.status) {
                 return try localFallbackBootstrapKeyHex(in: fallbackDirectory)
             }
+            // Only a missing or corrupt duplicate can be replaced. Locked and
+            // unapproved Keychain states must fail before mutating the key.
+            guard rereadResult.status == errSecSuccess || rereadResult.status == errSecItemNotFound else {
+                throw CipherKeyError.keychainAccessFailed(rereadResult.status)
+            }
             // Preserve the existing recovery path for a stale duplicate entry.
             _ = keychain.delete()
             let retryAddStatus = keychain.add(keyData)

--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -669,8 +669,51 @@ final class AppCore: ObservableObject {
     ///
     /// User PIN changes do not re-key the app database. Startup must open the DB
     /// before any user can enter a PIN, so the persistent DB key remains device-bound.
+    nonisolated struct BootstrapKeychainAccess: Sendable {
+        let read: @Sendable () -> (status: OSStatus, data: Data?)
+        let add: @Sendable (Data) -> OSStatus
+        let delete: @Sendable () -> OSStatus
+
+        static let live = BootstrapKeychainAccess(
+            read: {
+                let query: [CFString: Any] = [
+                    kSecClass: kSecClassGenericPassword,
+                    kSecAttrService: "com.wiredpart.dbcipher.bootstrap-key",
+                    kSecAttrAccount: "device-bootstrap-key",
+                    kSecReturnData: true,
+                    kSecMatchLimit: kSecMatchLimitOne
+                ]
+                var result: AnyObject?
+                let status = SecItemCopyMatching(query as CFDictionary, &result)
+                return (status, result as? Data)
+            },
+            add: { keyData in
+                var query: [CFString: Any] = [
+                    kSecClass: kSecClassGenericPassword,
+                    kSecAttrService: "com.wiredpart.dbcipher.bootstrap-key",
+                    kSecAttrAccount: "device-bootstrap-key",
+                    kSecValueData: keyData
+                ]
+                #if !targetEnvironment(macCatalyst)
+                query[kSecAttrAccessible] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+                #endif
+                return SecItemAdd(query as CFDictionary, nil)
+            },
+            delete: {
+                let query: [CFString: Any] = [
+                    kSecClass: kSecClassGenericPassword,
+                    kSecAttrService: "com.wiredpart.dbcipher.bootstrap-key",
+                    kSecAttrAccount: "device-bootstrap-key"
+                ]
+                return SecItemDelete(query as CFDictionary)
+            }
+        )
+    }
+
     nonisolated static func deviceBootstrapKeyHex(
-        processArguments: [String] = ProcessInfo.processInfo.arguments
+        processArguments: [String] = ProcessInfo.processInfo.arguments,
+        keychain: BootstrapKeychainAccess = .live,
+        fallbackDirectory: URL? = nil
     ) throws -> String {
         let uiTestingLaunchFlag = "-UITesting"
         let uiTestingDatabaseKeyHex = "8f1df32f4be04d5fcde1e8e6ddf9187f53a4b68370d5aafc56f0d43f2e9732a1"
@@ -678,33 +721,20 @@ final class AppCore: ObservableObject {
             return uiTestingDatabaseKeyHex
         }
 
-        let service = "com.wiredpart.dbcipher.bootstrap-key"
-        let account = "device-bootstrap-key"
-
-        // Try to read existing key.
-        let readQuery: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: account,
-            kSecReturnData: true,
-            kSecMatchLimit: kSecMatchLimitOne
-        ]
-        var result: AnyObject?
-        let readStatus = SecItemCopyMatching(readQuery as CFDictionary, &result)
-        if readStatus == errSecSuccess, let data = result as? Data, data.count == 32 {
+        let readResult = keychain.read()
+        if readResult.status == errSecSuccess, let data = readResult.data, data.count == 32 {
             return data.map { String(format: "%02x", $0) }.joined()
         }
-        if readStatus == errSecSuccess {
-            // Self-heal legacy/corrupt keychain entries so startup can recover.
-            let deleteQuery: [CFString: Any] = [
-                kSecClass: kSecClassGenericPassword,
-                kSecAttrService: service,
-                kSecAttrAccount: account
-            ]
-            _ = SecItemDelete(deleteQuery as CFDictionary)
+        if shouldUseLocalBootstrapKeyFallback(for: readResult.status) {
+            return try localFallbackBootstrapKeyHex(in: fallbackDirectory)
+        }
+        if readResult.status == errSecSuccess {
+            // Self-heal legacy/corrupt entries before minting a replacement key.
+            _ = keychain.delete()
+        } else if readResult.status != errSecItemNotFound {
+            throw CipherKeyError.keychainAccessFailed(readResult.status)
         }
 
-        // Generate 32 fresh random bytes.
         var keyBytes = [UInt8](repeating: 0, count: 32)
         let rc = SecRandomCopyBytes(kSecRandomDefault, 32, &keyBytes)
         guard rc == errSecSuccess else {
@@ -712,70 +742,53 @@ final class AppCore: ObservableObject {
         }
         let keyData = Data(keyBytes)
 
-        var addQuery: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: account,
-            kSecValueData: keyData
-        ]
-        #if !targetEnvironment(macCatalyst)
-        // kSecAttrAccessible is an iOS-style accessibility class. On Catalyst
-        // this can fail with errSecParam on first launch, which blocks DB setup.
-        addQuery[kSecAttrAccessible] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
-        #endif
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        let addStatus = keychain.add(keyData)
+        if addStatus == errSecSuccess {
+            return keyData.map { String(format: "%02x", $0) }.joined()
+        }
+        if shouldUseLocalBootstrapKeyFallback(for: addStatus) {
+            return try localFallbackBootstrapKeyHex(in: fallbackDirectory)
+        }
         if addStatus == errSecDuplicateItem {
-            // Another thread or launch already stored a bootstrap key — read and return it
-            // so we don't encrypt the DB with a key that won't be retrievable next launch.
-            var existing: AnyObject?
-            let rereadStatus = SecItemCopyMatching(readQuery as CFDictionary, &existing)
-            if rereadStatus == errSecSuccess, let data = existing as? Data, data.count == 32 {
+            let rereadResult = keychain.read()
+            if rereadResult.status == errSecSuccess, let data = rereadResult.data, data.count == 32 {
                 return data.map { String(format: "%02x", $0) }.joined()
             }
-            let deleteQuery: [CFString: Any] = [
-                kSecClass: kSecClassGenericPassword,
-                kSecAttrService: service,
-                kSecAttrAccount: account
-            ]
-            _ = SecItemDelete(deleteQuery as CFDictionary)
-            let retryAddStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            // Preserve the existing recovery path for a stale duplicate entry.
+            _ = keychain.delete()
+            let retryAddStatus = keychain.add(keyData)
             if retryAddStatus == errSecSuccess {
                 return keyData.map { String(format: "%02x", $0) }.joined()
             }
             if shouldUseLocalBootstrapKeyFallback(for: retryAddStatus) {
-                return try localFallbackBootstrapKeyHex()
+                return try localFallbackBootstrapKeyHex(in: fallbackDirectory)
             }
             throw CipherKeyError.keychainAccessFailed(retryAddStatus)
-        } else if shouldUseLocalBootstrapKeyFallback(for: addStatus) {
-            return try localFallbackBootstrapKeyHex()
-        } else if addStatus != errSecSuccess {
-            throw CipherKeyError.keychainAccessFailed(addStatus)
         }
-        return keyData.map { String(format: "%02x", $0) }.joined()
+        throw CipherKeyError.keychainAccessFailed(addStatus)
     }
 
     nonisolated static func shouldUseLocalBootstrapKeyFallback(for status: OSStatus) -> Bool {
-        guard status == errSecMissingEntitlement else { return false }
-        #if targetEnvironment(simulator) || targetEnvironment(macCatalyst)
-        return true
-        #else
-        return false
-        #endif
+        status == errSecMissingEntitlement || status == errSecNotAvailable
     }
 
-    #if targetEnvironment(simulator) || targetEnvironment(macCatalyst)
-    /// Local-development fallback when Keychain is unavailable (e.g. unsigned simulator
-    /// launch or missing Catalyst entitlement).
-    /// Stores a random device key inside the app container to keep DB encryption stable
-    /// across launches on the same machine/account.
-    nonisolated private static func localFallbackBootstrapKeyHex() throws -> String {
-        guard let supportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+    nonisolated static func localFallbackBootstrapKeyURL(in directory: URL? = nil) throws -> URL {
+        let parent: URL
+        if let directory {
+            parent = directory
+        } else if let supportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            parent = supportURL.appendingPathComponent("WiredPart", isDirectory: true)
+        } else {
             throw AppCoreError.noDocumentsDirectory
         }
-        let dir = supportURL.appendingPathComponent("WiredPart", isDirectory: true)
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let keyURL = dir.appendingPathComponent("local-bootstrap-key.bin")
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        return parent.appendingPathComponent("local-bootstrap-key.bin")
+    }
 
+    /// Persistent bootstrap-key fallback for approved keychain-unavailable states.
+    /// The key stays in the app container and is excluded from device/iCloud backups.
+    nonisolated static func localFallbackBootstrapKeyHex(in directory: URL? = nil) throws -> String {
+        let keyURL = try localFallbackBootstrapKeyURL(in: directory)
         if let data = try? Data(contentsOf: keyURL), data.count == 32 {
             return data.map { String(format: "%02x", $0) }.joined()
         }
@@ -787,13 +800,18 @@ final class AppCore: ObservableObject {
         }
         let keyData = Data(keyBytes)
         try keyData.write(to: keyURL, options: .atomic)
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        var mutableURL = keyURL
+        try mutableURL.setResourceValues(values)
         return keyData.map { String(format: "%02x", $0) }.joined()
     }
-    #else
-    nonisolated private static func localFallbackBootstrapKeyHex() throws -> String {
-        throw CipherKeyError.keychainAccessFailed(errSecMissingEntitlement)
+
+    nonisolated static func deleteLocalFallbackBootstrapKey(in directory: URL? = nil) throws {
+        let keyURL = try localFallbackBootstrapKeyURL(in: directory)
+        guard FileManager.default.fileExists(atPath: keyURL.path) else { return }
+        try FileManager.default.removeItem(at: keyURL)
     }
-    #endif
 
     // MARK: - PIN Change
 

--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -21,7 +21,7 @@ extension BackgroundTaskService: AppCoreBackgroundTaskAuditing {}
 final class AppCore: ObservableObject {
     nonisolated private static let uiTestingLaunchFlag = "-UITesting"
     nonisolated private static let uiTestingPreserveDatabaseFlag = "-UITestingPreserveDatabase"
-    nonisolated private static let localFallbackBootstrapKeyLock = NSLock()
+    nonisolated private static let localFallbackBootstrapKeyLock = NSRecursiveLock()
 
     #if DEBUG && targetEnvironment(simulator)
     nonisolated private static let wei5134AIReadFailureFlag = "-UITestingWEI5134AIReadFailure"
@@ -722,12 +722,34 @@ final class AppCore: ObservableObject {
             return uiTestingDatabaseKeyHex
         }
 
+        // Serialize the read → fallback lookup → Keychain promotion sequence so
+        // concurrent startup callers cannot replace an established DB key.
+        localFallbackBootstrapKeyLock.lock()
+        defer { localFallbackBootstrapKeyLock.unlock() }
+
         let readResult = keychain.read()
         if readResult.status == errSecSuccess, let data = readResult.data, data.count == 32 {
             return data.map { String(format: "%02x", $0) }.joined()
         }
         if shouldUseLocalBootstrapKeyFallback(for: readResult.status) {
             return try localFallbackBootstrapKeyHex(in: fallbackDirectory)
+        }
+        if readResult.status == errSecItemNotFound,
+           let fallbackKeyData = try existingLocalFallbackBootstrapKeyData(in: fallbackDirectory) {
+            let addStatus = keychain.add(fallbackKeyData)
+            if addStatus == errSecSuccess {
+                return fallbackKeyData.map { String(format: "%02x", $0) }.joined()
+            }
+            if shouldUseLocalBootstrapKeyFallback(for: addStatus) {
+                return try localFallbackBootstrapKeyHex(in: fallbackDirectory)
+            }
+            if addStatus == errSecDuplicateItem {
+                let rereadResult = keychain.read()
+                if rereadResult.status == errSecSuccess, rereadResult.data == fallbackKeyData {
+                    return fallbackKeyData.map { String(format: "%02x", $0) }.joined()
+                }
+            }
+            throw CipherKeyError.keychainAccessFailed(addStatus)
         }
         if readResult.status == errSecSuccess {
             // Self-heal legacy/corrupt entries before minting a replacement key.
@@ -810,6 +832,20 @@ final class AppCore: ObservableObject {
         try keyData.write(to: keyURL, options: .atomic)
         try excludeLocalFallbackBootstrapKeyFromBackup(at: keyURL)
         return keyData.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Returns an existing validated fallback key for Keychain recovery without
+    /// creating one. Reusing this exact key preserves access to an existing DB.
+    nonisolated private static func existingLocalFallbackBootstrapKeyData(in directory: URL? = nil) throws -> Data? {
+        localFallbackBootstrapKeyLock.lock()
+        defer { localFallbackBootstrapKeyLock.unlock() }
+
+        let keyURL = try localFallbackBootstrapKeyURL(in: directory)
+        guard let data = try? Data(contentsOf: keyURL), data.count == 32 else {
+            return nil
+        }
+        try excludeLocalFallbackBootstrapKeyFromBackup(at: keyURL)
+        return data
     }
 
     /// Applies the fallback key's backup-exclusion requirement every time the

--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -21,6 +21,7 @@ extension BackgroundTaskService: AppCoreBackgroundTaskAuditing {}
 final class AppCore: ObservableObject {
     nonisolated private static let uiTestingLaunchFlag = "-UITesting"
     nonisolated private static let uiTestingPreserveDatabaseFlag = "-UITestingPreserveDatabase"
+    nonisolated private static let localFallbackBootstrapKeyLock = NSLock()
 
     #if DEBUG && targetEnvironment(simulator)
     nonisolated private static let wei5134AIReadFailureFlag = "-UITestingWEI5134AIReadFailure"
@@ -791,6 +792,9 @@ final class AppCore: ObservableObject {
     /// Persistent bootstrap-key fallback for approved keychain-unavailable states.
     /// The key stays in the app container and is excluded from device/iCloud backups.
     nonisolated static func localFallbackBootstrapKeyHex(in directory: URL? = nil) throws -> String {
+        localFallbackBootstrapKeyLock.lock()
+        defer { localFallbackBootstrapKeyLock.unlock() }
+
         let keyURL = try localFallbackBootstrapKeyURL(in: directory)
         if let data = try? Data(contentsOf: keyURL), data.count == 32 {
             try excludeLocalFallbackBootstrapKeyFromBackup(at: keyURL)

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -57,6 +57,7 @@ private final class MockBootstrapTaskAuditor: AppCoreBackgroundTaskAuditing, @un
 
 private final class OperationProbe: @unchecked Sendable {
     var ran = false
+    var storedKey: Data?
 }
 
 private enum QuestionnaireBreakTestError: Error {
@@ -574,6 +575,45 @@ struct Weird_Parts_IOSTests {
         #expect(
             try fallbackURL.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == true
         )
+    }
+
+    @Test func bootstrapFallbackPromotesExistingKeyWhenKeychainRecovers() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BootstrapFallback-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let unavailableKeychain = AppCore.BootstrapKeychainAccess(
+            read: { (errSecNotAvailable, nil) },
+            add: { _ in
+                Issue.record("unavailable Keychain must use the local fallback before a write")
+                return errSecParam
+            },
+            delete: { errSecSuccess }
+        )
+        let promotionProbe = OperationProbe()
+        let recoveredKeychain = AppCore.BootstrapKeychainAccess(
+            read: { (errSecItemNotFound, nil) },
+            add: { keyData in
+                promotionProbe.storedKey = keyData
+                return errSecSuccess
+            },
+            delete: { errSecSuccess }
+        )
+
+        let fallbackKey = try AppCore.deviceBootstrapKeyHex(
+            processArguments: [],
+            keychain: unavailableKeychain,
+            fallbackDirectory: directory
+        )
+        let recoveredKey = try AppCore.deviceBootstrapKeyHex(
+            processArguments: [],
+            keychain: recoveredKeychain,
+            fallbackDirectory: directory
+        )
+        let fallbackURL = try AppCore.localFallbackBootstrapKeyURL(in: directory)
+
+        #expect(recoveredKey == fallbackKey)
+        #expect(promotionProbe.storedKey?.map { String(format: "%02x", $0) }.joined() == fallbackKey)
+        #expect(try fallbackURL.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == true)
     }
 
     @Test func bootstrapFallbackConcurrentCallersShareOnePersistedKey() async throws {

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -555,6 +555,27 @@ struct Weird_Parts_IOSTests {
         #expect(!FileManager.default.fileExists(atPath: fallbackURL.path))
     }
 
+    @Test func bootstrapFallbackExistingKeyRepairsBackupExclusion() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BootstrapFallback-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fallbackURL = try AppCore.localFallbackBootstrapKeyURL(in: directory)
+        let existingKey = Data(repeating: 0xa5, count: 32)
+        try existingKey.write(to: fallbackURL, options: .atomic)
+
+        var unexcludedValues = URLResourceValues()
+        unexcludedValues.isExcludedFromBackup = false
+        var mutableURL = fallbackURL
+        try mutableURL.setResourceValues(unexcludedValues)
+
+        let keyHex = try AppCore.localFallbackBootstrapKeyHex(in: directory)
+
+        #expect(keyHex == String(repeating: "a5", count: 32))
+        #expect(
+            try fallbackURL.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == true
+        )
+    }
+
     @Test func bootstrapFallbackUsesNotAvailableButRejectsLockedKeychain() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("BootstrapFallback-\(UUID().uuidString)", isDirectory: true)

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -576,6 +576,31 @@ struct Weird_Parts_IOSTests {
         )
     }
 
+    @Test func bootstrapFallbackConcurrentCallersShareOnePersistedKey() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BootstrapFallback-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let keyHexes = try await withThrowingTaskGroup(of: String.self, returning: [String].self) { group in
+            for _ in 0..<16 {
+                group.addTask {
+                    try AppCore.localFallbackBootstrapKeyHex(in: directory)
+                }
+            }
+
+            var values: [String] = []
+            for try await keyHex in group {
+                values.append(keyHex)
+            }
+            return values
+        }
+        let fallbackURL = try AppCore.localFallbackBootstrapKeyURL(in: directory)
+
+        #expect(Set(keyHexes).count == 1)
+        #expect(try Data(contentsOf: fallbackURL).count == 32)
+        #expect(try fallbackURL.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == true)
+    }
+
     @Test func bootstrapFallbackUsesNotAvailableButRejectsLockedKeychain() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("BootstrapFallback-\(UUID().uuidString)", isDirectory: true)

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -616,6 +616,37 @@ struct Weird_Parts_IOSTests {
         #expect(FileManager.default.fileExists(atPath: fallbackURL.path))
     }
 
+    @Test func bootstrapFallbackUsesApprovedStatusAfterDuplicateItemReread() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BootstrapFallback-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let probe = OperationProbe()
+        let racingKeychain = AppCore.BootstrapKeychainAccess(
+            read: {
+                if probe.ran {
+                    return (errSecNotAvailable, nil)
+                }
+                probe.ran = true
+                return (errSecItemNotFound, nil)
+            },
+            add: { _ in errSecDuplicateItem },
+            delete: {
+                Issue.record("approved reread failure must use fallback before deleting")
+                return errSecSuccess
+            }
+        )
+
+        let keyHex = try AppCore.deviceBootstrapKeyHex(
+            processArguments: [],
+            keychain: racingKeychain,
+            fallbackDirectory: directory
+        )
+        let fallbackURL = try AppCore.localFallbackBootstrapKeyURL(in: directory)
+
+        #expect(keyHex.count == 64)
+        #expect(FileManager.default.fileExists(atPath: fallbackURL.path))
+    }
+
     @Test func debugCipherRecoveryOnlyMatchesDecryptNotADB() {
         let sqlCipherError = NSError(
             domain: "GRDB.DatabaseError",

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -58,6 +58,7 @@ private final class MockBootstrapTaskAuditor: AppCoreBackgroundTaskAuditing, @un
 private final class OperationProbe: @unchecked Sendable {
     var ran = false
     var storedKey: Data?
+    var addCallCount = 0
 }
 
 private enum QuestionnaireBreakTestError: Error {
@@ -679,6 +680,47 @@ struct Weird_Parts_IOSTests {
         }
         let fallbackURL = try AppCore.localFallbackBootstrapKeyURL(in: directory)
         #expect(FileManager.default.fileExists(atPath: fallbackURL.path))
+    }
+
+    @Test func bootstrapFallbackRejectsLockedDuplicateRereadBeforeKeychainMutation() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BootstrapFallback-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let probe = OperationProbe()
+        let lockedDuplicateKeychain = AppCore.BootstrapKeychainAccess(
+            read: {
+                if probe.ran {
+                    return (errSecInteractionNotAllowed, nil)
+                }
+                probe.ran = true
+                return (errSecItemNotFound, nil)
+            },
+            add: { _ in
+                probe.addCallCount += 1
+                if probe.addCallCount > 1 {
+                    Issue.record("unexpected retry add after locked reread")
+                }
+                return errSecDuplicateItem
+            },
+            delete: {
+                Issue.record("locked duplicate reread must not delete the Keychain key")
+                return errSecSuccess
+            }
+        )
+
+        do {
+            _ = try AppCore.deviceBootstrapKeyHex(
+                processArguments: [],
+                keychain: lockedDuplicateKeychain,
+                fallbackDirectory: directory
+            )
+            Issue.record("locked duplicate reread unexpectedly recovered")
+        } catch let CipherKeyError.keychainAccessFailed(status) {
+            #expect(status == errSecInteractionNotAllowed)
+        }
+
+        let fallbackURL = try AppCore.localFallbackBootstrapKeyURL(in: directory)
+        #expect(!FileManager.default.fileExists(atPath: fallbackURL.path))
     }
 
     @Test func bootstrapFallbackUsesApprovedStatusAfterDuplicateItemReread() throws {

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -514,13 +514,85 @@ struct Weird_Parts_IOSTests {
         #expect(keyHex.count == 64)
     }
 
-    @Test func simulatorMissingEntitlementCanUseLocalBootstrapKeyFallback() {
-        #if targetEnvironment(simulator) || targetEnvironment(macCatalyst)
+    @Test func bootstrapFallbackUsesOnlyApprovedKeychainStatuses() {
         #expect(AppCore.shouldUseLocalBootstrapKeyFallback(for: errSecMissingEntitlement))
-        #else
-        #expect(!AppCore.shouldUseLocalBootstrapKeyFallback(for: errSecMissingEntitlement))
-        #endif
+        #expect(AppCore.shouldUseLocalBootstrapKeyFallback(for: errSecNotAvailable))
+        #expect(!AppCore.shouldUseLocalBootstrapKeyFallback(for: errSecInteractionNotAllowed))
         #expect(!AppCore.shouldUseLocalBootstrapKeyFallback(for: errSecAuthFailed))
+    }
+
+    @Test func bootstrapFallbackPersistsForApprovedReadFailureAndCleansUp() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BootstrapFallback-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let unavailableKeychain = AppCore.BootstrapKeychainAccess(
+            read: { (errSecMissingEntitlement, nil) },
+            add: { _ in
+                Issue.record("fallback must be used before a Keychain write")
+                return errSecParam
+            },
+            delete: { errSecSuccess }
+        )
+
+        let first = try AppCore.deviceBootstrapKeyHex(
+            processArguments: [],
+            keychain: unavailableKeychain,
+            fallbackDirectory: directory
+        )
+        let second = try AppCore.deviceBootstrapKeyHex(
+            processArguments: [],
+            keychain: unavailableKeychain,
+            fallbackDirectory: directory
+        )
+        let fallbackURL = try AppCore.localFallbackBootstrapKeyURL(in: directory)
+
+        #expect(first.count == 64)
+        #expect(first == second)
+        #expect(FileManager.default.fileExists(atPath: fallbackURL.path))
+        #expect(try fallbackURL.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == true)
+
+        try AppCore.deleteLocalFallbackBootstrapKey(in: directory)
+        #expect(!FileManager.default.fileExists(atPath: fallbackURL.path))
+    }
+
+    @Test func bootstrapFallbackUsesNotAvailableButRejectsLockedKeychain() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BootstrapFallback-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let unavailableKeychain = AppCore.BootstrapKeychainAccess(
+            read: { (errSecNotAvailable, nil) },
+            add: { _ in
+                Issue.record("fallback must be used before a Keychain write")
+                return errSecParam
+            },
+            delete: { errSecSuccess }
+        )
+        let lockedKeychain = AppCore.BootstrapKeychainAccess(
+            read: { (errSecInteractionNotAllowed, nil) },
+            add: { _ in
+                Issue.record("locked keychain must not attempt a write")
+                return errSecParam
+            },
+            delete: { errSecSuccess }
+        )
+
+        _ = try AppCore.deviceBootstrapKeyHex(
+            processArguments: [],
+            keychain: unavailableKeychain,
+            fallbackDirectory: directory
+        )
+        do {
+            _ = try AppCore.deviceBootstrapKeyHex(
+                processArguments: [],
+                keychain: lockedKeychain,
+                fallbackDirectory: directory
+            )
+            Issue.record("locked keychain unexpectedly used fallback")
+        } catch let CipherKeyError.keychainAccessFailed(status) {
+            #expect(status == errSecInteractionNotAllowed)
+        }
+        let fallbackURL = try AppCore.localFallbackBootstrapKeyURL(in: directory)
+        #expect(FileManager.default.fileExists(atPath: fallbackURL.path))
     }
 
     @Test func debugCipherRecoveryOnlyMatchesDecryptNotADB() {


### PR DESCRIPTION
Closes #1627

Tracked in WEI-6743. Repair tracked in WEI-6812.

## Summary
- Route `AppCore.deviceBootstrapKeyHex()` through a narrowly injected Keychain access surface so the actual startup path can persist a backup-excluded local key only for `errSecMissingEntitlement` and `errSecNotAvailable`.
- Fail closed for `errSecInteractionNotAllowed` and every other unapproved Keychain status, including a duplicate-add reread, before any Keychain delete/replacement.
- Make backup exclusion an idempotent, fail-closed invariant for a newly created and pre-existing valid local fallback key.
- Preserve stale-duplicate Keychain recovery and promote a recovered Keychain with the established fallback key rather than rekeying the encrypted database.

## Exact-head local verification
- `924088201f2c982dd4b24b5ec4a08654c8693925` is rebased onto `db8a117e3c34b3356f77f72507f09beaadad345f` (`main`).
- Focused XCTest: `bootstrapFallbackRejectsLockedDuplicateRereadBeforeKeychainMutation` passed (1 test, 0 failures) using `xcodebuild test -workspace "Weird Parts.xcworkspace" -scheme WiredPart-iOS ... -only-testing:"Weird Parts IOSTests/Weird_Parts_IOSTests/bootstrapFallbackRejectsLockedDuplicateRereadBeforeKeychainMutation()"`.
- `git diff --check origin/main...HEAD` passed.

## Remaining merge gates
- Fresh exact-head Artifact Guard, CodeQL/Analyze, iPhone+iPad checks; LocalFirstReviewer → GPTReviewer → ClaudeReviewer; Copilot review; resolved threads; and CTO serialized merge evaluation.