### PR TITLE
fix(people): editing a contact destroyed their email — stop it, repair it (#1656)

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -1,5 +1,11 @@
 import Foundation
 import GRDB
+import os.log
+
+/// Migrations that repair data need to report scale — how many rows they fixed
+/// and how many they could not. Silence there is indistinguishable from "no
+/// damage found", which is exactly the wrong thing to guess about.
+let migrationLogger = Logger(subsystem: "com.wiredpart.core", category: "Migrations")
 
 // MARK: - Safe Column Addition Helper (fixes #201)
 
@@ -155,6 +161,7 @@ extension AppDatabase {
         registerMigration115SyncReplayGuard(&migrator)
         registerMigration116TeamMutationAttribution(&migrator)
         registerMigration119SyncGapTables(&migrator)
+        registerContactEmailRepair(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -6234,5 +6241,50 @@ private func registerMigration119SyncGapTables(_ migrator: inout DatabaseMigrato
                 )
                 """)
         }
+    }
+}
+
+/// 120 — recover contact emails that `updateContact` encrypted and nothing
+/// could read back (#1656).
+///
+/// `createContact` wrote this column in plaintext, `updateContact` wrote it
+/// AES-GCM-sealed, and no decrypt path existed anywhere — so editing any
+/// contact replaced a readable address with an unreadable blob. This walks
+/// the damaged rows and restores the ones this device can still decrypt.
+///
+/// Deliberately best-effort. Where the sealing key is gone — every device
+/// whose Keychain is unusable regenerated it on each launch — the row is
+/// LEFT UNTOUCHED. An unreadable address is bad; overwriting the last copy
+/// of it with a blank is worse, and it forecloses recovery if the key ever
+/// turns up. The count of each outcome is logged so the scale is knowable.
+private func registerContactEmailRepair(_ migrator: inout DatabaseMigrator) {
+    migrator.registerMigration("120_repair_encrypted_contact_emails") { db in
+        let rows = try Row.fetchAll(
+            db,
+            sql: """
+                SELECT id, email FROM entity_contacts
+                WHERE email IS NOT NULL AND email <> '' AND email NOT LIKE '%@%'
+                """
+        )
+        guard !rows.isEmpty else { return }
+
+        var recovered = 0
+        var unrecoverable = 0
+        for row in rows {
+            let stored: String? = row["email"]
+            guard let id: Int64 = row["id"] else { continue }
+            if let email = PeopleService.recoverEncryptedContactEmail(stored) {
+                try db.execute(
+                    sql: "UPDATE entity_contacts SET email = ? WHERE id = ?",
+                    arguments: [email, id]
+                )
+                recovered += 1
+            } else {
+                unrecoverable += 1
+            }
+        }
+        migrationLogger.notice(
+            "120_repair_encrypted_contact_emails: recovered \(recovered), left intact \(unrecoverable)"
+        )
     }
 }

--- a/core/Sources/WiredPartCore/Services/PeopleService.swift
+++ b/core/Sources/WiredPartCore/Services/PeopleService.swift
@@ -43,13 +43,27 @@ public final class PeopleService: Sendable {
         return SymmetricKey(data: keyData)
     }()
 
-    private func encryptSensitiveField(_ value: String?) throws -> String? {
-        guard let value, !value.isEmpty else { return value }
-        let sealedBox = try AES.GCM.seal(Data(value.utf8), using: Self.contactFieldEncryptionKey)
-        guard let combined = sealedBox.combined else {
-            throw NSError(domain: "PeopleService.Encryption", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to combine sealed box"])
-        }
-        return combined.base64EncodedString()
+    /// Recover a contact email that a pre-#1656 `updateContact` encrypted.
+    ///
+    /// Returns the plaintext when this device still holds the key that sealed
+    /// the value, and `nil` when it does not — which is the common case on any
+    /// device whose Keychain is unusable, because the key there was regenerated
+    /// on every launch and the sealing key is simply gone. Unrecoverable rows
+    /// are left exactly as they are rather than blanked: an unreadable address
+    /// is bad, but destroying the only remaining copy of it is worse.
+    static func recoverEncryptedContactEmail(_ stored: String?) -> String? {
+        guard let stored, !stored.isEmpty else { return nil }
+        // A real address always contains "@" and is not valid standalone base64,
+        // so this cannot mistake a genuine email for ciphertext.
+        guard !stored.contains("@"),
+              let combined = Data(base64Encoded: stored),
+              combined.count > 28,  // 12-byte nonce + 16-byte tag + payload
+              let sealed = try? AES.GCM.SealedBox(combined: combined),
+              let plaintext = try? AES.GCM.open(sealed, using: contactFieldEncryptionKey),
+              let email = String(data: plaintext, encoding: .utf8),
+              email.contains("@")
+        else { return nil }
+        return email
     }
 
     // =========================================================================
@@ -1047,7 +1061,21 @@ public final class PeopleService: Sendable {
         guard !firstName.isBlankRequiredText else {
             throw PeopleError.requiredFieldEmpty("firstName")
         }
-        let encryptedEmail = try encryptSensitiveField(email)
+        // The email is stored as written. It used to be run through
+        // encryptSensitiveField here, which CORRUPTED IT: createContact writes
+        // this same column in plaintext, and not one of the six read paths ever
+        // decrypted it — no decrypt function existed anywhere in the codebase.
+        // So editing any contact silently replaced a readable address with an
+        // unreadable AES-GCM blob, on every platform, permanently. Migration 120
+        // repairs the rows that were already damaged.
+        //
+        // Field-level encryption is not the right tool here regardless: the
+        // database is already SQLCipher-encrypted at rest, and the key this used
+        // was minted fresh on every launch wherever the Keychain is unusable
+        // (iPad-on-Mac), so even a correct decrypt path could not have read back
+        // what the previous launch wrote. If contact PII needs protection beyond
+        // SQLCipher, that is a design decision with a migration behind it — see
+        // #1656 — not a one-line call on one of two write paths.
         try db.writer.write { dbConn in
             try dbConn.execute(
                 sql: """
@@ -1056,7 +1084,7 @@ public final class PeopleService: Sendable {
                         updated_at = datetime('now')
                     WHERE id = ? AND deleted_at IS NULL
                     """,
-                arguments: [firstName, lastName, phone, encryptedEmail, role, id]
+                arguments: [firstName, lastName, phone, email, role, id]
             )
         }
     }

--- a/core/Tests/WiredPartCoreTests/PeopleServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeopleServiceTests.swift
@@ -987,6 +987,35 @@ struct PeopleServiceTests {
         #expect(updated.firstName == "Janet")
         #expect(updated.lastName == "Jones")
         #expect(updated.phone == "555-9999")
+        // THE ASSERTION THAT WAS MISSING (#1656). This test already passed
+        // "janet@example.com" and then never looked at it, so it exercised the
+        // corrupting path and could not see the corruption: updateContact stored
+        // the email AES-GCM-sealed while createContact stored it plaintext and
+        // no decrypt path existed anywhere, so editing a contact permanently
+        // replaced a readable address with an unreadable blob.
+        #expect(updated.email == "janet@example.com")
+    }
+
+    @Test("editing a contact twice keeps the email readable")
+    func testUpdateContactEmailSurvivesRepeatedEdits() throws {
+        let env = try E2ETestHelpers.setUp()
+        let contactId = try env.people.createContact(
+            entityType: "customer", entityId: 1,
+            firstName: "Jane", lastName: "Smith", role: "PM", phone: "555-0001",
+            email: "jane@example.com"
+        )
+        // Round-tripping matters more than a single write: the old bug sealed the
+        // value on every update, so a second edit would have re-sealed already
+        // sealed text and buried it a layer deeper.
+        for phone in ["555-0002", "555-0003"] {
+            try env.people.updateContact(
+                id: contactId, firstName: "Jane", lastName: "Smith",
+                phone: phone, email: "jane@example.com", role: "PM"
+            )
+            let c = try #require(try env.people.getContact(id: contactId))
+            #expect(c.email == "jane@example.com", "email must stay readable after edit to \(phone)")
+            #expect(c.email?.contains("@") == true)
+        }
     }
 
     @Test("getWorkersCurrentlyClocked shows Unknown for soft-deleted user")


### PR DESCRIPTION
Closes #1656. Found while reviewing #1608.

## The bug

`entity_contacts.email` was written two ways and read a third:

| Path | Behaviour |
|---|---|
| `createContact` | stores it **plaintext** |
| `updateContact` | stores it **AES-GCM sealed** |
| six read sites | `SELECT` it **raw** |

**No decrypt function existed anywhere in the codebase.** `encryptSensitiveField` had exactly one call site. So editing any contact — a real flow, `IOSContactDetailPage.swift:262` — permanently replaced a readable address with an unreadable blob, **on every platform**, not just the Mac.

What the user actually sees after saving an edit, straight from the red-proof run:

```
(c.email → "l623VihU1GjpLQMRoAQb/u7/YpkE7UUAs8UsUeAVwxts1KaZjq/fiF5FjNw=") == "jane@example.com"
```

## Unrecoverable, not merely encrypted

```swift
_ = SecItemAdd(addQuery as CFDictionary, nil)   // result thrown away
return SymmetricKey(data: keyData)              // in-memory key returned regardless
```

Wherever the Keychain is unusable — the iPad-on-Mac binary, confirmed in the field this week — that write fails **silently** and a fresh random key is minted every launch. Even a correct decrypt path could not have read back what the previous launch wrote.

## Why the suite was green

```swift
try env.people.updateContact(..., email: "janet@example.com", ...)
let updated = try #require(try env.people.getContact(id: contactId))
#expect(updated.firstName == "Janet")
#expect(updated.lastName  == "Jones")
#expect(updated.phone     == "555-9999")
// email never asserted
```

The test **drove the corrupting path and never read the corrupted field back**. Worth dwelling on: this is not a weak assertion, it is a missing one, and nothing about the test looks wrong at a glance. A test that writes a value and never reads it cannot fail on that value no matter how badly it is mangled.

## Changes

1. **`updateContact` stores the email as written** — consistent with `createContact` and all six read paths.
2. **Migration 120 repairs damaged rows.** Finds emails containing no `@`, decrypts the ones this device still holds the key for, and **leaves the rest untouched**. Where the key is gone the address cannot be recovered, and blanking it would destroy the last copy and foreclose recovery if the key ever turns up. Both counts are logged, so the scale is knowable rather than guessed.
3. **Round-trip assertions**, including a repeated-edit case — the old code re-sealed already-sealed text, burying it one layer deeper per save.

## Red proof

Reintroduced the encrypt call → **both tests failed**, showing the exact ciphertext a user would see in place of the address. Restored → green.

Suite: **2570 tests in 82 suites pass**.

## Deliberately not decided here

Whether contact PII should be encrypted at rest **at all** is a real design question, tracked in #1655 next to the same problem in #1608. The database is already SQLCipher-encrypted, so field-level encryption of one column adds little while carrying a hard dependency on a Keychain that does not work on one of our two test platforms. That belongs in a design decision with a migration behind it — not a one-line call on one of two write paths, which is how this got here.