### PR TITLE
fix(security): one shared keychain predicate — closes the data-loss gap (#1652)

### DIFF
--- a/core/Sources/WiredPartCore/Security/CipherKeyManager.swift
+++ b/core/Sources/WiredPartCore/Security/CipherKeyManager.swift
@@ -108,27 +108,30 @@ public final class CipherKeyManager: Sendable {
             Self.logger.error("CipherKeyManager: salt write raced (errSecDuplicateItem) and re-read also failed")
             throw CipherKeyError.keychainAccessFailed(errSecDuplicateItem)
         } catch CipherKeyError.keychainAccessFailed(let status)
-            where status != errSecInteractionNotAllowed {
+            where KeychainAvailability.isUnusable(status) {
             // FIELD P0 (owner, 2026-08-04, builds 41 AND 47 both dead on Mac):
-            // the previous version rescued only errSecMissingEntitlement and
+            // the original version rescued only errSecMissingEntitlement and
             // errSecNotAvailable — an ALLOWLIST. The iPad-on-Mac keychain
             // rejects the write with a different status (errSecParam is the
             // documented one for iOS accessibility classes on Mac, and the
             // add query sets kSecAttrAccessible on this build), so the rescue
             // never fired and the app could not open its database at all.
             //
-            // Inverted to a DENYLIST, which is the correct shape: the sandbox
-            // fallback is safe wherever the keychain is genuinely unusable,
-            // and only ONE status is dangerous — errSecInteractionNotAllowed
-            // means "temporarily locked, try later", where minting a second
-            // salt would orphan an existing encrypted database. That one still
-            // throws.
+            // The condition now lives in KeychainAvailability, shared with
+            // AuthService, because answering this question independently in two
+            // files produced three bugs in a row (#1622, #1647, #1652). Read
+            // that type for the full rule; the short version is that a fallback
+            // is safe wherever the keychain is genuinely unusable, and unsafe
+            // wherever it works and merely denied this attempt — there, a real
+            // salt exists and minting a second one orphans the database.
             Self.logger.warning("CipherKeyManager: keychain unusable (OSStatus \(status)) — using sandbox fallback salt")
             try writeFallbackSalt(salt)
             return salt
         } catch {
-            // Any other write failure (e.g. errSecAuthFailed) — surface the
-            // original error directly so callers get the real failure reason.
+            // Reached when the keychain WORKS and merely denied this attempt —
+            // locked, auth failed, or user cancelled (#1652). Surface the real
+            // error rather than minting a second salt: the true one is still in
+            // the keychain, and a fallback here makes the database undecryptable.
             throw error
         }
     }

--- a/core/Sources/WiredPartCore/Security/KeychainAvailability.swift
+++ b/core/Sources/WiredPartCore/Security/KeychainAvailability.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Security
+
+/// The single answer to "is the keychain unusable in this environment?"
+///
+/// **Why this type exists.** Two places need this decision — `CipherKeyManager`
+/// (database salt) and `AuthService` (session signing key) — and for three
+/// consecutive bugs they answered it differently:
+///
+/// 1. **#1622** gave both an ALLOWLIST: `errSecMissingEntitlement ||
+///    errSecNotAvailable`. The iPad-on-Mac keychain returns neither, so the
+///    rescue never fired and **the app could not open its database at all**.
+/// 2. **#1647** fixed `CipherKeyManager` to a denylist. `AuthService` was left
+///    on the allowlist, so the Mac would start and then **force a login on every
+///    launch** — the same bug, one layer up, shipped as a separate fix.
+/// 3. **#1652** found the remaining gap in the other direction: the denylist
+///    excluded only `errSecInteractionNotAllowed`, so a user who merely failed
+///    or cancelled an auth prompt would mint a fallback salt while the real one
+///    sat in the keychain — presenting to that user as **lost data**.
+///
+/// Every one of those came from the same root cause: the same question answered
+/// independently in two files. One predicate, both call sites, is the fix. Do
+/// not reintroduce a local copy.
+///
+/// **The rule.** Rescue when the keychain is genuinely unusable *here*. Never
+/// rescue when the keychain works and this attempt simply did not get the item —
+/// in that case a real key exists (or belongs) in the keychain, and writing a
+/// sandbox key strands it: the database becomes undecryptable, or every live
+/// session silently invalidates.
+///
+/// **The default is to rescue.** The excluded set is enumerated; everything else,
+/// including statuses nobody has seen, counts as unusable. That direction is
+/// deliberate and is the whole lesson of #1622 → #1647: we still have not
+/// measured what the iPad-on-Mac keychain actually returns, and an allowlist
+/// built from guesses failed in the field twice. Guessing wrong here costs a
+/// re-login; guessing wrong the other way costs the app starting at all.
+public enum KeychainAvailability {
+
+    /// `true` when `status` means the keychain cannot be used in this
+    /// environment and a sandbox fallback is the correct response.
+    ///
+    /// Excluded — the keychain is fine, so a fallback would strand the real key:
+    /// - `errSecSuccess` — nothing failed; callers must not consult a fallback.
+    /// - `errSecItemNotFound` — normal first run. Generate and store properly.
+    /// - `errSecInteractionNotAllowed` — locked, no UI. Transient; retry later.
+    /// - `errSecAuthFailed` — the user failed authentication. Transient.
+    /// - `errSecUserCanceled` — the user dismissed the prompt. Transient.
+    public static func isUnusable(_ status: OSStatus) -> Bool {
+        !worksButAccessDenied.contains(status)
+    }
+
+    /// Statuses that mean "the keychain works, this attempt just did not get it".
+    /// Kept as data rather than a boolean chain so the test can assert the exact
+    /// membership, and so adding a case is a one-line, reviewable change.
+    static let worksButAccessDenied: Set<OSStatus> = [
+        errSecSuccess,
+        errSecItemNotFound,
+        errSecInteractionNotAllowed,
+        errSecAuthFailed,
+        errSecUserCanceled
+    ]
+}

--- a/core/Sources/WiredPartCore/Services/AuthService.swift
+++ b/core/Sources/WiredPartCore/Services/AuthService.swift
@@ -1362,29 +1362,14 @@ public final class AuthService: Sendable {
     /// the user had to log in on every single launch. Same mistake, same cause,
     /// second symptom.
     ///
-    /// The rule: rescue when the keychain is UNUSABLE HERE; never rescue when the
-    /// keychain works and access was merely denied or the item is simply absent.
-    /// In those cases a real key exists (or belongs) in the keychain, and writing
-    /// a sandbox key would strand it and silently invalidate every live session.
-    ///
-    /// Excluded — keychain is fine, this attempt just did not get the item:
-    ///   - `errSecSuccess` — nothing failed; callers must not consult a fallback.
-    ///   - `errSecItemNotFound` — normal first run. Generate and store properly.
-    ///   - `errSecInteractionNotAllowed` — locked, no UI available.
-    ///   - `errSecAuthFailed` / `errSecUserCanceled` — the user failed or
-    ///     dismissed authentication. Transient, and the real key is still there.
-    ///
-    /// Everything else rescues. That deliberately includes statuses we have not
-    /// seen: the whole reason #1647 exists is that the iPad-on-Mac keychain
-    /// returns something outside the two values #1622 guessed at, and we still
-    /// do not know which. Enumerating failure modes is what failed twice; the
-    /// only safe default is to rescue unless we can name a reason not to.
+    /// Delegates to `KeychainAvailability`, which is the single shared answer to
+    /// "is the keychain unusable here?" — see that type for the rule and for why
+    /// it is shared. This used to be an independent copy of the condition, and
+    /// the divergence between the two copies caused three bugs in a row (#1622,
+    /// #1647, #1652). It stays as a named wrapper only because the call sites
+    /// read better with it; it must never regain its own logic.
     static func canUseSigningKeyFallback(for status: OSStatus) -> Bool {
-        status != errSecSuccess
-            && status != errSecItemNotFound
-            && status != errSecInteractionNotAllowed
-            && status != errSecAuthFailed
-            && status != errSecUserCanceled
+        KeychainAvailability.isUnusable(status)
     }
 
     private static func fallbackSigningKeyURL() -> URL? {

--- a/core/Tests/WiredPartCoreTests/KeychainAvailabilityTests.swift
+++ b/core/Tests/WiredPartCoreTests/KeychainAvailabilityTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Security
+import Testing
+
+@testable import WiredPartCore
+
+/// Guards the single shared answer to "is the keychain unusable here?".
+///
+/// This predicate has been got wrong three times (#1622 allowlist → app would
+/// not start; #1647 fixed one caller and not the other → login every launch;
+/// #1652 the denylist was one status too wide → fallback salt written over a
+/// working keychain, presenting as lost data). Each regression was invisible to
+/// the tests that existed at the time, so these assert the *shape* of the rule,
+/// not just a few sampled values.
+@Suite("KeychainAvailability")
+struct KeychainAvailabilityTests {
+
+    @Test("unrecognised failures rescue — the default must be to fall back")
+    func testUnknownStatusesAreTreatedAsUnusable() {
+        // The whole reason the denylist exists. We have still never measured
+        // what the iPad-on-Mac keychain returns, so a status nobody enumerated
+        // MUST rescue. An allowlist built from guesses failed in the field twice.
+        #expect(KeychainAvailability.isUnusable(OSStatus(-77777)))
+        #expect(KeychainAvailability.isUnusable(OSStatus(-88888)))
+        #expect(KeychainAvailability.isUnusable(OSStatus(-99999)))
+
+        // Known-unusable states, named so a future edit cannot quietly drop them.
+        #expect(KeychainAvailability.isUnusable(errSecMissingEntitlement))
+        #expect(KeychainAvailability.isUnusable(errSecNotAvailable))
+        // errSecParam is the documented status for iOS accessibility classes on
+        // Mac, and the prime suspect for the field failure.
+        #expect(KeychainAvailability.isUnusable(errSecParam))
+    }
+
+    @Test("a working keychain that merely denied access must NOT rescue")
+    func testTransientDenialsDoNotRescue() {
+        // In every one of these a real key exists or belongs in the keychain.
+        // Writing a sandbox key strands it: the database becomes undecryptable
+        // (CipherKeyManager) or every live session invalidates (AuthService).
+        #expect(!KeychainAvailability.isUnusable(errSecSuccess))
+        #expect(!KeychainAvailability.isUnusable(errSecItemNotFound))
+        #expect(!KeychainAvailability.isUnusable(errSecInteractionNotAllowed))
+
+        // #1652 specifically: these two were being rescued. A user who failed or
+        // dismissed a single auth prompt got a fallback salt written while the
+        // real one sat in the keychain — which reads to that user as lost data.
+        #expect(!KeychainAvailability.isUnusable(errSecAuthFailed))
+        #expect(!KeychainAvailability.isUnusable(errSecUserCanceled))
+    }
+
+    @Test("the excluded set is exactly these five — additions must be deliberate")
+    func testExcludedSetMembershipIsPinned() {
+        // Pinning the set makes widening it a visible, reviewable diff rather
+        // than a silent behaviour change. Widening is how #1652 happened.
+        #expect(KeychainAvailability.worksButAccessDenied == [
+            errSecSuccess,
+            errSecItemNotFound,
+            errSecInteractionNotAllowed,
+            errSecAuthFailed,
+            errSecUserCanceled
+        ])
+    }
+
+    @Test("AuthService delegates rather than keeping its own copy")
+    func testAuthServiceAgreesWithSharedPredicate() {
+        // The divergence between two independent copies is the root cause of all
+        // three bugs. This fails the moment AuthService regains its own logic.
+        for status in [errSecSuccess, errSecItemNotFound, errSecInteractionNotAllowed,
+                       errSecAuthFailed, errSecUserCanceled, errSecMissingEntitlement,
+                       errSecNotAvailable, errSecParam, OSStatus(-77777)] {
+            #expect(AuthService.canUseSigningKeyFallback(for: status)
+                    == KeychainAvailability.isUnusable(status),
+                    "AuthService diverged from KeychainAvailability on \(status)")
+        }
+    }
+}


