### PR TITLE
fix(sync): unify AppCore keychain fallback predicate

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/AppCore.swift
@@ -825,7 +825,7 @@ final class AppCore: ObservableObject {
     }
 
     nonisolated static func shouldUseLocalBootstrapKeyFallback(for status: OSStatus) -> Bool {
-        status == errSecMissingEntitlement || status == errSecNotAvailable
+        KeychainAvailability.isUnusable(status)
     }
 
     nonisolated static func localFallbackBootstrapKeyURL(in directory: URL? = nil) throws -> URL {

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -516,11 +516,26 @@ struct Weird_Parts_IOSTests {
         #expect(keyHex.count == 64)
     }
 
-    @Test func bootstrapFallbackUsesOnlyApprovedKeychainStatuses() {
-        #expect(AppCore.shouldUseLocalBootstrapKeyFallback(for: errSecMissingEntitlement))
-        #expect(AppCore.shouldUseLocalBootstrapKeyFallback(for: errSecNotAvailable))
-        #expect(!AppCore.shouldUseLocalBootstrapKeyFallback(for: errSecInteractionNotAllowed))
-        #expect(!AppCore.shouldUseLocalBootstrapKeyFallback(for: errSecAuthFailed))
+    @Test func bootstrapFallbackDelegatesToSharedKeychainAvailabilityPredicate() {
+        // This intentionally includes statuses outside the old two-value allowlist.
+        // It must fail if this consumer narrows the shared denylist again.
+        for status in [
+            errSecSuccess,
+            errSecItemNotFound,
+            errSecInteractionNotAllowed,
+            errSecAuthFailed,
+            errSecUserCanceled,
+            errSecMissingEntitlement,
+            errSecNotAvailable,
+            errSecParam,
+            OSStatus(-77777)
+        ] {
+            #expect(
+                AppCore.shouldUseLocalBootstrapKeyFallback(for: status)
+                    == KeychainAvailability.isUnusable(status),
+                "AppCore diverged from KeychainAvailability on \(status)"
+            )
+        }
     }
 
     @Test func bootstrapFallbackPersistsForApprovedReadFailureAndCleansUp() throws {


### PR DESCRIPTION
## Summary
- delegate `AppCore.deviceBootstrapKeyHex` fallback eligibility to `KeychainAvailability.isUnusable`
- add a regression test covering the shared denylist and unknown statuses so the old two-value allowlist cannot return

## Tests
- `swift test --filter KeychainAvailabilityTests`
- `xcodebuild -project "Weird Parts.xcodeproj" -scheme "Weird Parts" -destination "platform=iOS Simulator,id=92D732B3-48CE-4B52-9769-10225134FBE8" test -only-testing:"Weird Parts IOSTests"` (229 passed; one failure outside this diff: `bootstrapFallbackRejectsLockedDuplicateRereadBeforeKeychainMutation`)

Closes #1655
Tracked in WEI-6914