### PR TITLE
fix(sync): Bluetooth-only pairing — connect window must outlast the invitation (field P0)

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Auth/DevicePairingView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/DevicePairingView.swift
@@ -68,7 +68,7 @@ struct DevicePairingView: View {
 
             Spacer()
 
-            Text("Both devices need Wi-Fi turned on — pairing connects over peer-to-peer Wi-Fi even with no network. Bluetooth helps them find each other; a shared network makes syncing fastest.")
+            Text("Works over Bluetooth alone (slower — keep both devices awake and close). Turning Wi-Fi ON on both makes it much faster and needs no network; a shared network is fastest of all.")
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)
@@ -360,11 +360,20 @@ struct DevicePairingView: View {
         }
     }
 
+    /// Shown after a connect timeout when this device's Wi-Fi radio is off.
+    ///
+    /// Rewritten 2026-08-03 after the owner tested Bluetooth-only on purpose
+    /// ("We are on Bluetooth only right now") and was told to turn Wi-Fi on as
+    /// if that were the only option. Bluetooth-only pairing IS attempted and
+    /// now gets a connect window that outlasts the invitation (PeerManager
+    /// .multipeerConnectWait) — it is simply much slower. So: lead with what
+    /// to do to make Bluetooth-only work, and offer Wi-Fi as the faster route
+    /// rather than the required one.
     private var wifiOffGuidance: String {
         #if targetEnvironment(macCatalyst)
-        return "Pairing connects over peer-to-peer Wi-Fi (Bluetooth only finds nearby devices). This Mac's Wi-Fi looks off — turn Wi-Fi ON in the menu bar (it doesn't need to join a network), or put both devices on the same network and enter the shop device's address manually below."
+        return "Couldn't connect yet. Bluetooth-only pairing works but is slow — keep both devices awake, unlocked, and close together, and give it up to a minute. Faster: turn Wi-Fi ON in the menu bar (no network needed), or enter the shop device's address manually below."
         #else
-        return "Pairing connects over peer-to-peer Wi-Fi (Bluetooth only finds nearby devices). This device's Wi-Fi looks off — turn Wi-Fi ON in Settings (it doesn't need to join a network), then try again."
+        return "Couldn't connect yet. Bluetooth-only pairing works but is slow — keep both devices awake, unlocked, and close together, and give it up to a minute. Faster: turn Wi-Fi ON in Settings (it doesn't need to join a network), then try again."
         #endif
     }
 

