### PR TITLE
fix(ci): retry a phase once when its xcresult comes out half-written (6x flake)

### DIFF
--- a/scripts/ci/run-ios-beta-gate.sh
+++ b/scripts/ci/run-ios-beta-gate.sh
@@ -109,6 +109,47 @@ should_retry_ui_smoke_bootstrap_failure() {
     grep -Eq "Test crashed with signal (term|abrt) while preparing to run tests\." "$xcode_log"
 }
 
+result_bundle_is_corrupt() {
+  # A phase-timeout alarm (or runner starvation) can kill xcodebuild mid-write,
+  # leaving an xcresult directory without its Info.plist — xcresulttool then
+  # refuses the bundle and the gate fails with NO failing test. Observed 6x on
+  # 2026-08-02 (e.g. runs 30725941573, 30730370453, 30759152155). A MISSING
+  # bundle stays a hard fail; only the half-written state is retryable.
+  local result_bundle="$1"
+  [[ -d "$result_bundle" ]] || return 1
+  [[ ! -f "$result_bundle/Info.plist" ]]
+}
+
+preserve_corrupt_phase_attempt() {
+  # Same evidence discipline as the bootstrap retry: the corrupt attempt's raw
+  # output is retained before the retry may overwrite the result path.
+  local phase="$1"
+  local result_bundle="$2"
+  local xcode_log="$3"
+  mv "$xcode_log" "$artifact_dir/${phase}-corrupt-attempt-1-xcodebuild.log" || fail "could not preserve corrupt-attempt log for $phase"
+  mv "$artifact_dir/${phase}-xcode-status.txt" "$artifact_dir/${phase}-corrupt-attempt-1-xcode-status.txt" || fail "could not preserve corrupt-attempt Xcode status for $phase"
+  mv "$artifact_dir/${phase}-tee-status.txt" "$artifact_dir/${phase}-corrupt-attempt-1-tee-status.txt" || fail "could not preserve corrupt-attempt tee status for $phase"
+  mv "$result_bundle" "$artifact_dir/${phase}-corrupt-attempt-1-${gate_name}.xcresult" || fail "could not preserve corrupt-attempt xcresult for $phase"
+}
+
+retry_phase_if_bundle_corrupt() {
+  # One bounded re-run per phase, ONLY for the half-written-bundle state.
+  local phase="$1"
+  local scheme="$2"
+  local result_bundle="$3"
+  local xcode_log="$4"
+  local phase_timeout="$5"
+  shift 5
+  if result_bundle_is_corrupt "$result_bundle"; then
+    echo "$gate_name $phase produced a corrupt xcresult (no Info.plist); preserving evidence and retrying the phase once" | tee -a "$artifact_dir/gate.log"
+    preserve_corrupt_phase_attempt "$phase" "$result_bundle" "$xcode_log"
+    run_xcode_phase "$phase" "$scheme" "$result_bundle" "$xcode_log" "$phase_timeout" "$@"
+    echo "${phase}_corrupt_bundle_retry=1" >> "$metadata_file"
+  else
+    echo "${phase}_corrupt_bundle_retry=0" >> "$metadata_file"
+  fi
+}
+
 preserve_failed_ui_smoke_attempt() {
   # A bootstrap retry can only be trusted if the failed attempt's raw result is
   # retained. Do this check before moving any other evidence and before a retry
@@ -212,6 +253,16 @@ if [[ "${IOS_BETA_GATE_SELF_TEST:-}" == "1" ]]; then
   [[ ! -e "$artifact_dir/ui-smokes-xcode-status.txt" ]] || exit 1
   [[ ! -e "$artifact_dir/ui-smokes-tee-status.txt" ]] || exit 1
   [[ ! -e "$ui_result" ]] || exit 1
+  # Corrupt-bundle detector: half-written (dir, no Info.plist) = corrupt;
+  # healthy (Info.plist present) and missing (no dir) = not retryable here.
+  corrupt_dir="$self_test_dir/corrupt.xcresult"
+  healthy_dir="$self_test_dir/healthy.xcresult"
+  mkdir -p "$corrupt_dir" "$healthy_dir"
+  touch "$healthy_dir/Info.plist"
+  result_bundle_is_corrupt "$corrupt_dir" || exit 1
+  result_bundle_is_corrupt "$healthy_dir" && exit 1
+  result_bundle_is_corrupt "$self_test_dir/absent.xcresult" && exit 1
+
   echo "iOS beta-gate bounded recovery self-test passed"
   exit 0
 fi
@@ -414,6 +465,9 @@ ui_log="$artifact_dir/ui-smokes-xcodebuild.log"
 run_xcode_phase \
   "unit-regression" "WiredPart-iOS" "$unit_result" "$unit_log" "$xcode_phase_timeout_seconds" \
   -skip-testing:"Weird PartsUITests"
+retry_phase_if_bundle_corrupt \
+  "unit-regression" "WiredPart-iOS" "$unit_result" "$unit_log" "$xcode_phase_timeout_seconds" \
+  -skip-testing:"Weird PartsUITests"
 run_xcode_phase \
   "ui-smokes" "WiredPart-iOS-Stage9-Smokes" "$ui_result" "$ui_log" "$ui_smoke_phase_timeout_seconds"
 
@@ -427,6 +481,8 @@ if should_retry_ui_smoke_bootstrap_failure "$(<"$artifact_dir/ui-smokes-xcode-st
     "ui-smokes" "WiredPart-iOS-Stage9-Smokes" "$ui_result" "$ui_log" "$ui_smoke_phase_timeout_seconds"
 fi
 echo "ui_smoke_bootstrap_retry=$ui_smoke_bootstrap_retry" >> "$metadata_file"
+retry_phase_if_bundle_corrupt \
+  "ui-smokes" "WiredPart-iOS-Stage9-Smokes" "$ui_result" "$ui_log" "$ui_smoke_phase_timeout_seconds"
 
 phase_failure=0
 aggregate_total=0

--- a/scripts/ci/validate-ios-beta-gate-source.py
+++ b/scripts/ci/validate-ios-beta-gate-source.py
@@ -50,6 +50,10 @@ required_runner_fragments = {
     "UI-smoke retry preserves the required first-attempt xcresult": 'mv "$ui_result" "$artifact_dir/ui-smokes-attempt-1-${gate_name}.xcresult" || fail "could not preserve first UI-smoke xcresult bundle"',
     "UI-smoke retry remains one bounded pass": "ui_smoke_bootstrap_retry=1",
     "UI-smoke retry uses its separate bounded timeout": "ui_smoke_phase_timeout_seconds",
+    "corrupt-bundle retry detects only the half-written state": '[[ ! -f "$result_bundle/Info.plist" ]]',
+    "corrupt-bundle retry keeps a missing bundle a hard fail": '[[ -d "$result_bundle" ]] || return 1',
+    "corrupt-bundle retry preserves first-attempt evidence": "preserve_corrupt_phase_attempt",
+    "corrupt-bundle retry remains one bounded pass per phase": "corrupt_bundle_retry=1",
 }
 
 errors: list[str] = []


### PR DESCRIPTION
## The flake (six occurrences, 2026-08-02 alone)

Beta gates failing with **`Failed to create a new result bundle reader … Info.plist does not exist`** and no failing test anywhere — the phase-timeout alarm or runner starvation kills xcodebuild mid-write, leaving a half-written xcresult that `xcresulttool` refuses. Every occurrence cost a ~30-minute runner slot plus a manual requeue, and tonight it blocked the P0 sync fix (#1633).

## Fix — bounded, evidence-preserving, fail-closed

Mirrors the existing UI-smoke bootstrap retry exactly:
- **Detector:** bundle directory exists **without** `Info.plist` = the half-written state. A *missing* bundle remains a hard fail (that's a different defect).
- **One retry per phase**, after preserving the corrupt attempt's log, both status files, and the bundle as `${phase}-corrupt-attempt-1-*`.
- `${phase}_corrupt_bundle_retry` recorded in gate metadata either way.

## Verification

`bash -n` clean; embedded self-test extended (corrupt/healthy/absent detector cases) and passing; `validate-ios-beta-gate-source.py` extended with four new pinned fragments and passing. Script-only — no workflow-file changes.

Evidence runs: 30725941573, 30730370453, 30731770353, 30759152155, tonight's #1633 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1639
Tracked in WEI-6538