### PR TITLE
feat(diagnostics): replicated device logs with 30-day self-clean

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -154,6 +154,7 @@ extension AppDatabase {
         registerMigration114AIConversationRecency(&migrator)
         registerMigration115SyncReplayGuard(&migrator)
         registerMigration116TeamMutationAttribution(&migrator)
+        registerMigration120DeviceLogs(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -6175,5 +6176,57 @@ private func registerMigration116TeamMutationAttribution(_ migrator: inout Datab
         try addColumnIfMissing(db, table: "employee_teams", column: "deleted_by", type: .integer)
         try addColumnIfMissing(db, table: "employee_team_members", column: "added_by", type: .integer)
         try addColumnIfMissing(db, table: "employee_team_members", column: "removed_by", type: .integer)
+    }
+}
+
+/// Fleet diagnostics: every device keeps a bounded technical log and REPLICATES
+/// it, so a failure in the field is readable from the shop Mac instead of
+/// requiring the owner to screenshot and describe it (owner request
+/// 2026-08-03). `activity_log` records what USERS did; this records what the
+/// APP did — sync outcomes, pairing failures, startup errors.
+///
+/// Three properties make this safe to sync:
+/// 1. **Append-only and self-pruning** — rows older than the retention window
+///    are deleted on launch, so the table (and the sync payload) stay bounded.
+/// 2. **No secrets** — callers pass diagnostic text only; the service refuses
+///    obviously key-shaped payloads (see DeviceLogService).
+/// 3. **Device-stamped** — every row carries the originating device id/name and
+///    app version, so the Mac can tell which device in the field produced it.
+private func registerMigration120DeviceLogs(_ migrator: inout DatabaseMigrator) {
+    migrator.registerMigration("120_device_logs") { db in
+        try db.create(table: "device_logs", ifNotExists: true) { t in
+            t.autoIncrementedPrimaryKey("id")
+            t.column("device_id", .text).notNull()
+            t.column("device_name", .text)
+            t.column("app_version", .text)
+            t.column("level", .text).notNull()          // error | warn | info
+            t.column("category", .text).notNull()       // sync | pairing | startup | ...
+            t.column("message", .text).notNull()
+            t.column("detail", .text)                   // optional JSON
+            t.column("created_at", .text).notNull().defaults(sql: "(datetime('now'))")
+            t.column("updated_at", .text).notNull().defaults(sql: "(datetime('now'))")
+        }
+        try db.create(
+            index: "idx_device_logs_created", on: "device_logs",
+            columns: ["created_at"], ifNotExists: true
+        )
+        try db.create(
+            index: "idx_device_logs_device_level", on: "device_logs",
+            columns: ["device_id", "level"], ifNotExists: true
+        )
+
+        // Replicate like any other synced table (same trigger shape as
+        // migration 112, which only covered tables existing at ITS run).
+        for (op, rowRef) in [("INSERT", "NEW"), ("UPDATE", "NEW"), ("DELETE", "OLD")] {
+            try db.execute(sql: """
+                CREATE TRIGGER IF NOT EXISTS trg_sync_device_logs_\(op.lowercased())
+                AFTER \(op) ON [device_logs]
+                WHEN (SELECT COUNT(*) FROM _sync_apply_guard) = 0
+                BEGIN
+                    INSERT INTO _change_log (device_id, table_name, record_id, operation)
+                    VALUES ('', 'device_logs', \(rowRef).id, '\(op)');
+                END
+                """)
+        }
     }
 }

--- a/core/Sources/WiredPartCore/Services/DeviceLogService.swift
+++ b/core/Sources/WiredPartCore/Services/DeviceLogService.swift
@@ -1,0 +1,206 @@
+import Foundation
+import GRDB
+
+/// Fleet diagnostics — a bounded, self-pruning, **replicated** technical log.
+///
+/// Owner request 2026-08-03: *"let's get the devices syncing and storing the
+/// other devices' logs, self-clean old logs in 30 days, then the TestFlight
+/// version on this computer syncs with the ones in the field so you have logs
+/// to work with."* Field failures currently reach the developer only as
+/// screenshots and recollection; this makes them first-class data that travels
+/// on the same sync path as company records.
+///
+/// Relationship to `activity_log`: that table records what **users** did
+/// (business audit). This records what the **app** did — sync outcomes,
+/// pairing failures, startup errors — and is safe to prune.
+public final class DeviceLogService: Sendable {
+    /// Retention window. Rows older than this are removed on `prune()`.
+    public static let retentionDays = 30
+    /// Hard cap so a pathological logger cannot bloat the database or the sync
+    /// payload between prunes; the newest rows always win.
+    public static let maxRows = 5_000
+
+    public enum Level: String, Sendable, CaseIterable {
+        case error, warn, info
+    }
+
+    public struct Entry: Sendable, Equatable {
+        public let id: Int64
+        public let deviceId: String
+        public let deviceName: String?
+        public let appVersion: String?
+        public let level: Level
+        public let category: String
+        public let message: String
+        public let detail: String?
+        public let createdAt: String
+    }
+
+    private let db: AppDatabase
+    private let deviceId: String
+    private let deviceName: String?
+    private let appVersion: String?
+
+    public init(
+        db: AppDatabase,
+        deviceId: String = DeviceIdentity.current,
+        deviceName: String? = nil,
+        appVersion: String? = nil
+    ) {
+        self.db = db
+        self.deviceId = deviceId
+        self.deviceName = deviceName
+        self.appVersion = appVersion
+    }
+
+    // MARK: - Writing
+
+    /// Record one diagnostic line. Never throws: a logger that can break the
+    /// operation it is describing is worse than no logger.
+    public func log(
+        _ level: Level,
+        category: String,
+        message: String,
+        detail: String? = nil
+    ) {
+        let safeMessage = Self.redact(message)
+        let safeDetail = detail.map(Self.redact)
+        do {
+            try db.writer.write { dbc in
+                try dbc.execute(
+                    sql: """
+                    INSERT INTO device_logs
+                        (device_id, device_name, app_version, level, category, message, detail)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [
+                        deviceId, deviceName, appVersion,
+                        level.rawValue, category, safeMessage, safeDetail,
+                    ]
+                )
+            }
+        } catch {
+            // Deliberately silent — see doc comment.
+        }
+    }
+
+    public func error(_ category: String, _ message: String, detail: String? = nil) {
+        log(.error, category: category, message: message, detail: detail)
+    }
+
+    public func warn(_ category: String, _ message: String, detail: String? = nil) {
+        log(.warn, category: category, message: message, detail: detail)
+    }
+
+    public func info(_ category: String, _ message: String, detail: String? = nil) {
+        log(.info, category: category, message: message, detail: detail)
+    }
+
+    // MARK: - Reading (the point of the exercise)
+
+    /// Most recent entries across ALL devices — the fleet view the shop Mac
+    /// reads after field devices sync their logs in.
+    public func recent(
+        limit: Int = 200,
+        level: Level? = nil,
+        category: String? = nil,
+        deviceId: String? = nil
+    ) throws -> [Entry] {
+        var conditions: [String] = []
+        var args: [DatabaseValueConvertible] = []
+        if let level { conditions.append("level = ?"); args.append(level.rawValue) }
+        if let category { conditions.append("category = ?"); args.append(category) }
+        if let deviceId { conditions.append("device_id = ?"); args.append(deviceId) }
+        let whereClause = conditions.isEmpty ? "" : "WHERE " + conditions.joined(separator: " AND ")
+        args.append(min(max(limit, 1), 1000))
+        return try db.writer.read { dbc in
+            try Row.fetchAll(
+                dbc,
+                sql: """
+                SELECT * FROM device_logs \(whereClause)
+                ORDER BY created_at DESC, id DESC LIMIT ?
+                """,
+                arguments: StatementArguments(args)
+            ).map(Self.entry(from:))
+        }
+    }
+
+    /// Devices that have reported logs, with counts — "who is out there and
+    /// how noisy are they".
+    public func deviceSummary() throws -> [(deviceId: String, deviceName: String?, errors: Int, total: Int, lastSeen: String?)] {
+        try db.writer.read { dbc in
+            try Row.fetchAll(dbc, sql: """
+                SELECT device_id,
+                       MAX(device_name) AS device_name,
+                       SUM(CASE WHEN level = 'error' THEN 1 ELSE 0 END) AS errors,
+                       COUNT(*) AS total,
+                       MAX(created_at) AS last_seen
+                FROM device_logs GROUP BY device_id ORDER BY last_seen DESC
+                """).map {
+                (
+                    deviceId: $0["device_id"],
+                    deviceName: $0["device_name"],
+                    errors: $0["errors"] ?? 0,
+                    total: $0["total"] ?? 0,
+                    lastSeen: $0["last_seen"]
+                )
+            }
+        }
+    }
+
+    // MARK: - Pruning
+
+    /// Delete entries older than the retention window, then enforce the row
+    /// cap. Call on launch; safe to call repeatedly. Returns rows removed.
+    @discardableResult
+    public func prune(retentionDays: Int = DeviceLogService.retentionDays) throws -> Int {
+        let days = max(retentionDays, 1)
+        return try db.writer.write { dbc in
+            try dbc.execute(
+                sql: "DELETE FROM device_logs WHERE created_at < datetime('now', ?)",
+                arguments: ["-\(days) days"]
+            )
+            var removed = dbc.changesCount
+            // Newest-wins cap.
+            try dbc.execute(sql: """
+                DELETE FROM device_logs WHERE id NOT IN (
+                    SELECT id FROM device_logs ORDER BY created_at DESC, id DESC LIMIT \(Self.maxRows)
+                )
+                """)
+            removed += dbc.changesCount
+            return removed
+        }
+    }
+
+    // MARK: - Safety
+
+    /// Strip anything key-shaped before it reaches a replicated table. Logs
+    /// travel between devices, so a leaked token would travel with them.
+    static func redact(_ text: String) -> String {
+        var out = text
+        for pattern in [
+            #"wpal_[A-Za-z0-9_-]{8,}"#,                  // Agent Link keys
+            #"[A-Za-z0-9+/]{40,}={0,2}"#,                // base64 key material
+            #"(?i)(token|secret|password|pin)\s*[:=]\s*\S+"#,
+        ] {
+            out = out.replacingOccurrences(
+                of: pattern, with: "[redacted]", options: .regularExpression
+            )
+        }
+        return String(out.prefix(2_000))
+    }
+
+    private static func entry(from row: Row) -> Entry {
+        Entry(
+            id: row["id"],
+            deviceId: row["device_id"],
+            deviceName: row["device_name"],
+            appVersion: row["app_version"],
+            level: Level(rawValue: row["level"] ?? "info") ?? .info,
+            category: row["category"],
+            message: row["message"],
+            detail: row["detail"],
+            createdAt: row["created_at"]
+        )
+    }
+}

--- a/core/Sources/WiredPartCore/Sync/ConflictResolver.swift
+++ b/core/Sources/WiredPartCore/Sync/ConflictResolver.swift
@@ -173,6 +173,9 @@ public enum ConflictResolver {
         "payment_records", "customer_communications", "contractor_notes", "contractor_ratings",
         // Work classification audit
         "classification_history",
+        // Fleet diagnostics — every device's technical log replicates so field
+        // failures are readable from the shop Mac (owner 2026-08-03).
+        "device_logs",
         // Estimation
         "estimation_questions", "estimation_responses", "estimation_results",
         "estimation_reviews", "estimation_question_rejections",

--- a/core/Tests/WiredPartCoreTests/DeviceLogServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/DeviceLogServiceTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+import GRDB
+@testable import WiredPartCore
+
+/// Fleet diagnostics: logs must replicate, prune themselves, and never carry
+/// secrets between devices (owner request 2026-08-03).
+@Suite("Device log service")
+struct DeviceLogServiceTests {
+
+    private func makeService(deviceId: String = "dev-A") throws -> (AppDatabase, DeviceLogService) {
+        let db = try AppDatabase.openInMemoryDatabase()
+        return (db, DeviceLogService(db: db, deviceId: deviceId, deviceName: "Test \(deviceId)", appVersion: "1.0.0"))
+    }
+
+    @Test("Entries are written and read newest-first, filterable by level and device")
+    func writeAndRead() throws {
+        let (_, svc) = try makeService()
+        svc.info("startup", "app launched")
+        svc.error("sync", "join failed", detail: #"{"seconds":8}"#)
+        let all = try svc.recent()
+        #expect(all.count == 2)
+        #expect(all.first?.message == "join failed")   // newest first
+        let errorsOnly = try svc.recent(level: .error)
+        #expect(errorsOnly.count == 1)
+        #expect(errorsOnly.first?.category == "sync")
+        #expect(errorsOnly.first?.detail == #"{"seconds":8}"#)
+        #expect(try svc.recent(deviceId: "nobody").isEmpty)
+    }
+
+    @Test("Logs REPLICATE — writes are change-tracked like company data")
+    func logsAreChangeTracked() throws {
+        let (db, svc) = try makeService()
+        svc.error("sync", "pairing timed out")
+        let logged = try db.writer.read { dbc in
+            try Int.fetchOne(dbc, sql: """
+                SELECT COUNT(*) FROM _change_log
+                WHERE table_name = 'device_logs' AND operation = 'INSERT'
+                """) ?? 0
+        }
+        #expect(logged >= 1, "device_logs writes must enter the sync change log")
+        #expect(ConflictResolver.allowedSyncTables.contains("device_logs"))
+    }
+
+    @Test("Fleet view: one device reads another device's synced-in logs")
+    func fleetView() throws {
+        let (db, macService) = try makeService(deviceId: "mac-shop")
+        macService.info("startup", "shop mac up")
+        // Simulate an iPad's log arriving over sync.
+        try db.writer.write { dbc in
+            try dbc.execute(sql: """
+                INSERT INTO device_logs (device_id, device_name, app_version, level, category, message)
+                VALUES ('ipad-field', 'I Work Tablet', '1.0.0', 'error', 'sync', 'download stalled at 8s')
+                """)
+        }
+        let summary = try macService.deviceSummary()
+        #expect(summary.count == 2)
+        let ipad = summary.first { $0.deviceId == "ipad-field" }
+        #expect(ipad?.deviceName == "I Work Tablet")
+        #expect(ipad?.errors == 1)
+        let fieldErrors = try macService.recent(level: .error, deviceId: "ipad-field")
+        #expect(fieldErrors.first?.message == "download stalled at 8s")
+    }
+
+    @Test("Prune removes entries past the retention window and keeps recent ones")
+    func pruneByAge() throws {
+        let (db, svc) = try makeService()
+        svc.info("sync", "fresh entry")
+        try db.writer.write { dbc in
+            try dbc.execute(sql: """
+                INSERT INTO device_logs (device_id, level, category, message, created_at)
+                VALUES ('dev-A', 'info', 'sync', 'ancient entry', datetime('now', '-45 days'))
+                """)
+        }
+        #expect(try svc.recent().count == 2)
+        let removed = try svc.prune()
+        #expect(removed >= 1)
+        let left = try svc.recent()
+        #expect(left.count == 1)
+        #expect(left.first?.message == "fresh entry")
+    }
+
+    @Test("Secrets never reach a replicated log line")
+    func redaction() throws {
+        let (_, svc) = try makeService()
+        svc.error("agent-link", "minted wpal_AbCdEfGhIjKlMnOpQrStUvWxYz012345 for Claude")
+        svc.error("auth", "token: sk-super-secret-value")
+        let lines = try svc.recent().map(\.message)
+        #expect(lines.allSatisfy { !$0.contains("wpal_AbCdEfGhIjKlMnOpQrStUvWxYz012345") })
+        #expect(lines.allSatisfy { !$0.lowercased().contains("sk-super-secret-value") })
+        #expect(lines.contains { $0.contains("[redacted]") })
+    }
+}


### PR DESCRIPTION
## Why

Owner, 2026-08-03: *"let's get the devices syncing and storing the other devices' logs, self-clean old logs in 30 days, then the TestFlight version on this computer syncs with the ones we are putting in the field so you have logs to work with."*

Today a field failure reaches the developer as a screenshot and a recollection — last night's Bluetooth bug took three round trips and a stopwatch reading to pin down. This turns the app's technical trail into data that rides the existing sync path to the shop Mac.

## What

- **Migration 120** — `device_logs`: originating device id/name, app version, level (error/warn/info), category, message, optional JSON detail, timestamps; indexes on `created_at` and `(device_id, level)`; plus the same change-tracking triggers migration 112 installs (112 only covered tables that existed at *its* run).
- **Allowlisted** in `ConflictResolver` → replicates like company data.
- **`DeviceLogService`** — level helpers; `recent()` filtered by level/category/device; `deviceSummary()` for the fleet view; `prune()` enforcing the **30-day window** *and* a **5,000-row newest-wins cap** so the table and the sync payload stay bounded between prunes. Never throws — a logger that can break the operation it describes is worse than no logger.
- **Redaction before write** — logs travel between devices, so a leaked key would travel with them. Agent Link keys, base64 key material, and `token=`/`secret:`/`password`/`pin` assignments are stripped; lines capped at 2 KB.

Relationship to `activity_log`: that records what **users** did (business audit, never pruned). This records what the **app** did, and is safe to prune.

## Verification — red proof on both load-bearing guards

- Allowlist entry removed → *"Logs REPLICATE"* failed ✅
- Redaction disabled → *"Secrets never reach a replicated log line"* failed on all three assertions ✅
- Restored → 5/5 green.

## Next slice

Agent Link MCP tools (`device_logs_recent`, `device_logs_summary`) so the logs are readable from this Mac by an agent, and `prune()` on launch. Tracked with the Agent Link PR (#1611).

🤖 Generated with [Claude Code](https://claude.com/claude-code)