### PR TITLE
fix(sync): pace and retry the Bluetooth snapshot; stop showing failures as successes

### DIFF
--- a/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAddDeviceSheet.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Features/Warehouse/IOSAddDeviceSheet.swift
@@ -152,9 +152,23 @@ struct IOSAddDeviceSheet: View {
                 }
                 .accessibilityElement(children: .combine)
             } else if let summary = syncManager.lastHostSyncSummary {
-                Label(summary, systemImage: "checkmark.circle.fill")
-                    .font(.subheadline)
-                    .foregroundStyle(.green)
+                // The icon must follow the OUTCOME. This was a hardcoded green
+                // checkmark, so "Sync with iPhone failed" shipped under a success
+                // mark (owner screenshot, build 62) — the screen told the user the
+                // opposite of what happened.
+                Label(
+                    summary,
+                    systemImage: syncManager.lastHostSyncSucceeded
+                        ? "checkmark.circle.fill"
+                        : "exclamationmark.triangle.fill"
+                )
+                .font(.subheadline)
+                .foregroundStyle(syncManager.lastHostSyncSucceeded ? .green : .orange)
+                .accessibilityLabel(
+                    syncManager.lastHostSyncSucceeded
+                        ? "Sync succeeded. \(summary)"
+                        : "Sync failed. \(summary)"
+                )
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
+++ b/Weird Parts IOS/Weird Parts IOS/Sync/IOSSyncManager.swift
@@ -26,6 +26,12 @@ final class IOSSyncManager {
     var activeSyncPeerName: String?
     /// Host-side: human summary of the most recent completed peer transfer.
     var lastHostSyncSummary: String?
+    /// Whether `lastHostSyncSummary` describes a SUCCESS.
+    ///
+    /// The Add-a-Device sheet used to render that summary with a hardcoded green
+    /// checkmark, so "Sync with iPhone failed" appeared under a success icon
+    /// (owner screenshot, build 62). A failure must never carry a success mark.
+    var lastHostSyncSucceeded = false
     /// Bluetooth change delivery is currently send-only for one manual action:
     /// the other device must send its own pending changes back. Keeping this
     /// separate from `syncStatus` prevents a successful send from rendering as
@@ -823,6 +829,7 @@ final class IOSSyncManager {
             activeSyncPeerName = nil
         }
         if let latest = state.lastPeerSyncs.values.max(by: { $0.syncedAt < $1.syncedAt }) {
+            lastHostSyncSucceeded = latest.success
             lastHostSyncSummary = latest.success
                 ? "Sent \(latest.pushed) records to \(latest.peerName)"
                 : "Sync with \(latest.peerName) failed"

--- a/core/Sources/WiredPartCore/Sync/BluetoothSnapshotTransfer.swift
+++ b/core/Sources/WiredPartCore/Sync/BluetoothSnapshotTransfer.swift
@@ -24,14 +24,49 @@ enum BluetoothSnapshotTransferError: LocalizedError, Sendable {
 /// Deterministic host-side snapshot pipeline. All fallible operations are injected so
 /// table enumeration, page reads, encoding, and transport failures remain testable.
 enum BluetoothSnapshotTransfer {
+    /// Default pacing between batches. Multipeer's `send(_:toPeers:with:.reliable)`
+    /// buffers internally and reports no backpressure, so an unpaced loop hands it
+    /// batches faster than the radio drains them until the session is torn down.
+    static let defaultInterBatchPause: Duration = .milliseconds(15)
+
+    /// How many times one batch may be re-attempted while the session is briefly
+    /// not connected. Multipeer flaps under load; a single transient `false` must
+    /// not destroy a transfer that is otherwise progressing.
+    static let defaultMaxSendAttempts = 6
+
+    /// Host-side initial snapshot, paced and retried.
+    ///
+    /// **Why the pacing and retry exist (#1580 field failure, build 62).**
+    /// The Mac showed `iPhone connected` and then `Sync with iPhone failed`,
+    /// while the joiner sat at roughly a quarter of "Downloading data over
+    /// Bluetooth…". The loop used to read a page, `send`, and immediately read
+    /// the next — no pacing, no acknowledgement, no backpressure — flooding
+    /// MCSession as fast as SQLite could be read. The session gets torn down
+    /// under that load, the peer reverts to `.found`, `MultipeerManager.send`
+    /// then fails its `state == .connected` guard and returns `false`, and the
+    /// whole company transfer died on the first such batch.
+    ///
+    /// Two changes, both aimed at that chain:
+    /// 1. **Pace** — a short pause between batches lets the radio drain instead
+    ///    of being handed the next payload immediately.
+    /// 2. **Retry** — a batch that fails to send is re-attempted with backoff
+    ///    rather than aborting, so a momentary flap costs a few hundred
+    ///    milliseconds instead of the entire snapshot.
+    ///
+    /// Retries are bounded: a genuinely dead session still fails, and it fails
+    /// with the table and offset it died on.
     static func run(
         batchSize: Int = 200,
+        maxSendAttempts: Int = defaultMaxSendAttempts,
+        interBatchPause: Duration = defaultInterBatchPause,
+        sleep: @Sendable (Duration) async -> Void = { try? await Task.sleep(for: $0) },
         listTables: () async throws -> [String],
         readPage: (_ table: String, _ limit: Int, _ offset: Int) async throws -> BluetoothSnapshotPage,
         encode: (_ changes: [IncomingChange]) throws -> Data,
         send: (_ data: Data) -> Bool
     ) async throws -> Int {
         precondition(batchSize > 0)
+        precondition(maxSendAttempts > 0)
 
         let tables = try await listTables()
         var totalSent = 0
@@ -44,10 +79,20 @@ enum BluetoothSnapshotTransfer {
 
                 if !page.changes.isEmpty {
                     let payload = try encode(page.changes)
-                    guard send(payload) else {
-                        throw BluetoothSnapshotTransferError.batchSendFailed(table: table, offset: offset)
-                    }
+                    try await sendWithRetry(
+                        payload,
+                        table: table,
+                        offset: offset,
+                        maxSendAttempts: maxSendAttempts,
+                        sleep: sleep,
+                        send: send
+                    )
                     totalSent += page.changes.count
+
+                    // Let the transport drain before queueing the next batch.
+                    if interBatchPause > .zero {
+                        await sleep(interBatchPause)
+                    }
                 }
 
                 if page.sourceRowCount < batchSize { break }
@@ -56,6 +101,25 @@ enum BluetoothSnapshotTransfer {
         }
 
         return totalSent
+    }
+
+    /// One batch, re-attempted with linear backoff while the session recovers.
+    private static func sendWithRetry(
+        _ payload: Data,
+        table: String,
+        offset: Int,
+        maxSendAttempts: Int,
+        sleep: @Sendable (Duration) async -> Void,
+        send: (_ data: Data) -> Bool
+    ) async throws {
+        for attempt in 1...maxSendAttempts {
+            if send(payload) { return }
+            guard attempt < maxSendAttempts else { break }
+            // Linear backoff: 100ms, 200ms, 300ms… Enough for a Multipeer flap to
+            // resolve, short enough that a genuinely dead session fails quickly.
+            await sleep(.milliseconds(100 * attempt))
+        }
+        throw BluetoothSnapshotTransferError.batchSendFailed(table: table, offset: offset)
     }
 }
 

--- a/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
@@ -1558,6 +1558,70 @@ struct PeerManagerTests {
     }
     #endif
 
+    /// The build-62 field failure: the Mac showed "connected" then
+    /// "Sync with iPhone failed" while the joiner sat around a quarter of the
+    /// download. A transient Multipeer flap made one `send` return `false`, and
+    /// the loop aborted the entire company transfer on that single batch.
+    ///
+    /// A batch that fails once must be re-attempted, not fatal.
+    @Test("A transient send failure is retried, not fatal (#1580 build 62)")
+    func testSnapshotTransferRetriesTransientSendFailure() async throws {
+        let change = IncomingChange(
+            deviceId: "host", tableName: "users", recordId: "1",
+            operation: "INSERT", changedFields: "{\"id\":\"1\"}", timestamp: "2026-08-09T00:00:00Z"
+        )
+        var attempts = 0
+        var pagesServed = 0
+
+        let sent = try await BluetoothSnapshotTransfer.run(
+            maxSendAttempts: 4,
+            interBatchPause: .zero,
+            sleep: { _ in },                       // no real waiting in tests
+            listTables: { ["users"] },
+            readPage: { _, _, _ in
+                pagesServed += 1
+                return pagesServed == 1
+                    ? BluetoothSnapshotPage(changes: [change], sourceRowCount: 1)
+                    : BluetoothSnapshotPage(changes: [], sourceRowCount: 0)
+            },
+            encode: { _ in Data([0x01]) },
+            send: { _ in
+                attempts += 1
+                return attempts >= 3          // fails twice, then the session recovers
+            }
+        )
+
+        #expect(sent == 1, "the batch should have landed after the session recovered")
+        #expect(attempts == 3, "expected two failed attempts then a success")
+    }
+
+    /// Retries are bounded — a genuinely dead session still fails, and it fails
+    /// naming the table and offset rather than hanging forever.
+    @Test("A permanently dead session still fails, with the table and offset (#1580)")
+    func testSnapshotTransferGivesUpOnPermanentSendFailure() async {
+        let change = IncomingChange(
+            deviceId: "host", tableName: "users", recordId: "1",
+            operation: "INSERT", changedFields: "{\"id\":\"1\"}", timestamp: "2026-08-09T00:00:00Z"
+        )
+        var attempts = 0
+
+        await #expect(throws: BluetoothSnapshotTransferError.self) {
+            _ = try await BluetoothSnapshotTransfer.run(
+                maxSendAttempts: 3,
+                interBatchPause: .zero,
+                sleep: { _ in },
+                listTables: { ["users"] },
+                readPage: { _, _, _ in BluetoothSnapshotPage(changes: [change], sourceRowCount: 1) },
+                encode: { _ in Data([0x01]) },
+                send: { _ in
+                    attempts += 1
+                    return false
+                }
+            )
+        }
+        #expect(attempts == 3, "should stop at maxSendAttempts rather than retrying forever")
+    }
+
     @Test("Snapshot transfer fails when table enumeration fails")
     func testSnapshotTableEnumerationFailurePropagates() async {
         await #expect(throws: SnapshotProbeError.self) {


### PR DESCRIPTION
Refs #1580, #1417. Full-chain audit of Bluetooth sync, prompted by build-62 field evidence.

## What the field evidence changed

The pipeline now reaches **much** further than before. The Mac showed `iPhone connected`, and the joiner reached *"Downloading data over Bluetooth…"* at roughly a quarter. **Connect and pair work** (#1667). The failure moved into the snapshot transfer.

## 1. Flow control — the actual stall

`BluetoothSnapshotTransfer.run` read a 200-row page, sent it, and immediately read the next. No pacing, no acknowledgement, no backpressure. `send(_:toPeers:with:.reliable)` buffers internally and reports no pressure, so the loop handed Multipeer batches faster than the radio drained them.

The chain: session torn down under load → peer reverts to `.found` (correct, from #1667) → `MultipeerManager.send` fails its `state == .connected` guard → returns `false` → **one `false` aborted the entire company transfer.**

Now **paced** (15 ms between batches) and **retried** with linear backoff, bounded by `maxSendAttempts` so a genuinely dead session still fails — naming the table and offset it died on.

## 2. The UI told the user the opposite of the truth

`IOSAddDeviceSheet` rendered `lastHostSyncSummary` with a **hardcoded green checkmark**, so *"Sync with iPhone failed"* appeared under a success mark in the owner's own screenshot. Icon and colour now follow the outcome, and the accessibility label says which it is.

## Verified compatible with the watchdogs — checked, not assumed

Pacing adds time, so I confirmed it cannot trip the existing timers:

| Watchdog | Behaviour | Affected by pacing? |
|---|---|---|
| Joiner idle watchdog | 45 s **without a batch**; timestamp refreshed on every batch (`PeerManager:1160`) | No — a moving transfer never idles |
| Joiner hard cap | 15 min | No — 15 ms/batch would need ~60 000 batches to matter |
| Host ack timeout | 60 s, starts **after** the transfer | No |

## Verification

Two tests, red-proofed against the old unconditional abort:
- a transient send failure is retried and the batch lands
- a permanently dead session still fails, and stops at `maxSendAttempts` rather than retrying forever

Full core suite **2582/2582**. iOS app **BUILD SUCCEEDED**.

## Remaining defect from this audit — filed, not fixed here

The joiner accumulates **every** snapshot batch in memory (`pendingSnapshotChanges`) and only applies at the end. Two consequences: unbounded memory for a large company (a plausible second cause of the same symptom, since an iOS memory kill mid-download would look identical), and all-or-nothing — a drop at 99% discards everything. Fixing it properly means staging batches durably as they arrive and applying from staging at the end, which preserves the deliberate apply-then-ack atomicity. That is a schema + migration change and does not belong in a hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)