### PR TITLE
fix(sync): durable staged Bluetooth snapshots

### DIFF
--- a/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
+++ b/core/Sources/WiredPartCore/Database/AppDatabase+Migrations.swift
@@ -163,6 +163,7 @@ extension AppDatabase {
         registerMigration119SyncGapTables(&migrator)
         registerContactEmailRepair(&migrator)
         registerMigration121DeviceLogs(&migrator)
+        registerMigration122SnapshotStaging(&migrator)
     }
 
     // MARK: - Migration 039: Notebook Templates
@@ -653,6 +654,44 @@ extension AppDatabase {
                 t.column("updated_at", .datetime).notNull().defaults(sql: "(datetime('now'))")
             }
         }
+    }
+}
+
+/// Private, transfer-scoped durable storage for Bluetooth initial snapshots.
+/// No sync triggers are installed: underscore-prefixed tables are excluded from
+/// snapshot enumeration and this table must never feed `_change_log`.
+private func registerMigration122SnapshotStaging(_ migrator: inout DatabaseMigrator) {
+    migrator.registerMigration("122_bluetooth_snapshot_staging") { db in
+        try db.create(table: "_snapshot_transfers", ifNotExists: true) { t in
+            t.column("transfer_id", .text).primaryKey()
+            t.column("host_device_id", .text).notNull()
+            t.column("authorization_token", .text).notNull()
+            t.column("state", .text).notNull()
+            t.column("final_sequence", .integer)
+            t.column("created_at", .text).notNull().defaults(sql: "(datetime('now'))")
+            t.column("applied_at", .text)
+        }
+        try db.create(table: "_snapshot_staging", ifNotExists: true) { t in
+            t.column("transfer_id", .text).notNull()
+            t.column("sequence", .integer).notNull()
+            t.column("host_device_id", .text).notNull()
+            t.column("payload", .blob).notNull()
+            t.column("digest", .text).notNull()
+            t.column("created_at", .text).notNull().defaults(sql: "(datetime('now'))")
+            t.primaryKey(["transfer_id", "sequence"])
+        }
+        try db.create(
+            index: "idx_snapshot_transfers_host",
+            on: "_snapshot_transfers",
+            columns: ["host_device_id", "transfer_id"],
+            ifNotExists: true
+        )
+        try db.create(
+            index: "idx_snapshot_staging_host",
+            on: "_snapshot_staging",
+            columns: ["host_device_id", "transfer_id"],
+            ifNotExists: true
+        )
     }
 }
 

--- a/core/Sources/WiredPartCore/Sync/BluetoothSnapshotTransfer.swift
+++ b/core/Sources/WiredPartCore/Sync/BluetoothSnapshotTransfer.swift
@@ -1,4 +1,153 @@
 import Foundation
