### PR TITLE
fix(sync): publish Bluetooth startup failures immediately

### DIFF
--- a/core/Sources/WiredPartCore/Sync/PeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/PeerManager.swift
@@ -696,11 +696,12 @@ public actor PeerManager {
         setBluetoothPairingHostMode(false)
     }
 
-    /// Record a Bluetooth transport-start failure so the UI can explain why no
-    /// devices are appearing, instead of showing an empty list forever (#1580).
-    private func recordTransportError(_ message: String) {
+    /// Record and immediately publish a Bluetooth transport-start failure so the UI
+    /// can replace its spinner with the recovery code instead of waiting for polling.
+    func recordTransportError(_ message: String) {
         state.lastTransportError = message
         logger.error("[PeerManager] Bluetooth transport did not start: \(message, privacy: .public)")
+        notifyStateChanged()
     }
 
     /// Host: allow cross-company Bluetooth connections while a pairing code is

--- a/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
@@ -37,6 +37,18 @@ private final class SnapshotAcknowledgementCollector: @unchecked Sendable {
     }
 }
 
+private actor PeerManagerStateCollector {
+    private var snapshots: [PeerManagerState] = []
+
+    func append(_ state: PeerManagerState) {
+        snapshots.append(state)
+    }
+
+    func containsTransportError(_ message: String) -> Bool {
+        snapshots.contains { $0.lastTransportError == message }
+    }
+}
+
 private func authenticatedBluetoothPairingFixture(
     requestNonce: String = SyncCrypto.bluetoothPairingRequestNonce()
 ) throws -> (context: BluetoothPairingAttemptContext, response: SyncPairResponse) {
@@ -196,6 +208,27 @@ struct PeerManagerTests {
 
     private func freshDB() throws -> AppDatabase {
         try AppDatabase.openInMemoryDatabase()
+    }
+
+    @Test("Bluetooth startup errors immediately publish the recovery diagnostic")
+    func testTransportStartErrorPublishesStateImmediately() async throws {
+        let pm = PeerManager(db: try freshDB())
+        let collector = PeerManagerStateCollector()
+        let message = "BT-SCAN-START — access denied"
+
+        await pm.setOnStateChanged { state in
+            Task { await collector.append(state) }
+        }
+        await pm.recordTransportError(message)
+
+        for _ in 0..<20 {
+            if await collector.containsTransportError(message) {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(await collector.containsTransportError(message))
     }
 
     @Test("iOS unit-test runtime selects injected identity storage")


### PR DESCRIPTION
## Summary
- immediately publish `PeerManager` Bluetooth startup failures to its state observer
- allow the onboarding `IOSSyncManager` to end its scan and expose the existing diagnostic without waiting for the 10-second peer poll
- add a focused core regression for state-observer publication

Closes #1676
Refs #1677
Tracked in WEI-6935

## Tests
- `swift test --filter 'PeerManagerTests/testTransportStartErrorPublishesStateImmediately'`
- `xcodebuild -project 'Weird Parts.xcodeproj' -scheme 'Weird Parts' -destination 'generic/platform=iOS Simulator' build`

## Scope note
PR #1677 merged at `7972ecb9750673942f04ae02a960a2d118997894` before the final review finding was repaired. This follow-up closes the missed immediate-publication invariant.