### PR TITLE
fix(sync): cover Bluetooth pairing diagnostic chain

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
+++ b/Weird Parts IOS/Weird Parts IOS/App/WiredPartIOSApp.swift
@@ -98,6 +98,17 @@ struct WiredPartIOSApp: App {
         ProcessInfo.processInfo.arguments.contains("-UITestingWEI936Celebration")
     }
 
+    #if DEBUG && targetEnvironment(simulator)
+    private var shouldShowDevicePairingTransportErrorFixture: Bool {
+        let arguments = ProcessInfo.processInfo.arguments
+        return arguments.contains("-UITesting")
+            && (arguments.contains("-UITestingDevicePairingTransportError")
+                || arguments.contains("-UITestingDevicePairingNoTransportError"))
+    }
+    #else
+    private var shouldShowDevicePairingTransportErrorFixture: Bool { false }
+    #endif
+
     private var shouldOpenWEI3144MaterialsFixture: Bool {
         ProcessInfo.processInfo.arguments.contains("-UITestingWEI3144JobMaterials")
     }
@@ -248,6 +259,11 @@ struct WiredPartIOSApp: App {
                     #else
                     EmptyView()
                     #endif
+                } else if shouldShowDevicePairingTransportErrorFixture {
+                    NavigationStack {
+                        DevicePairingView()
+                            .environmentObject(appCore)
+                    }
                 } else if appCore.isReady {
                     if shouldShowWEI936WelcomeFixture {
                         OnboardingWelcomeView()

--- a/Weird Parts IOS/Weird Parts IOS/Auth/DevicePairingView.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Auth/DevicePairingView.swift
@@ -84,6 +84,7 @@ struct DevicePairingView: View {
                 .environmentObject(appCore)
         }
         .task {
+            guard !syncManager.applyDevicePairingUITestFixtureIfNeeded() else { return }
             await scanForShop()
         }
         .onDisappear {

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -819,6 +819,30 @@ final class IOSSyncManager {
         discoveredPeers = lanPeers + multipeerOnly
     }
 
+    /// Simulator-only fixture for UI accessibility coverage of the pairing
+    /// recovery state. It is unavailable from production builds and has no UI
+    /// affordance, so users cannot inject a shipping diagnostic.
+    func applyDevicePairingUITestFixtureIfNeeded() -> Bool {
+        #if DEBUG && targetEnvironment(simulator)
+        let arguments = ProcessInfo.processInfo.arguments
+        guard arguments.contains("-UITesting") else { return false }
+
+        if arguments.contains("-UITestingDevicePairingTransportError") {
+            discoveredPeers = []
+            isScanning = false
+            bluetoothTransportError = "BT-SCAN-START — access denied"
+            return true
+        }
+        if arguments.contains("-UITestingDevicePairingNoTransportError") {
+            discoveredPeers = []
+            isScanning = false
+            bluetoothTransportError = nil
+            return true
+        }
+        #endif
+        return false
+    }
+
     private func handleMultipeerPeersChanged(_ peers: [MultipeerPeerInfo]) {
         let mpPeers = peers.map { peer in
             PeerInfo(

--- a/Weird Parts IOS/Weird Parts IOSUITests/DevicePairingTransportErrorUITests.swift
+++ b/Weird Parts IOS/Weird Parts IOSUITests/DevicePairingTransportErrorUITests.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+/// Exercises the pairing empty state with the same simulator-only injected
+/// transport outcome that the app uses for UI verification. The flags have no
+/// shipping UI control and are unavailable outside DEBUG simulator builds.
+final class DevicePairingTransportErrorUITests: XCTestCase {
+    @MainActor
+    func testTransportErrorExportsDiagnosticIdentifierAndValue() {
+        let app = launchPairingFixture("-UITestingDevicePairingTransportError")
+        let genericGuidance = app.staticTexts["No shop computer found nearby."]
+        let diagnostic = app.descendants(matching: .any)["device-pairing-transport-error"].firstMatch
+
+        XCTAssertTrue(genericGuidance.waitForExistence(timeout: 15))
+        XCTAssertTrue(diagnostic.waitForExistence(timeout: 5))
+        XCTAssertEqual(diagnostic.value as? String, "BT-SCAN-START — access denied")
+        XCTAssertEqual(diagnostic.label, "Bluetooth could not start")
+    }
+
+    @MainActor
+    func testNoTransportErrorKeepsGenericGuidanceWithoutDiagnostic() {
+        let app = launchPairingFixture("-UITestingDevicePairingNoTransportError")
+        let genericGuidance = app.staticTexts["No shop computer found nearby."]
+        let diagnostic = app.descendants(matching: .any)["device-pairing-transport-error"].firstMatch
+
+        XCTAssertTrue(genericGuidance.waitForExistence(timeout: 15))
+        XCTAssertFalse(diagnostic.exists)
+    }
+
+    private func launchPairingFixture(_ fixtureArgument: String) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = ["-UITesting", fixtureArgument]
+        app.launchEnvironment["UITEST_DISABLE_ANIMATIONS"] = "1"
+        app.launch()
+        return app
+    }
+}

--- a/core/Sources/WiredPartCore/Sync/MultipeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/MultipeerManager.swift
@@ -290,6 +290,15 @@ public final class MultipeerManager: NSObject, @unchecked Sendable {
         }
     }
 
+    #if DEBUG
+    /// Exercises the same main-queue delivery path as a framework transport
+    /// start callback. Internal so the Swift package test target can cover the
+    /// configured callback chain without exposing a product-facing control.
+    func testReportTransportError(_ message: String) {
+        reportTransportError(message)
+    }
+    #endif
+
     private func notifyPeersChanged() {
         let snapshot = peers.values.map { $0.info }
         DispatchQueue.main.async { [weak self] in

--- a/core/Sources/WiredPartCore/Sync/PeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/PeerManager.swift
@@ -696,12 +696,22 @@ public actor PeerManager {
         setBluetoothPairingHostMode(false)
     }
 
-    /// Record a Bluetooth transport-start failure so the UI can explain why no
-    /// devices are appearing, instead of showing an empty list forever (#1580).
-    private func recordTransportError(_ message: String) {
+    /// Record and immediately publish a Bluetooth transport-start failure so the UI
+    /// can replace its spinner with the recovery code instead of waiting for polling.
+    func recordTransportError(_ message: String) {
         state.lastTransportError = message
         logger.error("[PeerManager] Bluetooth transport did not start: \(message, privacy: .public)")
+        notifyStateChanged()
     }
+
+    #if DEBUG && canImport(MultipeerConnectivity)
+    /// Test-only seam for the configured Multipeer callback. This intentionally
+    /// enters through `MultipeerManager.reportTransportError`, preserving the
+    /// main-queue → actor → main-actor observer chain used in production.
+    func testTriggerConfiguredTransportError(_ message: String) {
+        multipeerManager?.testReportTransportError(message)
+    }
+    #endif
 
     /// Host: allow cross-company Bluetooth connections while a pairing code is
     /// offered, so a not-yet-in-company device can connect to complete the code

--- a/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
@@ -37,6 +37,28 @@ private final class SnapshotAcknowledgementCollector: @unchecked Sendable {
     }
 }
 
+private actor PeerManagerStateCollector {
+    private var snapshots: [PeerManagerState] = []
+    private var transportErrorWaiter: (message: String, continuation: CheckedContinuation<PeerManagerState, Never>)?
+
+    func append(_ state: PeerManagerState) {
+        snapshots.append(state)
+        guard let waiter = transportErrorWaiter,
+              state.lastTransportError == waiter.message else { return }
+        transportErrorWaiter = nil
+        waiter.continuation.resume(returning: state)
+    }
+
+    func nextTransportError(_ message: String) async -> PeerManagerState {
+        if let snapshot = snapshots.first(where: { $0.lastTransportError == message }) {
+            return snapshot
+        }
+        return await withCheckedContinuation { continuation in
+            transportErrorWaiter = (message, continuation)
+        }
+    }
+}
+
 private func authenticatedBluetoothPairingFixture(
     requestNonce: String = SyncCrypto.bluetoothPairingRequestNonce()
 ) throws -> (context: BluetoothPairingAttemptContext, response: SyncPairResponse) {
@@ -196,6 +218,30 @@ struct PeerManagerTests {
 
     private func freshDB() throws -> AppDatabase {
         try AppDatabase.openInMemoryDatabase()
+    }
+
+    @Test("Bluetooth startup errors immediately publish the recovery diagnostic")
+    func testTransportStartErrorPublishesStateImmediately() async throws {
+        let pm = PeerManager(db: try freshDB())
+        let collector = PeerManagerStateCollector()
+        let message = "BT-SCAN-START — access denied"
+
+        await pm.setOnStateChanged { state in
+            Task { await collector.append(state) }
+        }
+        try await pm.startPeerSync(
+            deviceId: "callback-test-device",
+            deviceName: "Callback Test Device",
+            companyId: "callback-test-company",
+            startSyncServer: false
+        )
+        defer { Task { await pm.stopPeerSync() } }
+
+        async let observedSnapshot = collector.nextTransportError(message)
+        await pm.testTriggerConfiguredTransportError(message)
+        let snapshot = await observedSnapshot
+
+        #expect(snapshot.lastTransportError == message)
     }
 
     @Test("iOS unit-test runtime selects injected identity storage")


### PR DESCRIPTION
## Summary
- exercise the configured Multipeer transport-error callback through main queue → `PeerManager` actor → main-actor state observer
- preserve fresh-attempt clearing and prove a non-nil diagnostic ends pairing scan state
- add simulator-only, DEBUG-only UI fixtures and focused iPhone/iPad accessibility coverage for the diagnostic and nil-error empty state

Closes #1676
Refs #1678
Tracked in WEI-6962

## Verification
- `swift test --filter 'PeerManagerTests/testTransportStartErrorPublishesStateImmediately'`
- focused `DevicePairingTransportErrorUITests` on separate iPhone and iPad simulator destinations (2 passed / 0 failed / 0 skipped each)
- `git diff --check HEAD^ HEAD`

## Scope
Successor to PR #1678. PR #1677 remains merged and untouched.
