### PR TITLE
fix(sync): use .optional MCSession encryption so connections can form (#1580)

### DIFF
--- a/core/Sources/WiredPartCore/Sync/MultipeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/MultipeerManager.swift
@@ -134,7 +134,30 @@ public final class MultipeerManager: NSObject, @unchecked Sendable {
         self.session = MCSession(
             peer: localPeerId,
             securityIdentity: nil,
-            encryptionPreference: .required
+            // #1580 — `.optional`, not `.required`.
+            //
+            // `.required` makes MCSession refuse to form unless both ends
+            // negotiate transport encryption, and it is a well-known source of
+            // connections that discover fine and then never connect — the exact
+            // field symptom here, across every device combination.
+            //
+            // This does NOT put company data on the air in the clear. Change
+            // payloads are already sealed at the APPLICATION layer with
+            // AES-GCM (`SyncCrypto.encryptAESGCM` in `PeerManager`), keyed by
+            // the X25519 agreement established during pairing, so transport
+            // encryption was a redundant second wrapper. The pairing handshake
+            // itself carries only a MAC-style proof bound to a nonce and the
+            // participants' PUBLIC keys — safe in the clear by construction.
+            //
+            // Owner authorization 2026-08-07: "i dont minde there being publice
+            // bluetooth fall back to start and encrpting it latter as long as
+            // we have the sycing working."
+            //
+            // `.optional` still uses encryption whenever the peer asks for it,
+            // so a device on an older build that still sends `.required` keeps
+            // an encrypted link — mixed-build fleets stay compatible during
+            // rollout.
+            encryptionPreference: .optional
         )
         self.session.delegate = self
     }


### PR DESCRIPTION
Refs #1580, #1417. Owner asked directly whether any open bug or security item could be causing the sync failure. **This one can.**

## The suspect

```swift
MCSession(peer:, securityIdentity: nil, encryptionPreference: .required)
```

`.required` makes the session refuse to form unless both ends negotiate transport encryption. It is a well-known cause of peers that **discover fine and then never connect** — precisely the field symptom, on every combination tried (iPhone ↔ iPad *and* Mac ↔ iPhone).

## Why relaxing it is safe

Company data does **not** go on the air in the clear. Change payloads are already sealed at the **application** layer with AES-GCM (`SyncCrypto.encryptAESGCM` in `PeerManager`), keyed by the X25519 agreement established during pairing. MCSession encryption was a **redundant second wrapper around already-sealed bytes**.

The pairing handshake itself carries only a MAC-style proof bound to a nonce, plus the participants' **public** keys — safe in the clear by construction.

`.optional` still encrypts whenever the peer asks for it, so a device on an older build still sending `.required` keeps an encrypted link. **Mixed-build fleets stay compatible during rollout** — important since the owner tests across three devices that won't all update at once.

Owner authorization 2026-08-07: *"i dont minde there being publice bluetooth fall back to start and encrpting it latter as long as we have the sycing working."* Worth recording that the fallback is materially less exposed than that framing suggests.

## Verification

84 tests passing across SyncCrypto / Multipeer / PeerManager, including the AES-GCM **tamper test** — modified ciphertext is rejected, which is what proves the app layer is really carrying the protection.

## Related finding — do not merge #1608 as-is

While tracing trust I found a landmine. `PeerManager.trustedPeerKey` runs:

```sql
SELECT certificate FROM _device_registry WHERE device_id = ? AND is_trusted = 1 AND is_deactivated = 0
```

and the caller does `guard trustedPeerKey(...) == decoded.key`. #1608 proposes **encrypting that `certificate` column**. If it lands without updating this comparison, the stored value stops matching the plaintext key, **every peer becomes untrusted, and sync breaks completely** — the same double-encryption failure mode that corrupted contact emails in #1657 and needed migration 120 to repair. Flagged on #1608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)