### PR TITLE
fix(sync): stop erasing a discovered peer when its connection drops (#1580)

### DIFF
--- a/core/Sources/WiredPartCore/Sync/MultipeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/MultipeerManager.swift
@@ -72,6 +72,17 @@ public final class MultipeerManager: NSObject, @unchecked Sendable {
     /// Called when data is received from a peer. GUARDED BY syncQueue
     public var onDataReceived: ((ReceivedMultipeerMessage) -> Void)?
 
+    /// Called when the OS refuses to START advertising or browsing. (#1580)
+    ///
+    /// `MCNearbyServiceAdvertiserDelegate` / `MCNearbyServiceBrowserDelegate`
+    /// report denied Local Network permission, a missing `NSBonjourServices`
+    /// entry, and a disabled radio through these callbacks and nowhere else.
+    /// Both were unimplemented, so those failures were dropped on the floor and
+    /// every one of them reached the user as the same generic "couldn't
+    /// connect" — undiagnosable across four builds of fixes. Emitted as a
+    /// human-readable line so the caller can log or surface it.
+    public var onTransportError: ((String) -> Void)?
+
     private static let serviceType = "wiredpart-sync"
 
     private let deviceId: String
@@ -248,6 +259,14 @@ public final class MultipeerManager: NSObject, @unchecked Sendable {
         self.browser = browser
     }
 
+    /// Surface a transport-start failure. Delivered on the main queue so a UI
+    /// observer can present it directly. (#1580)
+    private func reportTransportError(_ message: String) {
+        DispatchQueue.main.async { [weak self] in
+            self?.onTransportError?(message)
+        }
+    }
+
     private func notifyPeersChanged() {
         let snapshot = peers.values.map { $0.info }
         DispatchQueue.main.async { [weak self] in
@@ -273,9 +292,25 @@ extension MultipeerManager: MCSessionDelegate {
                     let newState: MultipeerPeerState
                     switch state {
                     case .notConnected:
-                        self.peers.removeValue(forKey: key)
-                        self.notifyPeersChanged()
-                        return
+                        // #1580 — do NOT remove the peer here.
+                        //
+                        // Discovery lifetime belongs to the BROWSER (foundPeer /
+                        // lostPeer). The session only owns *connection* state. A
+                        // failed or dropped connection says nothing about whether
+                        // the peer is still advertising — and MCSession reports
+                        // `.notConnected` routinely when an invitation lapses.
+                        //
+                        // Removing the entry destroyed the record that
+                        // `invite(deviceId:)` looks up, so
+                        // `awaitMultipeerConnection`'s re-invite silently no-op'd
+                        // (its `false` return is discarded) and `isConnected` could
+                        // never become true again. The join then spun out the full
+                        // wait and failed with `connectionTimeout` — discovery
+                        // green, connection dead — on every device pairing,
+                        // regardless of transport.
+                        //
+                        // Revert to `.found` and let `lostPeer` do the removing.
+                        newState = .found
                     case .connecting:
                         newState = .connecting
                     case .connected:
@@ -389,6 +424,15 @@ extension MultipeerManager: MCNearbyServiceBrowserDelegate {
         }
     }
 
+    /// The OS refused to start browsing. Previously unimplemented, so a denied
+    /// Local Network permission looked identical to "no peers nearby". (#1580)
+    public func browser(
+        _ browser: MCNearbyServiceBrowser,
+        didNotStartBrowsingForPeers error: Error
+    ) {
+        reportTransportError("Could not start looking for nearby devices: \(error.localizedDescription)")
+    }
+
     public func browser(
         _ browser: MCNearbyServiceBrowser,
         lostPeer peerID: MCPeerID
@@ -410,6 +454,16 @@ extension MultipeerManager: MCNearbyServiceBrowserDelegate {
 // MARK: - MCNearbyServiceAdvertiserDelegate
 
 extension MultipeerManager: MCNearbyServiceAdvertiserDelegate {
+    /// The OS refused to start advertising. Previously unimplemented, so a host
+    /// that was never actually discoverable still showed the user a pairing code
+    /// and simply waited forever. (#1580)
+    public func advertiser(
+        _ advertiser: MCNearbyServiceAdvertiser,
+        didNotStartAdvertisingPeer error: Error
+    ) {
+        reportTransportError("Could not make this device discoverable: \(error.localizedDescription)")
+    }
+
     public func advertiser(
         _ advertiser: MCNearbyServiceAdvertiser,
         didReceiveInvitationFromPeer peerID: MCPeerID,

--- a/core/Tests/WiredPartCoreTests/MultipeerTests.swift
+++ b/core/Tests/WiredPartCoreTests/MultipeerTests.swift
@@ -2,6 +2,7 @@
 import Testing
 import Foundation
 import GRDB
+import MultipeerConnectivity
 @testable import WiredPartCore
 
 @Suite("MultipeerManager Tests")
@@ -69,6 +70,80 @@ struct MultipeerTests {
         )
         let msg = manager.popReceivedMessage()
         #expect(msg == nil)
+    }
+
+    // MARK: - #1580 — a failed connection must not erase the discovered peer
+
+    /// The pairing bug behind "discovery works, connecting fails".
+    ///
+    /// `awaitMultipeerConnection` invites, waits, and re-invites once if the
+    /// first invitation lapses. Both `invite(deviceId:)` and
+    /// `isConnected(toPeer:)` look the peer up in `peers` by device id. The
+    /// session delegate used to REMOVE that entry on `.notConnected`, which
+    /// MCSession reports whenever an invitation lapses — so the re-invite found
+    /// nothing, returned a discarded `false`, and the join burned its whole
+    /// timeout against a host that was still advertising the entire time.
+    ///
+    /// Discovery lifetime belongs to the browser (`foundPeer` / `lostPeer`).
+    /// A dropped connection means "not connected", never "gone".
+    @Test("a failed connection keeps the discovered peer so re-invite still works (#1580)")
+    func testNotConnectedKeepsDiscoveredPeer() {
+        let manager = MultipeerManager(
+            deviceId: "joiner-1",
+            deviceName: "Joiner iPhone",
+            companyId: "company-abc",
+            autoInvitePeers: false        // keep the test off the radio
+        )
+        let hostPeerId = MCPeerID(displayName: "Shop Mac")
+        let browser = MCNearbyServiceBrowser(
+            peer: MCPeerID(displayName: "Joiner iPhone"),
+            serviceType: "wiredpart-sync"
+        )
+
+        manager.browser(browser, foundPeer: hostPeerId, withDiscoveryInfo: [
+            "device_id": "host-1",
+            "device_name": "Shop Mac",
+            "company_id": "company-abc"
+        ])
+        // `getPeers()` is syncQueue.sync, and the delegate hops are
+        // syncQueue.async on the same serial queue, so this observes them.
+        #expect(manager.getPeers().contains { $0.deviceId == "host-1" })
+
+        // The invitation lapses — exactly what the joiner hits in the field.
+        let session = MCSession(peer: MCPeerID(displayName: "Joiner iPhone"))
+        manager.session(session, peer: hostPeerId, didChange: .notConnected)
+
+        let after = manager.getPeers()
+        #expect(
+            after.contains { $0.deviceId == "host-1" },
+            "peer was erased on .notConnected — re-invite can never find it again"
+        )
+        #expect(after.first { $0.deviceId == "host-1" }?.state == .found)
+    }
+
+    /// `lostPeer` is the one thing that legitimately removes a peer.
+    @Test("lostPeer still removes the peer (#1580)")
+    func testLostPeerRemoves() {
+        let manager = MultipeerManager(
+            deviceId: "joiner-1",
+            deviceName: "Joiner iPhone",
+            companyId: "company-abc",
+            autoInvitePeers: false
+        )
+        let hostPeerId = MCPeerID(displayName: "Shop Mac")
+        let browser = MCNearbyServiceBrowser(
+            peer: MCPeerID(displayName: "Joiner iPhone"),
+            serviceType: "wiredpart-sync"
+        )
+        manager.browser(browser, foundPeer: hostPeerId, withDiscoveryInfo: [
+            "device_id": "host-1",
+            "device_name": "Shop Mac",
+            "company_id": "company-abc"
+        ])
+        #expect(manager.getPeers().contains { $0.deviceId == "host-1" })
+
+        manager.browser(browser, lostPeer: hostPeerId)
+        #expect(!manager.getPeers().contains { $0.deviceId == "host-1" })
     }
 
     // MARK: - Cross-Device Sync with Different Cipher Keys


### PR DESCRIPTION
Closes #1580.

## The bug

Pairing failed on **every** device combination — iPhone ↔ iPad and Mac ↔ iPhone alike — with discovery showing a green *found* check and the connection then timing out. Four builds of transport-focused fixes did not move it, because the cause was never the transport.

`MCSessionDelegate`'s `.notConnected` branch **removed the peer** from `peers`:

```swift
case .notConnected:
    self.peers.removeValue(forKey: key)   // ← discovery record destroyed
```

MCSession reports `.notConnected` routinely when an invitation lapses — and `awaitMultipeerConnection` is built to recover from exactly that by re-inviting once. But both `invite(deviceId:)` and `isConnected(toPeer:)` resolve the peer *through* `peers`. Once the entry was gone:

- the re-invite silently no-op'd (`invite` returns `false`, and the caller discards it),
- `isConnected` could never become true again,
- so the join spun out its full wait against a host that was **still advertising the whole time**, and failed with `connectionTimeout`.

Discovery lifetime belongs to the **browser** (`foundPeer`/`lostPeer`). The session owns *connection* state only. A dropped connection means "not connected", never "gone".

**Fix:** revert the peer to `.found` and let `lostPeer` do the removing.

## Also: the reason this was undiagnosable

`didNotStartAdvertisingPeer` and `didNotStartBrowsingForPeers` were **not implemented at all**. Those are the only place Multipeer reports denied Local Network permission, a missing `NSBonjourServices` entry, or a disabled radio. Every one of those failures was dropped on the floor and reached the user as the same generic timeout. Both are now implemented and emit through a new `onTransportError` callback.

## Verification

- 2 regression tests added.
- **Red-proofed** — restoring the `removeValue` makes the peer-kept assertion fail (`after.contains { $0.deviceId == "host-1" }` → false, state → nil) while `lostPeer` correctly stays green.
- Full core suite: **2577/2577 passing, 83 suites**.

Hypotheses checked and ruled out along the way, recorded so nobody re-walks them: `NSBonjourServices` is correct (`_wiredpart-sync._tcp` + `._udp` both declared, matching `serviceType`); host pairing mode *is* enabled (`IOSSyncManager:602`); and the pairing proof/nonce protocol is sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)