### PR TITLE
fix(startup): session-key rescue was an allowlist too — lost from the #1649 squash

### DIFF
--- a/core/Sources/WiredPartCore/Services/AuthService.swift
+++ b/core/Sources/WiredPartCore/Services/AuthService.swift
@@ -1350,11 +1350,41 @@ public final class AuthService: Sendable {
         return SymmetricKey(data: keyData)
     }()
 
-    /// Sandbox fallback for the session signing key — used ONLY where the
-    /// keychain reports missing-entitlement/not-available (same tradeoff and
-    /// storage envelope as CipherKeyManager's salt fallback from #1622).
+    /// Sandbox fallback for the session signing key — used wherever the keychain
+    /// is *unusable*, which is a DENYLIST, not an allowlist.
+    ///
+    /// This was `status == errSecMissingEntitlement || status == errSecNotAvailable`,
+    /// copied from CipherKeyManager's original #1622 fix. That allowlist is
+    /// exactly what #1647 had to replace: the iPad-on-Mac keychain returns a
+    /// status outside that pair, so the rescue never fired and the app would not
+    /// start. Keeping the allowlist here reproduced the same failure one layer
+    /// up — the database would open but the signing key would not persist, so
+    /// the user had to log in on every single launch. Same mistake, same cause,
+    /// second symptom.
+    ///
+    /// The rule: rescue when the keychain is UNUSABLE HERE; never rescue when the
+    /// keychain works and access was merely denied or the item is simply absent.
+    /// In those cases a real key exists (or belongs) in the keychain, and writing
+    /// a sandbox key would strand it and silently invalidate every live session.
+    ///
+    /// Excluded — keychain is fine, this attempt just did not get the item:
+    ///   - `errSecSuccess` — nothing failed; callers must not consult a fallback.
+    ///   - `errSecItemNotFound` — normal first run. Generate and store properly.
+    ///   - `errSecInteractionNotAllowed` — locked, no UI available.
+    ///   - `errSecAuthFailed` / `errSecUserCanceled` — the user failed or
+    ///     dismissed authentication. Transient, and the real key is still there.
+    ///
+    /// Everything else rescues. That deliberately includes statuses we have not
+    /// seen: the whole reason #1647 exists is that the iPad-on-Mac keychain
+    /// returns something outside the two values #1622 guessed at, and we still
+    /// do not know which. Enumerating failure modes is what failed twice; the
+    /// only safe default is to rescue unless we can name a reason not to.
     static func canUseSigningKeyFallback(for status: OSStatus) -> Bool {
-        status == errSecMissingEntitlement || status == errSecNotAvailable
+        status != errSecSuccess
+            && status != errSecItemNotFound
+            && status != errSecInteractionNotAllowed
+            && status != errSecAuthFailed
+            && status != errSecUserCanceled
     }
 
     private static func fallbackSigningKeyURL() -> URL? {

--- a/core/Tests/WiredPartCoreTests/AuthServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/AuthServiceTests.swift
@@ -90,12 +90,33 @@ struct AuthServiceTests {
 
     // MARK: - Token Generation & Parsing
 
-    @Test("session signing-key fallback is limited to unavailable Keychain states")
-    func testSigningKeyFallbackStatesStayNarrow() {
+    @Test("session signing-key fallback rescues any unusable Keychain, not a fixed list")
+    func testSigningKeyFallbackRescuesUnknownFailures() {
+        // Known-unusable states still rescue.
         #expect(AuthService.canUseSigningKeyFallback(for: errSecMissingEntitlement))
         #expect(AuthService.canUseSigningKeyFallback(for: errSecNotAvailable))
+
+        // THE REGRESSION GUARD. This is the whole point of the fix and the
+        // assertion the old allowlist failed. The iPad-on-Mac keychain returns
+        // a status outside the two values #1622 guessed at, so the rescue never
+        // fired: first the app would not start (#1647), then it started but made
+        // the user log in every launch. We do not know which status the Mac
+        // returns, so an arbitrary unrecognised failure MUST rescue.
+        // Synthetic values, deliberately not any documented SecBase constant —
+        // they stand in for whatever the Mac actually returns, which we still
+        // have not measured.
+        #expect(AuthService.canUseSigningKeyFallback(for: OSStatus(-77777)))
+        #expect(AuthService.canUseSigningKeyFallback(for: OSStatus(-88888)))
+        #expect(AuthService.canUseSigningKeyFallback(for: OSStatus(-99999)))
+
+        // Keychain works and access was merely denied, or the item is simply
+        // absent — a real key exists or belongs there. Rescuing would strand it
+        // and silently invalidate every live session.
+        #expect(!AuthService.canUseSigningKeyFallback(for: errSecSuccess))
+        #expect(!AuthService.canUseSigningKeyFallback(for: errSecItemNotFound))
         #expect(!AuthService.canUseSigningKeyFallback(for: errSecInteractionNotAllowed))
         #expect(!AuthService.canUseSigningKeyFallback(for: errSecAuthFailed))
+        #expect(!AuthService.canUseSigningKeyFallback(for: errSecUserCanceled))
     }
 
     @Test("generateLocalToken produces signed payload.signature format")


### PR DESCRIPTION
## What happened

This fix was reviewed and committed onto the #1649 branch **before** that PR merged, but #1649 was **squash-merged from an earlier head** and the commit did not come with it. `main` currently has the old allowlist:

```swift
status == errSecMissingEntitlement || status == errSecNotAvailable
```

Verified on `main`: the export-compliance key is present, the `-77777` regression test is not. So the squash captured `3efb8c052` and dropped `1616da7f1`.

## Why it matters

`CipherKeyManager` (via #1647, now on `main`) uses a **denylist** — rescue any keychain status except interaction-not-allowed. `AuthService` still uses the **allowlist** that #1622 used and that demonstrably fails on the owner's Mac.

The consequence on **build 49, being built from `main` right now**: the Mac will **start** — the database key is rescued — and will still **force a login on every single launch**, because the signing-key rescue never fires. That is the bug #1628 claims to fix, failing for the identical reason a second time.

Build 49 is still a large net win (it fixes app-wont-start, the BIG). This makes build 50 fix the re-login. The build 49 release notes have been corrected to say the re-login is **not** fixed rather than claiming it is.

## The fix

`canUseSigningKeyFallback` becomes a denylist. Rescue whenever the keychain is unusable; never when it works and access was merely denied or the item is simply absent — a real key exists or belongs there, and a sandbox key would strand it and invalidate every live session. Excluded: `errSecSuccess`, `errSecItemNotFound`, `errSecInteractionNotAllowed`, `errSecAuthFailed`, `errSecUserCanceled`. Everything else rescues, deliberately including statuses never seen — enumerating failure modes is what failed twice.

## The old test asserted the bug

`testSigningKeyFallbackStatesStayNarrow` named *narrowness* as the requirement when narrowness **was** the defect, so it could never have failed on this. Replaced with a guard on synthetic unrecognised statuses standing in for whatever the Mac actually returns — still unmeasured.

**Proven red** against the old allowlist (both synthetic expectations failed), green after. Full suite was 2565/2565 on this change when it was part of #1649.

Related: #1647, #1628, #1649. Remaining divergence in `CipherKeyManager` tracked as #1652.