--- a/core/Sources/WiredPartCore/Sync/PeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/PeerManager.swift
@@ -515,11 +515,7 @@ public actor PeerManager {
                 // placeholder host, so HTTP could only throw badURL (-1000), which
                 // is the raw error the owner hit from the Nearby Devices sheet.
                 if !mpManager.isConnected(toPeer: peer.deviceId) {
-                    mpManager.invite(deviceId: peer.deviceId)
-                    let deadline = Date().addingTimeInterval(10)
-                    while !mpManager.isConnected(toPeer: peer.deviceId), Date() < deadline {
-                        try? await Task.sleep(nanoseconds: 300_000_000)
-                    }
+                    _ = await awaitMultipeerConnection(to: peer.deviceId, using: mpManager)
                 }
                 guard mpManager.isConnected(toPeer: peer.deviceId) else {
                     let result = PeerSyncResult(
@@ -1663,6 +1659,43 @@ public actor PeerManager {
         }
     }
 
+    /// Wait for an MCSession to reach `connected`, re-inviting once if the
+    /// first invitation lapses.
+    ///
+    /// FIELD P0 (owner, 2026-08-03, Bluetooth-only test): every wait here used
+    /// to be **20 s while `MultipeerManager.invite` sets a 30 s invitation
+    /// timeout** — the app gave up 10 s before iOS had finished trying, so a
+    /// link that needed longer than 20 s could never succeed. Peer-to-peer
+    /// Wi-Fi (AWDL) connects in ~1-3 s and hid this; **Bluetooth-only takes
+    /// far longer**, so the owner saw "couldn't connect" on every attempt with
+    /// Wi-Fi off. The wait must always exceed the invitation window, and a
+    /// dropped invitation (Multipeer delivers no failure callback) must be
+    /// re-sent rather than waited out.
+    static let multipeerInviteTimeout: TimeInterval = 30
+    static let multipeerConnectWait: TimeInterval = 75
+
+    private func awaitMultipeerConnection(
+        to deviceId: String,
+        using mpManager: MultipeerManager,
+        timeout: TimeInterval = PeerManager.multipeerConnectWait
+    ) async -> Bool {
+        if mpManager.isConnected(toPeer: deviceId) { return true }
+        mpManager.invite(deviceId: deviceId)
+        let started = Date()
+        var reinvited = false
+        while Date().timeIntervalSince(started) < timeout {
+            if mpManager.isConnected(toPeer: deviceId) { return true }
+            // Just past the invitation's own expiry, send exactly one more.
+            if !reinvited, Date().timeIntervalSince(started) > Self.multipeerInviteTimeout + 2 {
+                mpManager.invite(deviceId: deviceId)
+                reinvited = true
+                logger.info("[PeerManager] Re-invited \(String(deviceId.prefix(8)), privacy: .public) — first invitation lapsed without connecting")
+            }
+            try? await Task.sleep(nanoseconds: 300_000_000)
+        }
+        return mpManager.isConnected(toPeer: deviceId)
+    }
+
     /// Joiner side: request and await the full initial company sync over Bluetooth.
     public func requestFullSyncOverMultipeer(hostDeviceId: String) async throws {
         guard let mpManager = multipeerManager else { throw MultipeerPairingError.notAvailable }
@@ -1676,10 +1709,8 @@ public actor PeerManager {
         guard let authorizationToken = receivedSnapshotTokens[hostDeviceId] else {
             throw MultipeerPairingError.rejected
         }
-        let deadline = Date().addingTimeInterval(20)
-        while !mpManager.isConnected(toPeer: hostDeviceId) {
-            if Date() >= deadline { throw MultipeerPairingError.connectionTimeout }
-            try? await Task.sleep(nanoseconds: 300_000_000)
+        guard await awaitMultipeerConnection(to: hostDeviceId, using: mpManager) else {
+            throw MultipeerPairingError.connectionTimeout
         }
         let request = try JSONEncoder().encode(
             FullSyncRequest(authorizationToken: authorizationToken)
@@ -2032,12 +2063,10 @@ public actor PeerManager {
             throw MultipeerPairingError.responseVerificationFailed
         }
 
-        // 1. Invite the host and wait for the MCSession to connect.
-        mpManager.invite(deviceId: hostDeviceId)
-        let deadline = Date().addingTimeInterval(20)
-        while !mpManager.isConnected(toPeer: hostDeviceId) {
-            if Date() >= deadline { throw MultipeerPairingError.connectionTimeout }
-            try? await Task.sleep(nanoseconds: 300_000_000)
+        // 1. Invite the host and wait for the MCSession to connect. The wait
+        //    must outlast the invitation timeout (see awaitMultipeerConnection).
+        guard await awaitMultipeerConnection(to: hostDeviceId, using: mpManager) else {
+            throw MultipeerPairingError.connectionTimeout
         }
 
         // 2. Send a proof bound to this attempt, expected host, and durable device key.


### PR DESCRIPTION
## Field failure (owner, 2026-08-03, build 46 — Bluetooth-only by choice)

"**We are on Bluetooth only right now**" / "**Still not working**". iPad on LTE, Wi-Fi off. Discovery succeeded ("Shop Computer Found — iPhone"); the connect failed every attempt.

## Root cause — an off-by-10-seconds that only Bluetooth could expose

`MultipeerManager.invite` sets **timeout: 30 s** on `invitePeer`. Every caller waited **20 s** (10 s on the manual per-peer path) and then threw `connectionTimeout`. **The app quit 10 seconds before iOS stopped trying.** Peer-to-peer Wi-Fi connects in 1–3 s, so this never mattered — until Wi-Fi was off and the only transport left was the slow one. With Wi-Fi off, the wait could not succeed regardless of how healthy the Bluetooth link was.

## Fix

- **`awaitMultipeerConnection()`** — one helper, used by all three call sites: waits **75 s** (comfortably past the 30 s invitation) and **re-invites once** just after the first invitation lapses, since Multipeer delivers no callback when an invitation is silently dropped.
- **Copy corrected.** The old timeout guidance told the owner to turn Wi-Fi on as if Bluetooth-only were impossible — while he was deliberately testing Bluetooth-only. It now leads with how to make BT-only succeed (both devices awake, close, allow up to a minute) and offers Wi-Fi as the *faster* option. Join-screen footer matches.

## Verification

88 sync tests green, core clean. **Owner field test:** same BT-only setup — reset iPad, fresh code, rejoin, and give it up to a minute. This does not yet make BT-only *fast*; it makes it possible. Throughput work is planned in #1640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)