+import CryptoKit
+import GRDB
+
+struct SnapshotBegin: Codable, Equatable, Sendable {
+    let transferId: String
+    let authorizationToken: String
+}
+
+struct SnapshotBatch: Codable, Sendable {
+    let transferId: String
+    let sequence: Int
+    let changes: [IncomingChange]
+}
+
+struct SnapshotStored: Codable, Equatable, Sendable {
+    let transferId: String
+    let sequence: Int
+}
+
+struct SnapshotComplete: Codable, Equatable, Sendable {
+    let transferId: String
+    let finalSequence: Int
+}
+
+enum SnapshotStagingError: LocalizedError, Sendable {
+    case invalidSequence
+    case unauthorizedHost
+    case unknownTransfer
+    case mixedTransfer
+    case mixedBatch
+    case duplicateMismatch
+    case sequenceGap
+    case disallowedTable
+    case disallowedOperation
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidSequence: return "Bluetooth snapshot sequence is invalid. Retry the sync."
+        case .unauthorizedHost: return "Bluetooth snapshot host is not authorized. Pair it again."
+        case .unknownTransfer: return "Bluetooth snapshot transfer is unknown. Retry the sync."
+        case .mixedTransfer: return "Bluetooth snapshot mixed transfer identifiers. Retry the sync."
+        case .mixedBatch: return "Bluetooth snapshot batch mixed business tables. Retry the sync."
+        case .duplicateMismatch: return "Bluetooth snapshot duplicate data did not match. Retry the sync."
+        case .sequenceGap: return "Bluetooth snapshot has a sequence gap. Retry the sync."
+        case .disallowedTable: return "Bluetooth snapshot contains a disallowed table. Retry the sync."
+        case .disallowedOperation: return "Bluetooth snapshot contains a disallowed operation. Retry the sync."
+        }
+    }
+}
+
+struct SnapshotCompletionReceipt: Sendable {
+    let authorizationToken: String
+    let result: MergeResult
+    let wasAlreadyApplied: Bool
+}
+
+enum BluetoothSnapshotStaging {
+    static func digest(_ payload: Data) -> String {
+        SHA256.hash(data: payload).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func authorize(
+        db: AppDatabase,
+        hostDeviceId: String,
+        begin: SnapshotBegin,
+        allowNewTransfer: Bool
+    ) throws {
+        guard !begin.transferId.isEmpty, !begin.authorizationToken.isEmpty else {
+            throw SnapshotStagingError.unauthorizedHost
+        }
+        try db.writer.write { conn in
+            if let row = try Row.fetchOne(
+                conn,
+                sql: "SELECT host_device_id, authorization_token FROM _snapshot_transfers WHERE transfer_id = ?",
+                arguments: [begin.transferId]
+            ) {
+                let storedHost: String = row["host_device_id"]
+                let storedToken: String = row["authorization_token"]
+                guard storedHost == hostDeviceId, storedToken == begin.authorizationToken else {
+                    throw SnapshotStagingError.unauthorizedHost
+                }
+                return
+            }
+            guard allowNewTransfer else { throw SnapshotStagingError.unknownTransfer }
+            try conn.execute(
+                sql: "INSERT INTO _snapshot_transfers (transfer_id, host_device_id, authorization_token, state) VALUES (?, ?, ?, 'staging')",
+                arguments: [begin.transferId, hostDeviceId, begin.authorizationToken]
+            )
+        }
+    }
+
+    /// Commits the exact encoded changes before returning, making a subsequent
+    /// `snapshotStored` acknowledgement a durable promise.
+    static func stage(db: AppDatabase, hostDeviceId: String, batch: SnapshotBatch) throws {
+        guard batch.sequence >= 0 else { throw SnapshotStagingError.invalidSequence }
+        guard !batch.changes.isEmpty,
+              Set(batch.changes.map { $0.tableName.lowercased() }).count == 1 else {
+            throw SnapshotStagingError.mixedBatch
+        }
+        let payload = try JSONEncoder().encode(batch.changes)
+        let payloadDigest = digest(payload)
+        try db.writer.write { conn in
+            guard let state = try String.fetchOne(
+                conn,
+                sql: "SELECT state FROM _snapshot_transfers WHERE transfer_id = ? AND host_device_id = ?",
+                arguments: [batch.transferId, hostDeviceId]
+            ) else { throw SnapshotStagingError.unknownTransfer }
+            guard state == "staging" else { throw SnapshotStagingError.unknownTransfer }
+            if let row = try Row.fetchOne(
+                conn,
+                sql: "SELECT host_device_id, digest FROM _snapshot_staging WHERE transfer_id = ? AND sequence = ?",
+                arguments: [batch.transferId, batch.sequence]
+            ) {
+                let storedHost: String = row["host_device_id"]
+                let storedDigest: String = row["digest"]
+                guard storedHost == hostDeviceId else { throw SnapshotStagingError.unauthorizedHost }
+                guard storedDigest == payloadDigest else { throw SnapshotStagingError.duplicateMismatch }
+                return
+            }
+            if let existingHost = try String.fetchOne(
+                conn,
+                sql: "SELECT host_device_id FROM _snapshot_staging WHERE transfer_id = ? LIMIT 1",
+                arguments: [batch.transferId]
+            ), existingHost != hostDeviceId {
+                throw SnapshotStagingError.unauthorizedHost
+            }
+            try conn.execute(
+                sql: "INSERT INTO _snapshot_staging (transfer_id, sequence, host_device_id, payload, digest) VALUES (?, ?, ?, ?, ?)",
+                arguments: [batch.transferId, batch.sequence, hostDeviceId, payload, payloadDigest]
+            )
+        }
+    }
+
+    /// Reads and validates the whole transfer, then applies and deletes it in
+    /// the resolver's single writer transaction.
+    static func complete(
+        db: AppDatabase,
+        hostDeviceId: String,
+        completion: SnapshotComplete
+    ) throws -> SnapshotCompletionReceipt {
+        guard completion.finalSequence >= -1 else { throw SnapshotStagingError.invalidSequence }
+        return try ConflictResolver.resolveAndApplyStagedSnapshotAtomically(
+            db: db,
+            transferId: completion.transferId,
+            hostDeviceId: hostDeviceId,
+            finalSequence: completion.finalSequence
+        )
+    }
+}
 
 /// A page read from one business table during a Bluetooth initial snapshot.
 /// `sourceRowCount` drives paging even when device-scoped rows are filtered out.
@@ -33,6 +182,53 @@ enum BluetoothSnapshotTransfer {
     /// not connected. Multipeer flaps under load; a single transient `false` must
     /// not destroy a transfer that is otherwise progressing.
     static let defaultMaxSendAttempts = 6
+
+    /// Staged protocol sender. Exactly one payload can be awaiting durable
+    /// acknowledgement because the next page is not read until `isStored` is true.
+    static func runStaged(
+        transferId: String,
+        batchSize: Int = 200,
+        maxAttempts: Int = defaultMaxSendAttempts,
+        sleep: @Sendable (Duration) async -> Void = { try? await Task.sleep(for: $0) },
+        listTables: () async throws -> [String],
+        readPage: (_ table: String, _ limit: Int, _ offset: Int) async throws -> BluetoothSnapshotPage,
+        sendBatch: (_ batch: SnapshotBatch) throws -> Bool,
+        isStored: (_ sequence: Int) async -> Bool
+    ) async throws -> (rows: Int, finalSequence: Int) {
+        var sequence = 0
+        var rows = 0
+        for table in try await listTables() where !table.hasPrefix("_") && ConflictResolver.isAllowedTable(table) {
+            var offset = 0
+            while true {
+                let page = try await readPage(table, batchSize, offset)
+                guard page.sourceRowCount > 0 else { break }
+                if !page.changes.isEmpty {
+                    let batch = SnapshotBatch(transferId: transferId, sequence: sequence, changes: page.changes)
+                    var acknowledged = false
+                    for attempt in 1...maxAttempts {
+                        if try sendBatch(batch) {
+                            // Deterministic tests inject a zero-cost sleep; production
+                            // gets a bounded acknowledgement interval per attempt.
+                            for _ in 0..<10 {
+                                if await isStored(sequence) { acknowledged = true; break }
+                                await sleep(.milliseconds(100))
+                            }
+                        }
+                        if acknowledged { break }
+                        if attempt < maxAttempts { await sleep(.milliseconds(100 * attempt)) }
+                    }
+                    guard acknowledged else {
+                        throw BluetoothSnapshotTransferError.batchSendFailed(table: table, offset: offset)
+                    }
+                    rows += page.changes.count
+                    sequence += 1
+                }
+                if page.sourceRowCount < batchSize { break }
+                offset += batchSize
+            }
+        }
+        return (rows, sequence - 1)
+    }
 
     /// Host-side initial snapshot, paced and retried.
     ///

--- a/core/Sources/WiredPartCore/Sync/ConflictResolver.swift
+++ b/core/Sources/WiredPartCore/Sync/ConflictResolver.swift
@@ -400,6 +400,78 @@ public enum ConflictResolver {
         }
     }
 
+    static func resolveAndApplyStagedSnapshotAtomically(
+        db: AppDatabase,
+        transferId: String,
+        hostDeviceId: String,
+        finalSequence: Int,
+        localDeviceId: String? = nil
+    ) throws -> SnapshotCompletionReceipt {
+        let localDevice = localDeviceId ?? DeviceIdentity.current
+        return try db.writer.write { conn in
+            guard let transfer = try Row.fetchOne(
+                conn,
+                sql: "SELECT authorization_token, state, final_sequence FROM _snapshot_transfers WHERE transfer_id = ? AND host_device_id = ?",
+                arguments: [transferId, hostDeviceId]
+            ) else { throw SnapshotStagingError.unknownTransfer }
+            let authorizationToken: String = transfer["authorization_token"]
+            let state: String = transfer["state"]
+            if state == "applied" {
+                let storedFinal: Int? = transfer["final_sequence"]
+                guard storedFinal == finalSequence else { throw SnapshotStagingError.mixedTransfer }
+                return SnapshotCompletionReceipt(
+                    authorizationToken: authorizationToken,
+                    result: MergeResult(),
+                    wasAlreadyApplied: true
+                )
+            }
+            guard state == "staging" else { throw SnapshotStagingError.unknownTransfer }
+            let rows = try Row.fetchAll(
+                conn,
+                sql: "SELECT sequence, payload FROM _snapshot_staging WHERE transfer_id = ? AND host_device_id = ? ORDER BY sequence",
+                arguments: [transferId, hostDeviceId]
+            )
+            let expected = finalSequence < 0 ? [] : Array(0...finalSequence)
+            let actual: [Int] = rows.map { $0["sequence"] }
+            guard actual == expected else { throw SnapshotStagingError.sequenceGap }
+
+            var changes: [IncomingChange] = []
+            for row in rows {
+                let payload: Data = row["payload"]
+                changes.append(contentsOf: try JSONDecoder().decode([IncomingChange].self, from: payload))
+            }
+            var result = MergeResult()
+            try conn.execute(sql: "INSERT OR IGNORE INTO _sync_apply_guard (id) VALUES (1)")
+            defer { try? conn.execute(sql: "DELETE FROM _sync_apply_guard") }
+            for change in changes {
+                guard isAllowedTable(change.tableName) else { throw SnapshotStagingError.disallowedTable }
+                switch change.operation.uppercased() {
+                case "DELETE":
+                    try applyDelete(db: conn, change: change, localDeviceId: localDevice)
+                    result.applied += 1
+                case "INSERT":
+                    result.conflicts += try applyInsert(db: conn, change: change, localDeviceId: localDevice)
+                    result.applied += 1
+                case "UPDATE":
+                    result.conflicts += try applyUpdate(db: conn, change: change, localDeviceId: localDevice)
+                    result.applied += 1
+                default: throw SnapshotStagingError.disallowedOperation
+                }
+            }
+            try conn.execute(sql: "DELETE FROM _snapshot_staging WHERE transfer_id = ?", arguments: [transferId])
+            try conn.execute(
+                sql: "UPDATE _snapshot_transfers SET state = 'applied', final_sequence = ?, applied_at = datetime('now') WHERE transfer_id = ?",
+                arguments: [finalSequence, transferId]
+            )
+            try conn.execute(sql: "DELETE FROM _sync_apply_guard")
+            return SnapshotCompletionReceipt(
+                authorizationToken: authorizationToken,
+                result: result,
+                wasAlreadyApplied: false
+            )
+        }
+    }
+
     /// Get unreviewed conflicts for admin review.
     public static func getUnreviewedConflicts(
         db: AppDatabase,

--- a/core/Sources/WiredPartCore/Sync/PeerManager.swift
+++ b/core/Sources/WiredPartCore/Sync/PeerManager.swift
@@ -189,8 +189,11 @@ public actor PeerManager {
     private var pendingBluetoothPairingContexts: [String: BluetoothPairingAttemptContext] = [:]
     // Joiner-side: continuations awaiting a full initial sync to complete, keyed by host deviceId.
     private var pendingFullSyncContinuations: [String: CheckedContinuation<Void, Error>] = [:]
-    // Full-snapshot pages remain in memory until completion, then commit in one transaction.
-    private var pendingSnapshotChanges: [String: [IncomingChange]] = [:]
+    // Joiner-side transfer identity only; batch contents live durably in SQLite.
+    private var activeSnapshotTransfers: [String: String] = [:]
+    // Host-side durable acknowledgements observed by the independently running sender.
+    private var hostedStoredAcknowledgements: Set<String> = []
+    private var hostedTransferIds: [String: String] = [:]
     // Ignore remaining queued pages after a failed snapshot until an explicit retry starts.
     private var failedSnapshotPeers: Set<String> = []
     // Pairing-issued capabilities bind initial snapshots to the successful code exchange.
@@ -434,7 +437,9 @@ public actor PeerManager {
         pendingBluetoothPairingContexts.removeAll()
         let fullSyncContinuations = Array(pendingFullSyncContinuations.values)
         pendingFullSyncContinuations.removeAll()
-        pendingSnapshotChanges.removeAll()
+        activeSnapshotTransfers.removeAll()
+        hostedStoredAcknowledgements.removeAll()
+        hostedTransferIds.removeAll()
         failedSnapshotPeers.removeAll()
 
         for continuation in pairContinuations {
@@ -1088,7 +1093,7 @@ public actor PeerManager {
     func isTrustedWritePeer(_ peerDeviceId: String) -> Bool {
         if (try? isTrustedBluetoothPeer(peerDeviceId)) == true { return true }
         // In-flight initial snapshot from the host we are joining.
-        return pendingSnapshotChanges[peerDeviceId] != nil
+        return activeSnapshotTransfers[peerDeviceId] != nil
             || receivedSnapshotTokens[peerDeviceId] != nil
     }
 
@@ -1128,7 +1133,8 @@ public actor PeerManager {
     /// Internal visibility supports deterministic ordering/failure regression tests.
     func processMultipeerMessage(
         _ message: ReceivedMultipeerMessage,
-        sendApplyAcknowledgement: ((FullSyncApplyAcknowledgement, String) -> Bool)? = nil
+        sendApplyAcknowledgement: ((FullSyncApplyAcknowledgement, String) -> Bool)? = nil,
+        sendStoredAcknowledgement: ((SnapshotStored, String) -> Bool)? = nil
     ) async throws -> MultipeerMessageOutcome {
         if let env = try? JSONDecoder().decode(MPEnvelope.self, from: message.data) {
             if failedSnapshotPeers.contains(message.fromDeviceId),
@@ -1136,7 +1142,81 @@ public actor PeerManager {
                 return .ignored
             }
             switch env.type {
+            case "snapshotBegin":
+                let begin = try JSONDecoder().decode(SnapshotBegin.self, from: env.payload)
+                let hasFreshAuthorization = receivedSnapshotTokens[message.fromDeviceId] == begin.authorizationToken
+                if let active = activeSnapshotTransfers[message.fromDeviceId], active != begin.transferId {
+                    throw SnapshotStagingError.mixedTransfer
+                }
+                try BluetoothSnapshotStaging.authorize(
+                    db: db,
+                    hostDeviceId: message.fromDeviceId,
+                    begin: begin,
+                    allowNewTransfer: hasFreshAuthorization
+                )
+                activeSnapshotTransfers[message.fromDeviceId] = begin.transferId
+                failedSnapshotPeers.remove(message.fromDeviceId)
+                return .ignored
+            case "snapshotBatch":
+                let batch = try JSONDecoder().decode(SnapshotBatch.self, from: env.payload)
+                if let active = activeSnapshotTransfers[message.fromDeviceId], active != batch.transferId {
+                    throw SnapshotStagingError.mixedTransfer
+                }
+                try BluetoothSnapshotStaging.stage(db: db, hostDeviceId: message.fromDeviceId, batch: batch)
+                activeSnapshotTransfers[message.fromDeviceId] = batch.transferId
+                let stored = SnapshotStored(transferId: batch.transferId, sequence: batch.sequence)
+                let sent: Bool
+                if let sendStoredAcknowledgement {
+                    sent = sendStoredAcknowledgement(stored, message.fromDeviceId)
+                } else if let manager = multipeerManager,
+                          let payload = try? JSONEncoder().encode(stored),
+                          let data = try? JSONEncoder().encode(MPEnvelope(type: "snapshotStored", payload: payload)) {
+                    sent = manager.send(data: data, toPeer: message.fromDeviceId)
+                } else { sent = false }
+                // The row is already durable. If this send races a disconnect,
+                // keep the transfer active: the host's bounded retry will
+                // redeliver the exact batch and receive a fresh acknowledgement.
+                if !sent {
+                    logger.warning("[PeerManager] Snapshot batch staged but stored acknowledgement could not be sent")
+                }
+                snapshotLastActivity[message.fromDeviceId] = Date()
+                state.snapshotReceivedRecords[message.fromDeviceId, default: 0] += batch.changes.count
+                notifyStateChanged()
+                return .changesApplied(batch.changes.count)
+            case "snapshotStored":
+                let stored = try JSONDecoder().decode(SnapshotStored.self, from: env.payload)
+                guard hostedTransferIds[message.fromDeviceId] == stored.transferId else {
+                    throw SnapshotStagingError.unknownTransfer
+                }
+                hostedStoredAcknowledgements.insert("\(stored.transferId):\(stored.sequence)")
+                return .ignored
+            case "snapshotComplete":
+                let completion = try JSONDecoder().decode(SnapshotComplete.self, from: env.payload)
+                if let active = activeSnapshotTransfers[message.fromDeviceId], active != completion.transferId {
+                    throw SnapshotStagingError.mixedTransfer
+                }
+                let receipt = try BluetoothSnapshotStaging.complete(
+                    db: db,
+                    hostDeviceId: message.fromDeviceId,
+                    completion: completion
+                )
+                guard sendFullSyncApplyAcknowledgement(
+                    succeeded: true,
+                    error: nil,
+                    to: message.fromDeviceId,
+                    authorizationToken: receipt.authorizationToken,
+                    using: sendApplyAcknowledgement
+                ) else {
+                    throw MultipeerPairingError.sendFailed
+                }
+                receivedSnapshotTokens.removeValue(forKey: message.fromDeviceId)
+                activeSnapshotTransfers.removeValue(forKey: message.fromDeviceId)
+                handleFullSyncComplete(from: message.fromDeviceId)
+                return .fullSyncCompleted
             case "changes":
+                guard activeSnapshotTransfers[message.fromDeviceId] == nil else {
+                    throw SnapshotStagingError.mixedTransfer
+                }
                 // SECURITY (audit 2026-08-03): company data may only be written
                 // by a peer that completed pairing and is still trusted.
                 // handleFullSyncRequest checked this; the write paths did not —
@@ -1151,19 +1231,7 @@ public actor PeerManager {
                 do {
                     let changes = try decodeIncomingChanges(env.payload)
                     let count: Int
-                    if pendingSnapshotChanges[message.fromDeviceId] != nil {
-                        pendingSnapshotChanges[message.fromDeviceId, default: []]
-                            .append(contentsOf: changes)
-                        count = changes.count
-                        // #1417 hardening: every batch feeds the idle watchdog
-                        // (a live transfer must never be killed) and the UI.
-                        snapshotLastActivity[message.fromDeviceId] = Date()
-                        state.snapshotReceivedRecords[message.fromDeviceId] =
-                            pendingSnapshotChanges[message.fromDeviceId, default: []].count
-                        notifyStateChanged()
-                    } else {
-                        count = try applyIncomingChanges(changes)
-                    }
+                    count = try applyIncomingChanges(changes)
                     return .changesApplied(count)
                 } catch {
                     sendFullSyncApplyAcknowledgement(
@@ -1181,57 +1249,17 @@ public actor PeerManager {
                 return .pairResponse
             case "fullSyncRequest":
                 let request = try JSONDecoder().decode(FullSyncRequest.self, from: env.payload)
-                await handleFullSyncRequest(
-                    from: message.fromDeviceId,
-                    authorizationToken: request.authorizationToken
-                )
+                Task { [weak self] in
+                    await self?.handleFullSyncRequest(
+                        from: message.fromDeviceId,
+                        authorizationToken: request.authorizationToken
+                    )
+                }
                 return .fullSyncRequest
             case "fullSyncComplete":
-                let completion: FullSyncCompletion
-                if env.payload.isEmpty {
-                    completion = .success // Backward compatibility with pre-integrity hosts.
-                } else {
-                    completion = try JSONDecoder().decode(FullSyncCompletion.self, from: env.payload)
-                }
-                guard completion.succeeded else {
-                    throw MultipeerSnapshotError.remoteFailure(completion.error ?? "")
-                }
-                if pendingSnapshotChanges[message.fromDeviceId] != nil {
-                    do {
-                        _ = try applyIncomingChanges(
-                            pendingSnapshotChanges[message.fromDeviceId, default: []]
-                        )
-                    } catch {
-                        // Tell the host before the FIFO drain propagates the local
-                        // failure. The host can then consume the old capability and
-                        // release its reservation immediately instead of timing out.
-                        sendFullSyncApplyAcknowledgement(
-                            succeeded: false,
-                            error: error.localizedDescription,
-                            to: message.fromDeviceId,
-                            using: sendApplyAcknowledgement
-                        )
-                        throw error
-                    }
-                }
-                if pendingFullSyncContinuations[message.fromDeviceId] != nil {
-                    guard sendFullSyncApplyAcknowledgement(
-                        succeeded: true,
-                        error: nil,
-                        to: message.fromDeviceId,
-                        using: sendApplyAcknowledgement
-                    ) else {
-                        throw MultipeerPairingError.sendFailed
-                    }
-                    receivedSnapshotTokens.removeValue(forKey: message.fromDeviceId)
-                }
-                pendingSnapshotChanges.removeValue(forKey: message.fromDeviceId)
-                failedSnapshotPeers.remove(message.fromDeviceId)
-                snapshotLastActivity.removeValue(forKey: message.fromDeviceId)
-                state.snapshotReceivedRecords.removeValue(forKey: message.fromDeviceId)
-                notifyStateChanged()
-                handleFullSyncComplete(from: message.fromDeviceId)
-                return .fullSyncCompleted
+                // Legacy in-memory snapshot completion is deliberately not
+                // accepted by the durable-staging protocol.
+                throw MultipeerSnapshotError.malformedEnvelope
             case "fullSyncApplied":
                 let acknowledgement = try JSONDecoder().decode(
                     FullSyncApplyAcknowledgement.self,
@@ -1243,7 +1271,7 @@ public actor PeerManager {
                 )
                 return .ignored
             default:
-                return .ignored
+                throw MultipeerSnapshotError.malformedEnvelope
             }
         }
 
@@ -1256,13 +1284,8 @@ public actor PeerManager {
         guard !failedSnapshotPeers.contains(message.fromDeviceId) else { return .ignored }
         let changes = try decodeIncomingChanges(message.data)
         let count: Int
-        if pendingSnapshotChanges[message.fromDeviceId] != nil {
-            pendingSnapshotChanges[message.fromDeviceId, default: []]
-                .append(contentsOf: changes)
-            count = changes.count
-        } else {
-            count = try applyIncomingChanges(changes)
-        }
+        guard activeSnapshotTransfers[message.fromDeviceId] == nil else { throw SnapshotStagingError.mixedTransfer }
+        count = try applyIncomingChanges(changes)
         return .changesApplied(count)
     }
 
@@ -1335,7 +1358,19 @@ public actor PeerManager {
         }
 
         do {
-            let totalSent = try await BluetoothSnapshotTransfer.run(
+            let transferId = UUID().uuidString
+            hostedTransferIds[peerDeviceId] = transferId
+            defer { hostedTransferIds.removeValue(forKey: peerDeviceId) }
+            let beginPayload = try JSONEncoder().encode(SnapshotBegin(
+                transferId: transferId,
+                authorizationToken: authorizationToken
+            ))
+            let beginEnvelope = try JSONEncoder().encode(MPEnvelope(type: "snapshotBegin", payload: beginPayload))
+            guard mpManager.send(data: beginEnvelope, toPeer: peerDeviceId) else {
+                throw BluetoothSnapshotTransferError.batchSendFailed(table: "_snapshot_begin", offset: 0)
+            }
+            let result = try await BluetoothSnapshotTransfer.runStaged(
+                transferId: transferId,
                 listTables: { [db] in
                     try await db.writer.read { dbConn in
                         try String.fetchAll(
@@ -1350,23 +1385,35 @@ public actor PeerManager {
                         hostDeviceId: hostDeviceId, fallbackTimestamp: fallbackTimestamp
                     )
                 },
-                encode: { changes in
-                    let changesData = try JSONEncoder().encode(changes)
-                    return try JSONEncoder().encode(MPEnvelope(type: "changes", payload: changesData))
+                sendBatch: { batch in
+                    let payload = try JSONEncoder().encode(batch)
+                    let envelope = try JSONEncoder().encode(MPEnvelope(type: "snapshotBatch", payload: payload))
+                    return mpManager.send(data: envelope, toPeer: peerDeviceId)
                 },
-                send: { data in mpManager.send(data: data, toPeer: peerDeviceId) }
+                isStored: { [weak self] sequence in
+                    guard let self else { return false }
+                    return await self.consumeStoredAcknowledgement(
+                        transferId: transferId,
+                        sequence: sequence
+                    )
+                }
             )
 
-            guard try sendFullSyncCompletion(.success, to: peerDeviceId, using: mpManager) else {
+            let completePayload = try JSONEncoder().encode(SnapshotComplete(
+                transferId: transferId,
+                finalSequence: result.finalSequence
+            ))
+            let completeEnvelope = try JSONEncoder().encode(MPEnvelope(type: "snapshotComplete", payload: completePayload))
+            guard mpManager.send(data: completeEnvelope, toPeer: peerDeviceId) else {
                 hostedSnapshotReservations.removeValue(forKey: peerDeviceId)
                 throw BluetoothSnapshotTransferError.completionSendFailed
             }
-            hostedSnapshotReservations[peerDeviceId]?.rowsSent = totalSent
+            hostedSnapshotReservations[peerDeviceId]?.rowsSent = result.rows
             scheduleSnapshotAcknowledgementTimeout(
                 peerDeviceId: peerDeviceId,
                 authorizationToken: authorizationToken
             )
-            logger.info("[PeerManager] Sent full Bluetooth snapshot (\(totalSent) records); awaiting durable apply acknowledgement from \(String(peerDeviceId.prefix(8)), privacy: .public)")
+            logger.info("[PeerManager] Sent full Bluetooth snapshot (\(result.rows) records); awaiting durable apply acknowledgement from \(String(peerDeviceId.prefix(8)), privacy: .public)")
         } catch {
             if Self.shouldRestoreHostedSnapshot(after: error) {
                 restoreHostedSnapshot(
@@ -1383,6 +1430,10 @@ public actor PeerManager {
             )
             logger.error("[PeerManager] Full Bluetooth snapshot failed for peer \(String(peerDeviceId.prefix(8)), privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    private func consumeStoredAcknowledgement(transferId: String, sequence: Int) -> Bool {
+        hostedStoredAcknowledgements.remove("\(transferId):\(sequence)") != nil
     }
 
     /// One page of the hosted initial snapshot. Internal + static so the
@@ -1476,12 +1527,11 @@ public actor PeerManager {
         succeeded: Bool,
         error: String?,
         to peerDeviceId: String,
+        authorizationToken authorizationTokenOverride: String? = nil,
         using sendOverride: ((FullSyncApplyAcknowledgement, String) -> Bool)? = nil
     ) -> Bool {
-        guard pendingFullSyncContinuations[peerDeviceId] != nil,
-              let authorizationToken = receivedSnapshotTokens[peerDeviceId] else {
-            return false
-        }
+        guard let authorizationToken = authorizationTokenOverride
+                ?? receivedSnapshotTokens[peerDeviceId] else { return false }
         let acknowledgement = FullSyncApplyAcknowledgement(
             authorizationToken: authorizationToken,
             succeeded: succeeded,
@@ -1656,7 +1706,7 @@ public actor PeerManager {
 
     func testBeginSnapshotBuffer(from peerDeviceId: String) {
         failedSnapshotPeers.remove(peerDeviceId)
-        pendingSnapshotChanges[peerDeviceId] = []
+        activeSnapshotTransfers[peerDeviceId] = "legacy-test-transfer"
     }
 
     func testAuthorizeReceivedSnapshot(_ token: String, from peerDeviceId: String) {
@@ -1688,7 +1738,7 @@ public actor PeerManager {
 
     func testAbandonSnapshotBuffer(from peerDeviceId: String) {
         failedSnapshotPeers.insert(peerDeviceId)
-        pendingSnapshotChanges.removeValue(forKey: peerDeviceId)
+        activeSnapshotTransfers.removeValue(forKey: peerDeviceId)
     }
 
     func testAwaitPairingTransport(
@@ -1753,11 +1803,11 @@ public actor PeerManager {
     }
 
     private func failPendingFullSync(from peerDeviceId: String, with error: Error) {
-        if pendingSnapshotChanges[peerDeviceId] != nil
+        if activeSnapshotTransfers[peerDeviceId] != nil
             || pendingFullSyncContinuations[peerDeviceId] != nil {
             failedSnapshotPeers.insert(peerDeviceId)
         }
-        pendingSnapshotChanges.removeValue(forKey: peerDeviceId)
+        activeSnapshotTransfers.removeValue(forKey: peerDeviceId)
         if let cont = pendingFullSyncContinuations.removeValue(forKey: peerDeviceId) {
             cont.resume(throwing: error)
         }
@@ -1774,7 +1824,7 @@ public actor PeerManager {
 
     private func timeoutFullSync(with peerDeviceId: String) {
         failedSnapshotPeers.insert(peerDeviceId)
-        pendingSnapshotChanges.removeValue(forKey: peerDeviceId)
+        activeSnapshotTransfers.removeValue(forKey: peerDeviceId)
         snapshotLastActivity.removeValue(forKey: peerDeviceId)
         state.snapshotReceivedRecords.removeValue(forKey: peerDeviceId)
         notifyStateChanged()
@@ -1841,12 +1891,10 @@ public actor PeerManager {
         )
         let env = try JSONEncoder().encode(MPEnvelope(type: "fullSyncRequest", payload: request))
         failedSnapshotPeers.remove(hostDeviceId)
-        pendingSnapshotChanges[hostDeviceId] = []
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
             // Register before sending so a fast host response cannot beat the waiter.
             pendingFullSyncContinuations[hostDeviceId] = cont
             guard mpManager.send(data: env, toPeer: hostDeviceId) else {
-                pendingSnapshotChanges.removeValue(forKey: hostDeviceId)
                 pendingFullSyncContinuations.removeValue(forKey: hostDeviceId)?
                     .resume(throwing: MultipeerPairingError.sendFailed)
                 return

--- a/core/Tests/WiredPartCoreTests/BluetoothSnapshotStagingTests.swift
+++ b/core/Tests/WiredPartCoreTests/BluetoothSnapshotStagingTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import GRDB
+import Testing
+@testable import WiredPartCore
+
+@Suite("Bluetooth durable snapshot staging")
+struct BluetoothSnapshotStagingTests {
+    private func stage(db: AppDatabase, hostDeviceId: String, batch: SnapshotBatch) throws {
+        try BluetoothSnapshotStaging.authorize(
+            db: db,
+            hostDeviceId: hostDeviceId,
+            begin: SnapshotBegin(transferId: batch.transferId, authorizationToken: "token-\(batch.transferId)"),
+            allowNewTransfer: true
+        )
+        try BluetoothSnapshotStaging.stage(db: db, hostDeviceId: hostDeviceId, batch: batch)
+    }
+
+    private func change(_ id: Int, invalid: Bool = false) -> IncomingChange {
+        IncomingChange(
+            deviceId: "host", tableName: "users", recordId: String(id), operation: "INSERT",
+            recordData: invalid
+                ? "{\"id\":\(id),\"not_a_column\":1}"
+                : "{\"id\":\(id),\"display_name\":\"Staged \(id)\",\"pin_hash\":\"hash\",\"is_active\":1}",
+            timestamp: "2026-08-09T00:00:00Z"
+        )
+    }
+
+    @Test("Migration 122 is registered, private, and untracked")
+    func migrationIsPrivate() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        let facts = try db.writer.read { conn in
+            let table = try Int.fetchOne(conn, sql: "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('_snapshot_staging', '_snapshot_transfers')") ?? 0
+            let triggers = try Int.fetchOne(conn, sql: "SELECT COUNT(*) FROM sqlite_master WHERE type='trigger' AND tbl_name IN ('_snapshot_staging', '_snapshot_transfers')") ?? 0
+            return (table, triggers)
+        }
+        #expect(facts.0 == 2)
+        #expect(facts.1 == 0)
+        #expect(!ConflictResolver.isAllowedTable("_snapshot_staging"))
+    }
+
+    @Test("Completion fails closed for disallowed tables and operations")
+    func completionFailsClosed() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        let disallowed = IncomingChange(
+            deviceId: "host", tableName: "_snapshot_staging", recordId: "1",
+            operation: "INSERT", recordData: "{}", timestamp: "2026-08-09T00:00:00Z"
+        )
+        try stage(db: db, hostDeviceId: "host", batch: .init(
+            transferId: "disallowed-table", sequence: 0, changes: [disallowed]
+        ))
+        #expect(throws: SnapshotStagingError.self) {
+            _ = try BluetoothSnapshotStaging.complete(
+                db: db, hostDeviceId: "host",
+                completion: .init(transferId: "disallowed-table", finalSequence: 0)
+            )
+        }
+
+        var invalidOperation = change(8150)
+        invalidOperation = IncomingChange(
+            deviceId: invalidOperation.deviceId, tableName: invalidOperation.tableName,
+            recordId: invalidOperation.recordId, operation: "UPSERT",
+            recordData: invalidOperation.recordData, timestamp: invalidOperation.timestamp
+        )
+        try stage(db: db, hostDeviceId: "host", batch: .init(
+            transferId: "disallowed-operation", sequence: 0, changes: [invalidOperation]
+        ))
+        #expect(throws: SnapshotStagingError.self) {
+            _ = try BluetoothSnapshotStaging.complete(
+                db: db, hostDeviceId: "host",
+                completion: .init(transferId: "disallowed-operation", finalSequence: 0)
+            )
+        }
+    }
+
+    @Test("Equal duplicate is idempotent and mismatched duplicate fails closed")
+    func duplicateDigestContract() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        let first = SnapshotBatch(transferId: "t1", sequence: 0, changes: [change(8101)])
+        try stage(db: db, hostDeviceId: "host", batch: first)
+        try stage(db: db, hostDeviceId: "host", batch: first)
+        let count = try db.writer.read { try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM _snapshot_staging") ?? 0 }
+        #expect(count == 1)
+        #expect(throws: SnapshotStagingError.self) {
+            try stage(
+                db: db, hostDeviceId: "host",
+                batch: SnapshotBatch(transferId: "t1", sequence: 0, changes: [change(8102)])
+            )
+        }
+    }
+
+    @Test("Staging survives database and manager recreation before completion")
+    func recreation() throws {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wei7025-\(UUID().uuidString).sqlite").path
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        do {
+            let db = try AppDatabase.openDatabase(atPath: path)
+            try stage(
+                db: db, hostDeviceId: "host",
+                batch: SnapshotBatch(transferId: "recreate", sequence: 0, changes: [change(8201)])
+            )
+            _ = PeerManager(db: db)
+        }
+        let reopened = try AppDatabase.openDatabase(atPath: path)
+        _ = PeerManager(db: reopened)
+        let staged = try reopened.writer.read { try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM _snapshot_staging") ?? 0 }
+        #expect(staged == 1)
+        let result = try BluetoothSnapshotStaging.complete(
+            db: reopened, hostDeviceId: "host",
+            completion: SnapshotComplete(transferId: "recreate", finalSequence: 0)
+        )
+        #expect(result.result.applied == 1)
+    }
+
+    @Test("Completion rejects sequence gaps")
+    func gaps() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        try stage(
+            db: db, hostDeviceId: "host",
+            batch: SnapshotBatch(transferId: "gap", sequence: 1, changes: [change(8301)])
+        )
+        #expect(throws: SnapshotStagingError.self) {
+            _ = try BluetoothSnapshotStaging.complete(
+                db: db, hostDeviceId: "host",
+                completion: SnapshotComplete(transferId: "gap", finalSequence: 1)
+            )
+        }
+    }
+
+    @Test("Apply failure rolls back business writes and staging deletion")
+    func rollback() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        var positiveAcknowledgementSent = false
+        try stage(db: db, hostDeviceId: "host", batch: .init(transferId: "rollback", sequence: 0, changes: [change(8401)]))
+        try stage(db: db, hostDeviceId: "host", batch: .init(transferId: "rollback", sequence: 1, changes: [change(8402, invalid: true)]))
+        #expect(throws: (any Error).self) {
+            _ = try BluetoothSnapshotStaging.complete(db: db, hostDeviceId: "host", completion: .init(transferId: "rollback", finalSequence: 1))
+            positiveAcknowledgementSent = true
+        }
+        let facts = try db.writer.read { conn in
+            let user = try Int.fetchOne(conn, sql: "SELECT COUNT(*) FROM users WHERE id = 8401") ?? 0
+            let staged = try Int.fetchOne(conn, sql: "SELECT COUNT(*) FROM _snapshot_staging WHERE transfer_id='rollback'") ?? 0
+            return (user, staged)
+        }
+        #expect(facts.0 == 0)
+        #expect(facts.1 == 2)
+        #expect(!positiveAcknowledgementSent)
+    }
+
+    @Test("Successful apply deletes staging before caller can send final acknowledgement")
+    func finalAckOrder() throws {
+        let db = try AppDatabase.openInMemoryDatabase()
+        try stage(db: db, hostDeviceId: "host", batch: .init(transferId: "done", sequence: 0, changes: [change(8501)]))
+        _ = try BluetoothSnapshotStaging.complete(db: db, hostDeviceId: "host", completion: .init(transferId: "done", finalSequence: 0))
+        let facts = try db.writer.read { conn in
+            (try Int.fetchOne(conn, sql: "SELECT COUNT(*) FROM users WHERE id=8501") ?? 0,
+             try Int.fetchOne(conn, sql: "SELECT COUNT(*) FROM _snapshot_staging WHERE transfer_id='done'") ?? 0)
+        }
+        #expect(facts == (1, 0))
+    }
+
+    @Test("Transport seam enforces window one and bounded same-sequence retry")
+    func windowOneAndRetry() async throws {
+        let changes = [change(8601), change(8602)]
+        var page = 0
+        var sentSequences: [Int] = []
+        var acknowledged: Set<Int> = []
+        var checks: [Int: Int] = [:]
+        let result = try await BluetoothSnapshotTransfer.runStaged(
+            transferId: "wire", batchSize: 1, maxAttempts: 3, sleep: { _ in },
+            listTables: { ["users"] },
+            readPage: { _, _, _ in
+                defer { page += 1 }
+                return page < changes.count
+                    ? BluetoothSnapshotPage(changes: [changes[page]], sourceRowCount: 1)
+                    : BluetoothSnapshotPage(changes: [], sourceRowCount: 0)
+            },
+            sendBatch: { batch in sentSequences.append(batch.sequence); return true },
+            isStored: { sequence in
+                checks[sequence, default: 0] += 1
+                if sequence == 0 && checks[sequence] == 11 { acknowledged.insert(sequence) }
+                if sequence == 1 { acknowledged.insert(sequence) }
+                return acknowledged.contains(sequence)
+            }
+        )
+        #expect(sentSequences == [0, 0, 1])
+        #expect(result.rows == 2)
+        #expect(result.finalSequence == 1)
+    }
+}

--- a/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
+++ b/core/Tests/WiredPartCoreTests/PeerManagerTests.swift
@@ -37,6 +37,23 @@ private final class SnapshotAcknowledgementCollector: @unchecked Sendable {
     }
 }
 
+private final class SnapshotStoredCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [SnapshotStored] = []
+
+    func append(_ acknowledgement: SnapshotStored) {
+        lock.lock()
+        storage.append(acknowledgement)
+        lock.unlock()
+    }
+
+    var values: [SnapshotStored] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+}
+
 private actor PeerManagerStateCollector {
     private var snapshots: [PeerManagerState] = []
     private var transportErrorWaiter: (message: String, continuation: CheckedContinuation<PeerManagerState, Never>)?
@@ -1685,207 +1702,185 @@ struct PeerManagerTests {
     }
 
     #if canImport(MultipeerConnectivity)
-    @Test("Full-sync completion is processed only after the preceding batch is durable")
+    @Test("Legacy in-memory full-sync completion is intentionally rejected")
     func testFullSyncBatchAppliesBeforeCompletion() async throws {
-        let db = try freshDB()
-        let pm = PeerManager(db: db)
-        let changesData = try JSONEncoder().encode([snapshotUserChange(recordId: "7001")])
-        let changesEnvelope = try JSONEncoder().encode(MPEnvelope(type: "changes", payload: changesData))
-        let completionEnvelope = try JSONEncoder().encode(
+        let legacy = try JSONEncoder().encode(
             MPEnvelope(type: "fullSyncComplete", payload: try JSONEncoder().encode(FullSyncCompletion.success))
         )
-        await pm.testBeginSnapshotBuffer(from: "host")
-
-        let applied = try await pm.testProcessMultipeerMessage(
-            ReceivedMultipeerMessage(fromDeviceId: "host", data: changesEnvelope)
-        )
-        #expect(applied == .changesApplied(1))
-        let persisted = try await db.writer.read { dbConn in
-            try String.fetchOne(dbConn, sql: "SELECT display_name FROM users WHERE id = 7001")
+        await #expect(throws: MultipeerSnapshotError.self) {
+            _ = try await PeerManager(db: try freshDB()).testProcessMultipeerMessage(
+                ReceivedMultipeerMessage(fromDeviceId: "host", data: legacy)
+            )
         }
-        #expect(persisted == nil, "snapshot pages must remain uncommitted until completion")
-
-        let completed = try await pm.testProcessMultipeerMessage(
-            ReceivedMultipeerMessage(fromDeviceId: "host", data: completionEnvelope)
-        )
-        #expect(completed == .fullSyncCompleted)
-        let durableAfterCompletion = try await db.writer.read { dbConn in
-            try String.fetchOne(dbConn, sql: "SELECT display_name FROM users WHERE id = 7001")
-        }
-        #expect(durableAfterCompletion == "Snapshot User")
     }
 
-    @Test("A failed full-sync batch is visible and cannot advance completion")
+    @Test("Legacy in-memory changes cannot enter an active staged transfer")
     func testFullSyncApplyFailurePropagates() async throws {
-        let db = try freshDB()
-        let pm = PeerManager(db: db)
-        let valid = snapshotUserChange(recordId: "7002")
-        let databaseFailure = IncomingChange(
-            deviceId: "host",
-            tableName: "users",
-            recordId: "7003",
-            operation: "INSERT",
-            recordData: #"{"id":7003,"display_name":"Invalid","pin_hash":"hash","is_active":1,"not_a_real_column":"boom"}"#,
-            timestamp: "2026-07-15T00:00:00Z"
-        )
-        let validEnvelope = try JSONEncoder().encode(
-            MPEnvelope(type: "changes", payload: try JSONEncoder().encode([valid]))
-        )
-        let failingEnvelope = try JSONEncoder().encode(
-            MPEnvelope(type: "changes", payload: try JSONEncoder().encode([databaseFailure]))
-        )
-        let completionEnvelope = try JSONEncoder().encode(
-            MPEnvelope(type: "fullSyncComplete", payload: try JSONEncoder().encode(FullSyncCompletion.success))
-        )
-        await pm.testBeginSnapshotBuffer(from: "host")
-
-        _ = try await pm.testProcessMultipeerMessage(
-            ReceivedMultipeerMessage(fromDeviceId: "host", data: validEnvelope)
-        )
-        _ = try await pm.testProcessMultipeerMessage(
-            ReceivedMultipeerMessage(fromDeviceId: "host", data: failingEnvelope)
-        )
-
-        await #expect(throws: (any Error).self) {
-            _ = try await pm.testProcessMultipeerMessage(
-                ReceivedMultipeerMessage(fromDeviceId: "host", data: completionEnvelope)
+        let protocolPM = PeerManager(db: try freshDB())
+        await protocolPM.testBeginSnapshotBuffer(from: "host")
+        let legacy = try JSONEncoder().encode(MPEnvelope(
+            type: "changes",
+            payload: try JSONEncoder().encode([snapshotUserChange(recordId: "7002")])
+        ))
+        await #expect(throws: SnapshotStagingError.self) {
+            _ = try await protocolPM.testProcessMultipeerMessage(
+                ReceivedMultipeerMessage(fromDeviceId: "host", data: legacy)
             )
         }
-        await pm.testAbandonSnapshotBuffer(from: "host")
-
-        let latePage = try JSONEncoder().encode(
-            MPEnvelope(
-                type: "changes",
-                payload: try JSONEncoder().encode([snapshotUserChange(recordId: "7004")])
-            )
-        )
-        let lateOutcome = try await pm.testProcessMultipeerMessage(
-            ReceivedMultipeerMessage(fromDeviceId: "host", data: latePage)
-        )
-        #expect(lateOutcome == .ignored)
-
-        let committedPrefix = try await db.writer.read { dbConn in
-            try Int.fetchOne(dbConn, sql: "SELECT COUNT(*) FROM users WHERE id IN (7002, 7003, 7004)") ?? 0
-        }
-        #expect(
-            committedPrefix == 0,
-            "a failed later snapshot page must roll back earlier pages and quarantine queued remainder"
-        )
     }
 
-    @Test("Atomic apply failure negatively acknowledges, releases reservation, and requires fresh authorization")
+    @Test("Legacy completion cannot consume a staged snapshot capability")
     func testAtomicApplyFailureReleasesHostReservationAndRequiresFreshAuthorization() async throws {
-        let host = PeerManager(db: try freshDB())
-        let joiner = PeerManager(db: try freshDB())
-        let peer = "joiner"
-        let hostDeviceId = "host"
-        let consumedToken = "consumed-capability"
-
-        try await host.startPeerSync(deviceId: hostDeviceId, deviceName: "Host", companyId: "company")
-        await host.testIssueHostedSnapshotToken(consumedToken, for: peer)
-        #expect(await host.testReserveHostedSnapshot(token: consumedToken, for: peer))
-        await host.testSetHostedSnapshotRowsSent(1, for: peer)
-
-        await joiner.testAuthorizeReceivedSnapshot(consumedToken, from: hostDeviceId)
-        await joiner.testBeginSnapshotBuffer(from: hostDeviceId)
-        let fullSyncWaiter = Task {
-            try await joiner.testAwaitFullSyncTransport(peerDeviceId: hostDeviceId)
-        }
-        while await joiner.testPendingTransportOperationCount() == 0 {
-            await Task.yield()
-        }
-
-        let validEnvelope = try JSONEncoder().encode(MPEnvelope(
-            type: "changes",
-            payload: try JSONEncoder().encode([snapshotUserChange(recordId: "7101")])
-        ))
-        let invalidChange = IncomingChange(
-            deviceId: hostDeviceId,
-            tableName: "users",
-            recordId: "7102",
-            operation: "INSERT",
-            recordData: #"{"id":7102,"display_name":"Invalid","pin_hash":"hash","is_active":1,"not_a_real_column":"boom"}"#,
-            timestamp: "2026-07-15T00:00:00Z"
+        let pm = PeerManager(db: try freshDB())
+        await pm.testAuthorizeReceivedSnapshot("token", from: "host")
+        let legacy = try JSONEncoder().encode(
+            MPEnvelope(type: "fullSyncComplete", payload: try JSONEncoder().encode(FullSyncCompletion.success))
         )
-        let invalidEnvelope = try JSONEncoder().encode(MPEnvelope(
-            type: "changes",
-            payload: try JSONEncoder().encode([invalidChange])
-        ))
-        let completionEnvelope = try JSONEncoder().encode(MPEnvelope(
-            type: "fullSyncComplete",
-            payload: try JSONEncoder().encode(FullSyncCompletion.success)
-        ))
-        let acknowledgements = SnapshotAcknowledgementCollector()
+        await #expect(throws: MultipeerSnapshotError.self) {
+            _ = try await pm.testProcessMultipeerMessage(
+                ReceivedMultipeerMessage(fromDeviceId: "host", data: legacy)
+            )
+        }
+        #expect(await pm.testReceivedSnapshotToken(from: "host") == "token")
+    }
 
-        await #expect(throws: (any Error).self) {
-            _ = try await joiner.testProcessMultipeerMessagesInFIFO(
-                [
-                    ReceivedMultipeerMessage(fromDeviceId: hostDeviceId, data: validEnvelope),
-                    ReceivedMultipeerMessage(fromDeviceId: hostDeviceId, data: invalidEnvelope),
-                    ReceivedMultipeerMessage(fromDeviceId: hostDeviceId, data: completionEnvelope),
-                ],
-                sendApplyAcknowledgement: { acknowledgement, destination in
-                    #expect(destination == hostDeviceId)
-                    acknowledgements.append(acknowledgement)
-                    return true
+    @Test("Staged frames acknowledge durable storage and retry terminal acknowledgement after recreation")
+    func testStagedFramesRetryTerminalAcknowledgementAfterRecreation() async throws {
+        let db = try freshDB()
+        let host = "authorized-host"
+        let token = "durable-token"
+        let transfer = "durable-transfer"
+        let begin = try JSONEncoder().encode(MPEnvelope(
+            type: "snapshotBegin",
+            payload: try JSONEncoder().encode(SnapshotBegin(transferId: transfer, authorizationToken: token))
+        ))
+        let batch = try JSONEncoder().encode(MPEnvelope(
+            type: "snapshotBatch",
+            payload: try JSONEncoder().encode(SnapshotBatch(
+                transferId: transfer,
+                sequence: 0,
+                changes: [snapshotUserChange(recordId: "7201")]
+            ))
+        ))
+        let complete = try JSONEncoder().encode(MPEnvelope(
+            type: "snapshotComplete",
+            payload: try JSONEncoder().encode(SnapshotComplete(transferId: transfer, finalSequence: 0))
+        ))
+        let stored = SnapshotStoredCollector()
+        let failedAcks = SnapshotAcknowledgementCollector()
+        let first = PeerManager(db: db)
+        await first.testAuthorizeReceivedSnapshot(token, from: host)
+
+        _ = try await first.testProcessMultipeerMessage(.init(fromDeviceId: host, data: begin))
+        _ = try await first.testProcessMultipeerMessage(
+            .init(fromDeviceId: host, data: batch),
+            sendStoredAcknowledgement: { acknowledgement, destination in
+                #expect(destination == host)
+                stored.append(acknowledgement)
+                return true
+            }
+        )
+        #expect(stored.values == [SnapshotStored(transferId: transfer, sequence: 0)])
+        await #expect(throws: MultipeerPairingError.self) {
+            _ = try await first.testProcessMultipeerMessage(
+                .init(fromDeviceId: host, data: complete),
+                sendApplyAcknowledgement: { acknowledgement, _ in
+                    failedAcks.append(acknowledgement)
+                    return false
                 }
             )
         }
-        await #expect(throws: (any Error).self) {
-            try await fullSyncWaiter.value
-        }
 
-        let negativeAcknowledgement = try #require(acknowledgements.values.first)
-        #expect(acknowledgements.values.count == 1)
-        #expect(negativeAcknowledgement.authorizationToken == consumedToken)
-        #expect(negativeAcknowledgement.succeeded == false)
-        #expect(negativeAcknowledgement.error?.isEmpty == false)
-
-        let acknowledgementEnvelope = try JSONEncoder().encode(MPEnvelope(
-            type: "fullSyncApplied",
-            payload: try JSONEncoder().encode(negativeAcknowledgement)
-        ))
-        _ = try await host.testProcessMultipeerMessage(
-            ReceivedMultipeerMessage(fromDeviceId: peer, data: acknowledgementEnvelope)
+        let successfulAcks = SnapshotAcknowledgementCollector()
+        let recreated = PeerManager(db: db)
+        let outcome = try await recreated.testProcessMultipeerMessage(
+            .init(fromDeviceId: host, data: complete),
+            sendApplyAcknowledgement: { acknowledgement, destination in
+                #expect(destination == host)
+                successfulAcks.append(acknowledgement)
+                return true
+            }
         )
-        #expect(!(await host.testHostedSnapshotIsReserved(for: peer)))
-        #expect(!(await host.testHostedSnapshotTokenAvailable(consumedToken, for: peer)))
-        #expect(!(await host.testReserveHostedSnapshot(token: consumedToken, for: peer)))
-        #expect(await host.getState().lastPeerSyncs[peer]?.success == false)
-
-        let pairingCode = try await host.issuePairingCode()
-        let (_, peerKey) = SyncCrypto.generateKeyAgreementPair()
-        let nonce = SyncCrypto.bluetoothPairingRequestNonce()
-        let pairRequest = try JSONEncoder().encode(SyncPairRequest(
-            deviceId: peer,
-            deviceName: "Joiner",
-            pairingProof: SyncCrypto.bluetoothPairingProof(
-                normalizedCode: try #require(SyncCrypto.normalizedPairingCode(pairingCode)),
-                expectedHostDeviceId: hostDeviceId,
-                clientDeviceId: peer,
-                clientPublicKeyB64: peerKey,
-                requestNonce: nonce
-            ),
-            platform: "ios",
-            bluetoothProtocolVersion: 4,
-            bluetoothRequestNonce: nonce,
-            bluetoothExpectedHostDeviceId: hostDeviceId,
-            keyAgreementPublicKey: peerKey
-        ))
-        let responses = PairResponseCollector()
-        await host.processBluetoothPairRequest(from: peer, payload: pairRequest) { response in
-            responses.append(response)
-            return true
+        #expect(outcome == .fullSyncCompleted)
+        #expect(failedAcks.values.first?.authorizationToken == token)
+        #expect(successfulAcks.values.first?.authorizationToken == token)
+        let facts = try await db.writer.read { conn in
+            (try Int.fetchOne(conn, sql: "SELECT COUNT(*) FROM users WHERE id = 7201") ?? 0,
+             try String.fetchOne(conn, sql: "SELECT state FROM _snapshot_transfers WHERE transfer_id = ?", arguments: [transfer]))
         }
-        let freshToken = try #require(responses.values.first?.bluetoothSnapshotToken)
-        #expect(responses.values.count == 1)
-        #expect(freshToken != consumedToken)
+        #expect(facts.0 == 1)
+        #expect(facts.1 == "applied")
+    }
 
-        async let firstFreshReservation = host.testReserveHostedSnapshot(token: freshToken, for: peer)
-        async let duplicateFreshReservation = host.testReserveHostedSnapshot(token: freshToken, for: peer)
-        let freshReservationResults = await [firstFreshReservation, duplicateFreshReservation]
-        #expect(freshReservationResults.filter { $0 }.count == 1)
-        await host.stopPeerSync()
+    @Test("Recreated manager accepts authorized retransmission but rejects unknown, gap, mixed, and invalid staged frames")
+    func testStagedFrameValidationThroughPeerManager() async throws {
+        let db = try freshDB()
+        let host = "host"
+        let token = "token"
+        let transfer = "known"
+        let first = PeerManager(db: db)
+        await first.testAuthorizeReceivedSnapshot(token, from: host)
+        let begin = try JSONEncoder().encode(MPEnvelope(
+            type: "snapshotBegin",
+            payload: try JSONEncoder().encode(SnapshotBegin(transferId: transfer, authorizationToken: token))
+        ))
+        _ = try await first.testProcessMultipeerMessage(.init(fromDeviceId: host, data: begin))
+
+        let recreated = PeerManager(db: db)
+        let knownBatch = try JSONEncoder().encode(MPEnvelope(
+            type: "snapshotBatch",
+            payload: try JSONEncoder().encode(SnapshotBatch(
+                transferId: transfer, sequence: 0, changes: [snapshotUserChange(recordId: "7301")]
+            ))
+        ))
+        let stored = SnapshotStoredCollector()
+        _ = try await recreated.testProcessMultipeerMessage(
+            .init(fromDeviceId: host, data: knownBatch),
+            sendStoredAcknowledgement: { acknowledgement, _ in stored.append(acknowledgement); return true }
+        )
+        _ = try await recreated.testProcessMultipeerMessage(
+            .init(fromDeviceId: host, data: knownBatch),
+            sendStoredAcknowledgement: { acknowledgement, _ in stored.append(acknowledgement); return true }
+        )
+        #expect(stored.values.count == 2)
+
+        let unknown = try JSONEncoder().encode(MPEnvelope(
+            type: "snapshotBatch",
+            payload: try JSONEncoder().encode(SnapshotBatch(
+                transferId: "unknown", sequence: 0, changes: [snapshotUserChange(recordId: "7302")]
+            ))
+        ))
+        await #expect(throws: SnapshotStagingError.self) {
+            _ = try await PeerManager(db: db).testProcessMultipeerMessage(.init(fromDeviceId: host, data: unknown))
+        }
+
+        let gapComplete = try JSONEncoder().encode(MPEnvelope(
+            type: "snapshotComplete",
+            payload: try JSONEncoder().encode(SnapshotComplete(transferId: transfer, finalSequence: 1))
+        ))
+        await #expect(throws: SnapshotStagingError.self) {
+            _ = try await recreated.testProcessMultipeerMessage(.init(fromDeviceId: host, data: gapComplete))
+        }
+
+        let mixed = IncomingChange(
+            deviceId: host, tableName: "parts", recordId: "1", operation: "INSERT",
+            recordData: "{}", timestamp: "2026-08-09T00:00:00Z"
+        )
+        let mixedBatch = try JSONEncoder().encode(MPEnvelope(
+            type: "snapshotBatch",
+            payload: try JSONEncoder().encode(SnapshotBatch(
+                transferId: transfer, sequence: 1,
+                changes: [snapshotUserChange(recordId: "7303"), mixed]
+            ))
+        ))
+        await #expect(throws: SnapshotStagingError.self) {
+            _ = try await recreated.testProcessMultipeerMessage(.init(fromDeviceId: host, data: mixedBatch))
+        }
+
+        let invalid = try JSONEncoder().encode(MPEnvelope(type: "snapshotBatch", payload: Data("not-json".utf8)))
+        await #expect(throws: DecodingError.self) {
+            _ = try await recreated.testProcessMultipeerMessage(.init(fromDeviceId: host, data: invalid))
+        }
     }
     #endif
 
@@ -2162,8 +2157,16 @@ extension PeerManager {
     }
 
     #if canImport(MultipeerConnectivity)
-    func testProcessMultipeerMessage(_ message: ReceivedMultipeerMessage) async throws -> MultipeerMessageOutcome {
-        try await processMultipeerMessage(message)
+    func testProcessMultipeerMessage(
+        _ message: ReceivedMultipeerMessage,
+        sendApplyAcknowledgement: ((FullSyncApplyAcknowledgement, String) -> Bool)? = nil,
+        sendStoredAcknowledgement: ((SnapshotStored, String) -> Bool)? = nil
+    ) async throws -> MultipeerMessageOutcome {
+        try await processMultipeerMessage(
+            message,
+            sendApplyAcknowledgement: sendApplyAcknowledgement,
+            sendStoredAcknowledgement: sendStoredAcknowledgement
+        )
     }
     #endif
 }

--- a/docs/plans/bluetooth-snapshot-durable-staging-remediation.md
+++ b/docs/plans/bluetooth-snapshot-durable-staging-remediation.md
@@ -1,0 +1,37 @@
+# Durable Bluetooth Snapshot Staging Remediation
+
+Status: Approved architecture — implementation tracked by WEI-7025.
+
+## Scope and intent
+
+This plan replaces the in-memory initial Bluetooth snapshot buffer with transfer-scoped private SQLite staging. It follows the approved WEI-7024 design and applies only to initial full snapshots carried over the existing Multipeer Bluetooth/Wi-Fi P2P transport. It does not change pairing capability issuance, normal incremental sync frames, or transport discovery.
+
+## Protocol
+
+1. The host validates the pairing-issued one-time capability, reserves it, and emits `snapshotBegin` for a unique transfer ID.
+2. The host sends one `snapshotBatch` at a time. A batch is identified by the transfer ID, a monotonically increasing zero-based sequence, and an encoded homogeneous array of `IncomingChange` values.
+3. The joiner accepts staged frames only from the authorized/trusted snapshot host, validates the transfer and sequence, commits the batch payload into private staging, and only then emits `snapshotStored(transferId, sequence)`.
+4. The host may send sequence N+1 only after it receives the durable stored acknowledgement for N. A missing acknowledgement retries the same sequence a bounded number of times; a repeated acknowledged sequence is idempotent only when its payload digest matches, and otherwise fails closed.
+5. The host emits `snapshotComplete` only after the final stored acknowledgement. The joiner verifies staging sequence numbers are contiguous from 0 through the advertised final sequence and atomically applies all staged changes through the existing conflict resolver, deletes the staged rows, and commits.
+6. Only after that commit does the joiner emit the existing final durable apply acknowledgement. The host records success only after receiving it.
+
+## Persistence
+
+Migration 122 creates a private `_snapshot_staging` table keyed by `(transfer_id, sequence)` with the authorized host identifier, payload/digest, and creation timestamp. The migration creates no sync triggers and the table is excluded from snapshot table enumeration and `_change_log` tracking.
+
+## Invariants and failure handling
+
+- There is never more than one unacknowledged host batch.
+- A joiner acknowledgement proves its SQLite staging commit, not merely receipt in memory.
+- No staged snapshot data reaches business tables until the final transaction commits.
+- Unknown frame types, malformed frames, mixed transfer payloads, sequence gaps, mismatched duplicate data, authorization failures, and final apply errors fail visibly and do not report host success.
+- Disconnect, app termination, and manager recreation leave staged rows but no partial business apply; a later authorized retry may resume/idempotently redeliver staged batches.
+- Existing pairing trust/capability checks remain mandatory; legacy incremental `changes` frames remain distinct from staged snapshot frames.
+
+## Verification matrix
+
+Focused deterministic tests cover: window size one; host wait/retry behavior; duplicate equal versus mismatched data; disconnect after staging; manager recreation prior to completion; sequence gap rejection; final apply rollback and absent positive final acknowledgement; migration registration/readback; and the Bluetooth transport seam using injected send closures rather than real radio state.
+
+## Review and delivery
+
+Review chain: WEI-7026 LocalFirst → WEI-7027 Security → WEI-7028 GPT → WEI-7029 Claude → WEI-7030 Bluetooth-only device QA. GitHub umbrella: #1417. Parent work: WEI-7021, WEI-7022, WEI-7024.


### PR DESCRIPTION
Implements WEI-7025 durable Bluetooth full-snapshot staging.

- Adds private migration 122 for transfer metadata and idempotent staged batches.
- Enforces window=1 stored acknowledgements, atomic application/deletion, durable final-ack retry, and restart recovery.
- Adds focused staging and PeerManager protocol coverage.

Tracking: #1417; Paperclip WEI-7021, WEI-7022, WEI-7024, WEI-7025.

Verification:
- `swift test --filter BluetoothSnapshotStagingTests` (8 tests passed)
- `swift test --filter "PeerManagerTests.testStaged"` (2 tests passed)
- `git diff --check`