### PR TITLE
fix(sync): preserve orphaned encrypted databases

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -34,6 +34,10 @@ final class AppCore: ObservableObject {
 
     @Published var isReady = false
     @Published var loadError: String?
+    /// True only when SQLCipher reports that an existing database cannot be
+    /// unlocked by this device's current bootstrap key. The UI must require an
+    /// explicit archive-and-repair confirmation before it can create a new DB.
+    @Published private(set) var requiresUnreadableDatabaseRecovery = false
     @Published var needsBootstrap = false
     @Published var needsOnboarding = false
     @Published var currentUser: User?
@@ -392,15 +396,43 @@ final class AppCore: ObservableObject {
             logger.error(
                 "[AppCore] bootstrap failed domain=\(nsError.domain, privacy: .public) code=\(nsError.code, privacy: .public) description=\(error.localizedDescription, privacy: .public)"
             )
-            // A startup-failure screen is a DIAGNOSTIC surface: the generic
-            // "Couldn't start app. Pull down to retry." hid the OSStatus that
-            // would have identified the Mac keychain failure immediately
-            // (owner, 2026-08-04 — two builds burned guessing). Show the real
-            // reason underneath the friendly line.
-            let friendly = userFriendlyError(error, context: "start app")
-            let technical = "\(nsError.domain) \(nsError.code): \(error.localizedDescription)"
-            loadError = "\(friendly)\n\n\(technical)"
-            BugReportErrorLog.shared.record(loadError ?? friendly, context: "App startup")
+            if AppDatabase.isCipherKeyMismatchError(error) {
+                requiresUnreadableDatabaseRecovery = true
+                loadError = "This device has data it can no longer unlock. It has not been deleted or overwritten."
+            } else {
+                // A startup-failure screen is a DIAGNOSTIC surface: the generic
+                // "Couldn't start app. Pull down to retry." hid the OSStatus that
+                // would have identified the Mac keychain failure immediately
+                // (owner, 2026-08-04 — two builds burned guessing). Show the real
+                // reason underneath the friendly line.
+                let friendly = userFriendlyError(error, context: "start app")
+                let technical = "\(nsError.domain) \(nsError.code): \(error.localizedDescription)"
+                loadError = "\(friendly)\n\n\(technical)"
+            }
+            BugReportErrorLog.shared.record(loadError ?? error.localizedDescription, context: "App startup")
+        }
+    }
+
+    /// Archives the unreadable encrypted database only after an explicit user
+    /// confirmation, then boots an empty local database so the standard pairing
+    /// flow can download a replacement from a trusted peer.
+    func archiveUnreadableDatabaseAndPrepareToRepair() async -> String? {
+        guard requiresUnreadableDatabaseRecovery else {
+            return "Database recovery is not required."
+        }
+
+        do {
+            let path = try Self.databasePath()
+            let archivePath = try await Task.detached(priority: .userInitiated) {
+                try AppDatabase.archiveUnreadableCipherDatabase(atPath: path)
+            }.value
+            logger.notice("[AppCore] Archived unreadable encrypted database at \(archivePath, privacy: .private)")
+            requiresUnreadableDatabaseRecovery = false
+            loadError = nil
+            await bootstrap()
+            return nil
+        } catch {
+            return userFriendlyError(error, context: "archive unreadable database")
         }
     }
 

