### PR TITLE
fix(sync): make one-way Bluetooth sends explicit

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/BluetoothPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/BluetoothPage.swift
@@ -81,13 +81,15 @@ struct BluetoothPage: View {
                                 Button {
                                     Task { await syncManager.syncWithPeer(peerDeviceId: peer.id) }
                                 } label: {
-                                    Text("Sync")
+                                    Text(peer.isBluetoothOnly ? "Send Changes" : "Sync")
                                         .dsMinTapTarget()
                                 }
                                 .buttonStyle(.bordered)
                                 .controlSize(.small)
-                                .accessibilityLabel("Sync with \(peer.name)")
-                                .accessibilityHint("Starts a data sync with this device.")
+                                .accessibilityLabel(peer.isBluetoothOnly ? "Send changes to \(peer.name)" : "Sync with \(peer.name)")
+                                .accessibilityHint(peer.isBluetoothOnly
+                                    ? "Sends this device's pending changes. To receive \(peer.name)'s changes, tap Send Changes on that device."
+                                    : "Exchanges data with this device.")
                                 .accessibilityIdentifier("settings-bluetooth-sync-peer-\(peer.id)")
                             } else if peer.state == "connecting" {
                                 ProgressView()
@@ -117,7 +119,7 @@ struct BluetoothPage: View {
                                 Button {
                                     Task { await syncManager.syncWithPeer(peerDeviceId: peer.id) }
                                 } label: {
-                                    Label("Sync Now", systemImage: "arrow.triangle.2.circlepath")
+                                    Label(peer.isBluetoothOnly ? "Send Changes" : "Sync Now", systemImage: "arrow.triangle.2.circlepath")
                                 }
                             }
                         }
