### PR TITLE
fix(sync): snapshot skips id-less tables instead of aborting — field P0 (build 44)

### DIFF
--- a/core/Sources/WiredPartCore/Sync/PeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/PeerManager.swift
@@ -1237,43 +1237,10 @@ public actor PeerManager {
                     }
                 },
                 readPage: { [db] table, limit, offset in
-                    let rows = try await db.writer.read { dbConn in
-                        try Row.fetchAll(
-                            dbConn,
-                            sql: "SELECT * FROM [\(table)] ORDER BY rowid LIMIT ? OFFSET ?",
-                            arguments: [limit, offset]
-                        )
-                    }
-                    var changes: [IncomingChange] = []
-                    changes.reserveCapacity(rows.count)
-                    for row in rows {
-                        if table == "settings" {
-                            let key = (row["key"] as? String) ?? ""
-                            let category = row["category"] as String?
-                            if SettingsService.syncScope(for: key, category: category) == .device { continue }
-                        }
-
-                        guard let idValue = row["id"] as? Int64 else {
-                            throw MultipeerSnapshotError.missingRecordID(table: table)
-                        }
-                        let dict = Self.jsonRecordDict(from: row)
-                        guard JSONSerialization.isValidJSONObject(dict) else {
-                            throw MultipeerSnapshotError.rowEncodingFailed(table: table)
-                        }
-                        let jsonData = try JSONSerialization.data(withJSONObject: dict)
-                        guard let recordData = String(data: jsonData, encoding: .utf8) else {
-                            throw MultipeerSnapshotError.rowEncodingFailed(table: table)
-                        }
-                        changes.append(IncomingChange(
-                            deviceId: hostDeviceId,
-                            tableName: table,
-                            recordId: String(idValue),
-                            operation: "INSERT",
-                            recordData: recordData,
-                            timestamp: (row["updated_at"] as? String) ?? fallbackTimestamp
-                        ))
-                    }
-                    return BluetoothSnapshotPage(changes: changes, sourceRowCount: rows.count)
+                    try await Self.hostedSnapshotPage(
+                        db: db, table: table, limit: limit, offset: offset,
+                        hostDeviceId: hostDeviceId, fallbackTimestamp: fallbackTimestamp
+                    )
                 },
                 encode: { changes in
                     let changesData = try JSONEncoder().encode(changes)
@@ -1308,6 +1275,72 @@ public actor PeerManager {
             )
             logger.error("[PeerManager] Full Bluetooth snapshot failed for peer \(String(peerDeviceId.prefix(8)), privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    /// One page of the hosted initial snapshot. Internal + static so the
+    /// id-less-table guard is directly testable.
+    ///
+    /// Field P0 (owner, 2026-08-02, build 44): the snapshot died 5-8s into
+    /// every attempt — warehouse_user_positions is in allowedSyncTables but
+    /// has NO id column, and the row loop threw missingRecordID for it,
+    /// aborting the WHOLE company transfer. Migration 112's trigger installer
+    /// skips id-less tables; the snapshot must too (they cannot participate
+    /// in id-based sync at all). Checked once per table at offset 0.
+    static func hostedSnapshotPage(
+        db: AppDatabase,
+        table: String,
+        limit: Int,
+        offset: Int,
+        hostDeviceId: String,
+        fallbackTimestamp: String
+    ) async throws -> BluetoothSnapshotPage {
+        if offset == 0 {
+            let columns = try await db.writer.read { dbConn in
+                try String.fetchAll(
+                    dbConn, sql: "SELECT name FROM pragma_table_info(?)", arguments: [table]
+                )
+            }
+            guard columns.contains("id") else {
+                return BluetoothSnapshotPage(changes: [], sourceRowCount: 0)
+            }
+        }
+        let rows = try await db.writer.read { dbConn in
+            try Row.fetchAll(
+                dbConn,
+                sql: "SELECT * FROM [\(table)] ORDER BY rowid LIMIT ? OFFSET ?",
+                arguments: [limit, offset]
+            )
+        }
+        var changes: [IncomingChange] = []
+        changes.reserveCapacity(rows.count)
+        for row in rows {
+            if table == "settings" {
+                let key = (row["key"] as? String) ?? ""
+                let category = row["category"] as String?
+                if SettingsService.syncScope(for: key, category: category) == .device { continue }
+            }
+
+            guard let idValue = row["id"] as? Int64 else {
+                throw MultipeerSnapshotError.missingRecordID(table: table)
+            }
+            let dict = Self.jsonRecordDict(from: row)
+            guard JSONSerialization.isValidJSONObject(dict) else {
+                throw MultipeerSnapshotError.rowEncodingFailed(table: table)
+            }
+            let jsonData = try JSONSerialization.data(withJSONObject: dict)
+            guard let recordData = String(data: jsonData, encoding: .utf8) else {
+                throw MultipeerSnapshotError.rowEncodingFailed(table: table)
+            }
+            changes.append(IncomingChange(
+                deviceId: hostDeviceId,
+                tableName: table,
+                recordId: String(idValue),
+                operation: "INSERT",
+                recordData: recordData,
+                timestamp: (row["updated_at"] as? String) ?? fallbackTimestamp
+            ))
+        }
+        return BluetoothSnapshotPage(changes: changes, sourceRowCount: rows.count)
     }
 
     private func sendFullSyncCompletion(

--- a/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
@@ -310,6 +310,42 @@ struct PeerManagerTests {
         await pm.stopPeerSync()
     }
 
+    @Test("Hosted snapshot SKIPS id-less tables instead of aborting the transfer (#field P0 build 44)")
+    func testSnapshotSkipsIdlessTables() async throws {
+        let db = try freshDB()
+        // Synthetic stand-in for warehouse_user_positions (composite/user_id
+        // primary key, NO id column) — with a real row, the pre-fix pager
+        // threw missingRecordID here and killed the whole company download.
+        try await db.writer.write { dbc in
+            try dbc.execute(sql: "CREATE TABLE zz_no_id (k TEXT PRIMARY KEY, v TEXT)")
+            try dbc.execute(sql: "INSERT INTO zz_no_id (k, v) VALUES ('a', 'b')")
+        }
+        let page = try await PeerManager.hostedSnapshotPage(
+            db: db, table: "zz_no_id", limit: 200, offset: 0,
+            hostDeviceId: "host-1", fallbackTimestamp: "2026-08-02T00:00:00Z"
+        )
+        #expect(page.changes.isEmpty)
+        #expect(page.sourceRowCount == 0)   // pager treats it as exhausted, moves on
+
+        // And the production instance: warehouse_user_positions must also skip.
+        let prod = try await PeerManager.hostedSnapshotPage(
+            db: db, table: "warehouse_user_positions", limit: 200, offset: 0,
+            hostDeviceId: "host-1", fallbackTimestamp: "2026-08-02T00:00:00Z"
+        )
+        #expect(prod.sourceRowCount == 0)
+
+        // A normal id-ful table still pages rows.
+        try await db.writer.write { dbc in
+            try dbc.execute(sql: "INSERT INTO part_categories (name) VALUES ('Wire')")
+        }
+        let normal = try await PeerManager.hostedSnapshotPage(
+            db: db, table: "part_categories", limit: 200, offset: 0,
+            hostDeviceId: "host-1", fallbackTimestamp: "2026-08-02T00:00:00Z"
+        )
+        #expect(normal.sourceRowCount >= 1)
+        #expect(normal.changes.contains { $0.tableName == "part_categories" })
+    }
+
     @Test("Discovery-only peer sync starts browsing without a sync server")
     func testDiscoveryOnlyPeerSyncState() async throws {
         let db = try freshDB()


### PR DESCRIPTION
## Field failure (owner retest, 2026-08-02 evening, build 44)

Fresh code → download bar appears (**the transport fallback from #1616 works**) → dies after **5–8 seconds**, same Sync Error, every attempt.

## Root cause (deterministic, verified against the real schema)

The hosted snapshot pager **throws `missingRecordID` on the first row of any table without an integer `id` column** — and `warehouse_user_positions` (`user_id` primary key, no `id`) is in `allowedSyncTables` with live rows on the owner's phone. One structurally-unsyncable table aborted the entire company transfer, at exactly the moment the pager reached it. Migration 112's trigger installer already skips id-less tables; the snapshot didn't.

## Fix

`PeerManager.hostedSnapshotPage` (extracted, internal static, directly testable): at offset 0 the table's columns are checked once — no `id` → empty exhausted page, transfer moves on. Regression test: synthetic id-less table **with a row** (pre-fix: throw, post-fix: skip), the production `warehouse_user_positions` instance, and a normal table still paging rows. PeerManager suite **56/56**.

## Follow-up (filing separately)

`warehouse_user_positions` today neither snapshots nor change-syncs — it needs a proper `id` (migration) or explicit `deviceLocalTables` classification (#1619's gate will force this decision).

**Owner field check once shipped: reset the iPad → fresh code → rejoin. Expected: download runs PAST 8 seconds and completes with data.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)