### PR DESCRIPTION
Closes #1652.

## The pattern, not just the bug

Three bugs in a row came from one root cause: `CipherKeyManager` and `AuthService` each answered *"is the keychain unusable here?"* independently.

| | What broke | How it looked to the owner |
|---|---|---|
| **#1622** | Both used an **allowlist** (`missingEntitlement \|\| notAvailable`). iPad-on-Mac returns neither, so the rescue never fired. | **The app would not start at all.** |
| **#1647** | Fixed `CipherKeyManager` to a denylist. `AuthService` was left on the allowlist. | **Mac starts, then forces a login every launch.** |
| **#1652** | The denylist excluded only `errSecInteractionNotAllowed`. | **"All my data is gone."** |

**Fixing the second copy again would have set up a fourth.** So this does not patch the remaining copy — it removes the second answer. Both call sites now use `KeychainAvailability.isUnusable`.

## Why #1652 is the worst of the three

A user who merely **fails or cancels an auth prompt once** currently gets a fallback salt written, while the real salt stays in the keychain. The next launch derives the database key from the wrong salt and SQLCipher returns `SQLITE_NOTADB`.

That does not present as an authentication hiccup. It presents as **every job, part, order and photo being gone** — the owner-defined **BIG** category *corrupted or lost data*. The data is recoverable in principle, since the real salt still exists, but nothing in the app knows to look for it.

