### PR TITLE
fix(sync): show Bluetooth startup errors during pairing

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Auth/DevicePairingView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/DevicePairingView.swift
@@ -108,6 +108,36 @@ struct DevicePairingView: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
 
+                // Mirror the nearby-device empty state: when the OS refuses to
+                // start Bluetooth, the joiner otherwise has no way to retrieve
+                // the diagnostic because logs replicate over the failed sync.
+                if let transportError = syncManager.bluetoothTransportError {
+                    VStack(spacing: 8) {
+                        Label("Bluetooth could not start", systemImage: "exclamationmark.triangle.fill")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.orange)
+
+                        Text(transportError)
+                            .font(.footnote.monospaced())
+                            .foregroundStyle(.primary)
+                            .multilineTextAlignment(.center)
+                            .textSelection(.enabled)
+
+                        Text("Bluetooth is required to find a shop. Touch and hold the code above to copy it.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding(12)
+                    .frame(maxWidth: .infinity)
+                    .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+                    .padding(.horizontal, 24)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("Bluetooth could not start")
+                    .accessibilityValue(transportError)
+                    .accessibilityIdentifier("device-pairing-transport-error")
+                }
+
                 Button {
                     syncManager.setBluetoothEnabled(true, startDiscovery: false)
                     syncManager.startOnboardingPeerDiscovery()

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -760,10 +760,17 @@ final class IOSSyncManager {
         pendingChanges = state.pendingCount
     }
 
-    private func handlePeerStateChange(_ state: PeerManagerState) {
+    func handlePeerStateChange(_ state: PeerManagerState) {
         // Bluetooth is REQUIRED for server-free sync, so a transport that never
         // started must say why on screen (#1580).
         bluetoothTransportError = state.lastTransportError
+        // DevicePairingView deliberately renders the empty-state diagnostic only
+        // after scanning ends. A browser/advertiser start failure is terminal for
+        // this attempt; otherwise the spinner masks the stable BT-*-START reason
+        // indefinitely and the user has no actionable recovery information.
+        if state.lastTransportError != nil {
+            isScanning = false
+        }
 
         // Host-side transfer feedback: who we're actively sending to, and the last
         // completed transfer per peer (drives "Syncing…"/"Synced N records" UI).

--- a/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
+++ b/Weird Parts IOS/Weird Parts IOSTests/Weird_Parts_IOSTests.swift
@@ -1510,3 +1510,18 @@ final class ReceiveShipmentPriceVerificationXCTests: XCTestCase {
         XCTAssertNil(message)
     }
 }
+
+final class IOSSyncManagerTransportErrorXCTests: XCTestCase {
+    @MainActor
+    func testBluetoothBrowserStartFailureStopsScanSoPairingDiagnosticIsReachable() {
+        let manager = IOSSyncManager()
+        manager.isScanning = true
+        var failedState = PeerManagerState()
+        failedState.lastTransportError = "BT-SCAN-START — access denied"
+
+        manager.handlePeerStateChange(failedState)
+
+        XCTAssertEqual(manager.bluetoothTransportError, "BT-SCAN-START — access denied")
+        XCTAssertFalse(manager.isScanning)
+    }
+}


### PR DESCRIPTION
## Summary
- show the existing Bluetooth transport diagnostic in the Join a Business empty state
- stop the scan when a browser/advertiser startup failure reports `BT-ADV-START` or `BT-SCAN-START`, making the diagnostic reachable instead of masking it behind an indefinite spinner
- retain generic empty guidance when discovery finishes with no transport error

Closes #1676
Refs #1669
Tracked in WEI-6918; review fix WEI-6935

## Tests
- Injected `BT-SCAN-START — access denied` into `PeerManagerState` and verified `IOSSyncManager` ends the scan while retaining the exact diagnostic.
- iPhone 16 Pro simulator: `IOSSyncManagerTransportErrorXCTests/testBluetoothBrowserStartFailureStopsScanSoPairingDiagnosticIsReachable` (1/1 passed).
- iPad Pro 11-inch (M4) simulator: same injected-failure test (1/1 passed).

## UI verification
- The existing `DevicePairingView` empty-state branch retains the generic no-peer guidance and exposes `device-pairing-transport-error` only after scanning ends, with the stable error code selectable and combined for VoiceOver.
- Simulator evidence covers injected state propagation; it does not claim live Bluetooth-radio failure proof on physical devices.