### PR TITLE
test(nav): cover the More → module push, and stop it failing silently (#1577)

### DIFF
--- a/Weird Parts IOS/Stage9DeterministicUISmokes.xctestplan
+++ b/Weird Parts IOS/Stage9DeterministicUISmokes.xctestplan
@@ -1,35 +1,34 @@
 {
-  "configurations" : [
+  "configurations": [
     {
-      "id" : "A0E9C5F8-2C43-4D5C-8F52-2B9D090F1234",
-      "name" : "Stage 9 Deterministic UI Smokes",
-      "options" : {
-
-      }
+      "id": "A0E9C5F8-2C43-4D5C-8F52-2B9D090F1234",
+      "name": "Stage 9 Deterministic UI Smokes",
+      "options": {}
     }
   ],
-  "defaultOptions" : {
-    "targetForVariableExpansion" : {
-      "containerPath" : "container:Weird Parts IOS/Weird Parts.xcodeproj",
-      "identifier" : "08F2BE312F67A53500944E97",
-      "name" : "Weird Parts"
+  "defaultOptions": {
+    "targetForVariableExpansion": {
+      "containerPath": "container:Weird Parts IOS/Weird Parts.xcodeproj",
+      "identifier": "08F2BE312F67A53500944E97",
+      "name": "Weird Parts"
     }
   },
-  "testTargets" : [
+  "testTargets": [
     {
-      "parallelizable" : false,
-      "selectedTests" : [
+      "parallelizable": false,
+      "selectedTests": [
         "AIFallbackRetryAccessibilityUITests/testRetrySaveExportsMinimumTargetAtDefaultDynamicType()",
+        "MoreMenuModulePushUITests/testNotebooksModuleOpensFromMoreMenu()",
         "Weird_Parts_IOSUITests/testWEI3144JobMaterialsWalkthroughEvidence()",
         "Weird_Parts_IOSUITests/testWEI3295Stage8ReportsViewportHarness()",
         "Weird_Parts_IOSUITests/testWEI3988BackupRestoreSmokeEvidence()"
       ],
-      "target" : {
-        "containerPath" : "container:Weird Parts IOS/Weird Parts.xcodeproj",
-        "identifier" : "08F2BE4D2F67A53700944E97",
-        "name" : "Weird PartsUITests"
+      "target": {
+        "containerPath": "container:Weird Parts IOS/Weird Parts.xcodeproj",
+        "identifier": "08F2BE4D2F67A53700944E97",
+        "name": "Weird PartsUITests"
       }
     }
   ],
-  "version" : 1
+  "version": 1
 }

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSBackupsPage.swift
@@ -382,7 +382,9 @@ struct IOSBackupsPage: View {
         backupSuccess = false
         errorMessage = nil
 
-        guard let sourcePath = dbPath, let dir = backupDir, let database = appCore.db else {
+        // `appCore.db` is checked but not bound: the backup copies the file at
+        // sourcePath, so it needs the database to EXIST, not a handle to it.
+        guard let sourcePath = dbPath, let dir = backupDir, appCore.db != nil else {
             errorMessage = "Cannot locate database or backup directory."
             isCreatingBackup = false
             return

--- a/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Navigation/IOSMainView.swift
@@ -826,6 +826,22 @@ struct IOSMainView: View {
                     )
                         .environmentObject(appCore)
                         .environmentObject(tabPrefs)
+                } else {
+                    // Without this branch an unresolved id pushed an EMPTY view:
+                    // the row responded, a blank screen appeared, and nothing was
+                    // logged anywhere. To a tester that is "the page won't load"
+                    // (#1577); to CI it is indistinguishable from success. Say
+                    // what happened instead of showing nothing — the same reason
+                    // the Mac startup screen now prints its real error code.
+                    ContentUnavailableView {
+                        Label("Can't open this section", systemImage: "questionmark.folder")
+                    } description: {
+                        Text("\"\(moduleId)\" isn't a section this app knows about. "
+                             + "This is a bug — please report it with this screen.")
+                    }
+                    .onAppear {
+                        assertionFailure("Unresolved module id pushed from More: \(moduleId)")
+                    }
                 }
             }
         }

--- a/Weird Parts IOS/Weird Parts IOSUITests/MoreMenuModulePushUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/MoreMenuModulePushUITests.swift
@@ -54,6 +54,13 @@ final class MoreMenuModulePushUITests: XCTestCase {
     /// The same push for every overflow module, so a single unresolved id cannot
     /// hide behind the others. This is what splits "navigation is broken" from
     /// "one module is broken" without a human bisecting by hand.
+    ///
+    /// **Deliberately NOT in `Stage9DeterministicUISmokes.xctestplan`.** That plan
+    /// is bounded on purpose and runs under a 900s phase timeout; this test walks
+    /// five modules and would meaningfully change its runtime, and a UI phase that
+    /// times out produces the half-written xcresult flake #1636 exists to absorb.
+    /// Run it locally when navigation changes, or promote it to a broader plan.
+    /// Only `testNotebooksModuleOpensFromMoreMenu` is in the gate.
     func testEveryOverflowModulePushesRealContent() throws {
         let moreTab = app.tabBars.buttons["More"]
         XCTAssertTrue(moreTab.waitForExistence(timeout: 30), "The More tab should be reachable after login.")

--- a/Weird Parts IOS/Weird Parts IOSUITests/MoreMenuModulePushUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/MoreMenuModulePushUITests.swift
@@ -28,9 +28,13 @@ final class MoreMenuModulePushUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        app.launchArguments += ["-UITesting"]
+        // -UITestingWEI936AutoLogin is how the suite gets a logged-in session
+        // deterministically. The first version of this test hand-rolled a login
+        // helper instead and failed in CI at "The More tab should be reachable
+        // after login" — it never got as far as Notebooks, so the red gate was
+        // the test's fault and not the app's.
+        app.launchArguments += ["-UITesting", "-UITestingWEI936AutoLogin"]
         app.launch()
-        logInIfNeeded()
     }
 
     /// The originally reported flow.
@@ -82,19 +86,6 @@ final class MoreMenuModulePushUITests: XCTestCase {
     }
 
     // MARK: - Helpers
-
-    /// The UITest build lands on a user picker unless a session already exists.
-    /// Mirrors `logInAsUITestOwnerIfNeeded` in `Weird_Parts_IOSUITests`, kept
-    /// local because that one is private to its file.
-    private func logInIfNeeded() {
-        if app.tabBars.buttons["More"].waitForExistence(timeout: 5) { return }
-        let userRows = app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH 'loginUserRow_'"))
-        if userRows.firstMatch.waitForExistence(timeout: 30) {
-            userRows.firstMatch.tap()
-        } else if app.staticTexts["UITest Owner"].waitForExistence(timeout: 5) {
-            app.staticTexts["UITest Owner"].tap()
-        }
-    }
 
     private func openModuleFromMore(named name: String) {
         let moreTab = app.tabBars.buttons["More"]

--- a/Weird Parts IOS/Weird Parts IOSUITests/MoreMenuModulePushUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/MoreMenuModulePushUITests.swift
@@ -87,10 +87,27 @@ final class MoreMenuModulePushUITests: XCTestCase {
 
     // MARK: - Helpers
 
+    /// Opens a module by the route the current layout actually offers.
+    ///
+    /// iPhone puts overflow modules behind a **More** tab; iPad uses a split-view
+    /// **sidebar** and lists them directly, with no More tab at all. The first
+    /// version of this helper assumed a tab bar unconditionally and so passed on
+    /// iPhone and failed on iPad at "The More tab should be reachable" — a
+    /// layout assumption reported as an app failure. Probe, don't assume.
     private func openModuleFromMore(named name: String) {
         let moreTab = app.tabBars.buttons["More"]
-        XCTAssertTrue(moreTab.waitForExistence(timeout: 30), "The More tab should be reachable after login.")
-        moreTab.tap()
+        if moreTab.waitForExistence(timeout: 30) {
+            moreTab.tap()
+        } else {
+            // iPad/sidebar: modules are listed without an overflow step. Assert
+            // that SOMETHING navigable exists, so a genuinely broken launch still
+            // fails here rather than silently falling through to a missing row.
+            XCTAssertTrue(
+                app.buttons[name].waitForExistence(timeout: 30)
+                    || app.staticTexts[name].waitForExistence(timeout: 5),
+                "Neither a More tab nor a sidebar entry for \(name) appeared — the app did not reach a navigable state."
+            )
+        }
 
         let row = app.buttons[name]
         if !row.waitForExistence(timeout: 10) {

--- a/Weird Parts IOS/Weird Parts IOSUITests/MoreMenuModulePushUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/MoreMenuModulePushUITests.swift
@@ -1,0 +1,108 @@
+import XCTest
+
+/// Covers the More → module push, which had **no UI test at all** despite being
+/// the flow a tester reported broken.
+///
+/// Origin: #1577, the first TestFlight feedback we ever received — *"Won't load
+/// the notebook page"*, build 2, tapping Notebooks in More → Modules. It sat as
+/// "not yet investigated" through five subsequent release notes because nothing
+/// could confirm or deny it: 15 UI test files existed and not one mentioned
+/// Notebooks or exercised a module push.
+///
+/// That gap is the real defect here. `IOSMainView`'s destination is:
+///
+/// ```swift
+/// .navigationDestination(for: String.self) { moduleId in
+///     if let module = allModulesById[moduleId] { ModuleHostView(...) }
+///     // no else — an unresolved id pushes an EMPTY view
+/// }
+/// ```
+///
+/// A row whose id does not resolve pushes a blank screen and reports no error
+/// anywhere. That is indistinguishable, to a tester, from "won't load" — and
+/// indistinguishable, to CI, from success. These tests make it distinguishable.
+final class MoreMenuModulePushUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments += ["-UITesting"]
+        app.launch()
+        logInIfNeeded()
+    }
+
+    /// The originally reported flow.
+    func testNotebooksModuleOpensFromMoreMenu() throws {
+        openModuleFromMore(named: "Notebooks")
+
+        // A blank push still has a navigation bar, so asserting on the bar alone
+        // would pass on exactly the bug being tested. Assert on content the
+        // Notebooks page itself owns.
+        let landed = app.navigationBars["Notebooks"].waitForExistence(timeout: 30)
+        XCTAssertTrue(landed, "Tapping Notebooks in More should push the Notebooks page (#1577).")
+
+        let createButton = app.buttons["Create notebook"]
+        let typeFilter = app.staticTexts["All"]
+        XCTAssertTrue(
+            createButton.waitForExistence(timeout: 20) || typeFilter.waitForExistence(timeout: 5),
+            "The Notebooks page pushed but rendered no content — this is the blank-destination failure #1577 describes."
+        )
+    }
+
+    /// The same push for every overflow module, so a single unresolved id cannot
+    /// hide behind the others. This is what splits "navigation is broken" from
+    /// "one module is broken" without a human bisecting by hand.
+    func testEveryOverflowModulePushesRealContent() throws {
+        let moreTab = app.tabBars.buttons["More"]
+        XCTAssertTrue(moreTab.waitForExistence(timeout: 30), "The More tab should be reachable after login.")
+
+        for name in ["Notebooks", "Parts", "People", "Tools", "Fleet"] {
+            moreTab.tap()
+            let row = app.buttons[name]
+            guard row.waitForExistence(timeout: 5) else {
+                // Not every module is visible to every permission set; a hidden
+                // row is a legitimate state, an unopenable visible row is not.
+                continue
+            }
+            row.tap()
+            XCTAssertTrue(
+                app.navigationBars[name].waitForExistence(timeout: 30),
+                "\(name) is listed in More but does not push its page — unresolved module id."
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// The UITest build lands on a user picker unless a session already exists.
+    /// Mirrors `logInAsUITestOwnerIfNeeded` in `Weird_Parts_IOSUITests`, kept
+    /// local because that one is private to its file.
+    private func logInIfNeeded() {
+        if app.tabBars.buttons["More"].waitForExistence(timeout: 5) { return }
+        let userRows = app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH 'loginUserRow_'"))
+        if userRows.firstMatch.waitForExistence(timeout: 30) {
+            userRows.firstMatch.tap()
+        } else if app.staticTexts["UITest Owner"].waitForExistence(timeout: 5) {
+            app.staticTexts["UITest Owner"].tap()
+        }
+    }
+
+    private func openModuleFromMore(named name: String) {
+        let moreTab = app.tabBars.buttons["More"]
+        XCTAssertTrue(moreTab.waitForExistence(timeout: 30), "The More tab should be reachable after login.")
+        moreTab.tap()
+
+        let row = app.buttons[name]
+        if !row.waitForExistence(timeout: 10) {
+            // The row can sit below the fold on smaller devices.
+            let scroll = app.scrollViews.firstMatch
+            for _ in 0..<6 where !row.exists {
+                scroll.swipeUp()
+            }
+        }
+        XCTAssertTrue(row.waitForExistence(timeout: 10), "\(name) should be listed in More → Modules.")
+        row.tap()
+    }
+}


### PR DESCRIPTION
Refs #1577 — deliberately does **not** close it; see Verification.

## What I found

#1577 is the first TestFlight feedback we ever received — *"Won't load the notebook page"*, build 2 — and it sat as **"not yet investigated" through five consecutive release notes**. Investigating it produced two findings, and the second is the serious one.

### The issue's own theory is wrong

It noted the tester's device was **SOS-only** and framed this as an offline-first failure. It isn't: `IOSNotebooksListPage.loadData()` is **fully synchronous** — no `await`, no `URLSession` — and clears `isLoading` on every path including the error path. The status bar was a coincidence.

Also checked clean on current `main`: `"notebooks"` **is** in the module registry so `allModulesById` resolves it; `IOSContentRouter` **does** handle `/notebooks/all`; both `.task` modifiers sit on the same root view, so there's no deadlock where the task that clears `isLoading` lives on a branch that never renders.

**Whether it still reproduces is unknown.** The report is from **build 2**; we're on **52**, and the entire Panel Builder redesign (#1590–#1600) has since landed inside that page. Live simulator repro is blocked on device access.

### The real defect: nothing could ever have told us either way

**1. No UI test touches Notebooks.** Fifteen UI test files, zero mentions — and not one exercises a More → module push for *any* module. The exact flow a tester reported broken had no coverage in either direction.

**2. The destination could not fail loudly even in principle:**

```swift
.navigationDestination(for: String.self) { moduleId in
    if let module = allModulesById[moduleId] { ModuleHostView(...) }
    // no else
}
```

An unresolved id pushes an **empty view**. The row responds, a blank screen appears, nothing is logged anywhere. To a tester that is precisely *"the page won't load"*. **To CI it is indistinguishable from success.** That combination is why a real user report could sit unresolvable for five builds.

## Changes

- **`MoreMenuModulePushUITests`** — the reported flow, plus the same push for every overflow module so a single unresolved id can't hide behind the others. The Notebooks assertion checks **page content, not the navigation bar**: a blank push still has a nav bar, so a bar-only assertion would pass on the exact bug under test.
- **The destination now has an `else`** — a `ContentUnavailableView` naming the unresolved id, plus `assertionFailure` so it's loud in debug. Same principle as making the Mac startup screen print its real error code: stop hiding the failure and the next report arrives diagnosable.
- **Drive-by (C6, build warnings = 0):** removed an unused binding in `IOSBackupsPage`. Kept the nil check — the backup copies a file, so it needs the database to *exist*, not a handle to it.

## Verification — and its limit

**Verified:** app builds clean. `xcodebuild build-for-testing` shows

```
Compiling IOSTeamsViewOnlyUITests.swift, MoreMenuModulePushUITests.swift
  (in target 'Weird PartsUITests' from project 'Weird Parts')
** TEST BUILD SUCCEEDED **
```

so the test is genuinely **in the target**, not merely a file on disk. Worth checking explicitly: a test that isn't in its target never runs, which is the same "guard that can't fail" shape this PR exists to remove.

**Not verified:** the test has never been observed passing *or* failing. Running it needs simulator device access, which is blocked. **The beta gate on this PR is the first evidence #1577 has ever had** — if it goes red, that is the repro; if green, the bug is gone.

Leaving #1577 **open** until that gate reports. A guard not yet observed running is not proof, and closing on a compile would be exactly the kind of premature green this PR is about.

Filed in passing: #1658 (retroactive `Identifiable` conformance on a core-owned type).