### PR TITLE
feat(diagnostics): replicated device logs with 30-day self-clean (rebased #1646)

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -162,6 +162,7 @@ extension AppDatabase {
         registerMigration116TeamMutationAttribution(&migrator)
         registerMigration119SyncGapTables(&migrator)
         registerContactEmailRepair(&migrator)
+        registerMigration121DeviceLogs(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -6286,5 +6287,44 @@ private func registerContactEmailRepair(_ migrator: inout DatabaseMigrator) {
         migrationLogger.notice(
             "120_repair_encrypted_contact_emails: recovered \(recovered), left intact \(unrecoverable)"
         )
+    }
+}
+
+private func registerMigration121DeviceLogs(_ migrator: inout DatabaseMigrator) {
+    migrator.registerMigration("121_device_logs") { db in
+        try db.create(table: "device_logs", ifNotExists: true) { t in
+            t.autoIncrementedPrimaryKey("id")
+            t.column("device_id", .text).notNull()
+            t.column("device_name", .text)
+            t.column("app_version", .text)
+            t.column("level", .text).notNull()          // error | warn | info
+            t.column("category", .text).notNull()       // sync | pairing | startup | ...
+            t.column("message", .text).notNull()
+            t.column("detail", .text)                   // optional JSON
+            t.column("created_at", .text).notNull().defaults(sql: "(datetime('now'))")
+            t.column("updated_at", .text).notNull().defaults(sql: "(datetime('now'))")
+        }
+        try db.create(
+            index: "idx_device_logs_created", on: "device_logs",
+            columns: ["created_at"], ifNotExists: true
+        )
+        try db.create(
+            index: "idx_device_logs_device_level", on: "device_logs",
+            columns: ["device_id", "level"], ifNotExists: true
+        )
+
+        // Replicate like any other synced table (same trigger shape as
+        // migration 112, which only covered tables existing at ITS run).
+        for (op, rowRef) in [("INSERT", "NEW"), ("UPDATE", "NEW"), ("DELETE", "OLD")] {
+            try db.execute(sql: """
+                CREATE TRIGGER IF NOT EXISTS trg_sync_device_logs_\(op.lowercased())
+                AFTER \(op) ON [device_logs]
+                WHEN (SELECT COUNT(*) FROM _sync_apply_guard) = 0
+                BEGIN
+                    INSERT INTO _change_log (device_id, table_name, record_id, operation)
+                    VALUES ('', 'device_logs', \(rowRef).id, '\(op)');
+                END
+                """)
+        }
     }
 }

--- a/core/Sources/WiredPartCore/Services/DeviceLogService.swift
+++ b/core/Sources/WiredPartCore/Services/DeviceLogService.swift
@@ -1,0 +1,206 @@
+import Foundation
+import GRDB
+
+/// Fleet diagnostics — a bounded, self-pruning, **replicated** technical log.
+///
+/// Owner request 2026-08-03: *"let's get the devices syncing and storing the
+/// other devices' logs, self-clean old logs in 30 days, then the TestFlight
+/// version on this computer syncs with the ones in the field so you have logs
+/// to work with."* Field failures currently reach the developer only as
+/// screenshots and recollection; this makes them first-class data that travels
+/// on the same sync path as company records.
+///
+/// Relationship to `activity_log`: that table records what **users** did
+/// (business audit). This records what the **app** did — sync outcomes,
+/// pairing failures, startup errors — and is safe to prune.
+public final class DeviceLogService: Sendable {
+    /// Retention window. Rows older than this are removed on `prune()`.
+    public static let retentionDays = 30
+    /// Hard cap so a pathological logger cannot bloat the database or the sync
+    /// payload between prunes; the newest rows always win.
+    public static let maxRows = 5_000
+
+    public enum Level: String, Sendable, CaseIterable {
+        case error, warn, info
+    }
+
+    public struct Entry: Sendable, Equatable {
+        public let id: Int64
+        public let deviceId: String
+        public let deviceName: String?
+        public let appVersion: String?
+        public let level: Level
+        public let category: String
+        public let message: String
+        public let detail: String?
+        public let createdAt: String
+    }
+
+    private let db: AppDatabase
+    private let deviceId: String
+    private let deviceName: String?
+    private let appVersion: String?
+
+    public init(
+        db: AppDatabase,
+        deviceId: String = DeviceIdentity.current,
+        deviceName: String? = nil,
+        appVersion: String? = nil
+    ) {
+        self.db = db
+        self.deviceId = deviceId
+        self.deviceName = deviceName
+        self.appVersion = appVersion
+    }
+
+    // MARK: - Writing
+
+    /// Record one diagnostic line. Never throws: a logger that can break the
+    /// operation it is describing is worse than no logger.
+    public func log(
+        _ level: Level,
+        category: String,
+        message: String,
+        detail: String? = nil
+    ) {
+        let safeMessage = Self.redact(message)
+        let safeDetail = detail.map(Self.redact)
+        do {
+            try db.writer.write { dbc in
+                try dbc.execute(
+                    sql: """
+                    INSERT INTO device_logs
+                        (device_id, device_name, app_version, level, category, message, detail)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [
+                        deviceId, deviceName, appVersion,
+                        level.rawValue, category, safeMessage, safeDetail,
+                    ]
+                )
+            }
+        } catch {
+            // Deliberately silent — see doc comment.
+        }
+    }
+
+    public func error(_ category: String, _ message: String, detail: String? = nil) {
+        log(.error, category: category, message: message, detail: detail)
+    }
+
+    public func warn(_ category: String, _ message: String, detail: String? = nil) {
+        log(.warn, category: category, message: message, detail: detail)
+    }
+
+    public func info(_ category: String, _ message: String, detail: String? = nil) {
+        log(.info, category: category, message: message, detail: detail)
+    }
+
+    // MARK: - Reading (the point of the exercise)
+
+    /// Most recent entries across ALL devices — the fleet view the shop Mac
+    /// reads after field devices sync their logs in.
+    public func recent(
+        limit: Int = 200,
+        level: Level? = nil,
+        category: String? = nil,
+        deviceId: String? = nil
+    ) throws -> [Entry] {
+        var conditions: [String] = []
+        var args: [DatabaseValueConvertible] = []
+        if let level { conditions.append("level = ?"); args.append(level.rawValue) }
+        if let category { conditions.append("category = ?"); args.append(category) }
+        if let deviceId { conditions.append("device_id = ?"); args.append(deviceId) }
+        let whereClause = conditions.isEmpty ? "" : "WHERE " + conditions.joined(separator: " AND ")
+        args.append(min(max(limit, 1), 1000))
+        return try db.writer.read { dbc in
+            try Row.fetchAll(
+                dbc,
+                sql: """
+                SELECT * FROM device_logs \(whereClause)
+                ORDER BY created_at DESC, id DESC LIMIT ?
+                """,
+                arguments: StatementArguments(args)
+            ).map(Self.entry(from:))
+        }
+    }
+
+    /// Devices that have reported logs, with counts — "who is out there and
+    /// how noisy are they".
+    public func deviceSummary() throws -> [(deviceId: String, deviceName: String?, errors: Int, total: Int, lastSeen: String?)] {
+        try db.writer.read { dbc in
+            try Row.fetchAll(dbc, sql: """
+                SELECT device_id,
+                       MAX(device_name) AS device_name,
+                       SUM(CASE WHEN level = 'error' THEN 1 ELSE 0 END) AS errors,
+                       COUNT(*) AS total,
+                       MAX(created_at) AS last_seen
+                FROM device_logs GROUP BY device_id ORDER BY last_seen DESC
+                """).map {
+                (
+                    deviceId: $0["device_id"],
+                    deviceName: $0["device_name"],
+                    errors: $0["errors"] ?? 0,
+                    total: $0["total"] ?? 0,
+                    lastSeen: $0["last_seen"]
+                )
+            }
+        }
+    }
+
+    // MARK: - Pruning
+
+    /// Delete entries older than the retention window, then enforce the row
+    /// cap. Call on launch; safe to call repeatedly. Returns rows removed.
+    @discardableResult
+    public func prune(retentionDays: Int = DeviceLogService.retentionDays) throws -> Int {
+        let days = max(retentionDays, 1)
+        return try db.writer.write { dbc in
+            try dbc.execute(
+                sql: "DELETE FROM device_logs WHERE created_at < datetime('now', ?)",
+                arguments: ["-\(days) days"]
+            )
+            var removed = dbc.changesCount
+            // Newest-wins cap.
+            try dbc.execute(sql: """
+                DELETE FROM device_logs WHERE id NOT IN (
+                    SELECT id FROM device_logs ORDER BY created_at DESC, id DESC LIMIT \(Self.maxRows)
+                )
+                """)
+            removed += dbc.changesCount
+            return removed
+        }
+    }
+
+    // MARK: - Safety
+
+    /// Strip anything key-shaped before it reaches a replicated table. Logs
+    /// travel between devices, so a leaked token would travel with them.
+    static func redact(_ text: String) -> String {
+        var out = text
+        for pattern in [
+            #"wpal_[A-Za-z0-9_-]{8,}"#,                  // Agent Link keys
+            #"[A-Za-z0-9+/]{40,}={0,2}"#,                // base64 key material
+            #"(?i)(token|secret|password|pin)\s*[:=]\s*\S+"#,
+        ] {
+            out = out.replacingOccurrences(
+                of: pattern, with: "[redacted]", options: .regularExpression
+            )
+        }
+        return String(out.prefix(2_000))
+    }
+
+    private static func entry(from row: Row) -> Entry {
+        Entry(
+            id: row["id"],
+            deviceId: row["device_id"],
+            deviceName: row["device_name"],
+            appVersion: row["app_version"],
+            level: Level(rawValue: row["level"] ?? "info") ?? .info,
+            category: row["category"],
+            message: row["message"],
+            detail: row["detail"],
+            createdAt: row["created_at"]
+        )
+    }
+}

--- a/core/Sources/WiredPartCore/Sync/ConflictResolver.swift
+++ b/core/Sources/WiredPartCore/Sync/ConflictResolver.swift
@@ -221,6 +221,11 @@ public enum ConflictResolver {
         // device-derived from local photos; binary payloads belong to
         // BinarySyncManager (Copilot review on PR #1422).
         "image_match_history",
+        // Fleet diagnostics — every device's technical log replicates so
+        // field failures are readable from the shop Mac (owner 2026-08-03).
+        // Its change triggers are installed by migration 121, NOT by 119:
+        // 119 uses a frozen table list that predates this table.
+        "device_logs",
         // Sync infrastructure (these are managed by sync itself)
         "_change_log", "_conflict_log", "_vector_clock", "_device_registry",
         "_binary_attachments", "_sync_transfer_log",

--- a/core/Tests/WiredPartCoreTests/DeviceLogServiceTests.swift
+++ b/core/Tests/WiredPartCoreTests/DeviceLogServiceTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+import GRDB
+@testable import WiredPartCore
+
+/// Fleet diagnostics: logs must replicate, prune themselves, and never carry
+/// secrets between devices (owner request 2026-08-03).
+@Suite("Device log service")
+struct DeviceLogServiceTests {
+
+    private func makeService(deviceId: String = "dev-A") throws -> (AppDatabase, DeviceLogService) {
+        let db = try AppDatabase.openInMemoryDatabase()
+        return (db, DeviceLogService(db: db, deviceId: deviceId, deviceName: "Test \(deviceId)", appVersion: "1.0.0"))
+    }
+
+    @Test("Entries are written and read newest-first, filterable by level and device")
+    func writeAndRead() throws {
+        let (_, svc) = try makeService()
+        svc.info("startup", "app launched")
+        svc.error("sync", "join failed", detail: #"{"seconds":8}"#)
+        let all = try svc.recent()
+        #expect(all.count == 2)
+        #expect(all.first?.message == "join failed")   // newest first
+        let errorsOnly = try svc.recent(level: .error)
+        #expect(errorsOnly.count == 1)
+        #expect(errorsOnly.first?.category == "sync")
+        #expect(errorsOnly.first?.detail == #"{"seconds":8}"#)
+        #expect(try svc.recent(deviceId: "nobody").isEmpty)
+    }
+
+    @Test("Logs REPLICATE — writes are change-tracked like company data")
+    func logsAreChangeTracked() throws {
+        let (db, svc) = try makeService()
+        svc.error("sync", "pairing timed out")
+        let logged = try db.writer.read { dbc in
+            try Int.fetchOne(dbc, sql: """
+                SELECT COUNT(*) FROM _change_log
+                WHERE table_name = 'device_logs' AND operation = 'INSERT'
+                """) ?? 0
+        }
+        #expect(logged >= 1, "device_logs writes must enter the sync change log")
+        #expect(ConflictResolver.allowedSyncTables.contains("device_logs"))
+    }
+
+    @Test("Fleet view: one device reads another device's synced-in logs")
+    func fleetView() throws {
+        let (db, macService) = try makeService(deviceId: "mac-shop")
+        macService.info("startup", "shop mac up")
+        // Simulate an iPad's log arriving over sync.
+        try db.writer.write { dbc in
+            try dbc.execute(sql: """
+                INSERT INTO device_logs (device_id, device_name, app_version, level, category, message)
+                VALUES ('ipad-field', 'I Work Tablet', '1.0.0', 'error', 'sync', 'download stalled at 8s')
+                """)
+        }
+        let summary = try macService.deviceSummary()
+        #expect(summary.count == 2)
+        let ipad = summary.first { $0.deviceId == "ipad-field" }
+        #expect(ipad?.deviceName == "I Work Tablet")
+        #expect(ipad?.errors == 1)
+        let fieldErrors = try macService.recent(level: .error, deviceId: "ipad-field")
+        #expect(fieldErrors.first?.message == "download stalled at 8s")
+    }
+
+    @Test("Prune removes entries past the retention window and keeps recent ones")
+    func pruneByAge() throws {
+        let (db, svc) = try makeService()
+        svc.info("sync", "fresh entry")
+        try db.writer.write { dbc in
+            try dbc.execute(sql: """
+                INSERT INTO device_logs (device_id, level, category, message, created_at)
+                VALUES ('dev-A', 'info', 'sync', 'ancient entry', datetime('now', '-45 days'))
+                """)
+        }
+        #expect(try svc.recent().count == 2)
+        let removed = try svc.prune()
+        #expect(removed >= 1)
+        let left = try svc.recent()
+        #expect(left.count == 1)
+        #expect(left.first?.message == "fresh entry")
+    }
+
+    @Test("Secrets never reach a replicated log line")
+    func redaction() throws {
+        let (_, svc) = try makeService()
+        svc.error("agent-link", "minted wpal_AbCdEfGhIjKlMnOpQrStUvWxYz012345 for Claude")
+        svc.error("auth", "token: sk-super-secret-value")
+        let lines = try svc.recent().map(\.message)
+        #expect(lines.allSatisfy { !$0.contains("wpal_AbCdEfGhIjKlMnOpQrStUvWxYz012345") })
+        #expect(lines.allSatisfy { !$0.lowercased().contains("sk-super-secret-value") })
+        #expect(lines.contains { $0.contains("[redacted]") })
+    }
+}


### PR DESCRIPTION
Replaces #1646, which conflicted with migrations 119 (#1619) and 120 (#1656) and carried a pre-#1657 `PeopleService`. Same feature, rebased cleanly onto current `main`.

## What you asked for

> *"let's get the devices sycing and storing the other devices logs, the self clean old logs in 30 days, then we can make the TestFlight version sync with the ones we are putting in the field so you have logs to work with."*

- **`DeviceLogService`** — `log`/`error`/`warn`/`info`, `recent(limit:level:deviceId:)`, `deviceSummary()`.
- **30-day self-clean** — `prune(retentionDays:)`, plus a newest-wins row cap so a chatty device cannot fill the database between prunes.
- **Replicated** — `device_logs` is in `allowedSyncTables`, so a field device's log is readable from the shop Mac.

## How the rebase was done, and why it is worth a sentence

A conflict-marker merge of the migrations file **cut through a Swift multi-line string literal** and produced parse errors two hundred lines away from the actual damage. That is the source-splicing hazard CLAUDE.md warns about, and it is genuinely hard to spot because the compiler points at the *cascade*, not the cause.

Redone by taking `main`'s migrations file **whole** and grafting the single new function onto it. One reviewable insertion instead of a hand-merged diff.

Three things that had to be checked rather than assumed:

1. **Migration renumbered 120 → 121** — 120 is the contact-email repair on `main`.
2. **Migration 121 installs its OWN change triggers.** Migration 119 works from a **frozen** table list that predates `device_logs`, so relying on it would have left this table silently unreplicated — the exact class of bug #1619 existed to fix.
3. **Registration order is 119 → 120 → 121.** GRDB runs migrations in *registration* order, not numeric order, so a correct-looking number with a wrong position would still misbehave.

## Red proof — two guards, both observed failing

**1. Trigger installation.** Removed it from migration 121:

```
✘ "Logs REPLICATE — writes are change-tracked like company data"
    Expectation failed: (logged → 0) >= 1
```

This is the one that mattered. Renumbering a migration is precisely the change that could stop triggers installing without any other symptom.

**2. Secret redaction.** Made `redact()` a pass-through:

```
✘ "Secrets never reach a replicated log line"  — 3 failures
    wpal_ key present · sk- token present · no [redacted] marker
```

Worth proving rather than trusting: **these logs now leave the device**. A dead redactor stops being a formatting bug and becomes a disclosure one.

Both restored → green.

## Verification

- `swift build --package-path core` — clean.
- `swift test --package-path core` — **2575 tests in 83 suites pass**.

Closes #1646.