--- a/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
@@ -11,6 +11,9 @@ struct WiredPartIOSApp: App {
     @StateObject private var appCore = AppCore()
     @StateObject private var tabPrefs = TabBarPreferences()
     @State private var showLaunchErrorReport = false
+    @State private var showUnreadableDatabaseRecoveryConfirmation = false
+    @State private var isPreparingUnreadableDatabaseRecovery = false
+    @State private var unreadableDatabaseRecoveryError: String?
     @State private var uiTestingPanelSchedule = PanelSchedule(
         panelName: "QA Panel A",
         panelType: .smallPanel,
@@ -151,6 +154,76 @@ struct WiredPartIOSApp: App {
         Color(hex: appCore.theme.primaryColor) ?? .accentColor
     }
 
+    private var unreadableDatabaseRecoveryView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "lock.trianglebadge.exclamationmark")
+                .font(.largeTitle)
+                .foregroundStyle(.orange)
+            Text("Database Needs Recovery")
+                .font(.headline)
+            Text("This device still has data, but it no longer has the encryption key needed to unlock it. The database has not been deleted or overwritten.")
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+            Text("To continue, keep this device near a trusted paired peer. The recovery action archives this unreadable database, then takes you to Join a Business so you can re-pair and download the company database again.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+            if let unreadableDatabaseRecoveryError {
+                Text(unreadableDatabaseRecoveryError)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+            Button {
+                showUnreadableDatabaseRecoveryConfirmation = true
+            } label: {
+                if isPreparingUnreadableDatabaseRecovery {
+                    ProgressView()
+                } else {
+                    Label("Archive and Re-pair", systemImage: "arrow.triangle.2.circlepath")
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isPreparingUnreadableDatabaseRecovery)
+            .accessibilityIdentifier("startup-unreadable-database-recovery-button")
+            .accessibilityHint("Archives the unreadable encrypted database before opening the re-pairing flow.")
+            Button("Report this startup problem") {
+                showLaunchErrorReport = true
+            }
+            .buttonStyle(.bordered)
+        }
+        .confirmationDialog(
+            "Archive the unreadable database?",
+            isPresented: $showUnreadableDatabaseRecoveryConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Archive and Continue to Re-pair", role: .destructive) {
+                Task {
+                    isPreparingUnreadableDatabaseRecovery = true
+                    unreadableDatabaseRecoveryError = await appCore.archiveUnreadableDatabaseAndPrepareToRepair()
+                    isPreparingUnreadableDatabaseRecovery = false
+                }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("This copies the unreadable database and its recovery files into local backups before clearing only the active copy. It cannot recover the missing key. Continue only when a trusted peer can provide a fresh download.")
+        }
+        .sheet(isPresented: $showLaunchErrorReport) {
+            NavigationStack {
+                ReportABugPage(originModule: "Unreadable encrypted database")
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Close") { showLaunchErrorReport = false }
+                        }
+                    }
+            }
+            .presentationDetents([.large])
+        }
+    }
+
     var body: some Scene {
         WindowGroup {
             Group {
@@ -237,6 +310,8 @@ struct WiredPartIOSApp: App {
                             .environmentObject(tabPrefs)
                             .environmentObject(appCore.badgeCountManager)
                     }
+                } else if appCore.requiresUnreadableDatabaseRecovery {
+                    unreadableDatabaseRecoveryView
                 } else if let error = appCore.loadError {
                     VStack(spacing: 16) {
                         Image(systemName: "exclamationmark.triangle.fill")

--- a/core/Sources/WiredPartCore/Database/AppDatabase+Cipher.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Cipher.swift
@@ -293,6 +293,71 @@ extension AppDatabase {
         return database
     }
 
+    /// Returns whether an encrypted-database open failed because the supplied
+    /// SQLCipher key cannot unlock the existing file.
+    ///
+    /// This is deliberately narrow: callers must not turn arbitrary startup
+    /// failures into a destructive recovery flow. SQLite reports this condition
+    /// as `SQLITE_NOTADB` (26), commonly while SQLCipher reads the first page.
+    public static func isCipherKeyMismatchError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        guard nsError.code == 26 else { return false }
+
+        let description = error.localizedDescription.lowercased()
+        return description.contains("file is not a database")
+            || description.contains("not a database")
+            || description.contains("decrypt")
+    }
+
+    /// Makes a complete, durable copy of an unreadable SQLCipher database bundle
+    /// before removing its canonical files so a user can explicitly re-pair and
+    /// download a replacement database.
+    ///
+    /// The archive is intentionally never pruned by automatic migration cleanup.
+    /// Every base/WAL/SHM file is copied before the original is touched. This method
+    /// is only for an explicit user-confirmed recovery action; normal startup must
+    /// never call it.
+    ///
+    /// - Returns: The archived database base-file path.
+    public static func archiveUnreadableCipherDatabase(atPath path: String) throws -> String {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: path) else {
+            throw CipherRecoveryError.databaseMissing
+        }
+
+        let directory = (path as NSString).deletingLastPathComponent
+        let backupsDirectory = directory + "/Backups"
+        try fileManager.createDirectory(atPath: backupsDirectory, withIntermediateDirectories: true)
+
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+        let archivePath = backupsDirectory + "/unreadable-cipher-\(timestamp)-\(UUID().uuidString.prefix(8)).sqlite"
+        let suffixes = ["", "-wal", "-shm"]
+
+        do {
+            for suffix in suffixes where fileManager.fileExists(atPath: path + suffix) {
+                try fileManager.copyItem(atPath: path + suffix, toPath: archivePath + suffix)
+            }
+        } catch {
+            for suffix in suffixes {
+                try? fileManager.removeItem(atPath: archivePath + suffix)
+            }
+            throw error
+        }
+
+        do {
+            for suffix in suffixes where fileManager.fileExists(atPath: path + suffix) {
+                try fileManager.removeItem(atPath: path + suffix)
+            }
+        } catch {
+            // The complete archive remains available even if clearing the canonical
+            // bundle is interrupted. Do not retry bootstrap in that state.
+            throw error
+        }
+
+        return archivePath
+    }
+
     static func replacePlaintextDatabaseWithEncryptedTemp(
         atPath path: String,
         tempPath: String,
@@ -430,6 +495,19 @@ extension AppDatabase {
 }
 
 // MARK: - CipherMigrationError
+
+public enum CipherRecoveryError: Error, Sendable {
+    case databaseMissing
+}
+
+extension CipherRecoveryError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .databaseMissing:
+            return "The unreadable database file is no longer present."
+        }
+    }
+}
 
 public enum CipherMigrationError: Error, Sendable {
     case exportFailed(Error)

--- a/core/Tests/WiredPartCoreTests/AppDatabaseCipherTests.swift
+++ b/core/Tests/WiredPartCoreTests/AppDatabaseCipherTests.swift
@@ -350,6 +350,64 @@ struct AppDatabaseCipherTests {
         #expect(value == "still_here", "Data must be intact after idempotent second migration call")
     }
 
+    @Test("wrong SQLCipher key is classified and leaves the encrypted database readable with its original key")
+    func wrongKeyDoesNotDestroyExistingEncryptedDatabase() throws {
+        let path = tmpPath("wrong-key")
+        defer { cleanup(path) }
+
+        let originalKey = String(repeating: "a1", count: 32)
+        let wrongKey = String(repeating: "b2", count: 32)
+        let database = try AppDatabase.openEncryptedDatabase(atPath: path, keyHex: originalKey)
+        try database.writer.write { db in
+            try db.execute(sql: """
+                INSERT OR REPLACE INTO settings (key, value, category)
+                VALUES ('wrong_key_sentinel', 'must_survive', 'test')
+            """)
+        }
+        try (database.writer as? DatabasePool)?.close()
+        let bytesBeforeWrongKeyOpen = try Data(contentsOf: URL(fileURLWithPath: path))
+
+        do {
+            _ = try AppDatabase.openEncryptedDatabaseAfterReleaseMigration(atPath: path, keyHex: wrongKey)
+            Issue.record("Opening an existing encrypted database with a wrong key must fail")
+        } catch {
+            #expect(AppDatabase.isCipherKeyMismatchError(error))
+        }
+
+        #expect(
+            try Data(contentsOf: URL(fileURLWithPath: path)) == bytesBeforeWrongKeyOpen,
+            "A wrong-key open must not overwrite or delete the existing encrypted database."
+        )
+        let reopened = try AppDatabase.openEncryptedDatabase(atPath: path, keyHex: originalKey)
+        let sentinel: String? = try reopened.writer.read { db in
+            try String.fetchOne(db, sql: "SELECT value FROM settings WHERE key = 'wrong_key_sentinel'")
+        }
+        #expect(sentinel == "must_survive")
+    }
+
+    @Test("explicit unreadable-database archive preserves the complete bundle before recovery clears the canonical path")
+    func archiveUnreadableCipherDatabasePreservesDatabaseBundle() throws {
+        let path = tmpPath("archive-unreadable")
+        defer { cleanup(path) }
+        let fileManager = FileManager.default
+        let baseBytes = Data("encrypted database bytes".utf8)
+        let walBytes = Data("encrypted WAL bytes".utf8)
+        let shmBytes = Data("encrypted SHM bytes".utf8)
+        try baseBytes.write(to: URL(fileURLWithPath: path))
+        try walBytes.write(to: URL(fileURLWithPath: path + "-wal"))
+        try shmBytes.write(to: URL(fileURLWithPath: path + "-shm"))
+
+        let archivePath = try AppDatabase.archiveUnreadableCipherDatabase(atPath: path)
+
+        #expect(try Data(contentsOf: URL(fileURLWithPath: archivePath)) == baseBytes)
+        #expect(try Data(contentsOf: URL(fileURLWithPath: archivePath + "-wal")) == walBytes)
+        #expect(try Data(contentsOf: URL(fileURLWithPath: archivePath + "-shm")) == shmBytes)
+        for suffix in ["", "-wal", "-shm"] {
+            #expect(!fileManager.fileExists(atPath: path + suffix), "The recovery action must clear only the canonical bundle after archiving: \(suffix)")
+            try? fileManager.removeItem(atPath: archivePath + suffix)
+        }
+    }
+
     @Test("testFailureMidImportLeavesOriginalDBIntact — original plaintext DB preserved on error")
     func testFailureMidImportLeavesOriginalDBIntact() throws {
         // Simulate a migration failure by making the parent directory read-only so the


### PR DESCRIPTION
## Summary
- detect wrong-key SQLCipher opens as a dedicated recovery-required startup state
- require explicit confirmation before copying the complete DB/WAL/SHM bundle into Backups and clearing only the active copy
- resume the established Join a Business pairing/full-download flow after archiving

## Tests
- `swift test --filter AppDatabaseCipherTests`
- `xcodebuild -project "Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "generic/platform=iOS Simulator" build CODE_SIGNING_ALLOWED=NO`

Closes #1663
Tracked in WEI-6915