### PR TITLE
fix(sync): a deferred peer is not a failed peer (self-audit, #1625 regression)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -300,9 +300,18 @@ final class IOSSyncManager {
                 totalPushed += r.pushed
                 totalPulled += r.pulled
             }
-            let failed = results.filter { !$0.success }
+            // A deferred peer is mid-onboarding, not broken (#1625) — counting
+            // it as a failure showed the HOST a red "Sync failed" while it was
+            // correctly waiting for the joiner's first download.
+            let failed = results.filter { !$0.success && !$0.deferred }
             if !failed.isEmpty, errorMessage == nil {
                 errorMessage = "Sync failed with \(failed.count) peer(s)"
+            }
+            let waiting = results.filter(\.deferred)
+            if !waiting.isEmpty, errorMessage == nil {
+                syncProgressMessage = waiting.count == 1
+                    ? "Waiting for \(waiting[0].peerName)'s first download to finish…"
+                    : "Waiting for \(waiting.count) devices' first download to finish…"
             }
         }
 

--- a/core/Sources/WiredPartCore/Sync/PeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/PeerManager.swift
@@ -12,6 +12,11 @@ public struct PeerSyncResult: Sendable {
     public var pulled: Int
     public var success: Bool
     public var error: String?
+    /// True when nothing was pushed BY DESIGN — the peer is mid-onboarding and
+    /// its initial snapshot has not been acknowledged yet (#1625). Callers must
+    /// not count a deferral as a sync failure: it is a normal waiting state and
+    /// the push resumes automatically once the snapshot lands.
+    public var deferred: Bool
     public let syncedAt: String
 
     public init(
@@ -21,6 +26,7 @@ public struct PeerSyncResult: Sendable {
         pulled: Int = 0,
         success: Bool = true,
         error: String? = nil,
+        deferred: Bool = false,
         syncedAt: String? = nil
     ) {
         self.peerDeviceId = peerDeviceId
@@ -29,6 +35,7 @@ public struct PeerSyncResult: Sendable {
         self.pulled = pulled
         self.success = success
         self.error = error
+        self.deferred = deferred
         self.syncedAt = syncedAt ?? CoreFormatters.iso8601Fractional.string(from: Date())
     }
 }
@@ -474,7 +481,8 @@ public actor PeerManager {
                 peerDeviceId: peer.deviceId,
                 peerName: peer.deviceName,
                 success: false,
-                error: "Waiting for the new device's initial download to finish."
+                error: "Waiting for the new device's initial download to finish.",
+                deferred: true
             )
         }
         state.syncingWith = peer.deviceId

--- a/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
@@ -303,6 +303,9 @@ struct PeerManagerTests {
         // Deferred: not a success (nothing was pushed), with the honest
         // waiting message — and NOT recorded as a completed sync.
         #expect(result.success == false)
+        // Deferral must be distinguishable from failure (#1625 follow-up): the
+        // host UI counts !success as a red "Sync failed" otherwise.
+        #expect(result.deferred == true)
         #expect(result.error == "Waiting for the new device's initial download to finish.")
         let state = await pm.getState()
         #expect(state.lastPeerSyncs["joiner-9"] == nil)


### PR DESCRIPTION
## Finding (full sync audit, P2 — self-inflicted)

#1625 taught the host to stop pushing incrementals to a peer that hasn't finished its initial download — correct. But it signals that by returning `success: false`, and `IOSSyncManager.syncNow` counts **every** `!success` as a failure. Net effect on the owner's phone: **a red "Sync failed with 1 peer(s)"** while the host was doing exactly the right thing and waiting.

That's the same false-signal class #1625 was written to eliminate ("Sent 9 records" reading as success), just inverted — and it would have shown up during the very field test the fix was shipped for.

## Fix

- `PeerSyncResult.deferred` — explicit, documented flag for "nothing pushed BY DESIGN, peer is mid-onboarding".
- App filters deferrals out of the failure count and shows **"Waiting for <device>'s first download to finish…"** instead of an error.
- The existing deferral test now asserts `deferred == true`, so the distinction can't silently regress.

PeerManager suite 56/56, core clean.

Part of the full syncing-system audit requested 2026-08-03; three subagents are auditing protocol, data-integrity, and security layers in parallel — further findings will be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)