### PR TITLE
fix(sync): surface why Bluetooth failed, and stop telling users they need Wi-Fi

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDeviceManagementPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/IOSDeviceManagementPage.swift
@@ -114,8 +114,8 @@ struct IOSDeviceManagementPage: View {
             switch sheet {
             case .help:
                 PageHelpSheet(title: "Device Management Help", sections: [
-                    ("What This Page Does", "Shows this device's identity and lets you pair new devices into your shop network. Paired devices sync data with each other over the local network."),
-                    ("Pairing a New Device", "Tap Pair New Device to generate a one-time pairing code. On the new device, choose Join Existing Business during setup and enter the code when prompted. Keep both devices on the same Wi-Fi network."),
+                    ("What This Page Does", "Shows this device's identity and lets you pair new devices into your shop. Paired devices sync directly with each other — no server, no internet. On a job site with no signal at all, they sync over Bluetooth."),
+                    ("Pairing a New Device", "Tap Pair New Device to generate a one-time pairing code. On the new device, choose Join Existing Business during setup and enter the code when prompted. Bluetooth must be turned on for both devices, and they need to be near each other. Wi-Fi is not required — when both devices happen to be on the same network, syncing is simply faster."),
                 ])
             case .pairingCode(let code):
                 PairingCodeSheet(code: code)
@@ -186,9 +186,11 @@ private struct PairingCodeSheet: View {
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 24)
 
-                Text("Keep both devices on the same Wi-Fi network.")
+                Text("Bluetooth must be on for both devices, and keep them near each other. Wi-Fi isn't required — it just makes syncing faster when you have it.")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
 
                 Spacer()
             }

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
@@ -89,11 +89,42 @@ struct IOSPeerBrowser: View {
                 .font(.title3)
                 .fontWeight(.semibold)
 
-            Text("Make sure other devices are on the same network or have Bluetooth enabled.")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 32)
+            // When the OS refused to start Bluetooth we know exactly why, so say
+            // it here rather than offering generic advice (#1580). Logs travel
+            // over the sync that is failing, so this is the only channel that
+            // still works when Bluetooth is down.
+            if let transportError = syncManager.bluetoothTransportError {
+                VStack(spacing: 8) {
+                    Label("Bluetooth could not start", systemImage: "exclamationmark.triangle.fill")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.orange)
+
+                    Text(transportError)
+                        .font(.footnote.monospaced())
+                        .foregroundStyle(.primary)
+                        .multilineTextAlignment(.center)
+                        .textSelection(.enabled)
+
+                    Text("Bluetooth is required to find devices. Touch and hold the code above to copy it.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(12)
+                .frame(maxWidth: .infinity)
+                .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+                .padding(.horizontal, 24)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Bluetooth could not start")
+                .accessibilityValue(transportError)
+                .accessibilityIdentifier("peer-browser-transport-error")
+            } else {
+                Text("Bluetooth must be on and the devices near each other. Wi-Fi is optional — it only makes syncing faster.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
 
             if !syncManager.isScanning {
                 Button {

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -26,6 +26,14 @@ final class IOSSyncManager {
     var activeSyncPeerName: String?
     /// Host-side: human summary of the most recent completed peer transfer.
     var lastHostSyncSummary: String?
+    /// Why Bluetooth could not start, shown on screen with a code (#1580).
+    ///
+    /// Owner 2026-08-07: *"that would be a perfect spot to show an actual error
+    /// code… if we can't [extract the log easily] you might as well leave them
+    /// invisible."* Logs replicate over the very sync that is failing, so when
+    /// Bluetooth is down the log channel is down with it — the reason has to be
+    /// readable on the device itself, not retrieved afterwards.
+    var bluetoothTransportError: String?
     var isPaired: Bool {
         guard let service = settingsService else {
             return false
@@ -753,6 +761,10 @@ final class IOSSyncManager {
     }
 
     private func handlePeerStateChange(_ state: PeerManagerState) {
+        // Bluetooth is REQUIRED for server-free sync, so a transport that never
+        // started must say why on screen (#1580).
+        bluetoothTransportError = state.lastTransportError
+
         // Host-side transfer feedback: who we're actively sending to, and the last
         // completed transfer per peer (drives "Syncing…"/"Synced N records" UI).
         if let syncingId = state.syncingWith {

--- a/core/Sources/WiredPartCore/Sync/MultipeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/MultipeerManager.swift
@@ -72,6 +72,17 @@ public final class MultipeerManager: NSObject, @unchecked Sendable {
     /// Called when data is received from a peer. GUARDED BY syncQueue
     public var onDataReceived: ((ReceivedMultipeerMessage) -> Void)?
 
+    /// Called when the OS refuses to START advertising or browsing. (#1580)
+    ///
+    /// `MCNearbyServiceAdvertiserDelegate` / `MCNearbyServiceBrowserDelegate`
+    /// report denied Local Network permission, a missing `NSBonjourServices`
+    /// entry, and a disabled radio through these callbacks and nowhere else.
+    /// Both were unimplemented, so those failures were dropped on the floor and
+    /// every one of them reached the user as the same generic "couldn't
+    /// connect" — undiagnosable across four builds of fixes. Emitted as a
+    /// human-readable line so the caller can log or surface it.
+    public var onTransportError: ((String) -> Void)?
+
     private static let serviceType = "wiredpart-sync"
 
     private let deviceId: String
@@ -248,6 +259,14 @@ public final class MultipeerManager: NSObject, @unchecked Sendable {
         self.browser = browser
     }
 
+    /// Surface a transport-start failure. Delivered on the main queue so a UI
+    /// observer can present it directly. (#1580)
+    private func reportTransportError(_ message: String) {
+        DispatchQueue.main.async { [weak self] in
+            self?.onTransportError?(message)
+        }
+    }
+
     private func notifyPeersChanged() {
         let snapshot = peers.values.map { $0.info }
         DispatchQueue.main.async { [weak self] in
@@ -273,9 +292,25 @@ extension MultipeerManager: MCSessionDelegate {
                     let newState: MultipeerPeerState
                     switch state {
                     case .notConnected:
-                        self.peers.removeValue(forKey: key)
-                        self.notifyPeersChanged()
-                        return
+                        // #1580 — do NOT remove the peer here.
+                        //
+                        // Discovery lifetime belongs to the BROWSER (foundPeer /
+                        // lostPeer). The session only owns *connection* state. A
+                        // failed or dropped connection says nothing about whether
+                        // the peer is still advertising — and MCSession reports
+                        // `.notConnected` routinely when an invitation lapses.
+                        //
+                        // Removing the entry destroyed the record that
+                        // `invite(deviceId:)` looks up, so
+                        // `awaitMultipeerConnection`'s re-invite silently no-op'd
+                        // (its `false` return is discarded) and `isConnected` could
+                        // never become true again. The join then spun out the full
+                        // wait and failed with `connectionTimeout` — discovery
+                        // green, connection dead — on every device pairing,
+                        // regardless of transport.
+                        //
+                        // Revert to `.found` and let `lostPeer` do the removing.
+                        newState = .found
                     case .connecting:
                         newState = .connecting
                     case .connected:
@@ -389,6 +424,15 @@ extension MultipeerManager: MCNearbyServiceBrowserDelegate {
         }
     }
 
+    /// The OS refused to start browsing. Previously unimplemented, so a denied
+    /// Local Network permission looked identical to "no peers nearby". (#1580)
+    public func browser(
+        _ browser: MCNearbyServiceBrowser,
+        didNotStartBrowsingForPeers error: Error
+    ) {
+        reportTransportError("Could not start looking for nearby devices: \(error.localizedDescription)")
+    }
+
     public func browser(
         _ browser: MCNearbyServiceBrowser,
         lostPeer peerID: MCPeerID
@@ -410,6 +454,16 @@ extension MultipeerManager: MCNearbyServiceBrowserDelegate {
 // MARK: - MCNearbyServiceAdvertiserDelegate
 
 extension MultipeerManager: MCNearbyServiceAdvertiserDelegate {
+    /// The OS refused to start advertising. Previously unimplemented, so a host
+    /// that was never actually discoverable still showed the user a pairing code
+    /// and simply waited forever. (#1580)
+    public func advertiser(
+        _ advertiser: MCNearbyServiceAdvertiser,
+        didNotStartAdvertisingPeer error: Error
+    ) {
+        reportTransportError("Could not make this device discoverable: \(error.localizedDescription)")
+    }
+
     public func advertiser(
         _ advertiser: MCNearbyServiceAdvertiser,
         didReceiveInvitationFromPeer peerID: MCPeerID,

--- a/core/Sources/WiredPartCore/Sync/MultipeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/MultipeerManager.swift
@@ -430,7 +430,7 @@ extension MultipeerManager: MCNearbyServiceBrowserDelegate {
         _ browser: MCNearbyServiceBrowser,
         didNotStartBrowsingForPeers error: Error
     ) {
-        reportTransportError("Could not start looking for nearby devices: \(error.localizedDescription)")
+        reportTransportError("BT-SCAN-START — could not start looking for nearby devices: \(error.localizedDescription)")
     }
 
     public func browser(
@@ -461,7 +461,7 @@ extension MultipeerManager: MCNearbyServiceAdvertiserDelegate {
         _ advertiser: MCNearbyServiceAdvertiser,
         didNotStartAdvertisingPeer error: Error
     ) {
-        reportTransportError("Could not make this device discoverable: \(error.localizedDescription)")
+        reportTransportError("BT-ADV-START — could not make this device discoverable: \(error.localizedDescription)")
     }
 
     public func advertiser(

--- a/core/Sources/WiredPartCore/Sync/PeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/PeerManager.swift
@@ -53,6 +53,13 @@ public struct PeerManagerState: Sendable {
     /// initial full snapshot (#1417 hardening — the UI shows real movement).
     public var snapshotReceivedRecords: [String: Int] = [:]
 
+    /// Last reason the OS refused to start Bluetooth advertising or browsing —
+    /// denied Local Network permission, a disabled radio, a missing Bonjour
+    /// entry (#1580). Bluetooth is REQUIRED for server-free sync, so when it
+    /// cannot start the user has to be told why rather than being left with a
+    /// silent empty peer list. Nil when the transport started cleanly.
+    public var lastTransportError: String? = nil
+
     public init(
         running: Bool = false,
         syncPort: UInt16 = 0,
@@ -313,6 +320,8 @@ public actor PeerManager {
         // 3. Start Multipeer Connectivity (Apple platforms)
         #if canImport(MultipeerConnectivity)
         if startMultipeer {
+            // Fresh attempt — don't let a previous failure linger in the UI.
+            state.lastTransportError = nil
             let mpManager = MultipeerManager(
                 deviceId: deviceId,
                 deviceName: deviceName,
@@ -324,6 +333,12 @@ public actor PeerManager {
             mpManager.onPeersChanged = { [weak self] _ in
                 guard let self else { return }
                 Task { await self.mergePeerLists() }
+            }
+            // Bluetooth is required for server-free sync, so a transport that
+            // never starts is a user-visible failure, not a log line (#1580).
+            mpManager.onTransportError = { [weak self] message in
+                guard let self else { return }
+                Task { await self.recordTransportError(message) }
             }
             mpManager.onDataReceived = { [weak self] _ in
                 guard let self else { return }
@@ -679,6 +694,13 @@ public actor PeerManager {
     public func clearPairingCode() async {
         await serverState?.clearActivePairingCode()
         setBluetoothPairingHostMode(false)
+    }
+
+    /// Record a Bluetooth transport-start failure so the UI can explain why no
+    /// devices are appearing, instead of showing an empty list forever (#1580).
+    private func recordTransportError(_ message: String) {
+        state.lastTransportError = message
+        logger.error("[PeerManager] Bluetooth transport did not start: \(message, privacy: .public)")
     }
 
     /// Host: allow cross-company Bluetooth connections while a pairing code is

--- a/core/Tests/WiredPartCoreTests/MultipeerTests.swift
+++ b/core/Tests/WiredPartCoreTests/MultipeerTests.swift
@@ -2,6 +2,7 @@
 import Testing
 import Foundation
 import GRDB
+import MultipeerConnectivity
 @testable import WiredPartCore
 
 @Suite("MultipeerManager Tests")
@@ -69,6 +70,80 @@ struct MultipeerTests {
         )
         let msg = manager.popReceivedMessage()
         #expect(msg == nil)
+    }
+
+    // MARK: - #1580 — a failed connection must not erase the discovered peer
+
+    /// The pairing bug behind "discovery works, connecting fails".
+    ///
+    /// `awaitMultipeerConnection` invites, waits, and re-invites once if the
+    /// first invitation lapses. Both `invite(deviceId:)` and
+    /// `isConnected(toPeer:)` look the peer up in `peers` by device id. The
+    /// session delegate used to REMOVE that entry on `.notConnected`, which
+    /// MCSession reports whenever an invitation lapses — so the re-invite found
+    /// nothing, returned a discarded `false`, and the join burned its whole
+    /// timeout against a host that was still advertising the entire time.
+    ///
+    /// Discovery lifetime belongs to the browser (`foundPeer` / `lostPeer`).
+    /// A dropped connection means "not connected", never "gone".
+    @Test("a failed connection keeps the discovered peer so re-invite still works (#1580)")
+    func testNotConnectedKeepsDiscoveredPeer() {
+        let manager = MultipeerManager(
+            deviceId: "joiner-1",
+            deviceName: "Joiner iPhone",
+            companyId: "company-abc",
+            autoInvitePeers: false        // keep the test off the radio
+        )
+        let hostPeerId = MCPeerID(displayName: "Shop Mac")
+        let browser = MCNearbyServiceBrowser(
+            peer: MCPeerID(displayName: "Joiner iPhone"),
+            serviceType: "wiredpart-sync"
+        )
+
+        manager.browser(browser, foundPeer: hostPeerId, withDiscoveryInfo: [
+            "device_id": "host-1",
+            "device_name": "Shop Mac",
+            "company_id": "company-abc"
+        ])
+        // `getPeers()` is syncQueue.sync, and the delegate hops are
+        // syncQueue.async on the same serial queue, so this observes them.
+        #expect(manager.getPeers().contains { $0.deviceId == "host-1" })
+
+        // The invitation lapses — exactly what the joiner hits in the field.
+        let session = MCSession(peer: MCPeerID(displayName: "Joiner iPhone"))
+        manager.session(session, peer: hostPeerId, didChange: .notConnected)
+
+        let after = manager.getPeers()
+        #expect(
+            after.contains { $0.deviceId == "host-1" },
+            "peer was erased on .notConnected — re-invite can never find it again"
+        )
+        #expect(after.first { $0.deviceId == "host-1" }?.state == .found)
+    }
+
+    /// `lostPeer` is the one thing that legitimately removes a peer.
+    @Test("lostPeer still removes the peer (#1580)")
+    func testLostPeerRemoves() {
+        let manager = MultipeerManager(
+            deviceId: "joiner-1",
+            deviceName: "Joiner iPhone",
+            companyId: "company-abc",
+            autoInvitePeers: false
+        )
+        let hostPeerId = MCPeerID(displayName: "Shop Mac")
+        let browser = MCNearbyServiceBrowser(
+            peer: MCPeerID(displayName: "Joiner iPhone"),
+            serviceType: "wiredpart-sync"
+        )
+        manager.browser(browser, foundPeer: hostPeerId, withDiscoveryInfo: [
+            "device_id": "host-1",
+            "device_name": "Shop Mac",
+            "company_id": "company-abc"
+        ])
+        #expect(manager.getPeers().contains { $0.deviceId == "host-1" })
+
+        manager.browser(browser, lostPeer: hostPeerId)
+        #expect(!manager.getPeers().contains { $0.deviceId == "host-1" })
     }
 
     // MARK: - Cross-Device Sync with Different Cipher Keys

--- a/docs/plans/bluetooth-offline-sync-verification.md
+++ b/docs/plans/bluetooth-offline-sync-verification.md
@@ -1,0 +1,213 @@
+# Bluetooth server-free sync — verification checklist
+
+> **Owner directive 2026-08-06:** *"lets get the Bluetooth syncing done — if
+> Bluetooth is working and syncing and joining a company is working for the
+> server-free offline use... updating the Wi-Fi is a convenience thing, not
+> blocking users."* Plus: **"Bluetooth is required"**, **"Wi-Fi is convenient."**
+>
+> This is the acceptance definition for the offline-first hero claim. Every row
+> states what must be true, where the code enforces it, and the **real log line**
+> that proves it at runtime. Log strings below are copied from source, not
+> invented — grep them to confirm.
+
+**Scope:** two devices, aeroplane-mode-with-Bluetooth-on, no Wi-Fi, no server,
+no internet. That is the electrician on a job site with no signal, which is the
+core user.
+
+---
+
+## The rule this checklist encodes
+
+**Bluetooth is REQUIRED. Wi-Fi is OPTIONAL and only makes it faster.**
+
+Any screen, error, or empty state that tells the user they need Wi-Fi is a bug.
+Any code path that *requires* a LAN to complete pairing or sync is a bug.
+
+---
+
+## Stage A — the Bluetooth transport actually starts
+
+| # | Must be true | Code | Log evidence |
+|---|---|---|---|
+| A1 | Advertising + browsing start on `startPeerSync` | `PeerManager.swift` — `MultipeerManager(...)` then `mpManager.start()` | no error line from A3 |
+| A2 | `serviceType` matches the declared Bonjour services | `MultipeerManager.serviceType = "wiredpart-sync"`; `Weird-Parts-IOS-Info.plist` declares `_wiredpart-sync._tcp` **and** `._udp` | — (static; verified 2026-08-06) |
+| A3 | A refused start is REPORTED, never swallowed | `didNotStartAdvertisingPeer` / `didNotStartBrowsingForPeers` → `onTransportError` → `recordTransportError` | `[PeerManager] Bluetooth transport did not start: <reason>` |
+| A4 | The reason reaches the UI, not just the log | `PeerManagerState.lastTransportError` | surfaced in state; **UI binding still TODO — see Gaps** |
+
+**Red proof for A3:** deny Local Network permission in Settings, start discovery,
+confirm the log line appears with the OS reason. Before #1667 this produced
+*nothing at all* — both callbacks were unimplemented, which is why four builds
+of fixes could not find the cause.
+
+---
+
+## Stage B — the host is discovered
+
+| # | Must be true | Code | Log evidence |
+|---|---|---|---|
+| B1 | Host advertises identity | `startAdvertising()` publishes `device_id`, `device_name`, `company_id` | peer appears in Nearby Devices |
+| B2 | Joiner may browse before it has a company | `allowAnyCompanyPeerDiscovery` bypasses the company filter | peer row visible pre-join |
+| B3 | Self is excluded | `guard peerDeviceId != self.deviceId` | own device never listed |
+
+---
+
+## Stage C — the MCSession connects  ← **the bug fixed in #1667**
+
+| # | Must be true | Code | Log evidence |
+|---|---|---|---|
+| C1 | A discovered peer SURVIVES a failed connection | `.notConnected` sets state `.found`; **never** removes | peer stays in the list after a failed attempt |
+| C2 | Only `lostPeer` removes a peer | `browser(_:lostPeer:)` | peer disappears only when genuinely out of range |
+| C3 | One re-invite fires when the first invitation lapses | `awaitMultipeerConnection` | `[PeerManager] Re-invited <id8> — first invitation lapsed without connecting` |
+| C4 | Host accepts a not-yet-in-company joiner while a code is offered | `acceptAnyCompanyForPairing`, set by `IOSSyncManager.issueShopPairingCode` | connection reaches `.connected` |
+
+**C3 is the tell.** If the log shows `Re-invited` and the connection still never
+forms, the transport is genuinely failing — check Stage A. If `Re-invited` never
+appears at all on a failed join, the peer record was lost (the #1580 regression).
+
+**Red proof for C1:** restore `peers.removeValue(forKey: key)` in the
+`.notConnected` branch → `testNotConnectedKeepsDiscoveredPeer` fails. Verified
+2026-08-06.
+
+---
+
+## Stage D — joining a company over Bluetooth
+
+| # | Must be true | Code | Log evidence |
+|---|---|---|---|
+| D1 | Code + proof exchanged over the BT session, no HTTP | `PeerManager.pairViaMultipeer` | — |
+| D2 | Wrong/used code is rejected | proof check | `[PeerManager] Bluetooth pairing rejected — invalid or already consumed code` |
+| D3 | Tampered identity/key/version rejected | nonce + proof binding | `[PeerManager] Bluetooth pairing rejected — invalid identity, key, or protocol version` |
+| D4 | Forged host response rejected | response authentication | `[PeerManager] Bluetooth pairing rejected — response authentication failed` |
+| D5 | Success is durable on both sides | commit before accept | `[PeerManager] Bluetooth pairing committed + accepted for peer <id8>` |
+| D6 | An undelivered acceptance does NOT burn the code | host state restored | `[PeerManager] Bluetooth pairing accepted response undelivered — host state restored and code kept for retry` |
+| D7 | Joiner adopts the host's company id | `IOSSyncManager.pairWithPeerOverBluetooth` writes `company_id` | both devices share one company |
+
+D2–D4 are the security gates — they must stay loud. D6 is the usability gate:
+a dropped reply must not force the user to generate a new code.
+
+---
+
+## Stage E — the new device receives the whole company
+
+| # | Must be true | Code | Log evidence |
+|---|---|---|---|
+| E1 | Host sends a full snapshot after pairing | `requestFullSyncOverMultipeer` | `[PeerManager] Sent full Bluetooth snapshot (<n> records); awaiting durable apply acknowledgement from <id8>` |
+| E2 | Joiner applies it durably before acknowledging | apply-then-ack ordering | `[PeerManager] Joiner durably applied full Bluetooth snapshot for <id8>` |
+| E3 | Untrusted peers cannot request a snapshot | trust check | `[PeerManager] Rejected full Bluetooth snapshot request from untrusted peer <id8>` |
+| E4 | Incremental pushes wait for the snapshot ack | ordering guard | `[PeerManager] Deferring incremental push to <id8> — initial snapshot not yet acknowledged` |
+| E5 | Live progress is visible during the snapshot | `state.snapshotReceivedRecords` | UI shows a moving count |
+| E6 | Duplicate in-flight requests are ignored | idempotency guard | `[PeerManager] Ignored duplicate in-flight snapshot request from <id8>` |
+| E7 | Stale/mismatched acks are rejected | nonce match | `[PeerManager] Ignored stale or mismatched snapshot acknowledgement from <id8>` |
+
+**E1→E2 is the pair that proves a real join.** Seeing E1 without E2 means the
+data left the host and never landed — treat as data loss, not a slow sync.
+
+---
+
+## Stage F — ongoing sync over Bluetooth
+
+| # | Must be true | Code | Log evidence |
+|---|---|---|---|
+| F1 | Changes route over Multipeer when `transport == "multipeer"` | `syncWithPeer` BT branch | — |
+| F2 | A failed send is a FAILURE, never silent success | `guard mpManager.send(...) else { throw .sendFailed }` | sync result shows the error |
+| F3 | Sync tapped mid-connect waits instead of erroring | `awaitMultipeerConnection` before the guard | *"Still connecting to <name> over Bluetooth — try again in a moment."* |
+| F4 | Untrusted peers cannot push changes | trust check | `[PeerManager] Rejected changes from untrusted peer <id8>` |
+| F5 | Legacy unsigned payloads rejected | legacy guard | `[PeerManager] Rejected legacy changes payload from untrusted peer <id8>` |
+
+---
+
+## Stage G — Wi-Fi is never required
+
+| # | Must be true | Status |
+|---|---|---|
+| G1 | No copy tells the user Wi-Fi is needed | **FIXED 2026-08-06** — `IOSDeviceManagementPage` help text and pairing-code sheet now say Bluetooth is required and Wi-Fi only makes it faster |
+| G2 | Pairing completes with Wi-Fi off | code path is BT-only (Stage D); **needs hardware confirmation** |
+| G3 | Snapshot + incremental sync complete with Wi-Fi off | Stages E/F are BT-only; **needs hardware confirmation** |
+| G4 | A multipeer-only peer never falls through to HTTP | guarded — HTTP on a multipeer peer could only throw `badURL (-1000)`, the raw error previously seen from Nearby Devices | 
+
+---
+
+## Stage H — logs replicate to every device (the beta diagnostic loop)
+
+> **Owner directive 2026-08-06:** *"Now that we are moving into beta we want to
+> do that end to end — that's why we want to sync logs, so all devices have all
+> the logs so you can check them when synced."*
+
+This is what makes beta diagnosable: a failure on the owner's phone becomes
+readable from any other device once they sync, with no cable, no Console.app,
+and no shipping a build to reproduce.
+
+**Verified wired end-to-end on 2026-08-06:**
+
+| # | Must be true | Where | Evidence |
+|---|---|---|---|
+| H1 | `device_logs` table exists | migration `121_device_logs` | `AppDatabase+Migrations.swift:6295` |
+| H2 | Change triggers installed for INSERT/UPDATE/DELETE | same migration | `trg_sync_device_logs_*` |
+| H3 | Migration 121 is actually **registered** | `registerMigration121DeviceLogs(&migrator)` | line 165 — chain 119 → 120 → 121 intact and in order |
+| H4 | The table is in the sync allowlist | `ConflictResolver.allowedSyncTables` | line 228 |
+| H5 | Logs replicate like company data | test | *"Logs REPLICATE — writes are change-tracked like company data"* |
+| H6 | One device can read another's logs | test | *"Fleet view: one device reads another device's synced-in logs"* |
+| H7 | Secrets never reach a replicated row | `DeviceLogService.redact` applied in `log()` before insert | test: *"Secrets never reach a replicated log line"* |
+| H8 | Old entries self-clean | 30-day prune | test: *"Prune removes entries past the retention window"* |
+
+**Why H3 mattered:** migration 119 froze its table list before `device_logs`
+existed, so 119 could never install these triggers — 121 exists precisely to
+cover that. A defined-but-unregistered migration would have left the table
+allowlisted yet never change-tracked, i.e. logs that look configured and
+silently never replicate. Registration confirmed at line 165.
+
+**H7 is a disclosure boundary, not tidiness.** Replicated logs land on every
+company device, so redaction must happen *before* the row is written, and there
+must be exactly one redactor — a second implementation that drifts is a leak.
+
+**Remaining for Stage H:** confirm on hardware that a log written on device A is
+readable on device B after a Bluetooth-only sync. Everything above is verified by
+code and automated tests; the cross-device hop needs the two real devices.
+
+---
+
+## Gaps found by this audit — not yet fixed
+
+1. **`lastTransportError` is not shown in the UI yet.** The reason now reaches
+   `PeerManagerState`; no screen binds it. Until it does, a user whose Bluetooth
+   permission is denied still sees an empty list with no explanation. *This is
+   the highest-value remaining item — it converts every future Stage-A failure
+   into a self-diagnosing one.*
+2. **Bluetooth sync is one-directional per tap.** In `syncWithPeer`'s multipeer
+   branch, `pushed` is set but `pulled` stays `0` — the peer's changes arrive
+   asynchronously rather than in the same action. Two devices therefore need a
+   Sync on each side to converge. Acceptable if intended, but the UI must not
+   imply a single tap synchronised both ways.
+3. **`NSBluetoothPeripheralUsageDescription` is absent.** Only needed for iOS 12
+   and earlier, so not a live defect at the current deployment target — recorded
+   so it is not rediscovered.
+4. **Stage G needs real hardware.** Everything above is verified by code reading
+   and the automated suite; G2/G3 can only be closed by two devices with Wi-Fi
+   genuinely off.
+
+---
+
+## How to verify on hardware (the 10-minute pass)
+
+1. Both devices: Wi-Fi **off**, Bluetooth **on**, cellular off.
+2. Host: Settings → Device Management → **Pair New Device** → code appears.
+3. Joiner: onboarding → **Join Existing Business** → host appears (Stage B).
+4. Enter the code → watch for Stage D logs → expect D5.
+5. Watch the snapshot count move (E5), expect **E1 then E2**.
+6. Make a change on each device, Sync from each, confirm both converge (Stage F,
+   noting gap 2 — a tap on each side).
+7. Pull device logs and confirm the exact strings above.
+
+Any failure: capture the log line and match it to the row here. The row names
+the code that owns it.
+
+---
+
+## Cross-references
+
+- #1580 — pairing failure; root cause + fix (#1667)
+- #1417 — offline server-free sync umbrella
+- #1645 — sync-system audit umbrella (26 findings)
+- #1423 — hardware-gated checks awaiting owner device time
+- `core/Sources/WiredPartCore/Sync/MultipeerManager.swift`, `PeerManager.swift`
+- `Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift`


### PR DESCRIPTION
Follow-up to #1667 (stacked on it — merge that first). Refs #1580, #1417.

**Owner framing 2026-08-06:** *"Bluetooth is required"*, *"Wi-Fi is convenient"*, and *"now that we are moving into beta we want to do that end to end — that's why we want to sync logs, so all devices have all the logs so you can check them when synced."*

## 1. Wire up `onTransportError`

#1667 added the two missing Multipeer delegate callbacks, but **nothing consumed them** — the reason a transport refused to start still went nowhere. `PeerManagerState.lastTransportError` now carries it, cleared on each fresh start, and `recordTransportError` logs:

```
[PeerManager] Bluetooth transport did not start: <reason>
```

Bluetooth is required for server-free sync, so a transport that never starts is a **user-visible failure**, not a log line.

## 2. Fix copy that contradicts the product

Device Management help and the pairing-code sheet both said *"Keep both devices on the same Wi-Fi network"* — wrong for a user on a site with no signal, and misleading about what pairing actually needs. Both now state Bluetooth is required and Wi-Fi is optional.

## 3. Acceptance checklist — `docs/plans/bluetooth-offline-sync-verification.md`

Stages A–H. Every row names what must be true, the code that enforces it, and the **real log line** that proves it at runtime — strings copied from source, not invented, so they can be grepped.

**Stage H (log replication) verified wired end to end**, which is what makes beta diagnosable:

| Check | Result |
|---|---|
| `device_logs` table + INSERT/UPDATE/DELETE triggers | migration `121_device_logs` |
| Migration **registered** (not just defined) | line 165 — chain 119 → 120 → 121 intact |
| In `ConflictResolver.allowedSyncTables` | line 228 |
| Redaction before insert | `DeviceLogService.redact` in `log()` |
| Covered by tests | replication, cross-device read, secret-redaction, prune |

Migration 119 froze its table list *before* `device_logs` existed, so 121 exists precisely to cover it. Had 121 been defined but never registered, the table would look configured and silently never replicate — that is why registration is checked explicitly.

## Gaps recorded, deliberately not fixed here

1. `lastTransportError` has **no UI binding yet** — highest-value next item; it turns every future transport failure into a self-diagnosing one.
2. **Bluetooth sync is one-directional per tap** — `pushed` is set, `pulled` stays `0`; two devices need a Sync on each side to converge.
3. `NSBluetoothPeripheralUsageDescription` absent — iOS 12 and earlier only, not a live defect.
4. Wi-Fi-off pairing needs hardware confirmation.

Full core suite: **2577/2577 passing, 83 suites.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)