### PR TITLE
fix(sync): trust-gate peer writes + make device revocation actually propagate (audit P0/P1)

### DIFF
--- a/core/Sources/WiredPartCore/Services/AuthService.swift
+++ b/core/Sources/WiredPartCore/Services/AuthService.swift
@@ -718,10 +718,33 @@ public final class AuthService: Sendable {
             let revokedCount = try Self.revokeTokenFamily(rootTokenId: sessionId, in: dbConnection, revokedAt: now)
             if revokedCount > 0 { return }
 
+            // Resolve the row's device_id BEFORE updating so the revocation can
+            // be replicated: peers key `_device_registry` on device_id, not rowid.
+            let targetDeviceId = try String.fetchOne(
+                dbConnection,
+                sql: "SELECT device_id FROM _device_registry WHERE rowid = ?",
+                arguments: [sessionId]
+            )
             try dbConnection.execute(
                 sql: "UPDATE _device_registry SET is_deactivated = 1 WHERE rowid = ?",
                 arguments: [sessionId]
             )
+            // SECURITY (audit 2026-08-03, P0): this admin revoke path wrote the
+            // flag locally and logged NOTHING, so kicking a lost or compromised
+            // device only revoked it on the device the admin happened to use.
+            // Emit the same change-log entry DeviceResetService does so every
+            // paired peer converges on the revocation.
+            if let targetDeviceId, !targetDeviceId.isEmpty {
+                let changedFieldsJSON = #"{"is_deactivated":1,"device_id":"\#(targetDeviceId)"}"#
+                try dbConnection.execute(
+                    sql: """
+                        INSERT INTO _change_log
+                            (table_name, record_id, operation, device_id, changed_fields, timestamp)
+                        VALUES ('_device_registry', 0, 'UPDATE', ?, ?, datetime('now'))
+                        """,
+                    arguments: [targetDeviceId, changedFieldsJSON]
+                )
+            }
         }
     }
 