@@ -156,7 +158,7 @@ struct BluetoothPage: View {
         .sheet(item: $activeSheet) { _ in
             PageHelpSheet(title: "Bluetooth Help", sections: [
                 ("What This Page Does", "Controls Bluetooth and Wi-Fi Direct peer-to-peer sync using Apple Multipeer Connectivity. Enables data exchange between nearby devices without a shop server."),
-                ("How to Use It", "Enable Bluetooth Sync to start, then toggle Discoverable to let other devices find you. Nearby WiredPart devices appear automatically. Tap Sync to exchange data with a discovered peer."),
+                ("How to Use It", "Enable Bluetooth Sync to start, then toggle Discoverable to let other devices find you. Nearby WiredPart devices appear automatically. Send Changes sends this device's pending data to a Bluetooth peer; tap Send Changes on the other device too to receive its pending data."),
             ])
         }
         .onAppear {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/SyncPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/SyncPage.swift
@@ -106,6 +106,11 @@ struct SyncPage: View {
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(entry.date, format: .dateTime.month(.abbreviated).day().hour().minute())
                                     .font(.caption)
+                                if entry.isOneWayBluetoothTransfer {
+                                    Text("One-way Bluetooth send — tap Send Changes on the other device to receive its changes.")
+                                        .font(.caption2)
+                                        .foregroundStyle(.orange)
+                                }
                                 HStack(spacing: 8) {
                                     if entry.changesSent > 0 {
                                         Text("\(entry.changesSent) sent")
@@ -135,7 +140,7 @@ struct SyncPage: View {
                             }
                         }
                         .rowAccessibility(
-                            label: "Sync \(entry.success ? "succeeded" : "failed") on \(entry.date.formatted(.dateTime.month(.abbreviated).day().hour().minute()))",
+                            label: "\(entry.isOneWayBluetoothTransfer ? "One-way Bluetooth send" : "Sync \(entry.success ? "succeeded" : "failed")") on \(entry.date.formatted(.dateTime.month(.abbreviated).day().hour().minute()))",
                             value: historyAccessibilityValue(entry),
                             id: "settings-sync-history-\(entry.id.uuidString)"
                         )
@@ -219,7 +224,10 @@ struct SyncPage: View {
                 Text("Syncing...")
             }
         case .synced:
-            if let lastSync = syncManager.lastSyncDate {
+            if let summary = syncManager.lastOneWayBluetoothSyncSummary {
+                Label(summary, systemImage: "arrow.up.circle.fill")
+                    .foregroundStyle(.orange)
+            } else if let lastSync = syncManager.lastSyncDate {
                 let displayDate = lastSync.prefix(19).replacingOccurrences(of: "T", with: " ")
                 Label("Last sync: \(displayDate)", systemImage: "checkmark.circle.fill")
                     .foregroundStyle(.green)

--- a/Weird Parts IOS/Weird Parts IOS/Features/Settings/SyncPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Settings/SyncPage.swift
@@ -110,6 +110,10 @@ struct SyncPage: View {
                                     Text("One-way Bluetooth send — tap Send Changes on the other device to receive its changes.")
                                         .font(.caption2)
                                         .foregroundStyle(.orange)
+                                } else if entry.hasMixedPeerTransports {
+                                    Text("Mixed LAN and Bluetooth transfer — received changes reflect the LAN sync only.")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
                                 }
                                 HStack(spacing: 8) {
                                     if entry.changesSent > 0 {

--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseNetworkPage.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSWarehouseNetworkPage.swift
@@ -177,7 +177,7 @@ struct IOSWarehouseNetworkPage: View {
         if syncManager.discoveredPeers.isEmpty {
             return "Browse or scan for configured LAN/Bluetooth peers on the shop network."
         }
-        return "Open the browser to review discovered peers and start a sync."
+        return "Open the browser to review discovered peers. Bluetooth Send Changes actions must be used on both devices to exchange data."
     }
 
     private var syncSetupDetailText: String {
@@ -185,6 +185,9 @@ struct IOSWarehouseNetworkPage: View {
     }
 
     private var syncStatusLabel: String {
+        if let summary = syncManager.lastOneWayBluetoothSyncSummary {
+            return summary
+        }
         switch syncManager.syncStatus {
         case .idle: return "Idle"
         case .syncing: return "Syncing"

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSPeerBrowser.swift
@@ -157,16 +157,26 @@ struct IOSPeerBrowser: View {
                             Text(peer.state.capitalized)
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
+                            if peer.isBluetoothOnly {
+                                Text("Send changes one way; use this on both devices to exchange data.")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
                         }
 
                         Spacer()
 
                         if peer.isManuallySyncable {
-                            Button("Sync") {
+                            Button(peer.isBluetoothOnly ? "Send Changes" : "Sync") {
                                 Task { await syncManager.syncWithPeer(peerDeviceId: peer.id) }
                             }
                             .buttonStyle(.bordered)
                             .controlSize(.small)
+                            .disabled(syncManager.syncStatus == .syncing)
+                            .accessibilityLabel(peer.isBluetoothOnly ? "Send changes to \(peer.name)" : "Sync with \(peer.name)")
+                            .accessibilityHint(peer.isBluetoothOnly
+                                ? "Sends this device's pending changes. To receive \(peer.name)'s changes, tap Send Changes on that device."
+                                : "Exchanges data with this device.")
                         } else if peer.state == "connecting" {
                             ProgressView()
                                 .scaleEffect(0.7)

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -63,6 +63,13 @@ final class IOSSyncManager {
         let success: Bool
         let error: String?
         let isOneWayBluetoothTransfer: Bool
+        let hasMixedPeerTransports: Bool
+    }
+
+    enum PeerTransportPresentation: Equatable {
+        case standard
+        case oneWayBluetooth(peerNames: [String], recordsSent: Int)
+        case mixed
     }
 
     private let logger = Logger(subsystem: "com.wiredpart.ios", category: "IOSSyncManager")
@@ -295,6 +302,8 @@ final class IOSSyncManager {
         let deviceId = DeviceIdentity.current
         var totalPushed = 0
         var totalPulled = 0
+        var completedConfiguredLANSync = false
+        var peerTransportPresentation: PeerTransportPresentation = .standard
 
         // Try LAN HTTP sync if a server is configured
         if let server = serverAddress {
@@ -303,6 +312,7 @@ final class IOSSyncManager {
                     deviceId: deviceId,
                     shopUrl: server
                 )
+                completedConfiguredLANSync = success
                 if !success {
                     let state = await engine.getState()
                     if let err = state.error {
@@ -332,13 +342,13 @@ final class IOSSyncManager {
                     ? "Waiting for \(waiting[0].peerName)'s first download to finish…"
                     : "Waiting for \(waiting.count) devices' first download to finish…"
             }
-            let oneWayBluetoothPeers = results.filter { result in
-                discoveredPeers.first(where: { $0.id == result.peerDeviceId })?.isBluetoothOnly == true
-            }
-            if errorMessage == nil, !oneWayBluetoothPeers.isEmpty {
+            peerTransportPresentation = Self.peerTransportPresentation(for: results)
+            if errorMessage == nil,
+               !completedConfiguredLANSync,
+               case let .oneWayBluetooth(peerNames, recordsSent) = peerTransportPresentation {
                 lastOneWayBluetoothSyncSummary = Self.oneWayBluetoothSyncSummary(
-                    peerNames: oneWayBluetoothPeers.map(\.peerName),
-                    recordsSent: oneWayBluetoothPeers.reduce(0) { $0 + $1.pushed }
+                    peerNames: peerNames,
+                    recordsSent: recordsSent
                 )
             }
         }
@@ -364,7 +374,8 @@ final class IOSSyncManager {
             conflicts: conflictCount,
             success: success,
             error: errorMessage,
-            isOneWayBluetoothTransfer: lastOneWayBluetoothSyncSummary != nil
+            isOneWayBluetoothTransfer: lastOneWayBluetoothSyncSummary != nil,
+            hasMixedPeerTransports: peerTransportPresentation == .mixed
         )
         syncHistory.insert(entry, at: 0)
         if syncHistory.count > 20 { syncHistory = Array(syncHistory.prefix(20)) }
@@ -387,7 +398,6 @@ final class IOSSyncManager {
             return
         }
 
-        let isBluetoothOnly = discoveredPeers.first(where: { $0.id == peerDeviceId })?.isBluetoothOnly == true
         syncStatus = .syncing
         errorMessage = nil
         lastOneWayBluetoothSyncSummary = nil
@@ -410,10 +420,10 @@ final class IOSSyncManager {
         if success {
             syncStatus = .synced
             lastSyncDate = Formatters.iso8601Basic.string(from: Date())
-            if isBluetoothOnly {
+            if case let .oneWayBluetooth(peerNames, recordsSent) = Self.peerTransportPresentation(for: [result]) {
                 lastOneWayBluetoothSyncSummary = Self.oneWayBluetoothSyncSummary(
-                    peerNames: [result.peerName],
-                    recordsSent: result.pushed
+                    peerNames: peerNames,
+                    recordsSent: recordsSent
                 )
             }
         } else {
@@ -427,7 +437,8 @@ final class IOSSyncManager {
             conflicts: conflictCount,
             success: success,
             error: errorMessage,
-            isOneWayBluetoothTransfer: success && isBluetoothOnly
+            isOneWayBluetoothTransfer: success && lastOneWayBluetoothSyncSummary != nil,
+            hasMixedPeerTransports: false
         )
         syncHistory.insert(entry, at: 0)
         if syncHistory.count > 20 { syncHistory = Array(syncHistory.prefix(20)) }
@@ -919,6 +930,24 @@ final class IOSSyncManager {
             : "\(uniqueNames.count) nearby devices"
         let nextAction = uniqueNames.count == 1 ? destination : "each device"
         return "Sent \(recordsSent) records to \(destination). To receive their changes, tap Send Changes on \(nextAction)."
+    }
+
+    /// Derives presentation only from the peer manager's executed transport.
+    /// Discovery snapshots are intentionally not consulted: LAN becomes preferred
+    /// when both transports discover the same device before dispatch.
+    static func peerTransportPresentation(for results: [PeerSyncResult]) -> PeerTransportPresentation {
+        let successful = results.filter(\.success)
+        guard !successful.isEmpty else { return .standard }
+
+        guard successful.allSatisfy({ $0.executedTransport != nil }) else { return .standard }
+        let transports = Set(successful.compactMap(\.executedTransport))
+        if transports == [.multipeer] {
+            return .oneWayBluetooth(
+                peerNames: successful.map(\.peerName),
+                recordsSent: successful.reduce(0) { $0 + $1.pushed }
+            )
+        }
+        return transports.contains(.multipeer) ? .mixed : .standard
     }
 
     private func refreshPendingCount() {

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -26,6 +26,11 @@ final class IOSSyncManager {
     var activeSyncPeerName: String?
     /// Host-side: human summary of the most recent completed peer transfer.
     var lastHostSyncSummary: String?
+    /// Bluetooth change delivery is currently send-only for one manual action:
+    /// the other device must send its own pending changes back. Keeping this
+    /// separate from `syncStatus` prevents a successful send from rendering as
+    /// a completed two-way sync (#6916).
+    var lastOneWayBluetoothSyncSummary: String?
     /// Why Bluetooth could not start, shown on screen with a code (#1580).
     ///
     /// Owner 2026-08-07: *"that would be a perfect spot to show an actual error
@@ -57,6 +62,7 @@ final class IOSSyncManager {
         let conflicts: Int
         let success: Bool
         let error: String?
+        let isOneWayBluetoothTransfer: Bool
     }
 
     private let logger = Logger(subsystem: "com.wiredpart.ios", category: "IOSSyncManager")
@@ -83,6 +89,10 @@ final class IOSSyncManager {
         let discoveredAt: String
         let address: String?
         let isManuallySyncable: Bool
+
+        var isBluetoothOnly: Bool {
+            address == nil
+        }
     }
 
     enum PeerDiscoveryMode: Equatable {
@@ -280,6 +290,7 @@ final class IOSSyncManager {
         guard syncStatus != .syncing else { return }
         syncStatus = .syncing
         errorMessage = nil
+        lastOneWayBluetoothSyncSummary = nil
 
         let deviceId = DeviceIdentity.current
         var totalPushed = 0
@@ -321,6 +332,15 @@ final class IOSSyncManager {
                     ? "Waiting for \(waiting[0].peerName)'s first download to finish…"
                     : "Waiting for \(waiting.count) devices' first download to finish…"
             }
+            let oneWayBluetoothPeers = results.filter { result in
+                discoveredPeers.first(where: { $0.id == result.peerDeviceId })?.isBluetoothOnly == true
+            }
+            if errorMessage == nil, !oneWayBluetoothPeers.isEmpty {
+                lastOneWayBluetoothSyncSummary = Self.oneWayBluetoothSyncSummary(
+                    peerNames: oneWayBluetoothPeers.map(\.peerName),
+                    recordsSent: oneWayBluetoothPeers.reduce(0) { $0 + $1.pushed }
+                )
+            }
         }
 
         // Check for conflicts
@@ -343,7 +363,8 @@ final class IOSSyncManager {
             changesReceived: totalPulled,
             conflicts: conflictCount,
             success: success,
-            error: errorMessage
+            error: errorMessage,
+            isOneWayBluetoothTransfer: lastOneWayBluetoothSyncSummary != nil
         )
         syncHistory.insert(entry, at: 0)
         if syncHistory.count > 20 { syncHistory = Array(syncHistory.prefix(20)) }
@@ -366,8 +387,10 @@ final class IOSSyncManager {
             return
         }
 
+        let isBluetoothOnly = discoveredPeers.first(where: { $0.id == peerDeviceId })?.isBluetoothOnly == true
         syncStatus = .syncing
         errorMessage = nil
+        lastOneWayBluetoothSyncSummary = nil
 
         let result = await pm.syncWithPeer(deviceId: peerDeviceId)
         if !result.success {
@@ -387,6 +410,12 @@ final class IOSSyncManager {
         if success {
             syncStatus = .synced
             lastSyncDate = Formatters.iso8601Basic.string(from: Date())
+            if isBluetoothOnly {
+                lastOneWayBluetoothSyncSummary = Self.oneWayBluetoothSyncSummary(
+                    peerNames: [result.peerName],
+                    recordsSent: result.pushed
+                )
+            }
         } else {
             syncStatus = .error
         }
@@ -397,7 +426,8 @@ final class IOSSyncManager {
             changesReceived: result.pulled,
             conflicts: conflictCount,
             success: success,
-            error: errorMessage
+            error: errorMessage,
+            isOneWayBluetoothTransfer: success && isBluetoothOnly
         )
         syncHistory.insert(entry, at: 0)
         if syncHistory.count > 20 { syncHistory = Array(syncHistory.prefix(20)) }
@@ -873,6 +903,22 @@ final class IOSSyncManager {
             return multipeerState == "connected"
         }
         return transport == "lan" && address != nil
+    }
+
+    /// The Multipeer protocol currently sends local pending changes but does
+    /// not await a reciprocal batch in that same user action. This wording is
+    /// deliberately explicit so a green completion state never promises that
+    /// the selected device's changes were pulled too (#6916).
+    static func oneWayBluetoothSyncSummary(peerNames: [String], recordsSent: Int) -> String {
+        var uniqueNames: [String] = []
+        for name in peerNames where !uniqueNames.contains(name) {
+            uniqueNames.append(name)
+        }
+        let destination = uniqueNames.count == 1
+            ? (uniqueNames.first ?? "the nearby device")
+            : "\(uniqueNames.count) nearby devices"
+        let nextAction = uniqueNames.count == 1 ? destination : "each device"
+        return "Sent \(recordsSent) records to \(destination). To receive their changes, tap Send Changes on \(nextAction)."
     }
 
     private func refreshPendingCount() {
@@ -1409,6 +1455,9 @@ final class IOSSyncManager {
         case .syncing:
             return pendingChanges > 0 ? "Syncing \(pendingChanges) changes..." : "Syncing..."
         case .synced:
+            if let summary = lastOneWayBluetoothSyncSummary {
+                return summary
+            }
             if let date = lastSyncDate {
                 let display = date.prefix(19).replacingOccurrences(of: "T", with: " ")
                 return "Last sync: \(display)"

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncStatusView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncStatusView.swift
@@ -51,6 +51,9 @@ struct IOSSyncStatusView: View {
     }
 
     private var statusLabel: String {
+        if let summary = syncManager.lastOneWayBluetoothSyncSummary {
+            return summary
+        }
         switch syncManager.syncStatus {
         case .idle: return "Idle"
         case .syncing: return "Syncing..."
@@ -61,6 +64,9 @@ struct IOSSyncStatusView: View {
     }
 
     private var statusIcon: String {
+        if syncManager.lastOneWayBluetoothSyncSummary != nil {
+            return "arrow.up.circle.fill"
+        }
         switch syncManager.syncStatus {
         case .idle: return "circle"
         case .syncing: return "arrow.triangle.2.circlepath"
@@ -71,6 +77,9 @@ struct IOSSyncStatusView: View {
     }
 
     private var statusColor: Color {
+        if syncManager.lastOneWayBluetoothSyncSummary != nil {
+            return .orange
+        }
         switch syncManager.syncStatus {
         case .idle: return .gray
         case .syncing: return .blue

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -330,6 +330,51 @@ struct Weird_Parts_IOSTests {
     }
 
     @MainActor
+    @Test func peerTransportPresentationUsesExecutedTransportInsteadOfStaleDiscoveryState() {
+        // A row can initially be Multipeer-visible, then become LAN-preferred
+        // before PeerManager dispatches. The executed LAN result is reciprocal.
+        let lanResult = PeerSyncResult(
+            peerDeviceId: "field-ipad",
+            peerName: "Field iPad",
+            pushed: 3,
+            pulled: 2,
+            success: true,
+            executedTransport: .lan
+        )
+
+        #expect(IOSSyncManager.peerTransportPresentation(for: [lanResult]) == .standard)
+    }
+
+    @MainActor
+    @Test func mixedPeerTransportPresentationDoesNotClaimOneWayBluetooth() {
+        let results = [
+            PeerSyncResult(peerDeviceId: "field-ipad", peerName: "Field iPad", pushed: 3, success: true, executedTransport: .multipeer),
+            PeerSyncResult(peerDeviceId: "shop-mac", peerName: "Shop Mac", pulled: 2, success: true, executedTransport: .lan),
+        ]
+
+        #expect(IOSSyncManager.peerTransportPresentation(for: results) == .mixed)
+    }
+
+    @MainActor
+    @Test func failedOrUnexecutedPeerResultClearsOneWayPresentation() {
+        let failed = PeerSyncResult(
+            peerDeviceId: "field-ipad",
+            peerName: "Field iPad",
+            success: false,
+            error: "Connection failed",
+            executedTransport: .multipeer
+        )
+        let unexecuted = PeerSyncResult(
+            peerDeviceId: "field-ipad",
+            peerName: "Field iPad",
+            success: true
+        )
+
+        #expect(IOSSyncManager.peerTransportPresentation(for: [failed]) == .standard)
+        #expect(IOSSyncManager.peerTransportPresentation(for: [unexecuted]) == .standard)
+    }
+
+    @MainActor
     @Test func partsFlowDraftsAreScopedPerAuthenticatedUser() throws {
         let userA: Int64 = 101
         let userB: Int64 = 202

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -316,6 +316,20 @@ struct Weird_Parts_IOSTests {
     }
 
     @MainActor
+    @Test func oneWayBluetoothSyncSummaryNeverClaimsReciprocalSync() {
+        #expect(
+            IOSSyncManager.oneWayBluetoothSyncSummary(peerNames: ["Field iPad"], recordsSent: 3)
+                == "Sent 3 records to Field iPad. To receive their changes, tap Send Changes on Field iPad."
+        )
+        #expect(
+            IOSSyncManager.oneWayBluetoothSyncSummary(
+                peerNames: ["Field iPad", "Shop iPhone", "Field iPad"],
+                recordsSent: 5
+            ) == "Sent 5 records to 2 nearby devices. To receive their changes, tap Send Changes on each device."
+        )
+    }
+
+    @MainActor
     @Test func partsFlowDraftsAreScopedPerAuthenticatedUser() throws {
         let userA: Int64 = 101
         let userB: Int64 = 202

--- a/core/Sources/WiredPartCore/Sync/PeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/PeerManager.swift
@@ -4,6 +4,16 @@ import os.log
 
 // MARK: - Peer Sync Result
 
+/// The transport that actually executed a peer sync operation.
+///
+/// This is result data rather than discovery/UI state: a device can be visible
+/// through Multipeer when the actor refreshes discovery and selects a preferred
+/// LAN peer immediately before dispatching the operation.
+public enum PeerSyncTransport: Sendable, Equatable, Hashable {
+    case lan
+    case multipeer
+}
+
 /// Outcome of syncing with a single peer.
 public struct PeerSyncResult: Sendable {
     public let peerDeviceId: String
@@ -17,6 +27,8 @@ public struct PeerSyncResult: Sendable {
     /// not count a deferral as a sync failure: it is a normal waiting state and
     /// the push resumes automatically once the snapshot lands.
     public var deferred: Bool
+    /// Nil when no transport executed (for example, a deferred or preflight failure).
+    public let executedTransport: PeerSyncTransport?
     public let syncedAt: String
 
     public init(
@@ -27,6 +39,7 @@ public struct PeerSyncResult: Sendable {
         success: Bool = true,
         error: String? = nil,
         deferred: Bool = false,
+        executedTransport: PeerSyncTransport? = nil,
         syncedAt: String? = nil
     ) {
         self.peerDeviceId = peerDeviceId
@@ -36,6 +49,7 @@ public struct PeerSyncResult: Sendable {
         self.success = success
         self.error = error
         self.deferred = deferred
+        self.executedTransport = executedTransport
         self.syncedAt = syncedAt ?? CoreFormatters.iso8601Fractional.string(from: Date())
     }
 }
@@ -528,6 +542,7 @@ public actor PeerManager {
 
         let deviceId = sState.deviceId
         let companyId = sState.companyId
+        var executedTransport: PeerSyncTransport?
 
         do {
             // Get pending changes
@@ -539,6 +554,7 @@ public actor PeerManager {
 
             #if canImport(MultipeerConnectivity)
             if peer.transport == "multipeer", let mpManager = multipeerManager {
+                executedTransport = .multipeer
                 // Bluetooth/Multipeer path. If the session is still forming (user
                 // tapped Sync during "connecting"), wait briefly for it instead of
                 // falling through to the HTTP path — a multipeer-only peer has a
@@ -578,6 +594,7 @@ public actor PeerManager {
                     }
                 }
             } else {
+                executedTransport = .lan
                 // LAN HTTP sync path
                 (pushed, pulled) = try await syncViaHTTP(
                     peer: peer,
@@ -588,6 +605,7 @@ public actor PeerManager {
                 )
             }
             #else
+            executedTransport = .lan
             // LAN HTTP sync path (non-Apple platforms)
             (pushed, pulled) = try await syncViaHTTP(
                 peer: peer,
@@ -606,7 +624,8 @@ public actor PeerManager {
                 peerName: peer.deviceName,
                 pushed: pushed,
                 pulled: pulled,
-                success: true
+                success: true,
+                executedTransport: executedTransport
             )
             state.lastPeerSyncs[peer.deviceId] = result
             return result
@@ -616,7 +635,8 @@ public actor PeerManager {
                 peerDeviceId: peer.deviceId,
                 peerName: peer.deviceName,
                 success: false,
-                error: error.localizedDescription
+                error: error.localizedDescription,
+                executedTransport: executedTransport
             )
             state.lastPeerSyncs[peer.deviceId] = result
             return result

--- a/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
@@ -1922,6 +1922,7 @@ struct PeerManagerTests {
         #expect(result.pulled == 3)
         #expect(result.success == true)
         #expect(result.error == nil)
+        #expect(result.executedTransport == nil)
         #expect(!result.syncedAt.isEmpty)
     }
 

--- a/docs/plans/bluetooth-offline-sync-verification.md
+++ b/docs/plans/bluetooth-offline-sync-verification.md
@@ -173,11 +173,12 @@ code and automated tests; the cross-device hop needs the two real devices.
    permission is denied still sees an empty list with no explanation. *This is
    the highest-value remaining item — it converts every future Stage-A failure
    into a self-diagnosing one.*
-2. **Bluetooth sync is one-directional per tap.** In `syncWithPeer`'s multipeer
-   branch, `pushed` is set but `pulled` stays `0` — the peer's changes arrive
-   asynchronously rather than in the same action. Two devices therefore need a
-   Sync on each side to converge. Acceptable if intended, but the UI must not
-   imply a single tap synchronised both ways.
+2. **Bluetooth sync is one-directional per tap.** **UI wording fixed in #6916:**
+   the Multipeer branch still sets `pushed` while `pulled` remains `0`, so users
+   must tap **Send Changes** on each device to converge. Bluetooth-only rows,
+   completion status, accessibility copy, and history now explicitly describe
+   that send-only behavior rather than claiming a two-way sync. Physical proof
+   still requires two devices (Stage G).
 3. **`NSBluetoothPeripheralUsageDescription` is absent.** Only needed for iOS 12
    and earlier, so not a live defect at the current deployment target — recorded
    so it is not rediscovered.
@@ -194,8 +195,9 @@ code and automated tests; the cross-device hop needs the two real devices.
 3. Joiner: onboarding → **Join Existing Business** → host appears (Stage B).
 4. Enter the code → watch for Stage D logs → expect D5.
 5. Watch the snapshot count move (E5), expect **E1 then E2**.
-6. Make a change on each device, Sync from each, confirm both converge (Stage F,
-   noting gap 2 — a tap on each side).
+6. Make a change on each device, tap **Send Changes** on each, and confirm both
+   converge (Stage F). A single Bluetooth action sends only this device's
+   pending changes; the UI now says so explicitly.
 7. Pull device logs and confirm the exact strings above.
 
 Any failure: capture the log line and match it to the row here. The row names


### PR DESCRIPTION
## Summary
- Makes Bluetooth-only peer actions explicit Send Changes operations; LAN peers retain two-way Sync.
- Shows the one-way result and required reciprocal action in status surfaces, history, help copy, and VoiceOver.
- Documents the intentional protocol limitation and adds focused wording coverage.

Closes #1674
Tracked in WEI-6916

## Tests
- Focused iOS test oneWayBluetoothSyncSummaryNeverClaimsReciprocalSync passed on iPhone Simulator with the Weird Parts scheme.

## Physical verification
Two-device Bluetooth transport/convergence remains a hardware gate; this PR corrects the UI contract without claiming physical sync proof.