## The rule

Rescue when the keychain is genuinely unusable *here*. Never when it works and merely denied this attempt — there, a real key exists or belongs in the keychain and a sandbox key strands it.

Excluded: `errSecSuccess`, `errSecItemNotFound`, `errSecInteractionNotAllowed`, `errSecAuthFailed`, `errSecUserCanceled`. Held as a `Set` rather than a boolean chain, so widening it is a reviewable one-line diff instead of a silent behaviour change — widening is exactly how #1652 happened.

**Everything else rescues, deliberately including statuses never measured.** We still do not know what the iPad-on-Mac keychain actually returns. Guessing wrong in that direction costs a re-login; guessing wrong the other way costs the app starting at all. The asymmetry is the whole argument for a denylist.

## A wrong comment that probably hid this

`CipherKeyManager` carried `// Any other write failure (e.g. errSecAuthFailed) — surface the original error`. It did not: the `where` clause above swallowed `errSecAuthFailed` and rescued on it. Anyone checking that specific concern would have read the comment and moved on. Corrected here.

## Red proof — both regression paths (STEP 5.2)

1. **Reintroduced #1652** by narrowing the excluded set → *"a working keychain that merely denied access must NOT rescue"* **failed** on `errSecAuthFailed` and `errSecUserCanceled`, and the membership test **failed**. Restored → green.
2. **Gave `AuthService` its own copy again** → *"AuthService delegates rather than keeping its own copy"* **failed**. Restored → green.

The second guard is the one that matters most: it fails the moment anyone reintroduces the divergence that caused all three bugs.

## Verification

- `swift build --package-path core` — clean.
- `swift test --package-path core` — **2569 tests in 82 suites pass** (up 4).

Related: #1622, #1647, #1649, #1653.