--- a/core/Sources/WiredPartCore/Sync/ConflictResolver.swift
+++ b/core/Sources/WiredPartCore/Sync/ConflictResolver.swift
@@ -252,6 +252,19 @@ public enum ConflictResolver {
 
                     let outcome: (applied: Int, conflicts: Int, skipped: Int)
 
+                    // `_device_registry` is keyed by device_id (TEXT), not `id`,
+                    // so the generic id-keyed apply below could NEVER apply it —
+                    // every incoming row failed with "no such column: id" and was
+                    // swallowed as result.errors. Net effect (security audit
+                    // 2026-08-03, P0): deactivating a lost/stolen device revoked
+                    // it ONLY on the device that performed the revocation; every
+                    // other paired device kept treating it as trusted forever.
+                    if change.tableName == "_device_registry" {
+                        let applied = try applyDeviceRegistryChange(db: dbConn, change: change)
+                        try dbConn.execute(sql: "DELETE FROM _sync_apply_guard")
+                        return (applied, 0, applied == 1 ? 0 : 1)
+                    }
+
                     switch change.operation.uppercased() {
                     case "DELETE":
                         try applyDelete(db: dbConn, change: change, localDeviceId: localDevice)
@@ -1042,6 +1055,69 @@ public enum ConflictResolver {
     }
 
     // MARK: - Private: Helpers
+
+    /// Apply an incoming `_device_registry` change.
+    ///
+    /// Two things make this table special:
+    /// 1. **Its primary key is `device_id` (TEXT), not `id`.** The producer
+    ///    (`DeviceResetService.deactivateCurrentDevice`) therefore writes
+    ///    `record_id = 0` and carries the real id inside `changed_fields`.
+    /// 2. **Revocation must be monotonic.** Sync may only ever make trust
+    ///    MORE restrictive: a device that has been deactivated cannot un-
+    ///    deactivate or re-trust itself by pushing a row back at us. Re-
+    ///    enabling a device is a deliberate local admin action, never a
+    ///    replicated one — otherwise revoking a stolen device would be
+    ///    undone by that same device's next sync.
+    ///
+    /// Returns 1 when a row was updated, 0 when there was nothing to apply.
+    static func applyDeviceRegistryChange(db: Database, change: IncomingChange) throws -> Int {
+        // The affected device id lives in changed_fields (preferred) or in a
+        // full record payload.
+        func stringField(_ json: String?, _ key: String) -> String? {
+            guard let json, let data = json.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return nil }
+            if let s = obj[key] as? String { return s }
+            if let n = obj[key] as? NSNumber { return n.stringValue }
+            return nil
+        }
+        func intField(_ json: String?, _ key: String) -> Int? {
+            guard let json, let data = json.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return nil }
+            if let n = obj[key] as? NSNumber { return n.intValue }
+            if let s = obj[key] as? String { return Int(s) }
+            return nil
+        }
+
+        let targetId = stringField(change.changedFields, "device_id")
+            ?? stringField(change.recordData, "device_id")
+        guard let targetId, !targetId.isEmpty else { return 0 }
+
+        let deactivated = intField(change.changedFields, "is_deactivated")
+            ?? intField(change.recordData, "is_deactivated")
+        let trusted = intField(change.changedFields, "is_trusted")
+            ?? intField(change.recordData, "is_trusted")
+
+        var applied = 0
+        // Monotonic revocation only: 1 -> deactivate; 0 is ignored.
+        if deactivated == 1 {
+            try db.execute(
+                sql: "UPDATE _device_registry SET is_deactivated = 1 WHERE device_id = ?",
+                arguments: [targetId]
+            )
+            applied = max(applied, db.changesCount)
+        }
+        // Monotonic distrust only: 0 -> untrust; 1 is ignored.
+        if trusted == 0 {
+            try db.execute(
+                sql: "UPDATE _device_registry SET is_trusted = 0 WHERE device_id = ?",
+                arguments: [targetId]
+            )
+            applied = max(applied, db.changesCount)
+        }
+        return applied > 0 ? 1 : 0
+    }
 
     /// Fetch a local record by ID from any table.
     private static func getLocalRecord(db: Database, tableName: String, recordId: String) throws -> Row? {

--- a/core/Sources/WiredPartCore/Sync/PeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/PeerManager.swift
@@ -535,7 +535,13 @@ public actor PeerManager {
                     let encoder = JSONEncoder()
                     let changesData = try encoder.encode(enrichedChanges)
                     let payload = try encoder.encode(MPEnvelope(type: "changes", payload: changesData))
-                    if mpManager.send(data: payload, toPeer: peer.deviceId) {
+                    // A failed send used to fall through to success:true with
+                    // pushed:0 — indistinguishable from a real sync in the UI
+                    // (audit 2026-08-03, same dishonesty class as #1625).
+                    guard mpManager.send(data: payload, toPeer: peer.deviceId) else {
+                        throw MultipeerPairingError.sendFailed
+                    }
+                    do {
                         pushed = enrichedChanges.count
                         let syncedIds = pendingChanges.compactMap { $0.id }
                         try ChangeTracker.markSynced(
@@ -1009,6 +1015,20 @@ public actor PeerManager {
     // MARK: - Private: Multipeer Message Handling
 
     #if canImport(MultipeerConnectivity)
+    /// Whether a peer may WRITE company data to this device.
+    ///
+    /// A peer qualifies while it is trusted and not deactivated, OR while we
+    /// are mid-onboarding against it as our snapshot host (the host sends the
+    /// initial company snapshot as `changes` frames before our own trust row
+    /// for it is durable). Anything else is rejected — discovery is
+    /// deliberately open, writes never are.
+    func isTrustedWritePeer(_ peerDeviceId: String) -> Bool {
+        if (try? isTrustedBluetoothPeer(peerDeviceId)) == true { return true }
+        // In-flight initial snapshot from the host we are joining.
+        return pendingSnapshotChanges[peerDeviceId] != nil
+            || receivedSnapshotTokens[peerDeviceId] != nil
+    }
+
     func isTrustedBluetoothPeer(_ peerDeviceId: String) throws -> Bool {
         try db.writer.read { dbConn in
             try Bool.fetchOne(
@@ -1054,6 +1074,17 @@ public actor PeerManager {
             }
             switch env.type {
             case "changes":
+                // SECURITY (audit 2026-08-03): company data may only be written
+                // by a peer that completed pairing and is still trusted.
+                // handleFullSyncRequest checked this; the write paths did not —
+                // and MultipeerManager auto-accepts any invitation asserting our
+                // company_id, which is broadcast in cleartext in the Bonjour TXT
+                // record. Any nearby device could therefore INSERT/UPDATE/DELETE
+                // in every allowed table without ever pairing.
+                guard isTrustedWritePeer(message.fromDeviceId) else {
+                    logger.error("[PeerManager] Rejected changes from untrusted peer \(String(message.fromDeviceId.prefix(8)), privacy: .public)")
+                    return .ignored
+                }
                 do {
                     let changes = try decodeIncomingChanges(env.payload)
                     let count: Int
@@ -1144,7 +1175,12 @@ public actor PeerManager {
             }
         }
 
-        // Legacy senders used a bare [IncomingChange] JSON array.
+        // Legacy senders used a bare [IncomingChange] JSON array. Same trust
+        // gate as the enveloped path above — this is a write path.
+        guard isTrustedWritePeer(message.fromDeviceId) else {
+            logger.error("[PeerManager] Rejected legacy changes payload from untrusted peer \(String(message.fromDeviceId.prefix(8)), privacy: .public)")
+            return .ignored
+        }
         guard !failedSnapshotPeers.contains(message.fromDeviceId) else { return .ignored }
         let changes = try decodeIncomingChanges(message.data)
         let count: Int

--- a/core/Tests/WiredPartCoreTests/SyncTrustAndRevocationTests.swift
+++ b/core/Tests/WiredPartCoreTests/SyncTrustAndRevocationTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+import GRDB
+@testable import WiredPartCore
+
+/// Guards for the two security findings from the 2026-08-03 sync audit:
+/// unauthenticated peer writes, and revocation that never propagated.
+@Suite("Sync trust and revocation")
+struct SyncTrustAndRevocationTests {
+
+    private func seedPeer(
+        _ db: AppDatabase, id: String, trusted: Bool, deactivated: Bool = false
+    ) throws {
+        try db.writer.write { dbc in
+            try dbc.execute(sql: """
+                INSERT OR REPLACE INTO _device_registry
+                    (device_id, device_name, platform, is_trusted, is_deactivated)
+                VALUES (?, 'Peer', 'ios', ?, ?)
+                """, arguments: [id, trusted ? 1 : 0, deactivated ? 1 : 0])
+        }
+    }
+
+    private func registryFlags(_ db: AppDatabase, _ id: String) throws -> (trusted: Int, deactivated: Int) {
+        try db.writer.read { dbc in
+            let row = try Row.fetchOne(
+                dbc,
+                sql: "SELECT is_trusted, is_deactivated FROM _device_registry WHERE device_id = ?",
+                arguments: [id]
+            )
+            return (row?["is_trusted"] ?? -1, row?["is_deactivated"] ?? -1)
+        }
+    }
+
+    private func registryChange(deviceId: String, deactivated: Int? = nil, trusted: Int? = nil) -> IncomingChange {
+        var fields: [String] = ["\"device_id\":\"\(deviceId)\""]
+        if let deactivated { fields.append("\"is_deactivated\":\(deactivated)") }
+        if let trusted { fields.append("\"is_trusted\":\(trusted)") }
+        return IncomingChange(
+            deviceId: "peer-sender",
+            tableName: "_device_registry",
+            recordId: "0",
+            operation: "UPDATE",
+            changedFields: "{\(fields.joined(separator: ","))}",
+            timestamp: CoreFormatters.nowISO()
+        )
+    }
+
+    @Test("Revocation propagates: an incoming deactivation applies to the right row")
+    func revocationApplies() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        try seedPeer(db, id: "stolen-device", trusted: true)
+        let result = try ConflictResolver.resolveAndApplyChanges(
+            db: db, changes: [registryChange(deviceId: "stolen-device", deactivated: 1)]
+        )
+        #expect(result.errors == 0, "device_registry change must not error out")
+        #expect(try registryFlags(db, "stolen-device").deactivated == 1)
+    }
+
+    @Test("Revocation is MONOTONIC: a revoked device cannot re-enable itself over sync")
+    func revocationIsMonotonic() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        try seedPeer(db, id: "stolen-device", trusted: false, deactivated: true)
+        // The stolen device pushes "I'm fine again".
+        _ = try ConflictResolver.resolveAndApplyChanges(
+            db: db, changes: [registryChange(deviceId: "stolen-device", deactivated: 0, trusted: 1)]
+        )
+        let flags = try registryFlags(db, "stolen-device")
+        #expect(flags.deactivated == 1, "sync must never un-deactivate a device")
+        #expect(flags.trusted == 0, "sync must never re-trust a device")
+    }
+
+    @Test("Admin revoke emits a replicable change-log entry")
+    func adminRevokeIsReplicated() throws {
+        let env = try E2ETestHelpers.setUp()
+        try seedPeer(env.db, id: "kicked-device", trusted: true)
+        let rowid = try env.db.writer.read { dbc in
+            try Int64.fetchOne(dbc, sql: "SELECT rowid FROM _device_registry WHERE device_id = ?",
+                               arguments: ["kicked-device"])
+        }
+        try env.auth.deactivateSession(sessionId: String(rowid ?? 0))
+        let logged = try env.db.writer.read { dbc in
+            try String.fetchOne(dbc, sql: """
+                SELECT changed_fields FROM _change_log
+                WHERE table_name = '_device_registry' ORDER BY id DESC LIMIT 1
+                """)
+        }
+        #expect(logged?.contains("kicked-device") == true, "revocation must be logged for sync")
+        #expect(logged?.contains("\"is_deactivated\":1") == true)
+    }
+
+    @Test("Untrusted peers cannot write company data; trusted peers can")
+    func writeGateHoldsBothWays() async throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        let pm = PeerManager(db: db)
+        try seedPeer(db, id: "trusted-peer", trusted: true)
+        try seedPeer(db, id: "revoked-peer", trusted: true, deactivated: true)
+        #expect(await pm.isTrustedWritePeer("trusted-peer") == true)
+        #expect(await pm.isTrustedWritePeer("revoked-peer") == false)
+        #expect(await pm.isTrustedWritePeer("never-paired-peer") == false)
+    }
+}


### PR DESCRIPTION
First fixes out of the full sync-system audit (three parallel specialist passes: protocol, data integrity, security).

## P0 — Revoking a device only revoked it on the device you used

`_device_registry` is keyed by **`device_id` (TEXT)**, but the generic change-apply path hardcodes `WHERE id = ?`. Every incoming registry row failed with *no such column: id* and was swallowed into `result.errors`. So "deactivate this device" propagated **nowhere** — every other paired device kept treating a lost/stolen/kicked device as trusted, forever. The admin revoke path (`AuthService.deactivateSession`) was worse: local `UPDATE`, no change-log entry at all, so it never even attempted to replicate.

- `ConflictResolver.applyDeviceRegistryChange` keys on `device_id` (read from `changed_fields`, exactly where `DeviceResetService` puts it).
- **Revocation is monotonic**: sync may only make trust *more* restrictive. A deactivated device cannot un-deactivate or re-trust itself by pushing a row back at us — otherwise revoking a stolen device would be undone by that device's very next sync. Re-enabling stays a deliberate local action.
- `deactivateSession` now emits the same change-log entry `DeviceResetService` does.

## P1 — Inbound changes were applied with no trust check

Only `handleFullSyncRequest` checked `isTrustedBluetoothPeer`. Both write paths applied whatever arrived — and `MultipeerManager` auto-accepts any invitation asserting our `company_id`, which is **broadcast in cleartext** in the Bonjour TXT record. Any nearby device could therefore write across every allowed table without pairing. Both paths now gate on `isTrustedWritePeer`.

## P2 — Failed Bluetooth push reported success

`if send(...) { }` with no `else` fell through to `success: true, pushed: 0`. Now throws.

## Verification — red proof on every guard

Each fix was reverted and the guard watched failing before being restored:
- registry special-case removed → *"result.errors → 1"*, row not deactivated ✅
- monotonic rule loosened → deactivated flipped back to 0, trusted back to 1 ✅
- write gate neutered → revoked and never-paired peers accepted ✅
- admin change-log removed → no entry logged ✅

4 new tests, 87 sync tests green.

Remaining audit findings (~20, incl. three more P0s in the data-integrity layer) are being filed as an umbrella issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)